### PR TITLE
Fix the density interaction probe deadlock under virtual time

### DIFF
--- a/benchmarks/bench_interaction.py
+++ b/benchmarks/bench_interaction.py
@@ -222,6 +222,15 @@ def _probe_js(reps: int) -> str:
     const el = document.createElement("div");
     document.getElementById("root").appendChild(el);
     const view = fastcharts.renderStandalone(el, payload.spec, fcBytesFromB64(payload.b64));
+    // Under --virtual-time-budget an outstanding Web Worker round-trip pauses
+    // virtual time forever: the first density zoom schedules the standalone
+    // sample-rebin worker and the page deadlocks until the wall-clock timeout
+    // (bisected: real worker + rebin hangs even when the reply is ignored; a
+    // stubbed worker completes). Same class the render smoke already dropped
+    // its worker probe for. Disable the rebin here — density interactions
+    // measure the stretched-overview path, all visual invariants still run;
+    // the worker path itself needs a non-virtual-time harness (see PR notes).
+    view._sampleRebinDisabled = true;
     view._drawNow();
     const before = {{...view.view}};
     const canvasRect = () => view.canvas.getBoundingClientRect();


### PR DESCRIPTION
Root-causes and fixes the CI failure that has kept `main` red: `density_scatter_interaction` never survived a single CI run.

## Diagnosis (reproduced and bisected locally)

The prior deflake PR (#10) added diagnostics that revealed the truth: all three probe attempts burned the **full 600s wall-clock timeout** — deterministic, not flaky. Bisecting with a local Playwright Chromium:

| probe variant | result |
|---|---|
| density 250k, render only | 3.3s, ok |
| density 250k, hover only | 2.5s, ok |
| density 250k, **one `_zoomAt`** | timeout at ANY virtual budget (even 1s) |
| zoom with the rebin worker **stubbed** | 1.9s, ok |
| zoom with real worker, reply **ignored** | timeout |

The first zoom on a density chart schedules the standalone **sample-rebin Web Worker**. Under `--virtual-time-budget`, an outstanding worker round-trip pauses virtual time forever — the probe sets its report `<title>` synchronously, but `--dump-dom` never fires. Same environment class the render smoke already dropped its worker probe for (`1a8fe5a`).

## Fix

The probe page sets `view._sampleRebinDisabled = true` (with a full explanatory comment). Density interactions measure the stretched-overview path; every visual invariant (blank frames, view changes, crosshair, box zoom, brush, tick overlap, color continuity) and every p95 budget still runs.

**Result: the density scenario completes in 3.5s and the whole 6-scenario smoke in ~30s locally** — previously 37+ minutes of serial timeouts in CI. The retry/headroom machinery from #10 remains as the safety net for genuinely slow runners.

## Honest gap

Disabling the rebin in the probe means the worker path now has **zero automated coverage** (it had none that ever passed — the "coverage" was a permanently red gate). It needs a non-virtual-time harness (CDP/Playwright-driven, or the planned `node --test` lane) — flagged as follow-up rather than snuck into this fix.

This PR's own CI run is the end-to-end proof. Remaining after this: the CodSpeed upload 403 (org subscription — needs an account decision, benchmarks themselves pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)