### PR TITLE
Chart live surface + transport-agnostic channel dispatcher

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "jupyter",
+      "runtimeExecutable": ".venv/bin/jupyter",
+      "runtimeArgs": [
+        "lab",
+        "--no-browser",
+        "--port=8899",
+        "--IdentityProvider.token=fastcharts"
+      ],
+      "port": 8899
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ in the README).
 
 ## [Unreleased]
 
+### Added
+- **Chart live surface (data-live, structure-immutable).** The declarative
+  `Chart` gains `append(trace_id, x, y, color=, size=)` (streaming — routed
+  through the live widget when one exists, else mutating the built figure
+  without touching the widget stack), `pick(trace_id, index)` (exact
+  canonical-row readout), and `select_range(...) -> Selection`. Structural
+  changes still mean composing a new chart.
+- **`fastcharts/channel.py`** — the kernel-side message dispatcher extracted
+  from `FigureWidget` (reflex-integration §3.1 build-order step 1):
+  `handle_message(fig, content, buffers, callbacks)` serves every transport;
+  the anywidget widget is now a thin comm wrapper over it, and a future
+  server transport (the planned Reflex adapter) drives the same tested
+  contract without importing the widget stack.
+
 ### Changed
 - **API layering inverted: the declarative layer is now the core.** The nine
   mark-builder implementations moved verbatim from `figure.py` into the new

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,9 @@ code comments cite dossier sections (e.g. §16 = deep-zoom re-centering).
   `marks.py` is the declarative mark core: the single implementation of every
   chart kind, bound onto `Figure` as its fluent methods (one body, one
   signature, one set of defaults — parity is identity, not convention).
-  `channels.py` resolves scatter color/size encodings.
+  `channels.py` resolves scatter color/size encodings. `channel.py` (singular)
+  is the transport-agnostic message dispatcher (widget comm today, Reflex
+  routes later) — it must never import the widget stack.
 - `js/src/*.js` — the render client as ordered parts (concat order in
   `js/build.mjs`; exports live only in `60_entries.js`), one dependency-free ES
   module. **No npm packages.** `node js/build.mjs` copies it to

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -319,8 +319,39 @@ chart
 ```
 
 Composed `Chart` objects expose the same `to_html(...)`, `html(...)`,
-`_repr_html_()`, `to_png(...)`, `widget()`, `show()`, and `memory_report()`
-readout methods as `Figure`.
+`_repr_html_()`, `to_png(...)`, `to_svg(...)`, `widget()`, `show()`, and
+`memory_report()` readout methods as `Figure`.
+
+## Live Data On A Composed Chart
+
+The data plane of a `Chart` is live — stream new points and read exact rows
+or selections from Python. Structure stays declarative: adding marks, axes,
+or annotations means composing a new chart.
+
+```python
+import fastcharts as fc
+
+chart = fc.scatter_chart(
+    fc.scatter(x=[0.0, 1.0, 2.0, 3.0], y=[0.0, 2.0, 4.0, 6.0], name="stream"),
+    fc.x_axis(label="t"),
+    fc.y_axis(label="value"),
+)
+
+# Streaming append: extends the trace in place. With a live widget the
+# client refreshes; headless, the next widget()/to_html() ships the
+# streamed state (already-exported HTML files are snapshots).
+chart.append(0, [4.0], [8.0])
+
+# Exact source-row readout from the canonical f64 store.
+row = chart.pick(0, 4)
+assert row["x"] == 4.0 and row["y"] == 8.0
+
+# Python-side box select: the same Selection object on_select receives.
+selection = chart.select_range(0.5, 3.5, 0.0, 10.0)
+assert len(selection) == 3
+xs, ys = selection.xy(0)
+chart
+```
 
 ## Layered Composition And Annotations
 

--- a/python/fastcharts/channel.py
+++ b/python/fastcharts/channel.py
@@ -1,0 +1,219 @@
+"""Transport-agnostic message dispatcher (docs/design/reflex-integration.md §3.1).
+
+One kernel-side dispatcher for every transport: the anywidget comm today, and
+any future host (the planned Reflex adapter's HTTP routes) tomorrow. A
+transport parses its wire format, calls `handle_message`, and ships whatever
+reply comes back; Python-side callbacks fire in here so every transport gets
+identical semantics. Not to be confused with `channels.py`, which resolves
+scatter color/size *encoding* channels.
+
+Contracts (moved verbatim from `FigureWidget._on_custom_msg`):
+
+- **Never raises on client-supplied data.** Malformed messages return None
+  (silently dropped — a hostile or racing client must not be able to crash
+  the kernel). Exceptions raised by *user callbacks* propagate: those are
+  bugs in caller code, not client data.
+- **Replies are return values, not sends.** The transport sends after this
+  returns, so callbacks now fire before the reply leaves the process
+  (previously the widget sent `pick_result` before `on_hover` and `selection`
+  between `on_brush` and `on_select`). No client, test, or doc observes that
+  interleaving — identical bytes arrive in the same order — and the named
+  ordering invariant, on_brush before on_select, is preserved and tested.
+- **`append` is not a message kind.** `Figure.append` already returns the
+  transport-agnostic `(msg, buffers)` refresh; each transport ships it its
+  own way (the widget re-syncs traits and sends; a server transport would
+  broadcast it). Do not add a third message shape here.
+- **`buffers` is accepted and currently unused** — no inbound message carries
+  binary payloads today, but the signature is part of the §3.1 contract so
+  the §3.2 length-prefixed HTTP framing (which would also live in this
+  module) can pass them through without a break.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional
+
+from .figure import Selection
+from .interaction import _integer_id
+from .lod import normalize_window
+
+if TYPE_CHECKING:
+    from .figure import Figure
+
+__all__ = ["ChannelCallbacks", "handle_message"]
+
+# (reply message, buffers to ship beside it — None when the reply has none).
+Reply = tuple[dict[str, Any], Optional[list[bytes]]]
+
+
+@dataclass(frozen=True)
+class ChannelCallbacks:
+    """Python-side event callbacks a transport wires into the dispatcher.
+
+    All optional; a transport with no Python callbacks (a bare export host)
+    passes nothing and still gets the wire replies.
+    """
+
+    on_hover: Optional[Callable[[dict[str, Any]], None]] = None
+    on_click: Optional[Callable[[dict[str, Any]], None]] = None
+    on_brush: Optional[Callable[[dict[str, float]], None]] = None
+    on_select: Optional[Callable[[Selection], None]] = None
+    on_view_change: Optional[Callable[[dict[str, Any]], None]] = None
+
+
+_NO_CALLBACKS = ChannelCallbacks()
+
+
+def handle_message(
+    fig: "Figure",
+    content: Any,
+    buffers: Optional[list[bytes]] = None,
+    callbacks: ChannelCallbacks = _NO_CALLBACKS,
+) -> Optional[Reply]:
+    """Dispatch one client message against a figure.
+
+    Returns the reply to ship back over the wire, or None when there is
+    nothing to send (malformed input, callback-only kinds, empty updates).
+    """
+    del buffers  # no inbound message carries buffers today (see module doc)
+    if not isinstance(content, dict):
+        return None
+    kind = content.get("type")
+    if kind == "view":
+        # Zoom/pan crossed what the shipped decimation can serve: recompute
+        # for the visible window only (§28), stale-while-revalidate on the
+        # client (§17 — it keeps drawing the old tier until this arrives).
+        seq = content.get("seq")
+        try:
+            x0 = float(content["x0"])
+            x1 = float(content["x1"])
+            if not x1 > x0:
+                return None
+            update, out = fig.decimate_view(
+                x0,
+                x1,
+                content.get("px", 2048),
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+        if update["traces"]:
+            return {"type": "tier_update", "seq": seq, **update}, out
+        return None
+    if kind == "density_view":
+        # Tier-2 scatter panned/zoomed: re-bin the visible window (§5).
+        seq = content.get("seq")
+        try:
+            update, out = fig.density_view(
+                content["trace"],
+                content["x0"],
+                content["x1"],
+                content["y0"],
+                content["y1"],
+                content.get("w", 512),
+                content.get("h", 384),
+            )
+        except (KeyError, TypeError, ValueError, IndexError):
+            return None
+        if update["traces"]:
+            return {"type": "density_update", "seq": seq, **update}, out
+        return None
+    if kind == "pick":
+        # Hover/click drill: exact f64 row from canonical (§16/§17). The
+        # client's drill_seq rejects picks that raced a subset swap.
+        dseq = content.get("drill_seq")
+        try:
+            trace_id = _integer_id(content.get("trace", -1), "trace")
+            index = _integer_id(content.get("index", -1), "index")
+            drill_seq = None if dseq is None else _integer_id(dseq, "drill_seq")
+            row = fig.pick(
+                trace_id,
+                index,
+                drill_seq,
+            )
+        except (TypeError, ValueError):
+            return None
+        if row is not None and callbacks.on_hover is not None:
+            callbacks.on_hover(row)
+        # Reply ships even when row is None (stale drill_seq): the client
+        # clears its hover state on the empty result.
+        return {"type": "pick_result", "seq": content.get("seq"), "row": row}, None
+    if kind == "click":
+        dseq = content.get("drill_seq")
+        row = None
+        try:
+            trace_id = _integer_id(content.get("trace", -1), "trace")
+            index = _integer_id(content.get("index", -1), "index")
+            drill_seq = None if dseq is None else _integer_id(dseq, "drill_seq")
+            row = fig.pick(trace_id, index, drill_seq)
+        except (TypeError, ValueError):
+            return None
+        if row is not None and callbacks.on_click is not None:
+            callbacks.on_click(row)
+        return None
+    if kind == "view_change":
+        if callbacks.on_view_change is None:
+            return None
+        try:
+            view = {
+                "x0": float(content["x0"]),
+                "x1": float(content["x1"]),
+                "y0": float(content["y0"]),
+                "y1": float(content["y1"]),
+                "source": str(content.get("source", "view")),
+            }
+        except (KeyError, TypeError, ValueError):
+            return None
+        callbacks.on_view_change(view)
+        return None
+    if kind == "select":
+        # Box-select → range predicate (§34 Tier A). Ship a selection mask
+        # per trace so the client dims unselected marks; call on_select with
+        # the resolved indices (Arrow-slice-shaped, not JSON — §34 API note).
+        try:
+            x0, x1, y0, y1 = normalize_window(
+                content["x0"],
+                content["x1"],
+                content["y0"],
+                content["y1"],
+                require_area=False,
+            )
+            sel = fig.select_range(
+                x0,
+                x1,
+                y0,
+                y1,
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+        if callbacks.on_brush is not None:
+            callbacks.on_brush({"x0": x0, "x1": x1, "y0": y0, "y1": y1})
+        traces = []
+        out: list[bytes] = []
+        total = 0
+        for tid, idx in sel.items():
+            # The wire mask speaks shipped-vertex positions; the Selection
+            # callback below keeps canonical rows (§34 — callbacks get real
+            # data, the GPU gets its own coordinate space).
+            wire_idx = fig.to_shipped_indices(tid, idx)
+            traces.append(
+                {
+                    "id": tid,
+                    "count": int(len(wire_idx)),
+                    "buf": len(out),
+                    # Which drilled subset this mask speaks for; the client
+                    # drops it if its buffers have moved on (§17).
+                    "drill_seq": fig.traces[tid].drill_seq,
+                }
+            )
+            out.append(wire_idx.tobytes())
+            total += len(idx)
+        if callbacks.on_select is not None:
+            callbacks.on_select(Selection(fig, sel))
+        return {"type": "selection", "traces": traces, "total": total}, out
+    if kind == "select_clear":
+        if callbacks.on_select is not None:
+            callbacks.on_select(Selection(fig, {}))
+        return {"type": "selection", "traces": [], "total": 0}, None
+    return None

--- a/python/fastcharts/components.py
+++ b/python/fastcharts/components.py
@@ -40,7 +40,7 @@ import numpy as np
 
 from . import _validate, channels
 from .dom import CHART_DOM_SLOTS, validate_dom_slots
-from .figure import Figure
+from .figure import Figure, Selection
 
 # Shared validators (single source of truth in `_validate`); these aliases keep
 # the module-private names their call sites already use.
@@ -1457,6 +1457,47 @@ class Chart(Component):
 
     def memory_report(self) -> dict[str, Any]:
         return self.figure().memory_report()
+
+    # -- live data (structure-immutable: build a new chart for new marks) ----
+
+    def append(self, trace_id: int, x: Any, y: Any, *, color: Any = None, size: Any = None) -> None:
+        """Streaming append: extend a trace's data in place.
+
+        Routed through the live widget when one exists (client refresh plus
+        notebook-reopen trait sync); otherwise the built figure mutates
+        directly and a later `widget()`/`to_html()` ships the streamed state.
+        Already-exported HTML files are snapshots and do not update. Trace ids
+        follow mark declaration order (one id per rendered series). Contract
+        violations (wrong trace kind, unsorted line x, missing channel tail)
+        raise exactly like `Figure.append`.
+        """
+        if self._widget is not None:
+            self._widget.append(trace_id, x, y, color=color, size=size)
+        else:
+            self.figure().append(trace_id, x, y, color=color, size=size)
+
+    def pick(self, trace_id: int, index: int) -> Optional[dict[str, Any]]:
+        """Exact source-row readout from the canonical f64 store.
+
+        Same index space as `Figure.pick`: a shipped vertex index, translated
+        to the canonical row when NaN rows were dropped at ship time. Returns
+        None when the index is out of range.
+        """
+        return self.figure().pick(trace_id, index)
+
+    def select_range(
+        self,
+        x0: float,
+        x1: float,
+        y0: float,
+        y1: float,
+        trace_id: Optional[int] = None,
+    ) -> "Selection":
+        """Python-side box select: points inside the window as a `Selection`
+        (canonical row indices per trace, with `.index` / `.xy()` access —
+        the same object `on_select` callbacks receive)."""
+        fig = self.figure()
+        return Selection(fig, fig.select_range(x0, x1, y0, y1, trace_id))
 
 
 def _resolve_color(data: Any, color: Any, *, context: Optional[str] = None) -> Any:

--- a/python/fastcharts/widget.py
+++ b/python/fastcharts/widget.py
@@ -14,11 +14,11 @@ from typing import TYPE_CHECKING, Any
 import anywidget
 import traitlets
 
+from .channel import ChannelCallbacks, handle_message
+
 # Selection lives in figure.py (it's the on_select payload and has no widget
 # dependency); re-exported here for backward compatibility.
 from .figure import Selection
-from .interaction import _integer_id
-from .lod import normalize_window
 
 if TYPE_CHECKING:
     from .figure import Figure
@@ -62,11 +62,13 @@ class FigureWidget(anywidget.AnyWidget):
         **kwargs: Any,
     ) -> None:
         self._figure = figure
-        self._on_hover = on_hover
-        self._on_click = on_click
-        self._on_brush = on_brush
-        self._on_select = on_select
-        self._on_view_change = on_view_change
+        self._callbacks = ChannelCallbacks(
+            on_hover=on_hover,
+            on_click=on_click,
+            on_brush=on_brush,
+            on_select=on_select,
+            on_view_change=on_view_change,
+        )
         spec, blob = figure.build_payload()
         super().__init__(spec=spec, buffers=blob, **kwargs)
         self.on_msg(self._on_custom_msg)
@@ -81,135 +83,10 @@ class FigureWidget(anywidget.AnyWidget):
         self.send(msg, buffers=buffers)
 
     def _on_custom_msg(self, widget: Any, content: Any, msg_buffers: Any) -> None:
-        if not isinstance(content, dict):
-            return
-        kind = content.get("type")
-        if kind == "view":
-            # Zoom/pan crossed what the shipped decimation can serve: recompute
-            # for the visible window only (§28), stale-while-revalidate on the
-            # client (§17 — it keeps drawing the old tier until this arrives).
-            seq = content.get("seq")
-            try:
-                x0 = float(content["x0"])
-                x1 = float(content["x1"])
-                if not x1 > x0:
-                    return
-                update, buffers = self._figure.decimate_view(
-                    x0,
-                    x1,
-                    content.get("px", 2048),
-                )
-            except (KeyError, TypeError, ValueError):
-                return
-            if update["traces"]:
-                self.send({"type": "tier_update", "seq": seq, **update}, buffers=buffers)
-        elif kind == "density_view":
-            # Tier-2 scatter panned/zoomed: re-bin the visible window (§5).
-            seq = content.get("seq")
-            try:
-                update, buffers = self._figure.density_view(
-                    content["trace"],
-                    content["x0"],
-                    content["x1"],
-                    content["y0"],
-                    content["y1"],
-                    content.get("w", 512),
-                    content.get("h", 384),
-                )
-            except (KeyError, TypeError, ValueError, IndexError):
-                return
-            if update["traces"]:
-                self.send({"type": "density_update", "seq": seq, **update}, buffers=buffers)
-        elif kind == "pick":
-            # Hover/click drill: exact f64 row from canonical (§16/§17). The
-            # client's drill_seq rejects picks that raced a subset swap.
-            dseq = content.get("drill_seq")
-            try:
-                trace_id = _integer_id(content.get("trace", -1), "trace")
-                index = _integer_id(content.get("index", -1), "index")
-                drill_seq = None if dseq is None else _integer_id(dseq, "drill_seq")
-                row = self._figure.pick(
-                    trace_id,
-                    index,
-                    drill_seq,
-                )
-            except (TypeError, ValueError):
-                return
-            self.send({"type": "pick_result", "seq": content.get("seq"), "row": row})
-            if row is not None and self._on_hover is not None:
-                self._on_hover(row)
-        elif kind == "click":
-            dseq = content.get("drill_seq")
-            row = None
-            try:
-                trace_id = _integer_id(content.get("trace", -1), "trace")
-                index = _integer_id(content.get("index", -1), "index")
-                drill_seq = None if dseq is None else _integer_id(dseq, "drill_seq")
-                row = self._figure.pick(trace_id, index, drill_seq)
-            except (TypeError, ValueError):
-                return
-            if row is not None and self._on_click is not None:
-                self._on_click(row)
-        elif kind == "view_change":
-            if self._on_view_change is None:
-                return
-            try:
-                view = {
-                    "x0": float(content["x0"]),
-                    "x1": float(content["x1"]),
-                    "y0": float(content["y0"]),
-                    "y1": float(content["y1"]),
-                    "source": str(content.get("source", "view")),
-                }
-            except (KeyError, TypeError, ValueError):
-                return
-            self._on_view_change(view)
-        elif kind == "select":
-            # Box-select → range predicate (§34 Tier A). Ship a selection mask
-            # per trace so the client dims unselected marks; call on_select with
-            # the resolved indices (Arrow-slice-shaped, not JSON — §34 API note).
-            try:
-                x0, x1, y0, y1 = normalize_window(
-                    content["x0"],
-                    content["x1"],
-                    content["y0"],
-                    content["y1"],
-                    require_area=False,
-                )
-                sel = self._figure.select_range(
-                    x0,
-                    x1,
-                    y0,
-                    y1,
-                )
-            except (KeyError, TypeError, ValueError):
-                return
-            if self._on_brush is not None:
-                self._on_brush({"x0": x0, "x1": x1, "y0": y0, "y1": y1})
-            traces = []
-            buffers = []
-            total = 0
-            for tid, idx in sel.items():
-                # The wire mask speaks shipped-vertex positions; the Selection
-                # callback below keeps canonical rows (§34 — callbacks get real
-                # data, the GPU gets its own coordinate space).
-                wire_idx = self._figure.to_shipped_indices(tid, idx)
-                traces.append(
-                    {
-                        "id": tid,
-                        "count": int(len(wire_idx)),
-                        "buf": len(buffers),
-                        # Which drilled subset this mask speaks for; the client
-                        # drops it if its buffers have moved on (§17).
-                        "drill_seq": self._figure.traces[tid].drill_seq,
-                    }
-                )
-                buffers.append(wire_idx.tobytes())
-                total += len(idx)
-            self.send({"type": "selection", "traces": traces, "total": total}, buffers=buffers)
-            if self._on_select is not None:
-                self._on_select(Selection(self._figure, sel))
-        elif kind == "select_clear":
-            self.send({"type": "selection", "traces": [], "total": 0})
-            if self._on_select is not None:
-                self._on_select(Selection(self._figure, {}))
+        # All dispatch and callback semantics live in channel.handle_message
+        # (reflex-integration §3.1) — this widget is one transport among
+        # (eventually) several; it only owns the anywidget comm send.
+        reply = handle_message(self._figure, content, msg_buffers, callbacks=self._callbacks)
+        if reply is not None:
+            msg, buffers = reply
+            self.send(msg, buffers=buffers)

--- a/scripts/check_public_api.py
+++ b/scripts/check_public_api.py
@@ -96,10 +96,14 @@ DECLARATIVE_CHART_READOUTS = (
     "to_html",
     "html",
     "_repr_html_",
+    "to_svg",
     "to_png",
     "memory_report",
     "chrome_components",
     "reflex_components",
+    "append",
+    "pick",
+    "select_range",
 )
 DECLARATIVE_API_EXPORTS = (
     *DECLARATIVE_MARK_EXPORTS,

--- a/scripts/check_public_api.py
+++ b/scripts/check_public_api.py
@@ -34,6 +34,7 @@ HEAVY_THIRD_PARTY_IMPORTS = {
 }
 HEAVY_FASTCHARTS_IMPORTS = {
     "fastcharts.channels",
+    "fastcharts.channel",
     "fastcharts.columns",
     "fastcharts.components",
     "fastcharts.figure",

--- a/scripts/verify_sdist.py
+++ b/scripts/verify_sdist.py
@@ -75,6 +75,7 @@ REQUIRED_FILES = {
     "python/fastcharts/config.py",
     "python/fastcharts/export.py",
     "python/fastcharts/figure.py",
+    "python/fastcharts/channel.py",
     "python/fastcharts/interaction.py",
     "python/fastcharts/kernels.py",
     "python/fastcharts/lod.py",

--- a/scripts/verify_wheel.py
+++ b/scripts/verify_wheel.py
@@ -28,6 +28,7 @@ REQUIRED_FILES = {
     "fastcharts/__init__.py",
     "fastcharts/_native.py",
     "fastcharts/channels.py",
+    "fastcharts/channel.py",
     "fastcharts/columns.py",
     "fastcharts/components.py",
     "fastcharts/config.py",

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -1,0 +1,213 @@
+"""The transport-agnostic dispatcher contract (reflex-integration §3.1).
+
+`tests/test_widget.py` pins the anywidget wrapper path; this file pins
+`channel.handle_message` directly — return values instead of captured sends —
+so any future transport (the planned Reflex adapter routes) inherits a tested
+contract. Deliberately never imports `fastcharts.widget`.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from fastcharts import Figure
+from fastcharts.channel import ChannelCallbacks, handle_message
+from fastcharts.figure import DECIMATION_THRESHOLD, Selection
+
+
+def handle(fig, content, **cbs):
+    return handle_message(fig, content, None, callbacks=ChannelCallbacks(**cbs))
+
+
+def test_malformed_view_messages_return_none():
+    n = DECIMATION_THRESHOLD + 1
+    fig = Figure().line(np.arange(n, dtype=np.float64), np.arange(n, dtype=np.float64))
+
+    assert handle(fig, None) is None
+    assert handle(fig, "view") is None
+    assert handle(fig, {"type": "unknown-kind"}) is None
+    assert handle(fig, {"type": "view", "x0": "left", "x1": 10.0}) is None
+    assert handle(fig, {"type": "view", "x0": 0.0, "x1": 10.0, "px": "wide"}) is None
+    assert handle(fig, {"type": "view", "x0": 0.0, "x1": 10.0, "px": True}) is None
+    assert handle(fig, {"type": "view", "x0": 10.0, "x1": 0.0}) is None
+
+
+def test_valid_view_returns_tier_update():
+    n = DECIMATION_THRESHOLD + 1
+    fig = Figure().line(np.arange(n, dtype=np.float64), np.arange(n, dtype=np.float64))
+
+    reply = handle(fig, {"type": "view", "x0": 100.0, "x1": 5_000.0, "px": 640, "seq": 3})
+
+    assert reply is not None
+    msg, buffers = reply
+    assert msg["type"] == "tier_update"
+    assert msg["seq"] == 3
+    assert msg["traces"]
+    assert buffers
+
+
+def test_malformed_density_pick_and_select_return_none_without_callbacks():
+    fig = Figure().scatter(np.arange(10.0), np.arange(10.0))
+    fired = []
+
+    assert handle(fig, {"type": "density_view", "trace": "bad"}) is None
+    assert handle(fig, {"type": "pick", "trace": "bad", "index": 0}) is None
+    assert handle(fig, {"type": "pick", "trace": 0, "index": "bad"}) is None
+    assert (
+        handle(
+            fig,
+            {"type": "select", "x0": "left", "x1": 1.0, "y0": 0.0, "y1": 1.0},
+            on_brush=fired.append,
+            on_select=fired.append,
+        )
+        is None
+    )
+    assert fired == []
+
+
+def test_valid_pick_replies_after_malformed_input_and_fires_hover():
+    fig = Figure().scatter(np.arange(3.0), np.arange(3.0))
+    hovered = []
+
+    assert handle(fig, {"type": "pick", "trace": "bad", "index": 0}) is None
+    reply = handle(fig, {"type": "pick", "trace": 0, "index": 1, "seq": 7}, on_hover=hovered.append)
+
+    assert reply is not None
+    msg, buffers = reply
+    assert buffers is None  # pick_result ships without a buffers list
+    assert msg["type"] == "pick_result"
+    assert msg["seq"] == 7
+    assert msg["row"]["index"] == 1
+    assert msg["row"]["x"] == 1.0
+    assert hovered == [msg["row"]]
+
+
+def test_stale_drill_seq_pick_replies_row_none_without_hover():
+    fig = Figure().scatter(np.arange(3.0), np.arange(3.0))
+    hovered = []
+
+    reply = handle(
+        fig,
+        {"type": "pick", "trace": 0, "index": 1, "seq": 9, "drill_seq": 42},
+        on_hover=hovered.append,
+    )
+
+    # The reply still ships (the client clears hover on the empty result),
+    # but the Python callback must not fire for a dead coordinate space.
+    assert reply is not None
+    msg, buffers = reply
+    assert msg == {"type": "pick_result", "seq": 9, "row": None}
+    assert buffers is None
+    assert hovered == []
+
+
+def test_click_fires_callback_and_returns_none():
+    fig = Figure().scatter(np.arange(3.0), np.arange(3.0))
+    clicked = []
+
+    assert handle(fig, {"type": "click", "trace": 0, "index": 2}, on_click=clicked.append) is None
+    assert clicked and clicked[0]["index"] == 2
+    # Malformed click: no callback, still None.
+    assert (
+        handle(fig, {"type": "click", "trace": "bad", "index": 2}, on_click=clicked.append) is None
+    )
+    assert len(clicked) == 1
+
+
+def test_view_change_short_circuits_without_callback():
+    fig = Figure().scatter(np.arange(3.0), np.arange(3.0))
+    views = []
+
+    # No callback: parsed or not, nothing happens.
+    assert handle(fig, {"type": "view_change", "x0": "bad"}) is None
+    assert handle(fig, {"type": "view_change", "x0": 0.0, "x1": 1.0, "y0": 0.0, "y1": 1.0}) is None
+    # Callback present: parsed floats + source.
+    reply = handle(
+        fig,
+        {"type": "view_change", "x0": 0, "x1": 2, "y0": 0, "y1": 3, "source": "wheel"},
+        on_view_change=views.append,
+    )
+    assert reply is None
+    assert views == [{"x0": 0.0, "x1": 2.0, "y0": 0.0, "y1": 3.0, "source": "wheel"}]
+    # Malformed with callback: dropped.
+    assert handle(fig, {"type": "view_change", "x0": "bad"}, on_view_change=views.append) is None
+    assert len(views) == 1
+
+
+def test_select_fires_brush_before_select_and_returns_selection_reply():
+    fig = Figure().scatter(np.arange(10.0), np.arange(10.0))
+    order = []
+    brush_calls = []
+    select_calls = []
+
+    reply = handle(
+        fig,
+        {"type": "select", "x0": 5.0, "x1": 2.0, "y0": 0.0, "y1": 6.0},
+        on_brush=lambda r: (order.append("brush"), brush_calls.append(r)),
+        on_select=lambda s: (order.append("select"), select_calls.append(s)),
+    )
+
+    assert order == ["brush", "select"]
+    assert brush_calls == [{"x0": 2.0, "x1": 5.0, "y0": 0.0, "y1": 6.0}]  # normalized
+    np.testing.assert_array_equal(select_calls[0].index, [2, 3, 4, 5])
+    assert reply is not None
+    msg, buffers = reply
+    assert msg["type"] == "selection"
+    assert msg["total"] == 4
+    assert buffers is not None and len(buffers) == len(msg["traces"])
+
+
+def test_select_wire_mask_is_shipped_space_selection_is_canonical():
+    x = np.array([0.0, np.nan, 2.0, 3.0, 4.0])
+    y = np.array([0.0, 1.0, 2.0, np.nan, 4.0])
+    fig = Figure().scatter(x, y)
+    select_calls = []
+
+    reply = handle(
+        fig,
+        {"type": "select", "x0": 1.5, "x1": 4.5, "y0": 1.5, "y1": 4.5},
+        on_select=select_calls.append,
+    )
+
+    assert reply is not None
+    msg, buffers = reply
+    # Canonical rows 2 and 4 are selected (rows 1 and 3 carry NaN).
+    np.testing.assert_array_equal(select_calls[0].index, [2, 4])
+    # The wire mask speaks shipped-vertex positions: NaN rows were dropped at
+    # ship time, so canonical rows [0, 2, 4] became shipped [0, 1, 2].
+    wire = np.frombuffer(buffers[0], dtype=np.uint32)
+    np.testing.assert_array_equal(wire, [1, 2])
+    assert msg["traces"][0]["count"] == 2
+
+
+def test_select_clear_returns_empty_selection_and_fires_callback():
+    fig = Figure().scatter(np.arange(3.0), np.arange(3.0))
+    select_calls = []
+
+    reply = handle(fig, {"type": "select_clear"}, on_select=select_calls.append)
+
+    assert reply == ({"type": "selection", "traces": [], "total": 0}, None)
+    assert len(select_calls) == 1
+    assert isinstance(select_calls[0], Selection)
+    assert len(select_calls[0]) == 0
+
+
+def test_buffers_argument_is_accepted_and_ignored():
+    fig = Figure().scatter(np.arange(3.0), np.arange(3.0))
+
+    reply = handle_message(fig, {"type": "pick", "trace": 0, "index": 0}, [b"ignored"])
+
+    assert reply is not None
+    assert reply[0]["row"]["index"] == 0
+
+
+def test_callback_exceptions_propagate():
+    """'Never raises' covers client-supplied data, not user-callback bugs."""
+    fig = Figure().scatter(np.arange(3.0), np.arange(3.0))
+
+    def boom(_row):
+        raise RuntimeError("user callback bug")
+
+    with pytest.raises(RuntimeError, match="user callback bug"):
+        handle(fig, {"type": "pick", "trace": 0, "index": 1}, on_hover=boom)

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1730,3 +1730,102 @@ def test_chart_styles_prop_is_the_documented_per_slot_mechanism() -> None:
         fc.chart(fc.scatter(x=xs, y=xs), styles={"tooltp": {"color": "#fff"}})
     with pytest.raises(ValueError, match="not a valid hex color"):
         fc.chart(fc.scatter(x=xs, y=xs), styles={"title": {"color": "#3b82zz"}})
+
+
+# -- Chart live surface (data-live, structure-immutable) ----------------------
+
+
+def test_chart_append_routes_through_live_widget(monkeypatch):
+    appends = []
+
+    class CapturingWidget:
+        def __init__(self, figure, **kwargs):
+            self.figure = figure
+
+        def append(self, trace_id, x, y, *, color=None, size=None):
+            appends.append((trace_id, x, y, color, size))
+
+    monkeypatch.setattr("fastcharts.widget.FigureWidget", CapturingWidget)
+    chart = fc.scatter_chart(fc.scatter(x=np.arange(3.0), y=np.arange(3.0)))
+    chart.widget()
+    n_before = len(chart.figure().traces[0].x.values)
+
+    chart.append(0, [3.0], [4.0])
+
+    assert appends == [(0, [3.0], [4.0], None, None)]
+    # Routed to the widget only — the figure was not double-appended (the
+    # real FigureWidget.append mutates it; the capture stub records instead).
+    assert len(chart.figure().traces[0].x.values) == n_before
+
+
+def test_chart_append_headless_mutates_figure_without_widget_stack():
+    chart = fc.scatter_chart(fc.scatter(x=np.arange(3.0), y=np.arange(3.0)))
+
+    chart.append(0, [3.0], [4.0])
+
+    assert chart._widget is None  # no widget instantiated as a side effect
+    trace = chart.figure().traces[0]
+    assert len(trace.x.values) == 4
+    assert trace.x.values[-1] == 3.0
+    spec, _blob = chart.figure().build_payload()
+    assert spec["traces"][0]["n_points"] == 4
+
+
+def test_chart_append_contract_violations_raise():
+    chart = fc.scatter_chart(fc.scatter(x=np.arange(3.0), y=np.arange(3.0)))
+
+    with pytest.raises(ValueError):
+        chart.append(0, [1.0], [1.0, 2.0])  # length mismatch
+
+
+def test_chart_pick_matches_figure_pick():
+    chart = fc.scatter_chart(fc.scatter(x=np.arange(5.0), y=np.arange(5.0) * 2))
+
+    row = chart.pick(0, 2)
+
+    assert row == chart.figure().pick(0, 2)
+    assert row["x"] == 2.0
+    assert row["y"] == 4.0
+    assert chart.pick(0, 99) is None  # out of range → None, like Figure
+
+
+def test_chart_select_range_returns_selection():
+    chart = fc.scatter_chart(fc.scatter(x=np.arange(10.0), y=np.arange(10.0)))
+
+    sel = chart.select_range(2.0, 5.0, 0.0, 6.0)
+
+    assert isinstance(sel, Selection)
+    np.testing.assert_array_equal(sel.index, [2, 3, 4, 5])
+    xs, ys = sel.xy(0)
+    np.testing.assert_array_equal(xs, [2.0, 3.0, 4.0, 5.0])
+    empty = chart.select_range(100.0, 200.0, 100.0, 200.0)
+    assert len(empty) == 0
+
+
+def test_declarative_chart_live_roundtrip():
+    """End to end: declarative chart -> real widget -> simulated client
+    messages fire callbacks -> chart.append streams -> readouts see new rows."""
+    hovered, brushes, sels = [], [], []
+    chart = fc.chart(
+        fc.scatter(x=np.arange(10.0), y=np.arange(10.0), name="pts"),
+        on_hover=hovered.append,
+        on_brush=brushes.append,
+        on_select=sels.append,
+    )
+    w = chart.widget()  # real FigureWidget -> real channel dispatch
+    sent = []
+    w.send = lambda content, buffers=None: sent.append((content, buffers))
+
+    w._on_custom_msg(None, {"type": "pick", "trace": 0, "index": 2, "seq": 1}, None)
+    w._on_custom_msg(None, {"type": "select", "x0": 5.0, "x1": 2.0, "y0": 0.0, "y1": 6.0}, None)
+    w._on_custom_msg(None, {"type": "select", "x0": "bad", "x1": 1, "y0": 0, "y1": 1}, None)
+    chart.append(0, [10.0], [11.0])
+
+    assert hovered[0]["x"] == 2.0
+    assert brushes == [{"x0": 2.0, "x1": 5.0, "y0": 0.0, "y1": 6.0}]  # normalized, before select
+    np.testing.assert_array_equal(sels[0].index, [2, 3, 4, 5])
+    kinds = [c["type"] for c, _ in sent]
+    assert kinds == ["pick_result", "selection", "append"]  # malformed select added nothing
+    assert w.spec["traces"][0]["n_points"] == 11  # trait re-sync carried the append
+    assert len(chart.figure().traces[0].x.values) == 11
+    assert chart.pick(0, 10)["x"] == 10.0  # readout sees the streamed row

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -14,6 +14,7 @@ HEAVY_MODULES = {
     "reflex_core",
     "traitlets",
     "fastcharts.channels",
+    "fastcharts.channel",
     "fastcharts.columns",
     "fastcharts.components",
     "fastcharts.figure",
@@ -340,5 +341,23 @@ def test_column_factory_does_not_shadow_columns_submodule() -> None:
             pass
         else:
             raise AssertionError("fastcharts.column must stay the public factory, not a submodule")
+        """
+    )
+
+
+def test_channel_dispatcher_loads_without_widget_stack() -> None:
+    """The Reflex-forward guarantee: a server transport can drive
+    channel.handle_message with no anywidget/traitlets installed."""
+    _run_fresh(
+        """
+        import sys
+
+        from fastcharts.channel import ChannelCallbacks, handle_message
+
+        assert callable(handle_message)
+        assert ChannelCallbacks() == ChannelCallbacks()
+        assert "fastcharts.widget" not in sys.modules
+        assert "anywidget" not in sys.modules
+        assert "traitlets" not in sys.modules
         """
     )

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -361,3 +361,23 @@ def test_channel_dispatcher_loads_without_widget_stack() -> None:
         assert "traitlets" not in sys.modules
         """
     )
+
+
+def test_chart_headless_append_does_not_load_widget_stack() -> None:
+    """chart.append on a never-shown chart must mutate the figure directly,
+    not instantiate the anywidget stack as a side effect."""
+    _run_fresh(
+        """
+        import sys
+
+        import fastcharts as fc
+
+        chart = fc.scatter_chart(fc.scatter(x=[0.0, 1.0], y=[0.0, 1.0]))
+        chart.append(0, [2.0], [3.0])
+
+        assert len(chart.figure().traces[0].x.values) == 3
+        assert "fastcharts.widget" not in sys.modules
+        assert "anywidget" not in sys.modules
+        assert "traitlets" not in sys.modules
+        """
+    )

--- a/tests/test_type_surface.py
+++ b/tests/test_type_surface.py
@@ -62,10 +62,14 @@ CHART_READOUTS = (
     "to_html",
     "html",
     "_repr_html_",
+    "to_svg",
     "to_png",
     "memory_report",
     "chrome_components",
     "reflex_components",
+    "append",
+    "pick",
+    "select_range",
 )
 FIGURE_BUILDERS = (
     "line",
@@ -318,6 +322,11 @@ def test_component_dataclass_and_chart_method_types_are_specific() -> None:
     memory_report_return = get_type_hints(components.Chart.memory_report)["return"]
     assert get_origin(memory_report_return) is dict
     assert get_args(memory_report_return) == (str, Any)
+
+    assert get_type_hints(components.Chart.append)["return"] is type(None)
+    pick_return = get_type_hints(components.Chart.pick)["return"]
+    assert type(None) in get_args(pick_return)  # Optional[dict[str, Any]]
+    assert get_type_hints(components.Chart.select_range)["return"] is figure_module.Selection
 
     for method in ("chrome_components", "reflex_components"):
         return_hint = get_type_hints(getattr(components.Chart, method))["return"]


### PR DESCRIPTION
Two core enablers toward a first-class Reflex integration — with **zero Reflex code**: the deferred adapter (registry, routes, SSE, `rx.Component`) becomes a thin consumer of what lands here.

## `fastcharts/channel.py` — one dispatcher for every transport

`FigureWidget._on_custom_msg`'s dispatch bodies (view / density_view / pick / click / view_change / select / select_clear) moved **verbatim** into `channel.handle_message(fig, content, buffers, callbacks) -> reply | None` (reflex-integration.md §3.1, build-order step 1), with callbacks carried by a frozen `ChannelCallbacks` dataclass. The widget is now a 7-line comm wrapper: parse message → `handle_message` → send reply.

- Same silent-drop rules for malformed client data ("never raises" covers client data; user-callback exceptions still propagate).
- Same shipped-vertex wire mask vs canonical-row `Selection` index spaces; `on_brush` still fires before `on_select`.
- Only delta: replies leave after callbacks fire (return-based dispatch) — unobservable on the wire, documented in the module docstring.
- **`tests/test_widget.py` has a 0-line diff and passes** — the extraction's behavior lock.
- New `tests/test_channel.py` (never imports the widget) pins the contract directly, including cases the widget suite never covered: stale-`drill_seq` pick replying `row=None` without `on_hover`, `select_clear`, click's fire-and-return-None, the NaN-row shipped-vs-canonical mapping, and the ignored `buffers` argument.
- A fresh-subprocess test proves importing `fastcharts.channel` loads **no** anywidget/traitlets — a server transport can drive it standalone.
- `fastcharts.channel` joins REQUIRED_FILES (wheel + sdist), HEAVY_MODULES, and HEAVY_FASTCHARTS_IMPORTS; CLAUDE.md disambiguates `channel.py` (dispatcher) vs `channels.py` (color/size encodings).

## Chart live surface — data-live, structure-immutable

The declarative `Chart` no longer requires reaching through `chart.figure()` for live data:

- `chart.append(trace_id, x, y, color=, size=)` — routed through the live widget when one exists (client refresh + notebook-reopen trait sync); otherwise mutates the built figure directly **without instantiating the widget stack** (fresh-subprocess test). Contract violations raise exactly like `Figure.append`.
- `chart.pick(trace_id, index)` — exact canonical-f64 row readout.
- `chart.select_range(x0, x1, y0, y1, trace_id=None) -> Selection` — the same object `on_select` callbacks receive.

Structural changes (new marks/axes/annotations) intentionally still mean composing a new chart, matching Reflex's model. `DECLARATIVE_CHART_READOUTS` gains the three methods plus the previously missing `to_svg`; `test_type_surface` mirrors the list and pins return types. An end-to-end test drives a real `FigureWidget`: simulated client pick/select fire callbacks in order, malformed select drops silently, `chart.append` pushes the append message + trait re-sync, and the streamed row is immediately visible to `chart.pick`.

Docs: runnable "Live Data On A Composed Chart" block in api-examples.md (executed by `test_docs_examples`), CHANGELOG entries.

## Verification

938 tests pass (917 on main + 21 new); ruff / format / ty / `check_public_api` (readouts + 200 ms import budget) / `node js/build.mjs --check` all clean. Streaming + ingest benchmarks vs pre-change baseline: noise-level or better (`stream_line_append_1k` 0.326→0.301 ms median), ingest copy counts exact-equal, oracles pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)