### PR TITLE
Deflake the CI interaction gate: probe headroom, retries, diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
         run: |
           CHROME=$(node -e "console.log(require('playwright').chromium.executablePath())")
           .venv/bin/python benchmarks/bench_interaction.py \
-            --sizes 1e4,2.5e5 --reps 24 --chromium "$CHROME" \
+            --sizes 1e4,2.5e5 --reps 24 --chromium "$CHROME" --retries 2 \
             --json interaction.json | tee -a docs/benchmark_ci.md
       - name: Many-chart dashboard startup (methodology dashboard_20)
         run: |

--- a/benchmarks/bench_interaction.py
+++ b/benchmarks/bench_interaction.py
@@ -639,7 +639,55 @@ def _flatten_probe_metrics(row: dict[str, Any], result: dict[str, Any]) -> None:
         row[f"{name}_reps"] = stats.get("reps")
 
 
-def run(*, sizes: list[int], reps: int, chromium: str | None = None) -> dict[str, Any]:
+# Virtual-time budget for the interaction probe pages. The default 15s is
+# plenty on developer hardware, but CI runs WebGL through SwiftShader on
+# shared runners, where the density scenario's reps can outlive it — the
+# probe then never writes its marker title and the row reports
+# "failed(no probe title)". Virtual time advances instantly once the page
+# goes idle, so a large budget costs nothing when the probe finishes early.
+# The wall-clock ceiling has the same failure mode — CI has produced
+# "failed(timeout)" for the density scenario at the default 180s — so it
+# gets matching headroom; a healthy probe never comes near either limit.
+PROBE_VIRTUAL_TIME_MS = 120_000
+PROBE_TIMEOUT_S = 600
+
+
+def _probe_with_retries(
+    html: str, *, chromium: str | None, scenario: str, retries: int
+) -> dict[str, Any]:
+    """One probe run, re-launched on a non-ok status up to `retries` times.
+
+    Headless-Chromium probes have environmental failure modes (budget
+    exhaustion, GPU init hiccups) that a fresh launch resolves; a genuine
+    client regression fails every attempt. Retries are printed, never
+    silent (§28: every reliability decision is recorded)."""
+    result = run_json_probe(
+        html,
+        marker="FC_INTERACTION",
+        chromium=chromium,
+        virtual_time_ms=PROBE_VIRTUAL_TIME_MS,
+        timeout_s=PROBE_TIMEOUT_S,
+    )
+    attempts = 1
+    while result.get("status") != "ok" and attempts <= retries:
+        print(
+            f"interaction probe retry {attempts}/{retries} for {scenario}: {result.get('status')}",
+            file=sys.stderr,
+        )
+        result = run_json_probe(
+            html,
+            marker="FC_INTERACTION",
+            chromium=chromium,
+            virtual_time_ms=PROBE_VIRTUAL_TIME_MS,
+            timeout_s=PROBE_TIMEOUT_S,
+        )
+        attempts += 1
+    return result
+
+
+def run(
+    *, sizes: list[int], reps: int, chromium: str | None = None, retries: int = 0
+) -> dict[str, Any]:
     rows: list[dict[str, Any]] = []
     for n in sizes:
         fig = _scatter_figure(n)
@@ -663,7 +711,9 @@ def run(*, sizes: list[int], reps: int, chromium: str | None = None) -> dict[str
             title="fastcharts interaction probe",
         )
         row["html_bytes"] = len(html.encode("utf-8"))
-        result = run_json_probe(html, marker="FC_INTERACTION", chromium=chromium)
+        result = _probe_with_retries(
+            html, chromium=chromium, scenario=row["scenario"], retries=retries
+        )
         _flatten_probe_metrics(row, result)
         rows.append(row)
 
@@ -686,7 +736,9 @@ def run(*, sizes: list[int], reps: int, chromium: str | None = None) -> dict[str
             title=f"fastcharts {case['scenario']} probe",
         )
         row["html_bytes"] = len(html.encode("utf-8"))
-        result = run_json_probe(html, marker="FC_INTERACTION", chromium=chromium)
+        result = _probe_with_retries(
+            html, chromium=chromium, scenario=case["scenario"], retries=retries
+        )
         _flatten_probe_metrics(row, result)
         rows.append(row)
 
@@ -813,9 +865,20 @@ def main() -> None:
     parser.add_argument("--chromium", default=None)
     parser.add_argument("--out", default=None, help="write Markdown report here")
     parser.add_argument("--json", default=None, help="write JSON report here")
+    parser.add_argument(
+        "--retries",
+        type=int,
+        default=0,
+        help="per-scenario probe relaunches on a non-ok status (for shared CI runners)",
+    )
     args = parser.parse_args()
 
-    report = run(sizes=_parse_sizes(args.sizes), reps=args.reps, chromium=args.chromium)
+    report = run(
+        sizes=_parse_sizes(args.sizes),
+        reps=args.reps,
+        chromium=args.chromium,
+        retries=args.retries,
+    )
     md = to_markdown(report)
     print(md)
     if args.out:

--- a/scripts/interaction_stress_smoke.py
+++ b/scripts/interaction_stress_smoke.py
@@ -41,6 +41,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--chromium", dest="chromium_flag", default=None)
     parser.add_argument("--sizes", default="1e4,2.5e5")
     parser.add_argument("--reps", type=int, default=12)
+    parser.add_argument(
+        "--retries",
+        type=int,
+        default=2,
+        help="per-scenario probe relaunches on a non-ok status (headless "
+        "Chromium on shared runners has environmental failure modes a fresh "
+        "launch resolves; a real regression fails every attempt)",
+    )
     parser.add_argument("--json", default=None, help="write the validated JSON report here")
     parser.add_argument("--markdown", default=None, help="write the Markdown report here")
     args = parser.parse_args(argv)
@@ -51,6 +59,7 @@ def main(argv: list[str] | None = None) -> int:
         sizes=bench_interaction._parse_sizes(args.sizes),
         reps=args.reps,
         chromium=chromium,
+        retries=args.retries,
     )
     with tempfile.TemporaryDirectory() as td:
         report_path = Path(td) / "interaction.json"
@@ -68,6 +77,12 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  - {error}", file=sys.stderr)
         if len(errors) > 20:
             print(f"  ... {len(errors) - 20} more errors", file=sys.stderr)
+        # The report JSON is not kept in CI, so surface every non-ok row's
+        # status here — this is the only diagnostic a failed run leaves.
+        for row in report.get("rows", []):
+            status = row.get("status")
+            if status != "ok":
+                print(f"  - scenario {row.get('scenario')!r}: status={status!r}", file=sys.stderr)
         return 1
 
     print(

--- a/tests/test_interaction_probe_retries.py
+++ b/tests/test_interaction_probe_retries.py
@@ -1,0 +1,84 @@
+"""The interaction probe's retry-and-headroom policy (CI reliability).
+
+Headless-Chromium probes on shared runners have environmental failure modes
+(virtual-time/wall-clock budget exhaustion, GPU init hiccups) that a fresh
+launch resolves; a genuine client regression fails every attempt. These tests
+pin that policy without launching a browser.
+"""
+
+from __future__ import annotations
+
+from benchmarks import bench_interaction
+
+
+def test_probe_relaunches_until_ok_and_reports_each_retry(monkeypatch, capsys):
+    calls: list[dict] = []
+
+    def fake_probe(html, *, marker, chromium, virtual_time_ms, timeout_s):
+        calls.append({"virtual_time_ms": virtual_time_ms, "timeout_s": timeout_s})
+        if len(calls) >= 3:
+            return {"status": "ok"}
+        return {"status": "failed(timeout)"}
+
+    monkeypatch.setattr(bench_interaction, "run_json_probe", fake_probe)
+
+    result = bench_interaction._probe_with_retries(
+        "<html/>", chromium=None, scenario="density_scatter_interaction", retries=2
+    )
+
+    assert result["status"] == "ok"
+    assert len(calls) == 3
+    # Retries are recorded, never silent.
+    err = capsys.readouterr().err
+    assert "retry 1/2 for density_scatter_interaction" in err
+    assert "failed(timeout)" in err
+    # Every attempt gets the shared-runner headroom, not the library defaults.
+    for call in calls:
+        assert call["virtual_time_ms"] == bench_interaction.PROBE_VIRTUAL_TIME_MS
+        assert call["timeout_s"] == bench_interaction.PROBE_TIMEOUT_S
+
+
+def test_zero_retries_keeps_first_failure(monkeypatch):
+    calls: list[int] = []
+
+    def fake_probe(html, **kwargs):
+        calls.append(1)
+        return {"status": "failed(timeout)"}
+
+    monkeypatch.setattr(bench_interaction, "run_json_probe", fake_probe)
+
+    result = bench_interaction._probe_with_retries(
+        "<html/>", chromium=None, scenario="s", retries=0
+    )
+
+    assert result["status"] == "failed(timeout)"
+    assert len(calls) == 1
+
+
+def test_persistent_failure_exhausts_retries_and_keeps_last_status(monkeypatch):
+    calls: list[int] = []
+
+    def fake_probe(html, **kwargs):
+        calls.append(1)
+        return {"status": "failed(no probe title)"}
+
+    monkeypatch.setattr(bench_interaction, "run_json_probe", fake_probe)
+
+    result = bench_interaction._probe_with_retries(
+        "<html/>", chromium=None, scenario="s", retries=2
+    )
+
+    assert result["status"] == "failed(no probe title)"
+    assert len(calls) == 3  # 1 + 2 retries, then the real regression surfaces
+
+
+def test_probe_headroom_exceeds_library_defaults():
+    """The budgets exist to out-wait slow shared runners; they must dominate
+    the run_json_probe defaults or the constants silently stop mattering."""
+    import inspect
+
+    from benchmarks import _fastcharts_browser
+
+    sig = inspect.signature(_fastcharts_browser.run_json_probe)
+    assert sig.parameters["virtual_time_ms"].default < bench_interaction.PROBE_VIRTUAL_TIME_MS
+    assert sig.parameters["timeout_s"].default < bench_interaction.PROBE_TIMEOUT_S


### PR DESCRIPTION
CI has been red on `main` (and therefore on every PR, including #9) since the recent merges. Root cause, confirmed from the benchmark job's report table: **`density_scatter_interaction` → `failed(timeout)`** — the 250k-point density scenario, running WebGL through SwiftShader on shared runners, outlives `run_json_probe`'s 15s virtual-time budget and 180s wall-clock ceiling. The Test job's smoke discards its report JSON, so the failure surfaced only as "missing required ok scenarios" with zero diagnostics.

Three changes, keeping the house policy (deterministic invariants stay hard; environment noise must not gate):

1. **Headroom**: interaction probes run with `PROBE_VIRTUAL_TIME_MS = 120s` / `PROBE_TIMEOUT_S = 600s`. Virtual time advances instantly once the page goes idle, so the larger budgets cost nothing on healthy machines — they exist purely to out-wait slow runners. A unit test pins that the constants dominate the library defaults so they can't silently stop applying.
2. **Per-scenario retries**: `bench_interaction.run(retries=N)` relaunches a probe on a non-ok status (fresh Chromium resolves environmental hiccups; a genuine client regression fails every attempt). Every retry is printed, never silent (§28). The stress smoke defaults to `--retries 2`; the benchmark lane passes `--retries 2` explicitly; direct runs keep `retries=0`.
3. **Diagnostics**: on failure the smoke now prints each non-ok row's scenario + status — the report JSON isn't kept in CI, so this is the only trace a failed run leaves. The root cause here was invisible until reproduced.

All in-browser correctness invariants (blank frames, view changes, crosshair, box zoom, brush selection, tick overlap, color continuity) and the p95 budgets are unchanged — a real interaction regression still fails all three attempts and blocks the merge.

Not addressed here (needs an account decision): the CodSpeed job fails only at upload with `403: reflex-dev is not subscribed` — all 28 benchmarks pass. Subscribe the org at app.codspeed.io, make the repo public, or gate the upload step.

Verification: 921 tests pass locally (4 new); `verify_ci_workflow.py`, ruff, format clean. The end-to-end proof is this PR's own CI run — it executes the smoke on the exact environment that has been failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)