### PR TITLE
Internalize the fluent Figure API: composition-only public surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ in the README).
 
 ## [Unreleased]
 
+### Removed
+- **The fluent `Figure` API is removed from the public surface.**
+  `fastcharts.Figure` is no longer exported; `figure.py` is internalized as
+  `fastcharts/_figure.py`. The declarative composition API (`fc.chart(...)`,
+  `fc.line_chart(...)`, `fc.scatter_chart(...)`, marks, axes, annotations,
+  chrome) is now the single public chart-building API. `Selection` stays
+  public, composed `Chart` objects keep the full readout surface
+  (`to_html`/`to_png`/`to_svg`/`widget`/`show`/`append`/`pick`/`select_range`/
+  `memory_report`), and `Chart.figure()` remains as an advanced escape hatch
+  to the internal engine object.
+
 ### Added
 - **Chart live surface (data-live, structure-immutable).** The declarative
   `Chart` gains `append(trace_id, x, y, color=, size=)` (streaming — routed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,10 +18,13 @@ code comments cite dossier sections (e.g. §16 = deep-zoom re-centering).
   Rust core; there is no NumPy fallback — `kernels.py` raises a clear
   ImportError if the native core can't load. `components.py`
   is the Reflex-flavored composition API (`scatter_chart`/`line_chart` + marks/
-  axes) — it builds a `Figure`; keep it dependency-free (no `reflex` import).
+  axes) — the **only public chart-building surface**; keep it dependency-free
+  (no `reflex` import). `_figure.py` is the internal scene/engine object
+  (`Figure`) that composed charts compile to via `Chart.figure()`; it is not
+  exported from `fastcharts` (only `Selection` is public from it).
   `marks.py` is the declarative mark core: the single implementation of every
-  chart kind, bound onto `Figure` as its fluent methods (one body, one
-  signature, one set of defaults — parity is identity, not convention).
+  chart kind, bound onto the internal `Figure` (one body, one signature, one
+  set of defaults — parity is identity, not convention).
   `channels.py` resolves scatter color/size encodings. `channel.py` (singular)
   is the transport-agnostic message dispatcher (widget comm today, Reflex
   routes later) — it must never import the widget stack.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ have.**
 
 ```mermaid
 flowchart LR
-    API["Python APIs<br/>Figure() / fc.chart()"]
+    API["Python API<br/>fc.chart() composition"]
     STORE["ColumnStore<br/>exact f64 source of truth"]
     KERNELS["Native Rust kernels<br/>binning, M4 decimation, encode"]
     PAYLOAD["Payload builder<br/>tiny JSON spec + raw f32 buffers"]
@@ -107,11 +107,10 @@ dive.
 
 Stable enough to build on today:
 
-- Python 3.11+ package import, fluent `Figure` construction, and standalone
-  HTML export.
+- Python 3.11+ package import and standalone HTML export.
 - Core declarative composition with `fc.chart(...)`, layered marks, axes,
   annotations, legends, tooltips, event props, CSS/Tailwind-friendly DOM hooks,
-  and the same notebook/static export methods as `Figure`.
+  and notebook/static export methods on the composed `Chart`.
 - Implemented 2D chart families: line, scatter, area, histogram, bar/column,
   grouped/stacked/horizontal bars, and heatmap.
 - Binary column payloads, committed JavaScript bundles, and native Rust kernels
@@ -126,10 +125,9 @@ Still experimental and expected to change before 1.0:
 
 | Surface | Current status | Notes |
 |---|---|---|
-| Fluent `Figure` API | Stable alpha | Preferred public API for implemented 2D chart families and standalone export. |
+| Composition API | Stabilizing alpha | The single public chart-building API: declarative `fc.chart(...children)`, layered marks, axes, annotations, custom legend/tooltip chrome, callbacks, CSS/Tailwind hooks, and notebook/static export methods. |
 | Standalone HTML export | Stable alpha | Self-contained output with bundled JS, escaped metadata, and binary payloads. |
 | Native Rust backend | Stable alpha; required compute core | Used for fast ingest, binning, and decimation. Bundled in every published wheel; on a platform with no wheel and no local Rust build, the compute layer raises a clear error rather than degrading. |
-| Composition API | Stabilizing alpha | Declarative `fc.chart(...children)`, layered marks, axes, annotations, custom legend/tooltip chrome, callbacks, CSS/Tailwind hooks, and notebook/static export parity. |
 | Reflex integration | Experimental | Example app exists; core `fastcharts` has no Reflex dependency; any future adapter should use no hard Reflex dependency, or only a supported Reflex core/component package unless full Reflex is proven necessary. |
 | Adaptive drilldown internals | Experimental | Thresholds and request protocol may move as the LOD engine evolves. |
 
@@ -218,9 +216,9 @@ python -c "import fastcharts.kernels as k; print(k.BACKEND)"
 that import raises `ImportError` with remediation rather than returning a
 degraded backend.
 
-Accessing chart-building APIs such as `Figure` or `scatter_chart` is the point
+Accessing chart-building APIs such as `fc.scatter_chart` is the point
 where NumPy and the compute backend may initialize. Notebook widget dependencies
-stay deferred until `.widget()`/display; standalone `Figure.to_html()` reads the
+stay deferred until `.widget()`/display; standalone `Chart.to_html()` reads the
 bundled static client directly.
 
 ## Getting Started
@@ -228,50 +226,61 @@ bundled static client directly.
 Create a small business chart:
 
 ```python
-from fastcharts import Figure
+import fastcharts as fc
 
 months = [1, 2, 3, 4, 5, 6]
 revenue = [42, 45, 48, 51, 55, 59]
 pipeline = [35, 38, 42, 40, 46, 50]
 
-fig = Figure(title="Revenue vs pipeline", x_label="month", y_label="USD thousands")
-fig.line(months, revenue, name="revenue", color="#2563eb", width=2.0)
-fig.line(months, pipeline, name="pipeline", color="#16a34a", width=2.0)
-fig
+chart = fc.line_chart(
+    fc.line(months, revenue, name="revenue", color="#2563eb", width=2.0),
+    fc.line(months, pipeline, name="pipeline", color="#16a34a", width=2.0),
+    fc.x_axis(label="month"),
+    fc.y_axis(label="USD thousands"),
+    title="Revenue vs pipeline",
+)
+chart
 ```
 
 Create a line chart:
 
 ```python
 import numpy as np
-from fastcharts import Figure
+import fastcharts as fc
 
 n = 100_000
 x = np.arange(n, dtype=np.float64)
 y = np.cumsum(np.random.default_rng(0).normal(size=n))
 
-fig = Figure(title="Random walk", x_label="sample", y_label="value")
-fig.line(x, y, name="walk")
-fig
+chart = fc.line_chart(
+    fc.line(x, y, name="walk"),
+    fc.x_axis(label="sample"),
+    fc.y_axis(label="value"),
+    title="Random walk",
+)
+chart
 ```
 
 Create a colored, sized scatter plot:
 
 ```python
 import numpy as np
-from fastcharts import Figure
+import fastcharts as fc
 
 rng = np.random.default_rng(1)
 x = rng.normal(size=50_000)
 y = x * 0.5 + rng.normal(scale=0.6, size=len(x))
 
-Figure(title="Correlated cloud").scatter(
-    x,
-    y,
-    color=y,
-    size=np.abs(y),
-    colormap="viridis",
-    size_range=(2, 14),
+fc.scatter_chart(
+    fc.scatter(
+        x,
+        y,
+        color=y,
+        size=np.abs(y),
+        colormap="viridis",
+        size_range=(2, 14),
+    ),
+    title="Correlated cloud",
 )
 ```
 
@@ -279,19 +288,19 @@ Export a standalone HTML file:
 
 ```python
 import numpy as np
-from fastcharts import Figure
+import fastcharts as fc
 
 rng = np.random.default_rng(2)
 x = rng.normal(size=2_000)
 y = 0.35 * x + rng.normal(scale=0.4, size=len(x))
 
-fig = Figure(title="Standalone").scatter(x, y)
-fig.to_html("chart.html")
+chart = fc.scatter_chart(fc.scatter(x, y), title="Standalone")
+chart.to_html("chart.html")
 ```
 
 ### Standalone HTML Safety And CSP
 
-`Figure.to_html()` writes one self-contained document with the JavaScript client,
+`Chart.to_html()` writes one self-contained document with the JavaScript client,
 JSON chart spec, and binary data blob inlined. That makes exports easy to share
 from notebooks, docs, and reports with no CDN or Python kernel required.
 
@@ -305,7 +314,7 @@ axis labels, trace names, legends, series names, and categories are escaped
 before entering inline JSON or `<title>`, and non-finite JSON metadata is
 rejected instead of emitted as browser-dependent JavaScript.
 
-`Figure.to_png()` defaults to `engine="native"`: the built-in Rust rasterizer
+`Chart.to_png()` defaults to `engine="native"`: the built-in Rust rasterizer
 paints the same decimated payload with no browser — millisecond export, small
 indexed PNGs, and it works anywhere the wheel imports (no Chrome needed). Pass
 `engine="chromium"` for a pixel-exact screenshot of the standalone HTML in local
@@ -330,22 +339,24 @@ trusted HTML in CI/container environments where sandboxed Chromium cannot launch
 - [`docs/api-examples.md`](docs/api-examples.md) has copyable examples for the
   currently implemented 2D chart families.
 
-## API Styles
+## The Composition API
 
-Use the fluent API when you want quick imperative chart construction:
+fastcharts has one public chart-building API: declarative composition. Charts
+are built from lightweight children — marks, axes, annotations, chrome — and
+take event props:
 
 ```python
 import numpy as np
-from fastcharts import Figure
+import fastcharts as fc
 
 timestamps = np.arange("2026-01-01", "2026-01-08", dtype="datetime64[h]")
 values = np.sin(np.linspace(0, 12, len(timestamps)))
 
-Figure(title="Telemetry").line(timestamps, values, name="sensor A")
+fc.line_chart(fc.line(timestamps, values, name="sensor A"), title="Telemetry")
 ```
 
-Use the composition API when you prefer declarative chart children and event
-props:
+Column names resolve through `data=`, and `on_*` props receive hover and
+selection events:
 
 ```python
 import fastcharts as fc
@@ -394,14 +405,14 @@ chart = fc.chart(
 chart
 ```
 
-Both APIs render in Jupyter, VS Code, Colab, Marimo, and standalone HTML through
-the same engine.
+Composed charts render in Jupyter, VS Code, Colab, Marimo, and standalone HTML
+through the same engine.
 
 The composition contract we are locking is intentionally narrow and durable:
 children are lightweight Python specs; `fc.chart(...)` can layer marks,
 annotations, axes, legends, tooltips, themes, and interaction config in one
-panel; `Chart` keeps `widget()`, `show()`, `to_html(...)`, `html(...)`,
-`_repr_html_()`, `to_png(...)`, and `memory_report()` parity with `Figure`;
+panel; `Chart` exposes `widget()`, `show()`, `to_html(...)`, `html(...)`,
+`_repr_html_()`, `to_png(...)`, and `memory_report()` directly;
 `class_name`, `class_names`, and `style` reach stable DOM slots for CSS/Tailwind
 styling (see [`docs/styling.md`](docs/styling.md) for the full slot + token
 reference and the zero-specificity defaults contract); and opaque framework
@@ -425,26 +436,31 @@ and full CSS-alpha colors (`docs/styling.md`):
 
 ```python
 import numpy as np
-from fastcharts import Figure
+import fastcharts as fc
 
 x = np.arange(24.0)
 y = np.abs(np.sin(x / 4.0)) * 10 + 2
 
 # The dashboard-sparkline look: smooth curve + gradient fading to the baseline
-Figure(padding=0).area(
-    x, y, color="#3b82f6", curve="smooth", opacity=0.5,
-    fill="linear-gradient(currentColor, transparent)",
+fc.area_chart(
+    fc.area(
+        x, y, color="#3b82f6", curve="smooth", opacity=0.5,
+        fill="linear-gradient(currentColor, transparent)",
+    ),
+    padding=0,
 )
 
 # Rounded-top, gradient bars — corner_radius=(tip, base) rounds only the value end
-Figure().bar(
-    ["Q1", "Q2", "Q3", "Q4"], [4.0, 7.0, 5.0, 8.0],
-    corner_radius=(6, 0), stroke="#1d4ed8", stroke_width=1.5,
-    fill="linear-gradient(to top, #1e40af, #93c5fd)",
+fc.bar_chart(
+    fc.bar(
+        ["Q1", "Q2", "Q3", "Q4"], [4.0, 7.0, 5.0, 8.0],
+        corner_radius=(6, 0), stroke="#1d4ed8", stroke_width=1.5,
+        fill="linear-gradient(to top, #1e40af, #93c5fd)",
+    ),
 )
 ```
 
-For a chrome-less, edge-to-edge sparkline, `Figure(padding=0)` fills the box and
+For a chrome-less, edge-to-edge sparkline, `padding=0` fills the box and
 `tick_label_strategy="none"` (with transparent grid/axis colors) hides the axes.
 
 ## Benchmark Snapshot
@@ -574,8 +590,8 @@ The same harness also measures Seaborn/Agg as a static chart-to-pixels baseline
 | Rust core: zone maps, offset-f32 encode, M4 decimation, 2-D binning | [`src/`](src/) |
 | ctypes native binding to the Rust core | [`python/fastcharts/_native.py`](python/fastcharts/_native.py) |
 | Column store, autorange, memory accounting | [`python/fastcharts/columns.py`](python/fastcharts/columns.py) |
-| Figure API, payload builder, line/scatter/area/histogram/bar/heatmap traces, annotations, mark styling (gradient/stroke/radius/curve/opacity) | [`python/fastcharts/figure.py`](python/fastcharts/figure.py) |
-| Composition API | [`python/fastcharts/components.py`](python/fastcharts/components.py) |
+| Internal scene/engine object, payload builder, line/scatter/area/histogram/bar/heatmap traces, annotations, mark styling (gradient/stroke/radius/curve/opacity) | [`python/fastcharts/_figure.py`](python/fastcharts/_figure.py) |
+| Composition API (the public chart-building surface) | [`python/fastcharts/components.py`](python/fastcharts/components.py) |
 | anywidget and standalone WebGL2 client | [`js/src/`](js/src/) (parts concatenated by `js/build.mjs`) |
 | Benchmarks | [`benchmarks/`](benchmarks/) |
 | Tests | [`tests/`](tests/) |
@@ -585,7 +601,7 @@ The same harness also measures Seaborn/Agg as a static chart-to-pixels baseline
 ```mermaid
 flowchart LR
     subgraph PY["Python kernel / app process"]
-        API["User APIs<br/>Figure fluent API<br/>Composition API"]
+        API["User APIs<br/>Composition API<br/>fc.chart() + marks"]
         VALIDATE["Builder validation<br/>shape, dtype, ranges"]
         STORE["ColumnStore<br/>canonical f64 data<br/>strings/categories<br/>rollback checkpoints"]
         KERNELS["Compute core<br/>native Rust C ABI<br/>(required; no fallback)"]
@@ -630,7 +646,7 @@ Important properties:
 - Wire format is memory format: raw f32 buffers, not JSON arrays.
 - Canonical data stays f64 in Python so hover/select can return exact rows.
 - Builder validation uses rollback checkpoints so failed public calls do not
-  partially mutate the `Figure` or column store.
+  partially mutate the chart's internal figure or column store.
 - Long lines ship M4-decimated points for first paint and re-decimate on zoom.
 - Large scatters switch to a fixed-size density surface above the threshold,
   then drill back to exact visible points when the view is small enough.
@@ -647,7 +663,7 @@ make check
 ```
 
 The JavaScript client is dependency-free. `js/build.mjs` copies the ESM client
-for anywidget and wraps a standalone IIFE for `Figure.to_html`.
+for anywidget and wraps a standalone IIFE for `Chart.to_html`.
 
 Use `make check-full` before production-facing changes; it adds fallback tests,
 JS bundle checks, Rust tests/lints/build, and the native ABI smoke. That full

--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -15,8 +15,8 @@ from pathlib import Path
 import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+import fastcharts as fc
 from categories import categories_for  # noqa: E402
-from fastcharts import Figure
 from fastcharts import kernels as k
 
 BENCH_CATEGORY_IDS = ("huge_line_time_series", "payload_export_size")
@@ -54,8 +54,7 @@ def bench_size(n: int) -> dict:
     row["m4_out_points"] = len(idx)
 
     # End-to-end first paint: figure build → payload bytes on the wire.
-    fig = Figure()
-    fig.line(x, y)
+    fig = fc.chart(fc.line(x=x, y=y)).figure()
     t, (_spec, blob) = timeit(fig.build_payload, 2048, repeat=1)
     row["payload_build_s"] = t
     row["payload_bytes"] = len(blob)

--- a/benchmarks/bench_2d_charts.py
+++ b/benchmarks/bench_2d_charts.py
@@ -390,7 +390,7 @@ def make_cases(profile: str) -> list[Case]:
 
     go = _plotly_or_none()
     seaborn = _seaborn_or_none()
-    from fastcharts import Figure
+    from fastcharts import area, bar, chart, column, heatmap, hist
 
     rng = np.random.default_rng(42)
     cases: list[Case] = []
@@ -404,7 +404,7 @@ def make_cases(profile: str) -> list[Case]:
         ).astype(np.float64, copy=False)
 
         def fc():
-            return Figure(width=RENDER_W, height=RENDER_H).hist(values, bins=bins)
+            return chart(hist(values, bins=bins), width=RENDER_W, height=RENDER_H).figure()
 
         def pl():
             fig = go.Figure(go.Histogram(x=values, nbinsx=bins, marker_color="#2563eb"))
@@ -436,7 +436,7 @@ def make_cases(profile: str) -> list[Case]:
         y = 30 + np.sin(np.linspace(0, 32, n)) * 9 + np.cumsum(rng.normal(0, 0.025, n))
 
         def fc():
-            return Figure(width=RENDER_W, height=RENDER_H).area(x, y, color="#0891b2")
+            return chart(area(x, y, color="#0891b2"), width=RENDER_W, height=RENDER_H).figure()
 
         def pl():
             fig = go.Figure(
@@ -452,7 +452,9 @@ def make_cases(profile: str) -> list[Case]:
         values = (rng.random(n) * 100).astype(np.float64)
 
         def fc():
-            return Figure(width=RENDER_W, height=RENDER_H).bar(labels, values, color="#2563eb")
+            return chart(
+                bar(labels, values, color="#2563eb"), width=RENDER_W, height=RENDER_H
+            ).figure()
 
         def pl():
             fig = go.Figure(go.Bar(x=labels, y=values, marker_color="#2563eb"))
@@ -491,13 +493,17 @@ def make_cases(profile: str) -> list[Case]:
         long_values = values.T.reshape(-1)
 
         def fc():
-            return Figure(width=RENDER_W, height=RENDER_H).bar(
-                labels,
-                values,
-                mode="grouped",
-                series=names,
-                colors=colors,
-            )
+            return chart(
+                bar(
+                    labels,
+                    values,
+                    mode="grouped",
+                    series=names,
+                    colors=colors,
+                ),
+                width=RENDER_W,
+                height=RENDER_H,
+            ).figure()
 
         def pl():
             fig = go.Figure(
@@ -540,13 +546,17 @@ def make_cases(profile: str) -> list[Case]:
         colors = ["#0f766e", "#7c3aed", "#dc2626", "#0891b2"][:series_count]
 
         def fc():
-            return Figure(width=RENDER_W, height=RENDER_H).column(
-                labels,
-                values,
-                mode="stacked",
-                series=names,
-                colors=colors,
-            )
+            return chart(
+                column(
+                    labels,
+                    values,
+                    mode="stacked",
+                    series=names,
+                    colors=colors,
+                ),
+                width=RENDER_W,
+                height=RENDER_H,
+            ).figure()
 
         def pl():
             fig = go.Figure(
@@ -582,7 +592,9 @@ def make_cases(profile: str) -> list[Case]:
         )
 
         def fc():
-            return Figure(width=RENDER_W, height=RENDER_H).heatmap(z, x=x, y=y, colormap="turbo")
+            return chart(
+                heatmap(z, x=x, y=y, colormap="turbo"), width=RENDER_W, height=RENDER_H
+            ).figure()
 
         def pl():
             fig = go.Figure(go.Heatmap(z=z, x=x, y=y, colorscale="Turbo"))

--- a/benchmarks/bench_dashboard.py
+++ b/benchmarks/bench_dashboard.py
@@ -48,7 +48,7 @@ def _parse_counts(text: str) -> list[int]:
 def _dashboard_figures(count: int) -> list[Any]:
     if np is None:
         raise SystemExit("numpy is required for benchmarks/bench_dashboard.py")
-    from fastcharts import Figure
+    import fastcharts as fc
 
     rng = np.random.default_rng(91_337)
     figures: list[Any] = []
@@ -59,18 +59,24 @@ def _dashboard_figures(count: int) -> list[Any]:
             x = np.arange(n, dtype=np.float64)
             y = np.cumsum(rng.normal(0.0, 0.05, n)).astype(np.float64, copy=False)
             figures.append(
-                Figure(width=RENDER_W, height=RENDER_H, title=f"Line {i + 1}").line(
-                    x, y, name="signal"
-                )
+                fc.chart(
+                    fc.line(x=x, y=y, name="signal"),
+                    width=RENDER_W,
+                    height=RENDER_H,
+                    title=f"Line {i + 1}",
+                ).figure()
             )
         elif kind == 1:
             n = 80_000
             x = rng.normal(0.0, 1.0, n).astype(np.float64, copy=False)
             y = (0.45 * x + rng.normal(0.0, 0.8, n)).astype(np.float64, copy=False)
             figures.append(
-                Figure(width=RENDER_W, height=RENDER_H, title=f"Scatter {i + 1}").scatter(
-                    x, y, name="points", opacity=0.65
-                )
+                fc.chart(
+                    fc.scatter(x=x, y=y, name="points", opacity=0.65),
+                    width=RENDER_W,
+                    height=RENDER_H,
+                    title=f"Scatter {i + 1}",
+                ).figure()
             )
         elif kind == 2:
             values = np.concatenate(
@@ -80,20 +86,28 @@ def _dashboard_figures(count: int) -> list[Any]:
                 ]
             ).astype(np.float64, copy=False)
             figures.append(
-                Figure(width=RENDER_W, height=RENDER_H, title=f"Histogram {i + 1}").hist(
-                    values, bins=160, name="distribution"
-                )
+                fc.chart(
+                    fc.hist(values, bins=160, name="distribution"),
+                    width=RENDER_W,
+                    height=RENDER_H,
+                    title=f"Histogram {i + 1}",
+                ).figure()
             )
         elif kind == 3:
             labels = np.array([f"C{j:02d}" for j in range(36)], dtype=object)
             values = rng.random((3, len(labels))) * 100
             figures.append(
-                Figure(width=RENDER_W, height=RENDER_H, title=f"Bars {i + 1}").bar(
-                    labels,
-                    values,
-                    mode="grouped",
-                    series=["A", "B", "C"],
-                )
+                fc.chart(
+                    fc.bar(
+                        labels,
+                        values,
+                        mode="grouped",
+                        series=["A", "B", "C"],
+                    ),
+                    width=RENDER_W,
+                    height=RENDER_H,
+                    title=f"Bars {i + 1}",
+                ).figure()
             )
         else:
             xs = np.linspace(-2.5, 2.5, 80)
@@ -104,9 +118,12 @@ def _dashboard_figures(count: int) -> list[Any]:
                 + rng.normal(0.0, 0.06, (len(ys), len(xs)))
             )
             figures.append(
-                Figure(width=RENDER_W, height=RENDER_H, title=f"Heatmap {i + 1}").heatmap(
-                    z, colormap="turbo"
-                )
+                fc.chart(
+                    fc.heatmap(z, colormap="turbo"),
+                    width=RENDER_W,
+                    height=RENDER_H,
+                    title=f"Heatmap {i + 1}",
+                ).figure()
             )
     return figures
 

--- a/benchmarks/bench_interaction.py
+++ b/benchmarks/bench_interaction.py
@@ -68,53 +68,54 @@ def _parse_sizes(text: str) -> list[int]:
 def _scatter_figure(n: int) -> Any:
     if np is None:
         raise SystemExit("numpy is required for benchmarks/bench_interaction.py")
-    from fastcharts import Figure
+    import fastcharts as fc
 
     rng = np.random.default_rng(70_011 + n)
     x = rng.normal(0.0, 1.0, n).astype(np.float64, copy=False)
     y = (0.58 * x + rng.normal(0.0, 0.72, n)).astype(np.float64, copy=False)
-    fig = Figure(
+    return fc.scatter_chart(
+        fc.scatter(x=x, y=y, name="points", opacity=0.72),
+        fc.x_axis(label="x"),
+        fc.y_axis(label="y"),
         width=RENDER_W,
         height=RENDER_H,
         title=f"{n:,} point interaction probe",
-        x_label="x",
-        y_label="y",
-    ).scatter(x, y, name="points", opacity=0.72)
-    fig.set_interaction(
         hover=True,
         click=True,
         select=True,
         brush=True,
         crosshair=True,
         view_change=True,
-    )
-    return fig
+    ).figure()
 
 
 def _core_interaction_figures() -> list[dict[str, Any]]:
     if np is None:
         raise SystemExit("numpy is required for benchmarks/bench_interaction.py")
-    from fastcharts import Figure
+    import fastcharts as fc
+
+    all_interactions = {
+        "hover": True,
+        "click": True,
+        "select": True,
+        "brush": True,
+        "crosshair": True,
+        "view_change": True,
+    }
 
     rng = np.random.default_rng(89_021)
 
     x_line = np.linspace(0.0, 18_000.0, 120_000, dtype=np.float64)
     y_line = np.cumsum(rng.normal(0.0, 0.18, x_line.size)).astype(np.float64, copy=False)
-    line = Figure(
+    line = fc.line_chart(
+        fc.line(x=x_line, y=y_line, name="signal", width=1.4),
+        fc.x_axis(label="sample"),
+        fc.y_axis(label="signal"),
         width=RENDER_W,
         height=RENDER_H,
         title="120k sample line interaction probe",
-        x_label="sample",
-        y_label="signal",
-    ).line(x_line, y_line, name="signal", width=1.4)
-    line.set_interaction(
-        hover=True,
-        click=True,
-        select=True,
-        brush=True,
-        crosshair=True,
-        view_change=True,
-    )
+        **all_interactions,
+    ).figure()
 
     hist_values = np.concatenate(
         [
@@ -122,21 +123,15 @@ def _core_interaction_figures() -> list[dict[str, Any]]:
             rng.normal(1.35, 0.68, 50_000),
         ]
     )
-    hist = Figure(
+    hist = fc.histogram_chart(
+        fc.histogram(hist_values, bins=180, name="distribution"),
+        fc.x_axis(label="value"),
+        fc.y_axis(label="count"),
         width=RENDER_W,
         height=RENDER_H,
         title="120k value histogram interaction probe",
-        x_label="value",
-        y_label="count",
-    ).histogram(hist_values, bins=180, name="distribution")
-    hist.set_interaction(
-        hover=True,
-        click=True,
-        select=True,
-        brush=True,
-        crosshair=True,
-        view_change=True,
-    )
+        **all_interactions,
+    ).figure()
 
     categories = [f"C{i:04d}" for i in range(1_200)]
     values = (
@@ -144,21 +139,15 @@ def _core_interaction_figures() -> list[dict[str, Any]]:
         + 18.0 * np.sin(np.linspace(0.0, 18.0, len(categories)))
         + rng.normal(0.0, 3.0, len(categories))
     )
-    bars = Figure(
+    bars = fc.bar_chart(
+        fc.bar(categories, values, name="bars"),
+        fc.x_axis(label="category"),
+        fc.y_axis(label="value"),
         width=RENDER_W,
         height=RENDER_H,
         title="1.2k bar interaction probe",
-        x_label="category",
-        y_label="value",
-    ).bar(categories, values, name="bars")
-    bars.set_interaction(
-        hover=True,
-        click=True,
-        select=True,
-        brush=True,
-        crosshair=True,
-        view_change=True,
-    )
+        **all_interactions,
+    ).figure()
 
     hx = np.linspace(-3.0, 3.0, 220)
     hy = np.linspace(-2.4, 2.4, 180)
@@ -166,21 +155,15 @@ def _core_interaction_figures() -> list[dict[str, Any]]:
     z = np.exp(-((xx - 0.85) ** 2 + (yy + 0.3) ** 2)) + 0.72 * np.exp(
         -((xx + 1.2) ** 2 + (yy - 0.65) ** 2) / 0.52
     )
-    heatmap = Figure(
+    heatmap = fc.heatmap_chart(
+        fc.heatmap(z, x=hx, y=hy, name="heat"),
+        fc.x_axis(label="x"),
+        fc.y_axis(label="y"),
         width=RENDER_W,
         height=RENDER_H,
         title="220x180 heatmap interaction probe",
-        x_label="x",
-        y_label="y",
-    ).heatmap(z, x=hx, y=hy, name="heat")
-    heatmap.set_interaction(
-        hover=True,
-        click=True,
-        select=True,
-        brush=True,
-        crosshair=True,
-        view_change=True,
-    )
+        **all_interactions,
+    ).figure()
 
     return [
         {

--- a/benchmarks/bench_line.py
+++ b/benchmarks/bench_line.py
@@ -45,12 +45,12 @@ def _series(n: int):
 
 def make_fastcharts(x, y):
     try:
-        from fastcharts import Figure
+        from fastcharts import chart, line
     except ImportError:
         return None
 
     def build():
-        return Figure(width=900, height=420).line(x, y)
+        return chart(line(x=x, y=y), width=900, height=420).figure()
 
     def render(fig):
         _spec, blob = fig.build_payload(N_OUT)  # same on-screen sample budget as resampler
@@ -104,10 +104,10 @@ ADAPTERS = {
 def _extrema_ok(x, y) -> bool:
     """M4 oracle: every populated pixel bucket must retain its y min and max."""
     try:
-        from fastcharts import Figure
+        from fastcharts import chart, line
     except ImportError:
         return False
-    fig = Figure(width=900, height=420).line(x, y)
+    fig = chart(line(x=x, y=y), width=900, height=420).figure()
     spec, blob = fig.build_payload(N_OUT)
     tr = spec["traces"][0]
     if tr.get("tier") != "decimated" or not all(isinstance(tr.get(k), int) for k in ("x", "y")):

--- a/benchmarks/bench_scatter_native.py
+++ b/benchmarks/bench_scatter_native.py
@@ -47,7 +47,7 @@ from abi_smoke import load  # noqa: E402
 from categories import BENCHMARK_CATEGORIES, categories_for  # noqa: E402
 from environment import SCHEMA_VERSION, collect_environment_metadata  # noqa: E402
 
-# Mirror the Python defaults (fastcharts.figure).
+# Mirror the Python defaults (fastcharts._figure).
 DENSITY_THRESHOLD = 200_000
 GRID_W, GRID_H = 512, 384
 RENDER_W, RENDER_H = 900, 420
@@ -124,14 +124,14 @@ def bench_production(n: int, x: array, y: array) -> dict:
     """Time the real Figure -> spec/blob path and assert its reduction contract."""
     import numpy as np
 
-    from fastcharts import Figure
+    import fastcharts as fc
 
     reps = 3 if n <= 2_000_000 else 1
     best = float("inf")
     result = None
     for _ in range(reps):
         t0 = time.perf_counter()
-        fig = Figure(width=RENDER_W, height=RENDER_H).scatter(x, y)
+        fig = fc.scatter_chart(fc.scatter(x=x, y=y), width=RENDER_W, height=RENDER_H).figure()
         spec, blob = fig.build_payload()
         best = min(best, time.perf_counter() - t0)
         result = (spec, blob)

--- a/benchmarks/bench_vs.py
+++ b/benchmarks/bench_vs.py
@@ -444,12 +444,12 @@ def make_hvplot_bokeh(x, y):
 
 def make_fastcharts(x, y):
     try:
-        from fastcharts import Figure
+        from fastcharts import scatter, scatter_chart
     except ImportError:
         return None
 
     def build():
-        return Figure(width=RENDER_W, height=RENDER_H).scatter(x, y)
+        return scatter_chart(scatter(x=x, y=y), width=RENDER_W, height=RENDER_H).figure()
 
     def render(fig):
         # The kernel-side "prepare to render" cost: encode direct f32, or bin to

--- a/benchmarks/bench_workflows.py
+++ b/benchmarks/bench_workflows.py
@@ -20,11 +20,12 @@ from typing import Any
 import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+import fastcharts as fc  # noqa: E402
 from _browser import find_chromium  # noqa: E402
 from categories import BENCHMARK_CATEGORIES, categories_for  # noqa: E402
 from environment import SCHEMA_VERSION, collect_environment_metadata  # noqa: E402
-from fastcharts import Figure  # noqa: E402
 from fastcharts import kernels as k  # noqa: E402
+from fastcharts._figure import Figure  # noqa: E402  (harness oracles/annotations only)
 from fastcharts.interaction import _ensure_pyramid  # noqa: E402
 
 WORKFLOW_CATEGORY_IDS = ("input_ingestion", "streaming_updates", "static_export")
@@ -173,7 +174,7 @@ def _ingestion_rows(n: int, reps: int) -> list[dict[str, Any]]:
                 family="ingestion",
                 n=n,
                 setup=lambda x=x, y=y: (x, y),
-                operation=lambda state: Figure().line(state[0], state[1]),
+                operation=lambda state: fc.chart(fc.line(x=state[0], y=state[1])).figure(),
                 reps=reps,
                 category_ids=("input_ingestion",),
                 scope="public-figure-ingest",
@@ -191,7 +192,7 @@ def _streaming_rows(base_n: int, reps: int) -> list[dict[str, Any]]:
     tail_y = np.sin(tail_x * 0.001)
 
     def line_setup() -> Figure:
-        fig = Figure().line(x, y)
+        fig = fc.chart(fc.line(x=x, y=y)).figure()
         fig.build_payload()
         return fig
 
@@ -220,7 +221,7 @@ def _streaming_rows(base_n: int, reps: int) -> list[dict[str, Any]]:
     append_y = np.linspace(45.0, 55.0, batch_n, dtype=np.float64)
 
     def density_setup() -> Figure:
-        fig = Figure().scatter(sx, sy, density=True)
+        fig = fc.chart(fc.scatter(x=sx, y=sy, density=True)).figure()
         fig.build_payload()
         assert _ensure_pyramid(fig.traces[0]) is not None
         return fig
@@ -261,7 +262,7 @@ def _export_rows(n: int, reps: int, chromium: str | None) -> list[dict[str, Any]
     y = np.sin(x * 0.002) + np.cos(x * 0.0003)
 
     def figure() -> Figure:
-        return Figure(width=900, height=420).line(x, y)
+        return fc.chart(fc.line(x=x, y=y), width=900, height=420).figure()
 
     rows = []
     for scenario, operation, oracle in (

--- a/benchmarks/test_codspeed_kernels.py
+++ b/benchmarks/test_codspeed_kernels.py
@@ -16,8 +16,8 @@ import numpy as np
 import pytest
 
 import fastcharts as fc
-from fastcharts import Figure
 from fastcharts import kernels as k
+from fastcharts._figure import Figure  # harness type annotations only
 
 # Small/medium/large sizes keep CodSpeed honest across normal dashboard charts,
 # exact WebGL workloads, and screen-bounded large-data paths without turning it
@@ -137,8 +137,7 @@ def drilldown_figure() -> Figure:
     rng = np.random.default_rng(17)
     x = rng.uniform(0.0, 100.0, DRILL_N).astype(np.float64, copy=False)
     y = rng.uniform(0.0, 100.0, DRILL_N).astype(np.float64, copy=False)
-    fig = Figure()
-    fig.scatter(x, y, density=True)
+    fig = fc.chart(fc.scatter(x=x, y=y, density=True)).figure()
     fig._benchmark_deep_expected = int(np.count_nonzero((x < 10.0) & (y < 10.0)))
 
     # Warm the lazily-built pyramid so CodSpeed tracks interactive viewport
@@ -242,49 +241,42 @@ def test_range_indices(benchmark, data):
 
 
 def _scatter_payload(x: np.ndarray, y: np.ndarray, *, density: bool | None = None) -> int:
-    fig = Figure()
-    fig.scatter(x, y, density=density)
+    fig = fc.chart(fc.scatter(x=x, y=y, density=density)).figure()
     _spec, blob = fig.build_payload(N_BUCKETS)
     return len(blob)
 
 
 def _line_payload(x: np.ndarray, y: np.ndarray) -> int:
-    fig = Figure()
-    fig.line(x, y)
+    fig = fc.chart(fc.line(x=x, y=y)).figure()
     _spec, blob = fig.build_payload(N_BUCKETS)
     return len(blob)
 
 
 def _density_memory_report(x: np.ndarray, y: np.ndarray) -> dict[str, object]:
-    fig = Figure()
-    fig.scatter(x, y, density=True)
+    fig = fc.chart(fc.scatter(x=x, y=y, density=True)).figure()
     return fig.memory_report()
 
 
 def _histogram_payload(values: np.ndarray) -> int:
-    fig = Figure()
-    fig.histogram(values, bins=200)
+    fig = fc.chart(fc.histogram(values, bins=200)).figure()
     _spec, blob = fig.build_payload(N_BUCKETS)
     return len(blob)
 
 
 def _area_payload(x: np.ndarray, y: np.ndarray) -> int:
-    fig = Figure()
-    fig.area(x, y)
+    fig = fc.chart(fc.area(x, y)).figure()
     _spec, blob = fig.build_payload(N_BUCKETS)
     return len(blob)
 
 
 def _bar_payload(categories: list[str], values: np.ndarray) -> int:
-    fig = Figure()
-    fig.bar(categories, values)
+    fig = fc.chart(fc.bar(categories, values)).figure()
     _spec, blob = fig.build_payload(N_BUCKETS)
     return len(blob)
 
 
 def _heatmap_payload(z: np.ndarray, x: np.ndarray, y: np.ndarray) -> int:
-    fig = Figure()
-    fig.heatmap(z, x=x, y=y)
+    fig = fc.chart(fc.heatmap(z, x=x, y=y)).figure()
     _spec, blob = fig.build_payload(N_BUCKETS)
     return len(blob)
 
@@ -430,8 +422,7 @@ def test_build_payload(benchmark, data):
     x, y = data
 
     def build():
-        fig = Figure()
-        fig.line(x, y)
+        fig = fc.chart(fc.line(x=x, y=y)).figure()
         return fig.build_payload(N_BUCKETS)
 
     benchmark(build)
@@ -440,8 +431,7 @@ def test_build_payload(benchmark, data):
 def test_decimate_view(benchmark, data):
     """Zoom interaction: kernel-side re-decimation of a 1% window."""
     x, y = data
-    fig = Figure()
-    fig.line(x, y)
+    fig = fc.chart(fc.line(x=x, y=y)).figure()
     x0, x1 = N * 0.495, N * 0.505
     benchmark(fig.decimate_view, x0, x1, N_BUCKETS)
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -12,19 +12,23 @@ the later per-chart examples show the same APIs scaling up.
 
 ## API Stability Notes
 
-Use the fluent `Figure` API for the most stable alpha surface today. It is the
-direct path for implemented chart families, standalone HTML export, PNG export,
-notebook display, and memory reporting.
-
-Use the composition API when you want Reflex-shaped, declarative chart children,
-column-name resolution through `data=`, or `on_hover` / `on_select` callbacks.
+fastcharts has one public chart-building API: the declarative composition API.
+Charts are Reflex-shaped, declarative chart children — marks, axes,
+annotations, legend/tooltip chrome — composed inside a family container
+(`fc.line_chart(...)`, `fc.bar_chart(...)`, ...) or the neutral layering
+container `fc.chart(...)`. Marks accept arrays directly or column-name
+resolution through `data=`, and charts take `on_hover` / `on_select` callbacks.
 The core composition contract is now stabilizing around lightweight Python
 children, layered marks, axes, annotations, built-in or custom legend/tooltip
-chrome, CSS/Tailwind-friendly DOM hooks, and the same notebook/static export
-methods as `Figure`. Callback payload details and future adapter packages may
-still evolve before 1.0.
+chrome, and CSS/Tailwind-friendly DOM hooks. Callback payload details and
+future adapter packages may still evolve before 1.0.
 
-Both APIs accept `width="100%"` and/or `height="100%"` for responsive charts.
+Composed `Chart` objects handle standalone HTML export, PNG/SVG export,
+notebook display, and memory reporting directly. The internal engine object a
+chart compiles to is reachable via `chart.figure()` as an advanced escape
+hatch, but it is not part of the public chart-building surface.
+
+Charts accept `width="100%"` and/or `height="100%"` for responsive layouts.
 Standalone `to_html(...)` needs no browser dependency, and `to_png(...)` defaults
 to a browser-free native rasterizer. `to_png(..., engine="chromium")` needs a
 local Chrome/Chromium executable because it screenshots the same standalone HTML
@@ -32,19 +36,19 @@ document for a pixel-exact match to the live chart.
 
 ## Chart Family Quick Reference
 
-| Chart family | Fluent API | Composition API |
-|---|---|---|
-| Line | `Figure().line(x, y)` | `fc.line_chart(fc.line(...))` |
-| Scatter | `Figure().scatter(x, y)` | `fc.scatter_chart(fc.scatter(...))` |
-| Area | `Figure().area(x, y, base=0.0)` | `fc.area_chart(fc.area(...))` |
-| Histogram | `Figure().histogram(values, bins=...)` or `Figure().hist(...)` | `fc.histogram_chart(fc.histogram(...))` |
-| Bar | `Figure().bar(categories, values)` | `fc.bar_chart(fc.bar(...))` |
-| Column | `Figure().column(categories, values)` | `fc.column_chart(fc.column(...))` |
-| Grouped bars | `Figure().bar(categories, matrix, mode="grouped")` | `fc.bar_chart(fc.bar(..., mode="grouped"))` |
-| Stacked bars | `Figure().bar(categories, matrix, mode="stacked")` | `fc.bar_chart(fc.bar(..., mode="stacked"))` |
-| Normalized bars | `Figure().bar(categories, matrix, mode="normalized")` | `fc.bar_chart(fc.bar(..., mode="normalized"))` |
-| Horizontal bars | `Figure().bar(categories, values, orientation="horizontal")` | `fc.bar_chart(fc.bar(..., orientation="horizontal"))` |
-| Heatmap | `Figure().heatmap(z, x=x, y=y)` | `fc.heatmap_chart(fc.heatmap(...))` |
+| Chart family | Composition API |
+|---|---|
+| Line | `fc.line_chart(fc.line(...))` |
+| Scatter | `fc.scatter_chart(fc.scatter(...))` |
+| Area | `fc.area_chart(fc.area(...))` |
+| Histogram | `fc.histogram_chart(fc.histogram(...))` or `fc.hist(...)` |
+| Bar | `fc.bar_chart(fc.bar(...))` |
+| Column | `fc.column_chart(fc.column(...))` |
+| Grouped bars | `fc.bar_chart(fc.bar(..., mode="grouped"))` |
+| Stacked bars | `fc.bar_chart(fc.bar(..., mode="stacked"))` |
+| Normalized bars | `fc.bar_chart(fc.bar(..., mode="normalized"))` |
+| Horizontal bars | `fc.bar_chart(fc.bar(..., orientation="horizontal"))` |
+| Heatmap | `fc.heatmap_chart(fc.heatmap(...))` |
 
 ## Axes And Scales
 
@@ -70,50 +74,61 @@ chart
 ## Small Business Chart
 
 ```python
-from fastcharts import Figure
+import fastcharts as fc
 
 month_number = [1, 2, 3, 4, 5, 6]
 revenue = [42, 45, 48, 51, 55, 59]
 pipeline = [35, 38, 42, 40, 46, 50]
 
-fig = Figure(title="Revenue vs pipeline", x_label="month number", y_label="USD thousands")
-fig.line(month_number, revenue, name="revenue", color="#2563eb", width=2.0)
-fig.line(month_number, pipeline, name="pipeline", color="#16a34a", width=2.0)
-fig
+chart = fc.line_chart(
+    fc.line(month_number, revenue, name="revenue", color="#2563eb", width=2.0),
+    fc.line(month_number, pipeline, name="pipeline", color="#16a34a", width=2.0),
+    fc.x_axis(label="month number"),
+    fc.y_axis(label="USD thousands"),
+    title="Revenue vs pipeline",
+)
+chart
 ```
 
 ## Line
 
 ```python
 import numpy as np
-from fastcharts import Figure
+import fastcharts as fc
 
 rng = np.random.default_rng(0)
 x = np.arange(1_000_000, dtype=np.float64)
 y = np.cumsum(rng.normal(size=len(x)))
 
-fig = Figure(title="Random walk", x_label="sample", y_label="value")
-fig.line(x, y, name="walk")
-fig
+chart = fc.line_chart(
+    fc.line(x, y, name="walk"),
+    fc.x_axis(label="sample"),
+    fc.y_axis(label="value"),
+    title="Random walk",
+)
+chart
 ```
 
 ## Scatter
 
 ```python
 import numpy as np
-from fastcharts import Figure
+import fastcharts as fc
 
 rng = np.random.default_rng(1)
 x = rng.normal(size=500_000)
 y = 0.5 * x + rng.normal(scale=0.6, size=len(x))
 
-Figure(title="Correlated scatter").scatter(
-    x,
-    y,
-    color=y,
-    size=np.abs(y),
-    colormap="viridis",
-    size_range=(2, 14),
+fc.scatter_chart(
+    fc.scatter(
+        x,
+        y,
+        color=y,
+        size=np.abs(y),
+        colormap="viridis",
+        size_range=(2, 14),
+    ),
+    title="Correlated scatter",
 )
 ```
 
@@ -121,26 +136,32 @@ Figure(title="Correlated scatter").scatter(
 
 ```python
 import numpy as np
-from fastcharts import Figure
+import fastcharts as fc
 
 x = np.linspace(0, 10, 100_000)
 y = np.sin(x) + 0.15 * x
 
-Figure(title="Area").area(x, y, base=0.0, name="signal", opacity=0.35)
+fc.area_chart(
+    fc.area(x, y, base=0.0, name="signal", opacity=0.35),
+    title="Area",
+)
 ```
 
 ## Histogram
 
 ```python
 import numpy as np
-from fastcharts import Figure
+import fastcharts as fc
 
 rng = np.random.default_rng(2)
 values = np.concatenate(
     [rng.normal(-1.2, 0.45, 300_000), rng.normal(1.4, 0.6, 200_000)]
 )
 
-Figure(title="Distribution").histogram(values, bins=240, name="samples")
+fc.histogram_chart(
+    fc.histogram(values, bins=240, name="samples"),
+    title="Distribution",
+)
 ```
 
 Pass `cumulative=True` to accumulate bins left-to-right. Combined with
@@ -148,43 +169,48 @@ Pass `cumulative=True` to accumulate bins left-to-right. Combined with
 
 ```python
 import numpy as np
-from fastcharts import Figure
+import fastcharts as fc
 
 rng = np.random.default_rng(3)
 latency_ms = rng.gamma(shape=2.0, scale=40.0, size=100_000)
 
-Figure(title="Latency CDF", x_label="ms", y_label="fraction").hist(
-    latency_ms, bins=200, density=True, cumulative=True, name="p(x)"
+fc.histogram_chart(
+    fc.hist(latency_ms, bins=200, density=True, cumulative=True, name="p(x)"),
+    fc.x_axis(label="ms"),
+    fc.y_axis(label="fraction"),
+    title="Latency CDF",
 )
 ```
 
 ## Bar
 
 ```python
-from fastcharts import Figure
+import fastcharts as fc
 
 channels = ["Search", "Ads", "Email", "Direct", "Partner", "Social"]
 conversions = [120, 94, 72, 66, 43, 31]
 
-Figure(title="Conversions", x_label="channel", y_label="count").bar(
-    channels,
-    conversions,
-    name="Desktop",
+fc.bar_chart(
+    fc.bar(channels, conversions, name="Desktop"),
+    fc.x_axis(label="channel"),
+    fc.y_axis(label="count"),
+    title="Conversions",
 )
 ```
 
 ## Column
 
 ```python
-from fastcharts import Figure
+import fastcharts as fc
 
 quarters = ["Q1", "Q2", "Q3", "Q4"]
 revenue = [42, 47, 51, 58]
 
-Figure(title="Quarterly revenue", x_label="quarter", y_label="revenue").column(
-    quarters,
-    revenue,
-    name="Revenue",
+fc.column_chart(
+    fc.column(quarters, revenue, name="Revenue"),
+    fc.x_axis(label="quarter"),
+    fc.y_axis(label="revenue"),
+    title="Quarterly revenue",
 )
 ```
 
@@ -192,7 +218,7 @@ Figure(title="Quarterly revenue", x_label="quarter", y_label="revenue").column(
 
 ```python
 import numpy as np
-from fastcharts import Figure
+import fastcharts as fc
 
 channels = ["Search", "Ads", "Email", "Direct", "Partner", "Social"]
 values = np.array(
@@ -207,11 +233,14 @@ values = np.array(
     dtype=float,
 )
 
-Figure(title="Grouped channels").bar(
-    channels,
-    values,
-    mode="grouped",
-    series=["Desktop", "Mobile", "Tablet"],
+fc.bar_chart(
+    fc.bar(
+        channels,
+        values,
+        mode="grouped",
+        series=["Desktop", "Mobile", "Tablet"],
+    ),
+    title="Grouped channels",
 )
 ```
 
@@ -219,7 +248,7 @@ Figure(title="Grouped channels").bar(
 
 ```python
 import numpy as np
-from fastcharts import Figure
+import fastcharts as fc
 
 quarters = ["Q1", "Q2", "Q3", "Q4"]
 values = np.array(
@@ -232,11 +261,14 @@ values = np.array(
     dtype=float,
 )
 
-Figure(title="Stacked revenue").bar(
-    quarters,
-    values,
-    mode="stacked",
-    series=["Product", "Services", "Partners"],
+fc.bar_chart(
+    fc.bar(
+        quarters,
+        values,
+        mode="stacked",
+        series=["Product", "Services", "Partners"],
+    ),
+    title="Stacked revenue",
 )
 ```
 
@@ -247,7 +279,7 @@ category renders the series' share of the whole (segments sum to 1):
 
 ```python
 import numpy as np
-from fastcharts import Figure
+import fastcharts as fc
 
 quarters = ["Q1", "Q2", "Q3", "Q4"]
 values = np.array(
@@ -260,27 +292,34 @@ values = np.array(
     dtype=float,
 ).T
 
-Figure(title="Revenue mix", y_label="share").bar(
-    quarters,
-    values,
-    mode="normalized",
-    series=["Product", "Services", "Partners"],
+fc.bar_chart(
+    fc.bar(
+        quarters,
+        values,
+        mode="normalized",
+        series=["Product", "Services", "Partners"],
+    ),
+    fc.y_axis(label="share"),
+    title="Revenue mix",
 )
 ```
 
 ## Horizontal Bars
 
 ```python
-from fastcharts import Figure
+import fastcharts as fc
 
 teams = ["Platform", "Growth", "Data", "Support"]
 latency_ms = [42, 56, 31, 73]
 
-Figure(title="Median latency").bar(
-    teams,
-    latency_ms,
-    orientation="horizontal",
-    name="latency",
+fc.bar_chart(
+    fc.bar(
+        teams,
+        latency_ms,
+        orientation="horizontal",
+        name="latency",
+    ),
+    title="Median latency",
 )
 ```
 
@@ -288,17 +327,25 @@ Figure(title="Median latency").bar(
 
 ```python
 import numpy as np
-from fastcharts import Figure
+import fastcharts as fc
 
 x = np.linspace(-3, 3, 160)
 y = np.linspace(-2, 2, 120)
 xx, yy = np.meshgrid(x, y)
 z = np.exp(-(xx**2 + yy**2)) + 0.3 * np.exp(-((xx - 1.5) ** 2 + (yy + 0.8) ** 2))
 
-Figure(title="Heatmap", x_label="x", y_label="y").heatmap(z, x=x, y=y)
+fc.heatmap_chart(
+    fc.heatmap(z, x=x, y=y),
+    fc.x_axis(label="x"),
+    fc.y_axis(label="y"),
+    title="Heatmap",
+)
 ```
 
 ## Composition API
+
+Marks resolve column names through `data=`, so charts can bind straight to a
+dict, DataFrame, or any mapping of columns:
 
 ```python
 import fastcharts as fc
@@ -318,9 +365,9 @@ chart = fc.bar_chart(
 chart
 ```
 
-Composed `Chart` objects expose the same `to_html(...)`, `html(...)`,
-`_repr_html_()`, `to_png(...)`, `to_svg(...)`, `widget()`, `show()`, and
-`memory_report()` readout methods as `Figure`.
+Composed `Chart` objects expose `to_html(...)`, `html(...)`, `_repr_html_()`,
+`to_png(...)`, `to_svg(...)`, `widget()`, `show()`, and `memory_report()`
+readout methods directly.
 
 ## Live Data On A Composed Chart
 

--- a/docs/chart-kind-contract.md
+++ b/docs/chart-kind-contract.md
@@ -28,13 +28,14 @@ by the string `K` on the wire (`trace.kind`).
 
 ### 1. Kernel — `python/fastcharts/`
 
-- **`figure.py`: `_emit_<K>(self, t, pw, xr, yr, px_width) -> dict`.** Dispatched
+- **`_figure.py`: `_emit_<K>(self, t, pw, xr, yr, px_width) -> dict`.** Dispatched
   by `_emit_trace` via `getattr(self, f"_emit_{t.kind}")` — no edit to the
   dispatcher. Returns the trace's spec entry and ships its columns through the
   `_PayloadWriter` (`pw.ship` for §4 offset-encoded geometry, `pw.ship_scalar`
   for raw f32 channels/grids). Set `tier` explicitly (`direct` | `decimated` |
   `density`) — every tier decision is recorded, never silent (§28).
-- **A builder on `Figure`** (e.g. `hist(...)`, `bar(...)`) that ingests columns
+- **A builder on the internal `Figure`** (`marks.py`, e.g. `hist(...)`,
+  `bar(...)`) that ingests columns
   into the `ColumnStore` and appends a `Trace`. Reuse `_ingest_xy` for the
   equal-length (x,y) contract; a non-xy mark ingests its own columns.
 - **Channels** (optional): if the mark has per-mark color/size, reuse
@@ -137,9 +138,11 @@ usually wrong). Each has an explicit trigger:
 
 ## Checklist for a new kind
 
-1. `Figure.<K>(...)` builder + `_emit_<K>` (kernel spec/columns, explicit tier).
+1. Internal `Figure.<K>(...)` builder (`marks.py`) + `_emit_<K>` (kernel
+   spec/columns, explicit tier).
 2. `MARK_KINDS[K] = { build, draw }` (+ shaders if a new primitive).
-3. Component wrapper: entry in `components._MARK_APPLIERS` + a `*_chart` fn.
+3. Public composition surface: a `fc.<K>(...)` mark factory, an entry in
+   `components._MARK_APPLIERS`, and a `*_chart` fn.
 4. Tests: payload shape + tier decision (pytest); a render probe in
    `scripts/render_smoke_nonumpy.py` asserting it lights pixels.
 5. If aggregating: an aggregate kernel (native Rust core) and wire

--- a/docs/chart-roadmap.md
+++ b/docs/chart-roadmap.md
@@ -94,13 +94,13 @@ not fall out of sight.
 |---:|---|---|---|---|
 | 1 | Line and time series | line, step line, spline, markers+line, multi-line, streaming line | Implemented core | Most universal analytical chart; core for finance, monitoring, science, product metrics. |
 | 2 | Scatter / marker plots | scatter, scattergl-style, bubble, colored scatter, sized scatter | Implemented core | Large-point interactivity is the fastcharts wedge; basis for drilldown, selection, and density. |
-| 3 | Bar / column | vertical bar, horizontal bar, grouped, stacked, normalized stacked, diverging bar | Implemented core | `Figure().bar(...)` / `Figure().column(...)` ship categorical/numeric vertical and horizontal bars, grouped bars, stacked bars, and normalized stacked bars (`mode="normalized"`) through the shared rectangle renderer. Follow-up: labels. |
-| 4 | Area | filled line, stacked area, streamgraph, ridgeline-lite area bands | Implemented core | `Figure().area(...)` ships a filled area with scalar/array baseline and optional line overlay. Follow-ups: stacked area helpers and streamgraph offsets. |
+| 3 | Bar / column | vertical bar, horizontal bar, grouped, stacked, normalized stacked, diverging bar | Implemented core | `fc.bar(...)` / `fc.column(...)` ship categorical/numeric vertical and horizontal bars, grouped bars, stacked bars, and normalized stacked bars (`mode="normalized"`) through the shared rectangle renderer. Follow-up: labels. |
+| 4 | Area | filled line, stacked area, streamgraph, ridgeline-lite area bands | Implemented core | `fc.area(...)` ships a filled area with scalar/array baseline and optional line overlay. Follow-ups: stacked area helpers and streamgraph offsets. |
 | 5 | Histogram | count, probability, density, cumulative histogram | Implemented core | Python-side binning plus the shared rectangle renderer; `cumulative=True` (count CDF and, with `density=True`, empirical CDF) is implemented. Follow-up: viewport-aware re-binning for huge streamed distributions. |
 | 6 | Pie / donut | pie, donut, nested donut, variable-radius pie | Planned compatibility | Extremely common in dashboards even though performance differentiation is low. |
-| 7 | Heatmap / image / matrix | heatmap, image, annotated matrix, correlation matrix, cohort heatmap | Implemented core | `Figure().heatmap(...)` renders matrix cells through a compact grid texture with continuous colormaps and categorical/numeric axes. Follow-ups: annotation and tiled huge-image paths. |
+| 7 | Heatmap / image / matrix | heatmap, image, annotated matrix, correlation matrix, cohort heatmap | Implemented core | `fc.heatmap(...)` renders matrix cells through a compact grid texture with continuous colormaps and categorical/numeric axes. Follow-ups: annotation and tiled huge-image paths. |
 | 8 | Box plot | box, grouped box, notched box, outlier points | Planned | Standard distribution summary across Plotly, Matplotlib, Seaborn, Altair. |
-| 9 | Candlestick / OHLC | candlestick, OHLC bars, volume overlay, range selector | Prototyped (PR closed unmerged) | `Figure().candlestick/ohlc(...)` + `fc.candlestick_chart(...)` on the closed `codex/finance-charting-surface` exploration branch: OHLC decimation, shared-y f32 frame, time axes, hover, and a volume pane. Critical finance surface; inherits LOD and time-axis work from core primitives. |
+| 9 | Candlestick / OHLC | candlestick, OHLC bars, volume overlay, range selector | Prototyped (PR closed unmerged) | `fc.candlestick(...)`/`fc.ohlc(...)` + `fc.candlestick_chart(...)` on the closed `codex/finance-charting-surface` exploration branch: OHLC decimation, shared-y f32 frame, time axes, hover, and a volume pane. Critical finance surface; inherits LOD and time-axis work from core primitives. |
 | 10 | Error and interval charts | error bars, error bands, confidence intervals, line range, bar range, whisker, rule | Planned | Needed for science, experimentation, forecasting, and statistical dashboards. |
 | 11 | 2D density charts | 2D histogram, hexbin, density heatmap, KDE contours | Planned | Makes dense scatter honest at scale and exposes aggregation as a first-class chart type. |
 | 12 | Violin and distribution shapes | violin, split violin, KDE plot, density ridge | Planned | Common in data science; builds on density and filled polygons. |
@@ -137,10 +137,10 @@ not fall out of sight.
 
 | Rank | Chart | Why it is popular | Why it fits fastcharts | Suggested API |
 |---:|---|---|---|---|
-| 1 | Histogram | Core statistical chart in Plotly, Matplotlib, Altair; common first chart for distributions. | Implemented core: Python-side binning + shared instanced rectangle renderer, incl. `density` and `cumulative` modes. Follow-up: viewport-aware re-binning for very large streamed distributions. | `Figure().hist(values, bins=512, cumulative=True)` |
-| 2 | Bar / column | Present in every major library; expected for categorical comparison. | Implemented core: category axis + shared instanced rectangle renderer for basic, grouped, stacked, normalized stacked, and horizontal bars. Follow-up: labels. | `Figure().bar(x, y)` |
-| 3 | Area / filled line | Common extension of line charts in Plotly, Chart.js, Highcharts, Altair. | Implemented core: sorted x, M4 first payload, and filled WebGL segment strips. Follow-up: stacked area helper. | `Figure().area(x, y)` |
-| 4 | Heatmap / image | Common in scientific and BI tools; Matplotlib, Plotly, Altair, Highcharts all surface it. | Implemented core: matrix-to-grid texture path with color channel reuse. Follow-up: image/raster tiling for huge grids. | `Figure().heatmap(z, x=None, y=None)` |
+| 1 | Histogram | Core statistical chart in Plotly, Matplotlib, Altair; common first chart for distributions. | Implemented core: Python-side binning + shared instanced rectangle renderer, incl. `density` and `cumulative` modes. Follow-up: viewport-aware re-binning for very large streamed distributions. | `fc.histogram_chart(fc.hist(values, bins=512, cumulative=True))` |
+| 2 | Bar / column | Present in every major library; expected for categorical comparison. | Implemented core: category axis + shared instanced rectangle renderer for basic, grouped, stacked, normalized stacked, and horizontal bars. Follow-up: labels. | `fc.bar_chart(fc.bar(x, y))` |
+| 3 | Area / filled line | Common extension of line charts in Plotly, Chart.js, Highcharts, Altair. | Implemented core: sorted x, M4 first payload, and filled WebGL segment strips. Follow-up: stacked area helper. | `fc.area_chart(fc.area(x, y))` |
+| 4 | Heatmap / image | Common in scientific and BI tools; Matplotlib, Plotly, Altair, Highcharts all surface it. | Implemented core: matrix-to-grid texture path with color channel reuse. Follow-up: image/raster tiling for huge grids. | `fc.heatmap_chart(fc.heatmap(z, x=None, y=None))` |
 
 P1 is now implemented at the core primitive level. The next implementation block
 should add statistical breadth on top of these primitives: box plots, error
@@ -366,7 +366,7 @@ breadth on top of them, then the two "completeness" charts users ask for first.
 
 3. **2D density / hexbin** — makes dense scatter honest as a *named* chart.
    - Generalize the existing Tier-2 density path: expose counts, log color
-     scaling, and hover readout as `Figure().hexbin(...)` / `density_heatmap`.
+     scaling, and hover readout as `fc.hexbin(...)` / `density_heatmap`.
 
 4. **Pie / donut** — low performance differentiation but a top dashboard ask;
    implement for completeness (arc geometry + label placement).
@@ -378,7 +378,7 @@ breadth on top of them, then the two "completeness" charts users ask for first.
 Parallel, non-chart-type tracks:
 
 - **Native PNG rasterizer** (perf) — **shipped** (dossier Phase 3).
-  `Figure.to_png(engine="native")`, now the default, paints the decimated
+  `Chart.to_png(engine="native")`, now the default, paints the decimated
   payload with a dependency-free AA rasterizer in the Rust core (ABI v8,
   `fc_rasterize`) — no browser, ~50× faster than the Chromium screenshot,
   indexed-palette PNGs, and a baked bitmap font for text. `engine="chromium"`
@@ -390,24 +390,24 @@ Parallel, non-chart-type tracks:
 ## Near-Term API Sketch
 
 ```python
-from fastcharts import Figure
+import fastcharts as fc
 
 # shipped
-Figure().hist(values, bins=512, density=False, cumulative=False)
-Figure().bar(categories, values, mode="grouped", orientation="vertical")
-Figure().area(x, y, baseline=0.0)          # + fill=linear-gradient, curve, dash
-Figure().heatmap(z, x=None, y=None, colormap="viridis")
-Figure().candlestick(x, open, high, low, close)   # prototyped (closed finance PR)
+fc.histogram_chart(fc.hist(values, bins=512, density=False, cumulative=False))
+fc.bar_chart(fc.bar(categories, values, mode="grouped", orientation="vertical"))
+fc.area_chart(fc.area(x, y, base=0.0))     # + fill=linear-gradient, curve, dash
+fc.heatmap_chart(fc.heatmap(z, x=None, y=None, colormap="viridis"))
+fc.candlestick_chart(fc.candlestick(x, open, high, low, close))  # prototyped (closed finance PR)
 
 # next
-Figure().box(values, group=None)
-Figure().violin(values, group=None, bandwidth="auto")
-Figure().errorbar(x, y, yerr=..., xerr=...)
-Figure().hexbin(x, y, gridsize=50, color_scale="log")
-Figure().pie(values, labels=..., donut=0.0)
+fc.box_chart(fc.box(values, group=None))
+fc.violin_chart(fc.violin(values, group=None, bandwidth="auto"))
+fc.chart(fc.errorbar(x, y, yerr=..., xerr=...))
+fc.chart(fc.hexbin(x, y, gridsize=50, color_scale="log"))
+fc.pie_chart(fc.pie(values, labels=..., donut=0.0))
 ```
 
-Composition API equivalents follow the current style
+New chart kinds land as composition marks plus a family container
 (`fc.box_chart(fc.box(...))`, `fc.pie_chart(fc.pie(...))`, …).
 
 ## Decision Summary

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -189,8 +189,8 @@ dry-run output uses `<CHROMIUM>` until you pass `--chromium` or `CHROMIUM=...`.
 ## Pull Request Checklist
 
 - Public errors are actionable and name the bad parameter.
-- Failed public builder calls leave `Figure.traces`, `ColumnStore`, and category
-  axes unchanged.
+- Failed public builder calls leave the internal `_figure.Figure` traces,
+  `ColumnStore`, and category axes unchanged.
 - `import fastcharts` stays lazy and under budget in fresh interpreters; no
   NumPy/native-core import on package import.
 - Standalone HTML handles hostile user strings in every text surface touched by

--- a/docs/design/chart-grammar.md
+++ b/docs/design/chart-grammar.md
@@ -17,18 +17,18 @@ A Panel owns **Scales** (x, y, and later y2) and a z-ordered list of
 **Marks**. A Mark = kind + data bindings + style props + optional channel
 encodings. Axes, legend, and title are Panel/Figure chrome that *read* scales
 and marks — they never own data. Everything is a plain declarative node
-(dataclass), composable as children, and compiles to the existing engine
-`Figure` + wire spec. Two front doors, one engine:
+(dataclass), composable as children, and compiles to the existing internal
+engine figure + wire spec. One public front door over that engine:
 
-- **Fluent:** `Figure().scatter(...).line(...)` — imperative, notebook-quick.
 - **Compositional (Reflex-flavored):** `fc.chart(fc.scatter(...), fc.line(...),
   fc.x_axis(...))` — declarative, component-tree shaped, what a Reflex wrapper
-  serializes naturally.
+  serializes naturally. (The internal `_figure.Figure` fluent methods share the
+  same mark implementations, so the vocabulary cannot fork.)
 
-Rule G0: **the fluent and compositional APIs are the same vocabulary** (same
-mark names, same prop names, same defaults). A user must be able to translate
-between them mechanically. This is already true and is the thing we must not
-break.
+Rule G0: **the public composition API and the internal mark core are the same
+vocabulary** (same mark names, same prop names, same defaults — one
+implementation in `marks.py`). This is already true and is the thing we must
+not break.
 
 ## 2. The layering/overlay rules (what makes composition sound)
 

--- a/docs/design/reflex-integration.md
+++ b/docs/design/reflex-integration.md
@@ -152,8 +152,8 @@ class Dash(rx.State):
     chart: str = ""                      # figure token — the ONLY chart state
 
     def load(self):
-        fig = fc.Figure().scatter(x, y, color=c)   # or fc.scatter_chart(...)
-        self.chart = rfc.register(fig)
+        chart = fc.scatter_chart(fc.scatter(x, y, color=c))
+        self.chart = rfc.register(chart)
 
     def picked(self, row: dict): ...
     def selected(self, sel: dict): ...
@@ -236,17 +236,17 @@ class Telemetry(rx.State):
 
         # 10M points: ships as a density surface, drills to real points on
         # zoom, hover reads exact f64 rows — all default behavior.
-        fig = fc.Figure().scatter(
-            pings["lon"], pings["lat"], color=pings["latency_ms"]
+        chart = fc.scatter_chart(
+            fc.scatter(pings["lon"], pings["lat"], color=pings["latency_ms"])
         )
-        self.map_chart = rfc.register(fig)
+        self.map_chart = rfc.register(chart)
 
         self.latency_chart = rfc.register(
-            fc.Figure().histogram(pings["latency_ms"], bins=120)
+            fc.histogram_chart(fc.histogram(pings["latency_ms"], bins=120))
         )
 
         self.live_chart = rfc.register(
-            fc.Figure().line(np.array([0.0]), np.array([0.0]))
+            fc.line_chart(fc.line(np.array([0.0]), np.array([0.0])))
         )
 
     @rx.event
@@ -263,7 +263,7 @@ class Telemetry(rx.State):
         self.selected_count = int(len(idx))
         rfc.release(self.latency_chart)
         self.latency_chart = rfc.register(
-            fc.Figure().histogram(self._pings["latency_ms"][idx], bins=120)
+            fc.histogram_chart(fc.histogram(self._pings["latency_ms"][idx], bins=120))
         )
 
     @rx.event(background=True)

--- a/docs/design/reflex-shaped-api.md
+++ b/docs/design/reflex-shaped-api.md
@@ -60,7 +60,7 @@ can be rendered by notebooks, static HTML export, and future adapters:
 flowchart LR
   USER["Python API<br/>fc.chart(...children)"]
   TREE["Framework-free<br/>component tree"]
-  FIG["Figure compiler<br/>ColumnStore + traces"]
+  FIG["Internal figure compiler<br/>ColumnStore + traces"]
   SPEC["Wire spec + buffers"]
   NB["Notebook widget<br/>.show()"]
   HTML["Standalone HTML<br/>to_html()"]
@@ -91,9 +91,10 @@ flowchart LR
 - **Declarative by default.** Component construction records intent. Rendering
   happens when the user calls `.show()`, `widget()`, `to_html(...)`,
   `to_png(...)`, or when an adapter mounts it.
-- **One chart vocabulary.** `Figure().scatter(...)` and
-  `fc.chart(fc.scatter(...))` use the same mark names, channel names, defaults,
-  and validation rules.
+- **One chart vocabulary.** Every mark factory (`fc.scatter(...)`,
+  `fc.line(...)`, ...) resolves to the single mark implementation in
+  `marks.py`, so mark names, channel names, defaults, and validation rules
+  cannot fork.
 - **CSS styles chrome, spec styles marks.** DOM chrome like title, tooltip,
   legend, modebar, and wrapper can be styled with classes and CSS variables.
   WebGL marks are pixels, so their color/opacity/width still come from mark
@@ -172,10 +173,10 @@ fc.line(x="t", y="p95", data=df, color="var(--chart-critical)", width=2)
 
 ### 3.3 Readout Methods
 
-Every renderable component should expose the same readouts as `Figure`:
+Every renderable component exposes the full readout surface directly:
 
 ```python
-chart.figure()       # compile to Figure
+chart.figure()       # advanced escape hatch: compile to the internal Figure
 chart.widget()       # anywidget object
 chart.show()         # display widget in notebook
 chart.to_html()      # standalone string
@@ -190,8 +191,8 @@ chart.memory_report()
 export path for notebook/export tools that inspect HTML representations instead
 of anywidget display hooks. `to_html()` remains the canonical method because it
 already exists and clearly communicates export behavior. `Chart.to_html(path)`
-delegates to the same standalone export path as `Figure.to_html(path)`,
-including same-directory atomic file replacement for path writes.
+delegates to the engine's standalone export path, including same-directory
+atomic file replacement for path writes.
 
 ## 4. Styling Contract
 
@@ -282,9 +283,9 @@ and tests do not have to copy this table by hand. That root export resolves
 through the lightweight DOM contract module, so framework adapters can inspect
 the styling surface without importing NumPy, the chart engine, or widget stack.
 `class_names` keys are validated against that tuple; unknown keys fail fast
-instead of being silently ignored. The same validation is applied by the fluent
-`Figure` export path, so mutating `fig.class_names` or `fig.chrome_styles`
-cannot bypass the public DOM-slot contract.
+instead of being silently ignored. The same validation is applied by the
+internal `_figure.Figure` export path, so mutating `fig.class_names` or
+`fig.chrome_styles` cannot bypass the public DOM-slot contract.
 
 Tailwind example:
 
@@ -538,8 +539,8 @@ chart.to_html("clusters.html")     # standalone shareable file
 chart.to_png("clusters.png")       # optional local Chromium screenshot
 ```
 
-The same object compiles to a `Figure`, so existing internals and future
-adapters share the same payload path:
+The same object compiles to the internal `_figure.Figure`, so engine
+internals and future adapters share the same payload path:
 
 ```python
 fig = chart.figure()
@@ -640,7 +641,8 @@ declarative chart object, binary payload, and renderer.
 
 Must keep:
 
-- `Figure` fluent API.
+- The composition API as the single public chart-building surface (the
+  internal `_figure.Figure` fluent API is no longer public).
 - Existing `scatter_chart`, `line_chart`, etc. wrappers.
 - `Chart.figure()`.
 - `Chart.widget()`.

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -42,7 +42,7 @@ These must pass before publishing or making a broad performance claim.
 |---|---|---|
 | Python floor | `pyproject.toml`, Ruff, docs, syntax, and annotations stay on the Python 3.11+ floor | `python scripts/check_python_floor.py` |
 | Public API | `__all__`, lazy exports, `__version__`, the source `py.typed` marker, focused type-surface tests, and fresh-process import-time budget stay coherent | `make check-api` |
-| Import-time budget | `fastcharts.__init__`, `dir(fastcharts)`, export helpers, Figure construction, and `.widget()` keep their lazy import boundaries | `make check-import` |
+| Import-time budget | `fastcharts.__init__`, `dir(fastcharts)`, export helpers, chart construction, and `.widget()` keep their lazy import boundaries | `make check-import` |
 | Claim guardrails | Public docs and package metadata avoid broad, unqualified performance claims | `make check-claims` |
 | CI/release workflows | Hard gates, non-blocking benchmarks, best-effort benchmark artifact upload/download, trusted publishing, and no-Rust clear-error jobs stay wired | `make check-ci` |
 | HTML export safety | Inline JSON/script escaping, atomic path writes, hostile user strings, and browser client text-node insertion stay protected | `make check-security` |
@@ -53,7 +53,7 @@ These must pass before publishing or making a broad performance claim.
 | Native ABI | C ABI can be loaded from the built core | `python scripts/abi_smoke.py` |
 | JavaScript | Committed bundles match source | `node js/build.mjs --check` |
 | Browser render | WebGL smoke reaches real pixels | `python scripts/render_smoke_nonumpy.py <chromium>` |
-| Real figure render | A real `Figure` exports and paints in Chromium | `python scripts/smoke_render.py <chromium>` |
+| Real chart render | A real composed chart exports and paints in Chromium | `python scripts/smoke_render.py <chromium>` |
 | sdist | Source archive contains required source/bundles, benchmark regression harness/baseline, release docs/tests/scripts, the Reflex example app, `PKG-INFO` version/dependencies matching `pyproject.toml`, no duplicate members, and no generated junk | `python scripts/verify_sdist.py dist/*.tar.gz` |
 | Native wheel | Platform wheel contains package-only files, exactly one native library, `METADATA` version/dependencies matching `pyproject.toml`, complete hash-checked `RECORD`, public export-surface markers, matching filename/`WHEEL` tags, and is tagged non-pure | `python scripts/verify_wheel.py dist/*.whl --expect-native` |
 | Fallback wheel | No-toolchain wheel contains package-only files, `METADATA` version/dependencies matching `pyproject.toml`, complete hash-checked `RECORD`, public export-surface markers, matching filename/`WHEEL` tags, is pure, and contains no native library | `python scripts/verify_wheel.py dist/*.whl --expect-pure` |
@@ -62,7 +62,7 @@ These must pass before publishing or making a broad performance claim.
 
 ## Standalone HTML Safety
 
-`Figure.to_html()` produces one self-contained document: inline JavaScript,
+`Chart.to_html()` produces one self-contained document: inline JavaScript,
 inline JSON spec, and a base64 data blob. That shape is convenient for notebooks,
 reports, and sharing a single file, but it has a clear security contract:
 
@@ -376,7 +376,7 @@ Not yet safe:
 Keep pushing these in low-conflict increments:
 
 - Add mutation-safety tests for every public builder: a failed call must leave
-  the `Figure` and column store unchanged.
+  the chart's internal figure and column store unchanged.
 - Keep weird-string export tests covering every text surface added to the
   public API, including titles, labels, legends, categories, and series names.
 - Styling arguments (colors, gradient stops, `style=` declarations) are gated

--- a/examples/dashboard/site_overview.py
+++ b/examples/dashboard/site_overview.py
@@ -1,15 +1,16 @@
 """A site-overview dashboard built from fastcharts sparklines.
 
-Card chrome is plain HTML/CSS; every metric sparkline is a real fastcharts
-`Figure` — chrome-hidden, edge-to-edge (`padding=0`), gradient area fills, and
-smooth curves. The client bundle is embedded once and each chart renders from
-its own spec + base64 blob into its card.
+Card chrome is plain HTML/CSS; every metric sparkline is a real composed
+fastcharts chart — chrome-hidden, edge-to-edge (`padding=...`), gradient area
+fills, and smooth curves. The client bundle is embedded once and each chart
+renders from its own spec + base64 blob into its card.
 
     uv run python examples/dashboard/site_overview.py       # writes site_overview.html
     uv run python examples/dashboard/site_overview.py --png  # also renders a PNG
 
-Showcases: `Figure(padding=...)`, `curve="smooth"`, `fill="linear-gradient(...)"`,
-`tick_label_strategy="none"`, and `width="100%"` responsive sizing.
+Showcases: `fc.chart(..., padding=...)`, `curve="smooth"`,
+`fill="linear-gradient(...)"`, `tick_label_strategy="none"`, and
+`width="100%"` responsive sizing.
 """
 
 from __future__ import annotations
@@ -20,7 +21,7 @@ from pathlib import Path
 
 import numpy as np
 
-from fastcharts import Figure
+import fastcharts as fc
 from fastcharts.export import _STANDALONE_CSP, _bundled_js, _json_for_inline_script
 
 HERE = Path(__file__).resolve().parent
@@ -33,9 +34,8 @@ def spark(kind: str, x, y, color: str, *, fill: bool = True, width: float = 2.4)
     `width="100%"` fills the (narrower) dashboard panel via the client's
     ResizeObserver rather than overflowing at a fixed pixel width.
     """
-    fig = Figure(width="100%", height=104, padding=[6, 1, 2, 1])
     if kind == "area":
-        fig.area(
+        mark = fc.area(
             x,
             y,
             color=color,
@@ -45,15 +45,23 @@ def spark(kind: str, x, y, color: str, *, fill: bool = True, width: float = 2.4)
             fill="linear-gradient(currentColor, transparent)" if fill else None,
         )
     else:
-        fig.line(x, y, color=color, curve="smooth", width=width)
-    fig.show_legend = fig.show_modebar = fig.show_tooltip = False
-    for ax in ("x", "y"):
-        fig.set_axis(
-            ax,
-            style={"grid_color": "rgba(0,0,0,0)", "axis_color": "rgba(0,0,0,0)"},
-            tick_label_strategy="none",
-        )
-    spec, blob = fig.build_payload()
+        mark = fc.line(x, y, color=color, curve="smooth", width=width)
+    hidden_axis = {
+        "style": {"grid_color": "rgba(0,0,0,0)", "axis_color": "rgba(0,0,0,0)"},
+        "tick_label_strategy": "none",
+    }
+    chart = fc.chart(
+        mark,
+        fc.x_axis(**hidden_axis),
+        fc.y_axis(**hidden_axis),
+        fc.legend(show=False),
+        fc.tooltip(show=False),
+        fc.modebar(show=False),
+        width="100%",
+        height=104,
+        padding=[6, 1, 2, 1],
+    )
+    spec, blob = chart.figure().build_payload()
     return spec, base64.b64encode(blob).decode("ascii")
 
 

--- a/examples/demo.ipynb
+++ b/examples/demo.ipynb
@@ -8,7 +8,7 @@
     "# fastcharts — demo\n",
     "\n",
     "Millions of points, interactive, in a notebook. Pan by dragging, zoom with the wheel, double-click to reset.\n",
-    "Shift-drag a scatter to box-select. Two APIs over one engine: the fluent `Figure` and the Reflex-flavored `fc.scatter_chart(...)`."
+    "Shift-drag a scatter to box-select. One declarative API over one engine: the Reflex-flavored `fc.scatter_chart(...)` composition."
    ]
   },
   {
@@ -22,7 +22,6 @@
     "\n",
     "import fastcharts as fc\n",
     "import fastcharts.kernels as k\n",
-    "from fastcharts import Figure\n",
     "\n",
     "rng = np.random.default_rng(0)\n",
     "print(\"kernel backend:\", k.BACKEND)"
@@ -175,8 +174,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = Figure().line(t, y)\n",
-    "report = fig.memory_report()\n",
+    "chart = fc.line_chart(fc.line(t, y))\n",
+    "report = chart.memory_report()\n",
     "print(f\"canonical: {report['canonical_bytes'] / 2**20:.1f} MB kernel-side\")\n",
     "print(f\"first-paint transport: {report['transport_bytes_first_paint'] / 2**10:.1f} KB\")\n",
     "print(f\"transport bytes/point: {report['transport_bytes_per_point']:.4f}\")"

--- a/examples/reflex/reflex_fastcharts_app/live_drilldown.py
+++ b/examples/reflex/reflex_fastcharts_app/live_drilldown.py
@@ -11,7 +11,12 @@ import numpy as np
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from fastcharts import Figure
+import fastcharts as fc
+
+# The live drilldown server probes the engine directly (traces, density_view,
+# drill bookkeeping), so it works on the internal figure compiled from the
+# public composition API via `Chart.figure()`.
+from fastcharts._figure import Figure
 from fastcharts.config import DRILL_EXIT_FACTOR, SCATTER_DENSITY_THRESHOLD
 from fastcharts.lod import grid_shape
 from fastcharts.widget import bundled_js
@@ -58,6 +63,25 @@ def colored_scatter_data(
     return x, y, color, size
 
 
+def colored_scatter_chart(
+    n: int = LIVE_SCATTER_POINTS,
+    *,
+    title: str | None = None,
+    width: Union[str, int] = "100%",
+    height: int = 430,
+) -> fc.Chart:
+    title = title or f"{_point_label(n)} live drilldown scatter"
+    x, y, color, size = colored_scatter_data(n)
+    return fc.scatter_chart(
+        fc.scatter(x, y, color=color, size=size, colormap="viridis", opacity=0.72, density=True),
+        fc.x_axis(label="feature A"),
+        fc.y_axis(label="feature B"),
+        title=title,
+        width=width,
+        height=height,
+    )
+
+
 def colored_scatter_figure(
     n: int = LIVE_SCATTER_POINTS,
     *,
@@ -65,15 +89,7 @@ def colored_scatter_figure(
     width: Union[str, int] = "100%",
     height: int = 430,
 ) -> Figure:
-    title = title or f"{_point_label(n)} live drilldown scatter"
-    x, y, color, size = colored_scatter_data(n)
-    return Figure(
-        title=title,
-        x_label="feature A",
-        y_label="feature B",
-        width=width,
-        height=height,
-    ).scatter(x, y, color=color, size=size, colormap="viridis", opacity=0.72, density=True)
+    return colored_scatter_chart(n, title=title, width=width, height=height).figure()
 
 
 @lru_cache(maxsize=1)

--- a/examples/reflex/reflex_fastcharts_app/reflex_fastcharts_app.py
+++ b/examples/reflex/reflex_fastcharts_app/reflex_fastcharts_app.py
@@ -308,7 +308,7 @@ def chart_panel():
     return fastcharts_html_chart(chart, "/charts/custom_chrome.html")
 """.strip(),
     "business-overview": """
-from fastcharts import Figure
+import fastcharts as fc
 import numpy as np
 
 months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun"]
@@ -317,24 +317,25 @@ values = np.array([
     [35, 38, 42, 40, 46, 50],
 ])
 
-fig = Figure(
+chart = fc.chart(
+    fc.column(
+        months,
+        values,
+        mode="grouped",
+        series=["Revenue", "Pipeline"],
+        colors=["#2563eb", "#16a34a"],
+    ),
+    fc.x_axis(label="month"),
+    fc.y_axis(label="USD thousands"),
     title="Small business overview",
-    x_label="month",
-    y_label="USD thousands",
     width="100%",
     height=430,
-).column(
-    months,
-    values,
-    mode="grouped",
-    series=["Revenue", "Pipeline"],
-    colors=["#2563eb", "#16a34a"],
 )
 
-fig.to_html("assets/charts/business_overview.html")
+chart.to_html("assets/charts/business_overview.html")
 """.strip(),
     "retention-cohort": """
-from fastcharts import Figure
+import fastcharts as fc
 import numpy as np
 
 cohorts = ["Jan", "Feb", "Mar", "Apr", "May", "Jun"]
@@ -348,16 +349,17 @@ retention = np.array([
     [1.00, 0.77, 0.68, 0.62, 0.57, 0.52],
 ])
 
-fig = Figure(
+chart = fc.chart(
+    fc.heatmap(retention, x=weeks, y=cohorts, name="retention", colormap="viridis"),
+    fc.x_axis(label="week"),
+    fc.y_axis(label="signup cohort"),
     title="Small retention cohort",
-    x_label="week",
-    y_label="signup cohort",
     width="100%",
     height=430,
-).heatmap(retention, x=weeks, y=cohorts, name="retention", colormap="viridis")
+)
 """.strip(),
     "line": """
-from fastcharts import Figure
+import fastcharts as fc
 import numpy as np
 
 rng = np.random.default_rng(7)
@@ -365,16 +367,17 @@ n = 120_000
 x = np.arange(n)
 y = np.cumsum(rng.normal(0, 0.35, n)) + np.sin(np.linspace(0, 24, n)) * 18
 
-fig = Figure(
+chart = fc.chart(
+    fc.line(x, y, name="walk", color="#3267c8", width=1.4),
+    fc.x_axis(label="sample"),
+    fc.y_axis(label="value"),
     title="120k sample random walk",
-    x_label="sample",
-    y_label="value",
     width="100%",
     height=430,
-).line(x, y, name="walk", color="#3267c8", width=1.4)
+)
 """.strip(),
     "area": """
-from fastcharts import Figure
+import fastcharts as fc
 import numpy as np
 
 rng = np.random.default_rng(13)
@@ -383,16 +386,17 @@ x = np.arange(n)
 y = 35 + np.sin(np.linspace(0, 28, n)) * 8 + np.cumsum(rng.normal(0, 0.025, n))
 base = np.full(n, 25.0)
 
-fig = Figure(
+chart = fc.chart(
+    fc.area(x, y, base=base, name="active users", color="#0891b2"),
+    fc.x_axis(label="sample"),
+    fc.y_axis(label="active users"),
     title="80k filled area",
-    x_label="sample",
-    y_label="active users",
     width="100%",
     height=430,
-).area(x, y, base=base, name="active users", color="#0891b2")
+)
 """.strip(),
     "histogram": """
-from fastcharts import Figure
+import fastcharts as fc
 import numpy as np
 
 rng = np.random.default_rng(41)
@@ -401,16 +405,17 @@ values = np.concatenate([
     rng.normal(1.4, 0.8, 250_000),
 ])
 
-fig = Figure(
+chart = fc.chart(
+    fc.hist(values, bins=160, name="distribution", color="#3b82f6"),
+    fc.x_axis(label="value"),
+    fc.y_axis(label="count"),
     title="500k sample histogram",
-    x_label="value",
-    y_label="count",
     width="100%",
     height=430,
-).hist(values, bins=160, name="distribution", color="#3b82f6")
+)
 """.strip(),
     "grouped-bars": """
-from fastcharts import Figure
+import fastcharts as fc
 import numpy as np
 
 categories = ["Search", "Ads", "Email", "Direct", "Partner", "Social"]
@@ -420,22 +425,23 @@ values = np.array([
     [42, 39, 26, 31, 19, 14],
 ])
 
-fig = Figure(
+chart = fc.chart(
+    fc.bar(
+        categories,
+        values,
+        mode="grouped",
+        series=["Desktop", "Mobile", "Tablet"],
+        colors=["#2563eb", "#16a34a", "#f59e0b"],
+    ),
+    fc.x_axis(label="channel"),
+    fc.y_axis(label="conversions"),
     title="Grouped category bars",
-    x_label="channel",
-    y_label="conversions",
     width="100%",
     height=430,
-).bar(
-    categories,
-    values,
-    mode="grouped",
-    series=["Desktop", "Mobile", "Tablet"],
-    colors=["#2563eb", "#16a34a", "#f59e0b"],
 )
 """.strip(),
     "stacked-bars": """
-from fastcharts import Figure
+import fastcharts as fc
 import numpy as np
 
 quarters = ["Q1", "Q2", "Q3", "Q4"]
@@ -445,37 +451,39 @@ values = np.array([
     [16, 19, 24, 29],
 ])
 
-fig = Figure(
+chart = fc.chart(
+    fc.column(
+        quarters,
+        values,
+        mode="stacked",
+        series=["Core", "Expansion", "Services"],
+        colors=["#0f766e", "#7c3aed", "#dc2626"],
+    ),
+    fc.x_axis(label="quarter"),
+    fc.y_axis(label="revenue"),
     title="Stacked revenue bars",
-    x_label="quarter",
-    y_label="revenue",
     width="100%",
     height=430,
-).column(
-    quarters,
-    values,
-    mode="stacked",
-    series=["Core", "Expansion", "Services"],
-    colors=["#0f766e", "#7c3aed", "#dc2626"],
 )
 """.strip(),
     "horizontal-bars": """
-from fastcharts import Figure
+import fastcharts as fc
 import numpy as np
 
 regions = ["NA", "EU", "APAC", "LATAM", "MEA"]
 values = np.array([142, 128, 116, 74, 52])
 
-fig = Figure(
+chart = fc.chart(
+    fc.bar(regions, values, orientation="horizontal", name="revenue", color="#9333ea"),
+    fc.x_axis(label="revenue"),
+    fc.y_axis(label="region"),
     title="Horizontal category bars",
-    x_label="revenue",
-    y_label="region",
     width="100%",
     height=430,
-).bar(regions, values, orientation="horizontal", name="revenue", color="#9333ea")
+)
 """.strip(),
     "heatmap": """
-from fastcharts import Figure
+import fastcharts as fc
 import numpy as np
 
 cols = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
@@ -489,13 +497,14 @@ z = np.array([
     [0.38, 0.40, 0.44, 0.48, 0.55, 0.58, 0.50],
 ])
 
-fig = Figure(
+chart = fc.chart(
+    fc.heatmap(z, x=cols, y=rows, name="activity", colormap="turbo"),
+    fc.x_axis(label="day"),
+    fc.y_axis(label="hour"),
     title="Weekly activity heatmap",
-    x_label="day",
-    y_label="hour",
     width="100%",
     height=430,
-).heatmap(z, x=cols, y=rows, name="activity", colormap="turbo")
+)
 """.strip(),
     "composed-layers": """
 import fastcharts as fc
@@ -705,7 +714,7 @@ chart = fc.chart(
 )
 """.strip(),
     "density-scatter": """
-from fastcharts import Figure
+import fastcharts as fc
 import numpy as np
 
 rng = np.random.default_rng(23)
@@ -715,24 +724,25 @@ groups = rng.integers(0, len(centers), n, dtype=np.int8)
 x = centers[groups, 0] + rng.normal(0, 0.33, n)
 y = centers[groups, 1] + rng.normal(0, 0.33, n)
 
-fig = Figure(
+chart = fc.chart(
+    fc.scatter(x, y, opacity=0.9),
+    fc.x_axis(label="x"),
+    fc.y_axis(label="y"),
     title="10M density scatter",
-    x_label="x",
-    y_label="y",
     width="100%",
     height=430,
-).scatter(x, y, opacity=0.9)
+)
 """.strip(),
     "fastcharts-scatter": """
-from reflex_fastcharts_app.live_drilldown import colored_scatter_figure
+from reflex_fastcharts_app.live_drilldown import colored_scatter_chart
 
-fig = colored_scatter_figure(
+chart = colored_scatter_chart(
     10_000_000,
     title="10M colored scatter",
     width="100%",
     height=430,
 )
-fig.to_html("assets/charts/colored_scatter.html")
+chart.to_html("assets/charts/colored_scatter.html")
 """.strip(),
     "plotly-scatter": """
 import plotly.graph_objects as go

--- a/examples/reflex/scripts/build_charts.py
+++ b/examples/reflex/scripts/build_charts.py
@@ -16,19 +16,18 @@ sys.path.insert(0, str(APP_ROOT))
 sys.path.insert(0, str(REPO_ROOT / "python"))
 
 from reflex_fastcharts_app.live_drilldown import (  # noqa: E402
+    colored_scatter_chart,
     colored_scatter_data,
-    colored_scatter_figure,
     live_drilldown_html,
 )
 
 import fastcharts as fc  # noqa: E402
-from fastcharts import Figure  # noqa: E402
 
 
-def write_chart(fig: Figure | fc.Chart, name: str) -> None:
+def write_chart(chart: fc.Chart, name: str) -> None:
     ASSET_DIR.mkdir(parents=True, exist_ok=True)
     path = ASSET_DIR / name
-    fig.to_html(str(path))
+    chart.to_html(str(path))
     print(f"wrote {path.relative_to(APP_ROOT)}")
 
 
@@ -77,22 +76,23 @@ def write_plotly_chart(name: str) -> None:
     print(f"wrote {path.relative_to(APP_ROOT)}")
 
 
-def line_walk() -> Figure:
+def line_walk() -> fc.Chart:
     rng = np.random.default_rng(7)
     n = 120_000
     x = np.arange(n, dtype=np.float64)
     trend = np.sin(np.linspace(0, 24, n)) * 18
     y = np.cumsum(rng.normal(0, 0.35, n)) + trend
-    return Figure(
+    return fc.line_chart(
+        fc.line(x, y, name="walk", color="#3267c8", width=1.4),
+        fc.x_axis(label="sample"),
+        fc.y_axis(label="value"),
         title="120k sample random walk",
-        x_label="sample",
-        y_label="value",
         width=980,
         height=430,
-    ).line(x, y, name="walk", color="#3267c8", width=1.4)
+    )
 
 
-def business_overview_demo() -> Figure:
+def business_overview_demo() -> fc.Chart:
     months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun"]
     values = np.array(
         [
@@ -100,23 +100,24 @@ def business_overview_demo() -> Figure:
             [35.0, 38.0, 42.0, 40.0, 46.0, 50.0],
         ]
     )
-    return Figure(
+    return fc.column_chart(
+        fc.column(
+            months,
+            values,
+            mode="grouped",
+            series=["Revenue", "Pipeline"],
+            colors=["#2563eb", "#16a34a"],
+            opacity=0.86,
+        ),
+        fc.x_axis(label="month"),
+        fc.y_axis(label="USD thousands"),
         title="Small business overview",
-        x_label="month",
-        y_label="USD thousands",
         width="100%",
         height=430,
-    ).column(
-        months,
-        values,
-        mode="grouped",
-        series=["Revenue", "Pipeline"],
-        colors=["#2563eb", "#16a34a"],
-        opacity=0.86,
     )
 
 
-def retention_cohort_demo() -> Figure:
+def retention_cohort_demo() -> fc.Chart:
     cohorts = ["Jan", "Feb", "Mar", "Apr", "May", "Jun"]
     weeks = ["W0", "W1", "W2", "W3", "W4", "W5"]
     retention = np.array(
@@ -130,33 +131,39 @@ def retention_cohort_demo() -> Figure:
         ],
         dtype=np.float64,
     )
-    return Figure(
+    return fc.heatmap_chart(
+        fc.heatmap(
+            retention, x=weeks, y=cohorts, name="retention", colormap="viridis", opacity=0.94
+        ),
+        fc.x_axis(label="week"),
+        fc.y_axis(label="signup cohort"),
         title="Small retention cohort",
-        x_label="week",
-        y_label="signup cohort",
         width="100%",
         height=430,
-    ).heatmap(retention, x=weeks, y=cohorts, name="retention", colormap="viridis", opacity=0.94)
+    )
 
 
-def area_demo() -> Figure:
+def area_demo() -> fc.Chart:
     rng = np.random.default_rng(13)
     n = 80_000
     x = np.arange(n, dtype=np.float64)
     seasonal = 35 + np.sin(np.linspace(0, 28, n)) * 8
     y = seasonal + np.cumsum(rng.normal(0, 0.025, n))
     base = np.full(n, 25.0)
-    return Figure(
+    return fc.area_chart(
+        fc.area(
+            x, y, base=base, name="active users", color="#0891b2", opacity=0.34, line_width=1.1
+        ),
+        fc.x_axis(label="sample"),
+        fc.y_axis(label="active users"),
         title="80k filled area",
-        x_label="sample",
-        y_label="active users",
         width="100%",
         height=430,
-    ).area(x, y, base=base, name="active users", color="#0891b2", opacity=0.34, line_width=1.1)
+    )
 
 
-def colored_scatter() -> Figure:
-    return colored_scatter_figure(
+def colored_scatter() -> fc.Chart:
+    return colored_scatter_chart(
         STATIC_COLORED_SCATTER_POINTS,
         title=f"{STATIC_COLORED_SCATTER_POINTS // 1_000_000}M colored scatter",
         width="100%",
@@ -164,7 +171,7 @@ def colored_scatter() -> Figure:
     )
 
 
-def density_scatter() -> Figure:
+def density_scatter() -> fc.Chart:
     rng = np.random.default_rng(23)
     n = 10_000_000
     centers = np.array([[-1.4, -0.9], [-0.2, 0.8], [1.0, -0.2], [1.8, 1.1]])
@@ -173,16 +180,17 @@ def density_scatter() -> Figure:
     y = centers[groups, 1].astype(np.float64, copy=True)
     x += rng.normal(0, 0.33, n)
     y += rng.normal(0, 0.33, n)
-    return Figure(
+    return fc.scatter_chart(
+        fc.scatter(x, y, opacity=0.9),
+        fc.x_axis(label="x"),
+        fc.y_axis(label="y"),
         title="10M density scatter",
-        x_label="x",
-        y_label="y",
         width="100%",
         height=430,
-    ).scatter(x, y, opacity=0.9)
+    )
 
 
-def histogram_demo() -> Figure:
+def histogram_demo() -> fc.Chart:
     rng = np.random.default_rng(41)
     n = 500_000
     values = np.concatenate(
@@ -191,16 +199,17 @@ def histogram_demo() -> Figure:
             rng.normal(1.4, 0.8, n // 2),
         ]
     )
-    return Figure(
+    return fc.histogram_chart(
+        fc.hist(values, bins=160, name="distribution", color="#3b82f6", opacity=0.82),
+        fc.x_axis(label="value"),
+        fc.y_axis(label="count"),
         title="500k sample histogram",
-        x_label="value",
-        y_label="count",
         width="100%",
         height=430,
-    ).hist(values, bins=160, name="distribution", color="#3b82f6", opacity=0.82)
+    )
 
 
-def bar_column_demo() -> Figure:
+def bar_column_demo() -> fc.Chart:
     categories = ["Search", "Ads", "Email", "Direct", "Partner", "Social"]
     values = np.array(
         [
@@ -209,23 +218,24 @@ def bar_column_demo() -> Figure:
             [42.0, 39.0, 26.0, 31.0, 19.0, 14.0],
         ]
     )
-    return Figure(
+    return fc.bar_chart(
+        fc.bar(
+            categories,
+            values,
+            mode="grouped",
+            series=["Desktop", "Mobile", "Tablet"],
+            colors=["#2563eb", "#16a34a", "#f59e0b"],
+            opacity=0.86,
+        ),
+        fc.x_axis(label="channel"),
+        fc.y_axis(label="conversions"),
         title="Grouped category bars",
-        x_label="channel",
-        y_label="conversions",
         width="100%",
         height=430,
-    ).bar(
-        categories,
-        values,
-        mode="grouped",
-        series=["Desktop", "Mobile", "Tablet"],
-        colors=["#2563eb", "#16a34a", "#f59e0b"],
-        opacity=0.86,
     )
 
 
-def stacked_bar_demo() -> Figure:
+def stacked_bar_demo() -> fc.Chart:
     quarters = ["Q1", "Q2", "Q3", "Q4"]
     values = np.array(
         [
@@ -234,42 +244,44 @@ def stacked_bar_demo() -> Figure:
             [16.0, 19.0, 24.0, 29.0],
         ]
     )
-    return Figure(
+    return fc.column_chart(
+        fc.column(
+            quarters,
+            values,
+            mode="stacked",
+            series=["Core", "Expansion", "Services"],
+            colors=["#0f766e", "#7c3aed", "#dc2626"],
+            opacity=0.88,
+        ),
+        fc.x_axis(label="quarter"),
+        fc.y_axis(label="revenue"),
         title="Stacked revenue bars",
-        x_label="quarter",
-        y_label="revenue",
         width="100%",
         height=430,
-    ).column(
-        quarters,
-        values,
-        mode="stacked",
-        series=["Core", "Expansion", "Services"],
-        colors=["#0f766e", "#7c3aed", "#dc2626"],
-        opacity=0.88,
     )
 
 
-def horizontal_bar_demo() -> Figure:
+def horizontal_bar_demo() -> fc.Chart:
     regions = ["NA", "EU", "APAC", "LATAM", "MEA"]
     values = np.array([142.0, 128.0, 116.0, 74.0, 52.0])
-    return Figure(
+    return fc.bar_chart(
+        fc.bar(
+            regions,
+            values,
+            orientation="horizontal",
+            name="revenue",
+            color="#9333ea",
+            opacity=0.86,
+        ),
+        fc.x_axis(label="revenue"),
+        fc.y_axis(label="region"),
         title="Horizontal category bars",
-        x_label="revenue",
-        y_label="region",
         width="100%",
         height=430,
-    ).bar(
-        regions,
-        values,
-        orientation="horizontal",
-        name="revenue",
-        color="#9333ea",
-        opacity=0.86,
     )
 
 
-def heatmap_demo() -> Figure:
+def heatmap_demo() -> fc.Chart:
     rng = np.random.default_rng(97)
     cols = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
     rows = ["00", "04", "08", "12", "16", "20"]
@@ -285,13 +297,14 @@ def heatmap_demo() -> Figure:
         dtype=np.float64,
     )
     z = base + rng.normal(0, 0.025, base.shape)
-    return Figure(
+    return fc.heatmap_chart(
+        fc.heatmap(z, x=cols, y=rows, name="activity", colormap="turbo", opacity=0.94),
+        fc.x_axis(label="day"),
+        fc.y_axis(label="hour"),
         title="Weekly activity heatmap",
-        x_label="day",
-        y_label="hour",
         width="100%",
         height=430,
-    ).heatmap(z, x=cols, y=rows, name="activity", colormap="turbo", opacity=0.94)
+    )
 
 
 def composed_layers_demo() -> fc.Chart:

--- a/python/fastcharts/__init__.py
+++ b/python/fastcharts/__init__.py
@@ -4,10 +4,8 @@ Cost scales with pixels on screen, not points in the dataset: native Rust core
 in the Python process, offset-encoded f32 binary transport, M4 decimation, GPU
 density aggregation, and a WebGL2 render client. See docs/design-dossier.md.
 
-Two APIs over one engine:
-
-- **Fluent** (`Figure().scatter(...).line(...)`) — quick and imperative.
-- **Composition** (Reflex-flavored) — declarative, `on_*` event props:
+One declarative API over one engine — Reflex-flavored composition with
+`on_*` event props:
 
       import fastcharts as fc
       fc.scatter_chart(
@@ -37,13 +35,12 @@ _EXPORTS = {
     "Column": ".columns",
     "ColumnStore": ".columns",
     "Component": ".components",
-    "Figure": ".figure",
     "Interaction": ".components",
     "Legend": ".components",
     "Mark": ".components",
     "MarkStyle": ".components",
     "Modebar": ".components",
-    "Selection": ".figure",
+    "Selection": "._figure",
     "Theme": ".components",
     "Tooltip": ".components",
     "ZoneMaps": ".columns",
@@ -92,7 +89,6 @@ __all__ = [
     "Column",
     "ColumnStore",
     "Component",
-    "Figure",
     "Interaction",
     "Legend",
     "Mark",
@@ -159,6 +155,7 @@ def __dir__() -> list[str]:
 
 
 if TYPE_CHECKING:
+    from ._figure import Selection
     from .columns import Column, ColumnStore, ZoneMaps
     from .components import (
         Annotation,
@@ -209,4 +206,3 @@ if TYPE_CHECKING:
         y_band,
     )
     from .dom import CHART_DOM_SLOTS
-    from .figure import Figure, Selection

--- a/python/fastcharts/_annotations.py
+++ b/python/fastcharts/_annotations.py
@@ -1,7 +1,7 @@
 """Annotation builders for `Figure` (vline/hline/band/callout/text/marker/
 arrow + reference-line and zone helpers) and the annotation spec compiler.
 
-Split out of `figure.py` as a mixin: `Figure` inherits `AnnotationsMixin`, so
+Split out of `_figure.py` as a mixin: `Figure` inherits `AnnotationsMixin`, so
 `fig.vline(...)` etc. are unchanged and every `self.*` (validators, the column
 store, `self.annotations`, rollback) resolves through the concrete `Figure` via
 the MRO. Only numpy + the columns/channels helpers are needed at module level."""
@@ -18,8 +18,8 @@ if TYPE_CHECKING:
     # Type-only host base: `self.*` (validators, column store, annotations)
     # resolves against the Figure surface. `FigureHost` is a Protocol, so there
     # is no nominal inheritance cycle; at runtime the base is plain `object`.
+    from ._figure import Figure  # noqa: F401  (resolves the `-> "Figure"` returns)
     from ._hosts import FigureHost as _Host
-    from .figure import Figure  # noqa: F401  (resolves the `-> "Figure"` returns)
 else:
     _Host = object
 

--- a/python/fastcharts/_figure.py
+++ b/python/fastcharts/_figure.py
@@ -23,7 +23,7 @@ from .columns import Column, ColumnStore, ColumnStoreCheckpoint
 
 # Tier/tuning constants live in config.py (shared with interaction/export/
 # _payload); several are re-exported here — this module is their historic
-# import path and tests import them from `fastcharts.figure` (F401 kept for
+# import path and tests import them from `fastcharts._figure` (F401 kept for
 # the re-exports; DIRECT_SOFT_CEILING/DEFAULT_PALETTE are also used below).
 from .config import (  # noqa: E402, F401
     DECIMATION_THRESHOLD,
@@ -529,7 +529,14 @@ class Figure(AnnotationsMixin, PayloadMixin):
     @staticmethod
     def _is_category_like(values: Any) -> bool:
         if hasattr(values, "to_numpy"):
-            values = values.to_numpy()
+            try:
+                values = values.to_numpy()
+            except ValueError:
+                # pyarrow Arrays with nulls refuse the default zero-copy
+                # conversion (ArrowInvalid is a ValueError). This is only a
+                # dtype probe, so inspect an empty slice instead of paying an
+                # O(n) copy of the column.
+                values = values[:0].to_numpy(zero_copy_only=False)
         arr = np.asarray(values)
         return arr.dtype.kind in ("U", "S", "O", "b")
 
@@ -540,6 +547,11 @@ class Figure(AnnotationsMixin, PayloadMixin):
         arr = np.asarray(values)
         if arr.ndim != 1:
             raise ValueError(f"{axis} categories must be 1-D, got shape {arr.shape}")
+        if arr.dtype.kind == "U":
+            # A unicode array cannot hold missing/bytes values, so
+            # `category_label` reduces to `str` — and `tolist()` already
+            # yields plain `str`. Skips two O(n) Python passes per axis.
+            return arr.tolist()
         return [channels.category_label(raw) for raw in arr.astype(object)]
 
     def _axis_positions(self, values: Any, axis: str, *, commit: bool = True) -> np.ndarray:

--- a/python/fastcharts/_native.py
+++ b/python/fastcharts/_native.py
@@ -24,7 +24,7 @@ import numpy.typing as npt
 
 from .config import MAX_SCREEN_DIM
 
-ABI_VERSION = 10
+ABI_VERSION = 11
 
 # Rust reports invalid arguments (and, via the ffi_guard panic shield, any
 # internal panic) by returning `usize::MAX` from size-returning entry points.
@@ -33,12 +33,6 @@ ABI_VERSION = 10
 # against 2**64-1 would never match on 32-bit targets and an error return
 # would be sliced as data.
 _USIZE_MAX = ctypes.c_size_t(-1).value
-
-_F64_P = ctypes.POINTER(ctypes.c_double)
-_F32_P = ctypes.POINTER(ctypes.c_float)
-_U64_P = ctypes.POINTER(ctypes.c_uint64)
-_U32_P = ctypes.POINTER(ctypes.c_uint32)
-_U8_P = ctypes.POINTER(ctypes.c_uint8)
 
 
 def _lib_filename() -> str:
@@ -87,40 +81,42 @@ def _load() -> ctypes.CDLL:
 
     lib.fc_zone_maps.restype = ctypes.c_size_t
     lib.fc_zone_maps.argtypes = [
-        _F64_P,
+        ctypes.c_void_p,
         ctypes.c_size_t,
         ctypes.c_size_t,
-        _F64_P,
-        _F64_P,
-        _U64_P,
-        _U64_P,
-        _F64_P,
-        _F64_P,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
     ]
     lib.fc_encode_f32.restype = ctypes.c_int32
     lib.fc_encode_f32.argtypes = [
-        _F64_P,
+        ctypes.c_void_p,
         ctypes.c_size_t,
         ctypes.c_double,
         ctypes.c_double,
-        _F32_P,
+        ctypes.c_void_p,
     ]
     lib.fc_m4_indices.restype = ctypes.c_size_t
     lib.fc_m4_indices.argtypes = [
-        _F64_P,
-        _F64_P,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
         ctypes.c_size_t,
         ctypes.c_double,
         ctypes.c_double,
         ctypes.c_size_t,
-        _U32_P,
+        ctypes.c_void_p,
     ]
     lib.fc_min_max.restype = ctypes.c_int32
-    lib.fc_min_max.argtypes = [_F64_P, ctypes.c_size_t, _F64_P, _F64_P]
+    lib.fc_min_max.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_void_p, ctypes.c_void_p]
+    lib.fc_is_sorted.restype = ctypes.c_int32
+    lib.fc_is_sorted.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
     lib.fc_bin_2d.restype = ctypes.c_int32
     lib.fc_bin_2d.argtypes = [
-        _F64_P,
-        _F64_P,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
         ctypes.c_size_t,
         ctypes.c_double,
         ctypes.c_double,
@@ -128,12 +124,12 @@ def _load() -> ctypes.CDLL:
         ctypes.c_double,
         ctypes.c_size_t,
         ctypes.c_size_t,
-        _F32_P,
+        ctypes.c_void_p,
     ]
     lib.fc_bin_2d_indices.restype = ctypes.c_size_t
     lib.fc_bin_2d_indices.argtypes = [
-        _F64_P,
-        _F64_P,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
         ctypes.c_size_t,
         ctypes.c_double,
         ctypes.c_double,
@@ -141,62 +137,62 @@ def _load() -> ctypes.CDLL:
         ctypes.c_double,
         ctypes.c_size_t,
         ctypes.c_size_t,
-        _F32_P,
-        _U32_P,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
     ]
     lib.fc_histogram_uniform.restype = ctypes.c_size_t
     lib.fc_histogram_uniform.argtypes = [
-        _F64_P,
+        ctypes.c_void_p,
         ctypes.c_size_t,
         ctypes.c_double,
         ctypes.c_double,
         ctypes.c_size_t,
         ctypes.c_int32,
-        _F64_P,
+        ctypes.c_void_p,
     ]
     lib.fc_normalize_f32.restype = ctypes.c_int32
     lib.fc_normalize_f32.argtypes = [
-        _F64_P,
+        ctypes.c_void_p,
         ctypes.c_size_t,
         ctypes.c_double,
         ctypes.c_double,
         ctypes.c_int32,
-        _F32_P,
+        ctypes.c_void_p,
     ]
     lib.fc_range_indices.restype = ctypes.c_size_t
     lib.fc_range_indices.argtypes = [
-        _F64_P,
-        _F64_P,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
         ctypes.c_size_t,
         ctypes.c_double,
         ctypes.c_double,
         ctypes.c_double,
         ctypes.c_double,
-        _U32_P,
+        ctypes.c_void_p,
     ]
     lib.fc_sample_mask.restype = ctypes.c_int32
     lib.fc_sample_mask.argtypes = [
-        _U64_P,
+        ctypes.c_void_p,
         ctypes.c_size_t,
         ctypes.c_uint64,
         ctypes.c_uint64,
-        _U8_P,
+        ctypes.c_void_p,
     ]
     lib.fc_stratified_sample_mask.restype = ctypes.c_int32
     lib.fc_stratified_sample_mask.argtypes = [
-        _U64_P,  # ids
-        _U32_P,  # groups
+        ctypes.c_void_p,  # ids
+        ctypes.c_void_p,  # groups
         ctypes.c_size_t,  # len
         ctypes.c_size_t,  # n_groups
         ctypes.c_uint64,  # seed
         ctypes.c_double,  # fraction
         ctypes.c_uint64,  # min_count
-        _U8_P,  # out
+        ctypes.c_void_p,  # out
     ]
     lib.fc_pyramid_build.restype = ctypes.c_uint64
     lib.fc_pyramid_build.argtypes = [
-        ctypes.POINTER(ctypes.c_double),
-        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_void_p,
+        ctypes.c_void_p,
         ctypes.c_size_t,
         ctypes.c_double,
         ctypes.c_double,
@@ -211,7 +207,7 @@ def _load() -> ctypes.CDLL:
         ctypes.c_double,
         ctypes.c_double,
         ctypes.c_double,
-        ctypes.POINTER(ctypes.c_double),
+        ctypes.c_void_p,
     ]
     lib.fc_pyramid_compose.restype = ctypes.c_int32
     lib.fc_pyramid_compose.argtypes = [
@@ -222,14 +218,14 @@ def _load() -> ctypes.CDLL:
         ctypes.c_double,
         ctypes.c_size_t,
         ctypes.c_size_t,
-        ctypes.POINTER(ctypes.c_float),
+        ctypes.c_void_p,
     ]
     lib.fc_pyramid_free.restype = ctypes.c_int32
     lib.fc_pyramid_free.argtypes = [ctypes.c_uint64]
     lib.fc_local_log_density.restype = ctypes.c_int32
     lib.fc_local_log_density.argtypes = [
-        _F64_P,
-        _F64_P,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
         ctypes.c_size_t,
         ctypes.c_double,
         ctypes.c_double,
@@ -237,13 +233,13 @@ def _load() -> ctypes.CDLL:
         ctypes.c_double,
         ctypes.c_size_t,
         ctypes.c_size_t,
-        _F32_P,
+        ctypes.c_void_p,
     ]
     lib.fc_rasterize.restype = ctypes.c_int32
     lib.fc_rasterize.argtypes = [
-        _U8_P,  # cmd
+        ctypes.c_void_p,  # cmd
         ctypes.c_size_t,  # cmd_len
-        _U8_P,  # out (w*h*4 RGBA8)
+        ctypes.c_void_p,  # out (w*h*4 RGBA8)
         ctypes.c_size_t,  # w
         ctypes.c_size_t,  # h
     ]
@@ -254,7 +250,7 @@ def _load() -> ctypes.CDLL:
         ctypes.c_size_t,  # prop_len
         ctypes.c_char_p,  # value (UTF-8)
         ctypes.c_size_t,  # value_len
-        _F32_P,  # out_rgba (4 f32s; written for statically-parsed colors)
+        ctypes.c_void_p,  # out_rgba (4 f32s; written for statically-parsed colors)
     ]
     return lib
 
@@ -269,12 +265,16 @@ def _as_f64(arr: npt.NDArray[np.float64], label: str = "data") -> npt.NDArray[np
     return out
 
 
-def _ptr_f64(arr: npt.NDArray[np.float64]):  # noqa: ANN202
-    return arr.ctypes.data_as(_F64_P)
+def _ptr_f64(arr: npt.NDArray[np.float64]) -> int:
+    # Raw address int for a c_void_p parameter: ~2x cheaper per call than
+    # `ctypes.data_as(...)`, which allocates a fresh pointer object. The
+    # typed wrappers above are the type-safety layer (`_as_f64` etc.), so
+    # the C boundary can take the untyped address.
+    return arr.ctypes.data
 
 
-def _ptr_u8(arr: npt.NDArray[np.uint8]):  # noqa: ANN202
-    return arr.ctypes.data_as(_U8_P)
+def _ptr_u8(arr: npt.NDArray[np.uint8]) -> int:
+    return arr.ctypes.data
 
 
 def _positive_int(value: int, label: str) -> int:
@@ -371,8 +371,8 @@ def zone_maps(
         chunk_size,
         _ptr_f64(mins),
         _ptr_f64(maxs),
-        counts.ctypes.data_as(_U64_P),
-        nulls.ctypes.data_as(_U64_P),
+        counts.ctypes.data,
+        nulls.ctypes.data,
         _ptr_f64(sums),
         _ptr_f64(sum_sqs),
     )
@@ -395,7 +395,7 @@ def encode_f32(
     if len(data) == 0:  # empty NumPy arrays may carry a null pointer
         return np.empty(0, dtype=np.float32)
     out = np.empty(len(data), dtype=np.float32)
-    ok = _lib.fc_encode_f32(_ptr_f64(data), len(data), offset, scale, out.ctypes.data_as(_F32_P))
+    ok = _lib.fc_encode_f32(_ptr_f64(data), len(data), offset, scale, out.ctypes.data)
     if ok != 1:
         raise RuntimeError("fastcharts native encode_f32 failed (output undefined)")
     return out
@@ -425,7 +425,7 @@ def m4_indices(
         x0,
         x1,
         n_buckets,
-        out.ctypes.data_as(_U32_P),
+        out.ctypes.data,
     )
     if written == _USIZE_MAX:
         raise ValueError("invalid m4 arguments")
@@ -463,7 +463,7 @@ def bin_2d(
             y1,
             w,
             h,
-            out.ctypes.data_as(_F32_P),
+            out.ctypes.data,
         )
         if not ok:
             raise ValueError("invalid bin_2d arguments")
@@ -508,12 +508,21 @@ def bin_2d_indices(
         y1,
         w,
         h,
-        grid.ctypes.data_as(_F32_P),
-        idx.ctypes.data_as(_U32_P),
+        grid.ctypes.data,
+        idx.ctypes.data,
     )
     if written == _USIZE_MAX:
         raise ValueError("invalid bin_2d_indices arguments")
     return grid, idx[:written].copy()
+
+
+def is_sorted(data: npt.NDArray[np.float64]) -> bool:
+    """Non-decreasing check with NaN-poisoning (any NaN fails its pairs) —
+    identical to ``np.all(np.diff(data) >= 0)`` without the two temporaries."""
+    data = _as_f64(data, "data")
+    if len(data) < 2:
+        return True
+    return bool(_lib.fc_is_sorted(_ptr_f64(data), len(data)))
 
 
 def min_max(data: npt.NDArray[np.float64]) -> Optional[tuple[float, float]]:
@@ -573,9 +582,7 @@ def normalize_f32(
     out = np.empty(len(data), dtype=np.float32)
     nan_mode = 1 if nonfinite == "nan" else 0
     if len(data):
-        ok = _lib.fc_normalize_f32(
-            _ptr_f64(data), len(data), lo, hi, nan_mode, out.ctypes.data_as(_F32_P)
-        )
+        ok = _lib.fc_normalize_f32(_ptr_f64(data), len(data), lo, hi, nan_mode, out.ctypes.data)
         if ok != 1:
             raise RuntimeError("fastcharts native normalize_f32 failed (output undefined)")
     return out
@@ -607,7 +614,7 @@ def range_indices(
         hi_x,
         lo_y,
         hi_y,
-        out.ctypes.data_as(_U32_P),
+        out.ctypes.data,
     )
     if written == _USIZE_MAX:
         raise ValueError("invalid range_indices arguments")
@@ -631,11 +638,11 @@ def sample_mask(
     out = np.empty(len(ids), dtype=np.uint8)
     if len(ids):
         ok = _lib.fc_sample_mask(
-            ids.ctypes.data_as(_U64_P),
+            ids.ctypes.data,
             len(ids),
             ctypes.c_uint64(int(seed)),
             ctypes.c_uint64(int(threshold)),
-            out.ctypes.data_as(_U8_P),
+            out.ctypes.data,
         )
         if ok != 1:
             raise RuntimeError("fastcharts native sample_mask failed (output undefined)")
@@ -675,14 +682,14 @@ def stratified_sample_mask(
     out = np.empty(len(ids), dtype=np.uint8)
     if len(ids):
         ok = _lib.fc_stratified_sample_mask(
-            ids.ctypes.data_as(_U64_P),
-            groups.ctypes.data_as(_U32_P),
+            ids.ctypes.data,
+            groups.ctypes.data,
             len(ids),
             n_groups,
             ctypes.c_uint64(int(seed)),
             ctypes.c_double(fraction),
             ctypes.c_uint64(min_count),
-            out.ctypes.data_as(_U8_P),
+            out.ctypes.data,
         )
         if ok != 1:
             raise ValueError(
@@ -712,8 +719,8 @@ def pyramid_build(
         return 0
     return int(
         _lib.fc_pyramid_build(
-            x.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
-            y.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+            x.ctypes.data,
+            y.ctypes.data,
             len(x),
             x0,
             x1,
@@ -759,7 +766,7 @@ def pyramid_compose(
         hi_y,
         w,
         h,
-        out.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+        out.ctypes.data,
     )
     if level < 0:
         return None
@@ -801,7 +808,7 @@ def local_log_density(
             hi_y,
             w,
             h,
-            out.ctypes.data_as(_F32_P),
+            out.ctypes.data,
         )
         if not ok:
             raise ValueError("invalid local_log_density arguments")

--- a/python/fastcharts/_payload.py
+++ b/python/fastcharts/_payload.py
@@ -1,6 +1,6 @@
 """Wire-spec compiler for `Figure`: `build_payload` plus the per-kind
 emitters and the Tier-2 density/sample specs, and the `_PayloadWriter` that
-owns the binary blob + column table. Split out of `figure.py` as a mixin;
+owns the binary blob + column table. Split out of `_figure.py` as a mixin;
 `Figure` inherits `PayloadMixin`, so every `self.*` resolves through the
 concrete `Figure` via the MRO (§29: data moves as raw f32 buffers)."""
 

--- a/python/fastcharts/_trace.py
+++ b/python/fastcharts/_trace.py
@@ -1,5 +1,5 @@
 """The `Trace` value object — one built chart series, canonical f64
-columns plus tier/drill bookkeeping. Split out of `figure.py` so both the
+columns plus tier/drill bookkeeping. Split out of `_figure.py` so both the
 builders (`figure`) and the wire-spec emitters (`_payload`) can share it
 without a load-time cycle."""
 

--- a/python/fastcharts/channel.py
+++ b/python/fastcharts/channel.py
@@ -35,12 +35,12 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
-from .figure import Selection
+from ._figure import Selection
 from .interaction import _integer_id
 from .lod import normalize_window
 
 if TYPE_CHECKING:
-    from .figure import Figure
+    from ._figure import Figure
 
 __all__ = ["ChannelCallbacks", "handle_message"]
 

--- a/python/fastcharts/components.py
+++ b/python/fastcharts/components.py
@@ -39,8 +39,8 @@ from typing import Any, Optional, TypeAlias, Union
 import numpy as np
 
 from . import _validate, channels
+from ._figure import Figure, Selection
 from .dom import CHART_DOM_SLOTS, validate_dom_slots
-from .figure import Figure, Selection
 
 # Shared validators (single source of truth in `_validate`); these aliases keep
 # the module-private names their call sites already use.
@@ -1117,14 +1117,36 @@ def _resolve(data: Any, key: Any, *, context: Optional[str] = None) -> Any:
 
 def _resolve_axis_values(fig: Figure, data: Any, key: Any, axis: str, context: str) -> Any:
     values = _resolve(data, key, context=context)
-    if values is not None and Figure._is_category_like(values) and not _is_datetime_like(values):
+    if values is None:
+        return None
+    # Fast paths that keep the dtype probes off the timed ingestion workflow
+    # (§12). A dtype-carrying numeric (NumPy array, pandas Series) can never
+    # be category- or datetime-like, so skip the probes outright. A plain
+    # Python list/tuple is converted exactly once here and the array is
+    # passed on — otherwise `_is_category_like`, `_is_datetime_like`, and
+    # engine ingest each re-run the same O(n) conversion on the raw list.
+    dtype = getattr(values, "dtype", None)
+    if dtype is not None:
+        if getattr(dtype, "kind", "") in "fiu":
+            return values
+    elif isinstance(values, (list, tuple)):
+        values = np.asarray(values)
+        if values.dtype.kind in "fiu":
+            return values
+    if Figure._is_category_like(values) and not _is_datetime_like(values):
         return fig._axis_positions(values, axis)
     return values
 
 
 def _is_datetime_like(values: Any) -> bool:
     if hasattr(values, "to_numpy"):
-        values = values.to_numpy()
+        try:
+            values = values.to_numpy()
+        except ValueError:
+            # pyarrow Arrays with nulls refuse the default zero-copy
+            # conversion (ArrowInvalid is a ValueError); this probe needs the
+            # actual values, so allow the copy.
+            values = values.to_numpy(zero_copy_only=False)
     arr = np.asarray(values)
     if np.issubdtype(arr.dtype, np.datetime64):
         return True

--- a/python/fastcharts/export.py
+++ b/python/fastcharts/export.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional, SupportsFloat, SupportsIndex, cast
 
 if TYPE_CHECKING:
-    from .figure import Figure
+    from ._figure import Figure
 
 # Warn above this payload size; base64 carries a stated ~33% tax (§29).
 EMBED_WARN_BYTES = 64 * 2**20

--- a/python/fastcharts/interaction.py
+++ b/python/fastcharts/interaction.py
@@ -31,7 +31,7 @@ from .config import (
 )
 
 if TYPE_CHECKING:
-    from .figure import Figure
+    from ._figure import Figure
 
 
 def _integer_id(value: int, label: str) -> int:

--- a/python/fastcharts/kernels.py
+++ b/python/fastcharts/kernels.py
@@ -35,6 +35,7 @@ css_check = _impl.css_check
 zone_maps = _impl.zone_maps
 encode_f32 = _impl.encode_f32
 m4_indices = _impl.m4_indices
+is_sorted = _impl.is_sorted
 min_max = _impl.min_max
 bin_2d = _impl.bin_2d
 bin_2d_indices = _impl.bin_2d_indices
@@ -61,6 +62,7 @@ __all__ = [
     "css_check",
     "encode_f32",
     "histogram_uniform",
+    "is_sorted",
     "local_log_density",
     "m4_indices",
     "min_max",

--- a/python/fastcharts/marks.py
+++ b/python/fastcharts/marks.py
@@ -4,7 +4,7 @@ Each function here IS both public dialects: `Figure` binds them as its fluent
 methods (`Figure.scatter is marks.scatter`), and the composition API's
 appliers call those same bound methods. One body, one signature, one set of
 defaults — the parity tests assert the identity. Functions take the figure
-as `self` (they are written as methods; `figure.py` assigns them in the class
+as `self` (they are written as methods; `__figure.py` assigns them in the class
 body) and reach engine state — store, traces, checkpoint/rollback, ingest and
 axis-position helpers — through it.
 """
@@ -21,7 +21,7 @@ from ._trace import Trace
 from .config import DEFAULT_PALETTE, DIRECT_SOFT_CEILING
 
 if TYPE_CHECKING:
-    from .figure import Figure
+    from ._figure import Figure
 
 
 def _bar_like(
@@ -154,11 +154,11 @@ def line(
     checkpoint = self._checkpoint()
     try:
         xc, yc = self._ingest_xy(x, y, "line")
-        if not np.all(np.diff(xc.values) >= 0):
+        if not kernels.is_sorted(xc.values):
             # LOD contract (§28): line x must be sorted; the engine sorts once
             # at ingest, and says so. The predicate is NaN-safe on purpose:
-            # `any(diff < 0)` is False for NaN diffs, which would let a
-            # NaN-carrying x skip the sort and violate M4's sorted precondition.
+            # a NaN fails its pairs, so a NaN-carrying x cannot skip the sort
+            # and violate M4's sorted precondition.
             # argsort places NaNs last, where the m4 window excludes them.
             order = np.argsort(xc.values, kind="stable")
             xc = self.store.ingest(xc.values[order])
@@ -225,7 +225,7 @@ def area(
         )
         if len(bc) != len(xc):
             raise ValueError(f"area base must have length {len(xc)}, got {len(bc)}")
-        if not np.all(np.diff(xc.values) >= 0):
+        if not kernels.is_sorted(xc.values):
             order = np.argsort(xc.values, kind="stable")
             xc = self.store.ingest(xc.values[order])
             yc = self.store.ingest(yc.values[order])

--- a/python/fastcharts/widget.py
+++ b/python/fastcharts/widget.py
@@ -14,14 +14,13 @@ from typing import TYPE_CHECKING, Any
 import anywidget
 import traitlets
 
-from .channel import ChannelCallbacks, handle_message
-
 # Selection lives in figure.py (it's the on_select payload and has no widget
 # dependency); re-exported here for backward compatibility.
-from .figure import Selection
+from ._figure import Selection
+from .channel import ChannelCallbacks, handle_message
 
 if TYPE_CHECKING:
-    from .figure import Figure
+    from ._figure import Figure
 
 _STATIC = pathlib.Path(__file__).parent / "static"
 

--- a/scripts/abi_smoke.py
+++ b/scripts/abi_smoke.py
@@ -83,6 +83,8 @@ def load() -> ctypes.CDLL:
     ]
     lib.fc_min_max.restype = ctypes.c_int32
     lib.fc_min_max.argtypes = [F64P, ctypes.c_size_t, F64P, F64P]
+    lib.fc_is_sorted.restype = ctypes.c_int32
+    lib.fc_is_sorted.argtypes = [F64P, ctypes.c_size_t]
     D = ctypes.c_double
     Z = ctypes.c_size_t
     lib.fc_bin_2d.restype = ctypes.c_int32
@@ -205,6 +207,14 @@ def main() -> None:
         == 0,
         "min_max empty/null returns zero",
     )
+    ok(lib.fc_is_sorted(null_f64, 0) == 1, "is_sorted empty is sorted")
+    ok(lib.fc_is_sorted(null_f64, 2) == 0, "is_sorted null non-empty returns unsorted")
+    sorted_pair = array("d", [1.0, 2.0])
+    unsorted_pair = array("d", [2.0, 1.0])
+    nan_pair = array("d", [1.0, float("nan")])
+    ok(lib.fc_is_sorted(_ptr(sorted_pair, ctypes.c_double), 2) == 1, "is_sorted sorted pair")
+    ok(lib.fc_is_sorted(_ptr(unsorted_pair, ctypes.c_double), 2) == 0, "is_sorted unsorted pair")
+    ok(lib.fc_is_sorted(_ptr(nan_pair, ctypes.c_double), 2) == 0, "is_sorted NaN poisons")
     empty_grid = array("f", [99.0]) * 4
     ok(
         lib.fc_bin_2d(

--- a/scripts/check_public_api.py
+++ b/scripts/check_public_api.py
@@ -37,7 +37,7 @@ HEAVY_FASTCHARTS_IMPORTS = {
     "fastcharts.channel",
     "fastcharts.columns",
     "fastcharts.components",
-    "fastcharts.figure",
+    "fastcharts._figure",
     "fastcharts.interaction",
     "fastcharts.kernels",
     "fastcharts.lod",

--- a/scripts/png_export_smoke.py
+++ b/scripts/png_export_smoke.py
@@ -5,7 +5,7 @@ Two engines, both without installing numpy:
 - **native** (always runs): drives the Rust rasterizer `fc_rasterize` directly
   via ctypes with a hand-built display-list command buffer, encodes the returned
   framebuffer to PNG, and asserts a real, correctly-sized, non-blank image — the
-  end-to-end browser-free `Figure.to_png(engine="native")` mechanism.
+  end-to-end browser-free `Chart.to_png(engine="native")` mechanism.
 - **chromium** (skipped without a browser): renders a hand-built standalone
   chart HTML through headless Chromium (`export.html_to_png`), the
   `engine="chromium"` path.

--- a/scripts/render_smoke_nonumpy.py
+++ b/scripts/render_smoke_nonumpy.py
@@ -1,7 +1,8 @@
 """Headless render smoke that needs neither numpy nor PyPI.
 
 Builds a payload by hand (stdlib `array` + `struct`) in exactly the wire shape
-`Figure.build_payload` emits, drives the pre-installed Chromium against the
+the internal figure's `build_payload` emits, drives the pre-installed Chromium
+against the
 standalone JS bundle, and reads back a lit-pixel count via gl.readPixels. This
 verifies the *render client* — the half cargo can't touch — in a locked-down
 environment. The numpy-backed `scripts/smoke_render.py` supersedes it once deps

--- a/scripts/smoke_render.py
+++ b/scripts/smoke_render.py
@@ -2,7 +2,7 @@
 screen for a real payload? (§12 — a renderer's correctness oracle is an image.)
 
 Drives headless Chromium directly (no Playwright dependency): builds a
-standalone page the same way `Figure.to_html` does, adds a probe that draws
+standalone page the same way `Chart.to_html` does, adds a probe that draws
 synchronously and counts non-transparent pixels via gl.readPixels, then reads
 the result out of the dumped DOM title.
 
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import numpy as np
 
-from fastcharts import Figure
+import fastcharts as fc
 from fastcharts.export import _bundled_js
 
 CHROMIUM_CANDIDATES = [
@@ -51,10 +51,12 @@ def build_page() -> str:
     x = np.arange(n, dtype=np.float64)
     rng = np.random.default_rng(1)
     y = np.cumsum(rng.normal(size=n))
-    fig = Figure(title="smoke")
-    fig.line(x, y, name="walk")
-    fig.scatter(x[::100], y[::100] + 20.0, name="pts", size=3.0)
-    spec, blob = fig.build_payload()
+    chart = fc.chart(
+        fc.line(x, y, name="walk"),
+        fc.scatter(x[::100], y[::100] + 20.0, name="pts", size=3.0),
+        title="smoke",
+    )
+    spec, blob = chart.figure().build_payload()
     assert spec["traces"][0]["tier"] == "decimated"
 
     return f"""<!doctype html>

--- a/scripts/verify_local.py
+++ b/scripts/verify_local.py
@@ -220,7 +220,7 @@ def _base_checks(
         ),
         Check(
             "smoke_render",
-            "real Figure HTML render smoke in Chromium",
+            "real composed-chart HTML render smoke in Chromium",
             (py, "scripts/smoke_render.py", chromium_arg),
             requires_modules=("numpy",),
             requires_paths=chromium_paths,

--- a/scripts/verify_sdist.py
+++ b/scripts/verify_sdist.py
@@ -74,7 +74,7 @@ REQUIRED_FILES = {
     "python/fastcharts/components.py",
     "python/fastcharts/config.py",
     "python/fastcharts/export.py",
-    "python/fastcharts/figure.py",
+    "python/fastcharts/_figure.py",
     "python/fastcharts/channel.py",
     "python/fastcharts/interaction.py",
     "python/fastcharts/kernels.py",
@@ -335,7 +335,7 @@ def verify_sdist(path: str) -> None:
             "Chart Family Quick Reference",
             "Small Business Chart",
             "Revenue vs pipeline",
-            "Figure().heatmap",
+            "fc.heatmap(",
             "fc.heatmap_chart",
         },
     )

--- a/scripts/verify_wheel.py
+++ b/scripts/verify_wheel.py
@@ -33,7 +33,7 @@ REQUIRED_FILES = {
     "fastcharts/components.py",
     "fastcharts/config.py",
     "fastcharts/export.py",
-    "fastcharts/figure.py",
+    "fastcharts/_figure.py",
     "fastcharts/marks.py",
     "fastcharts/interaction.py",
     "fastcharts/kernels.py",
@@ -295,8 +295,8 @@ def verify_wheel(path: Path, *, expect_native: Optional[bool]) -> None:
             {"__version__", "__all__", "_EXPORTS", "__getattr__"},
         )
         _require_text_markers(
-            "fastcharts/figure.py",
-            zf.read("fastcharts/figure.py"),
+            "fastcharts/_figure.py",
+            zf.read("fastcharts/_figure.py"),
             {
                 "class Figure",
                 "scatter = _marks.scatter",

--- a/src/kernels.rs
+++ b/src/kernels.rs
@@ -1045,6 +1045,15 @@ pub fn min_max(data: &[f64]) -> Option<(f64, f64)> {
     min_max_impl(data, par_threads(data.len()))
 }
 
+/// Non-decreasing check with NaN-poisoning: every consecutive pair must
+/// satisfy `next >= prev`, and any NaN in either position fails the pair
+/// (IEEE comparisons with NaN are false). This is exactly NumPy's
+/// `all(diff(x) >= 0)` — the line/area sorted-ingest predicate (§28) — but
+/// single-pass, allocation-free, and early-exit on the first violation.
+pub fn is_sorted_f64(data: &[f64]) -> bool {
+    data.windows(2).all(|pair| pair[1] >= pair[0])
+}
+
 /// Dispatches to the AVX2 clone when available (simd.rs).
 fn min_max_scan(data: &[f64]) -> (f64, f64) {
     if let Some(mm) = crate::simd::try_min_max(data) {
@@ -1817,5 +1826,19 @@ mod fuzz {
                 assert!((0.0..=1.0).contains(&d), "it={it} i={i} d={d}");
             }
         }
+    }
+
+    #[test]
+    fn is_sorted_matches_numpy_diff_predicate() {
+        assert!(is_sorted_f64(&[]));
+        assert!(is_sorted_f64(&[3.0]));
+        assert!(is_sorted_f64(&[f64::NAN])); // no pairs -> sorted, like all(diff) on empty
+        assert!(is_sorted_f64(&[1.0, 1.0, 2.0]));
+        assert!(is_sorted_f64(&[f64::NEG_INFINITY, 0.0, f64::INFINITY]));
+        assert!(!is_sorted_f64(&[2.0, 1.0]));
+        assert!(!is_sorted_f64(&[1.0, f64::NAN, 3.0])); // NaN poisons its pairs
+        assert!(!is_sorted_f64(&[1.0, 2.0, f64::NAN]));
+        assert!(!is_sorted_f64(&[f64::NAN, 1.0, 2.0]));
+        assert!(!is_sorted_f64(&[0.0, 1.0, 5.0, 4.0, 9.0]));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ fn ffi_guard<R>(sentinel: R, body: impl FnOnce() -> R) -> R {
 /// ABI version — bumped on any signature change. The Python wrapper checks this
 /// at load time and refuses a mismatched library loudly (§33 comm-versioning
 /// rule, applied to the in-process boundary).
-pub const ABI_VERSION: u32 = 10;
+pub const ABI_VERSION: u32 = 11;
 
 #[no_mangle]
 pub extern "C" fn fc_abi_version() -> u32 {
@@ -427,6 +427,26 @@ pub unsafe extern "C" fn fc_bin_2d_indices(
         return 0;
     }
     ffi_guard(usize::MAX, || kernels::bin_2d_indices(x, y, x0, x1, y0, y1, w, h, grid, idx))
+}
+
+/// Non-decreasing + NaN-poisoned check (`next >= prev` for every pair; any
+/// NaN fails its pairs) — the line/area sorted-ingest predicate (§28).
+/// Returns 1 when sorted, 0 when not. Null `data` with `len > 0` returns 0
+/// (callers then sort, which is always safe). Empty and single-element
+/// inputs are sorted.
+///
+/// # Safety
+/// `data` must point to `len` readable f64s (may be null only when `len == 0`).
+#[no_mangle]
+pub unsafe extern "C" fn fc_is_sorted(data: *const f64, len: usize) -> i32 {
+    if len < 2 {
+        return 1;
+    }
+    if data.is_null() {
+        return 0;
+    }
+    let data = std::slice::from_raw_parts(data, len);
+    ffi_guard(0, || i32::from(kernels::is_sorted_f64(data)))
 }
 
 /// NaN-skipping min/max (autorange primitive). Returns 1 and writes the result,

--- a/tests/test_api_parity.py
+++ b/tests/test_api_parity.py
@@ -1,17 +1,18 @@
-"""Guards that the two dialects stay one engine.
+"""Guards that the public composition API and the internal engine stay one.
 
 `marks.py` is the single mark implementation — the declarative core. The
-fluent `Figure` binds those functions as its per-kind methods
-(`Figure.scatter is marks.scatter`), and the composition factories build
-specs that `_MARK_APPLIERS` replay through those same bound methods. The
-recurring failure mode is a keyword or default threaded through one dialect
-but not the other. These tests turn that drift into a CI failure:
+internal `Figure` scene binds those functions as its per-kind methods
+(`Figure.scatter is marks.scatter`), and the public composition factories
+build specs that `_MARK_APPLIERS` replay through those same bound methods.
+The recurring failure mode is a keyword or default threaded through one
+layer but not the other. These tests turn that drift into a CI failure:
 
 1. every factory prop must map to a real engine parameter (or be one of
    the explicit composition-only props),
 2. every engine keyword must be reachable from the factory,
 3. every applier must forward every engine keyword to the engine call,
-4. the fluent methods must BE the marks implementations (identity), and
+4. the engine's per-kind methods must BE the marks implementations
+   (identity), and
 5. factory keyword defaults must equal the engine defaults by value.
 """
 
@@ -22,7 +23,7 @@ import inspect
 import pytest
 
 import fastcharts as fc
-from fastcharts import Figure
+from fastcharts._figure import Figure
 from fastcharts.components import _MARK_APPLIERS
 
 # Props the composition layer owns that intentionally never reach the engine:

--- a/tests/test_arrow_ingest.py
+++ b/tests/test_arrow_ingest.py
@@ -12,7 +12,7 @@ import pytest
 
 pa = pytest.importorskip("pyarrow")
 
-from fastcharts import Figure  # noqa: E402
+from fastcharts._figure import Figure  # noqa: E402
 from fastcharts.columns import ColumnStore  # noqa: E402
 
 

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -11,9 +11,8 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from fastcharts import Figure
+from fastcharts._figure import DECIMATION_THRESHOLD, Figure, Selection
 from fastcharts.channel import ChannelCallbacks, handle_message
-from fastcharts.figure import DECIMATION_THRESHOLD, Selection
 
 
 def handle(fig, content, **cbs):

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -13,6 +13,7 @@ import pytest
 
 import fastcharts as fc
 import fastcharts.export as export_module
+from fastcharts._figure import Figure
 from fastcharts.components import (
     Annotation,
     Axis,
@@ -359,7 +360,7 @@ def test_component_api_default_payload_matches_fluent_figure():
     y = x * 2
 
     component = fc.chart(fc.line(x=x, y=y)).figure()
-    fluent = fc.Figure().line(x, y)
+    fluent = Figure().line(x, y)
     component_spec, component_blob = component.build_payload()
     fluent_spec, fluent_blob = fluent.build_payload()
 
@@ -1531,7 +1532,7 @@ def test_component_to_png_delegates_to_composed_figure(monkeypatch):
         )
         return b"PNG"
 
-    monkeypatch.setattr("fastcharts.figure.Figure.to_png", fake_to_png)
+    monkeypatch.setattr("fastcharts._figure.Figure.to_png", fake_to_png)
 
     data = chart.to_png(
         "out.png",
@@ -1679,7 +1680,7 @@ def test_figure_cached():
 def test_select_range():
     x = np.arange(100.0)
     y = np.arange(100.0)
-    fig = fc.Figure().scatter(x, y)
+    fig = Figure().scatter(x, y)
     sel = fig.select_range(10.0, 20.0, 0.0, 1000.0)
     idx = sel[0]
     assert idx.dtype == np.uint32
@@ -1690,7 +1691,7 @@ def test_select_range_box():
     rng = np.random.default_rng(0)
     x = rng.uniform(0, 100, 1000)
     y = rng.uniform(0, 100, 1000)
-    fig = fc.Figure().scatter(x, y)
+    fig = Figure().scatter(x, y)
     sel = fig.select_range(25.0, 75.0, 25.0, 75.0)
     idx = sel[0]
     expect = np.flatnonzero((x >= 25) & (x <= 75) & (y >= 25) & (y <= 75))
@@ -1699,7 +1700,7 @@ def test_select_range_box():
 
 def test_selection_payload():
     x = np.arange(10.0)
-    fig = fc.Figure().scatter(x, x)
+    fig = Figure().scatter(x, x)
     sel = fig.select_range(2.0, 5.0, 0.0, 100.0)
     payload = Selection(fig, sel)
     assert len(payload) == 4  # indices 2,3,4,5

--- a/tests/test_css_validation.py
+++ b/tests/test_css_validation.py
@@ -13,7 +13,8 @@ import numpy as np
 import pytest
 
 import fastcharts as fc
-from fastcharts import Figure, kernels
+from fastcharts import kernels
+from fastcharts._figure import Figure
 from fastcharts._raster import _parse_color
 
 X = np.arange(8.0)

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -13,17 +13,17 @@ BENCHMARK_DOC = ROOT / "docs" / "benchmark.md"
 PRODUCTION_DOC = ROOT / "docs" / "production-readiness.md"
 REFLEX_SHAPED_API_DOC = ROOT / "docs" / "design" / "reflex-shaped-api.md"
 EXPECTED_QUICK_REFERENCE = {
-    "Line": ("Figure().line", "fc.line_chart", "fc.line"),
-    "Scatter": ("Figure().scatter", "fc.scatter_chart", "fc.scatter"),
-    "Area": ("Figure().area", "fc.area_chart", "fc.area"),
-    "Histogram": ("Figure().histogram", "fc.histogram_chart", "fc.histogram"),
-    "Bar": ("Figure().bar", "fc.bar_chart", "fc.bar"),
-    "Column": ("Figure().column", "fc.column_chart", "fc.column"),
+    "Line": ("fc.line_chart", "fc.line"),
+    "Scatter": ("fc.scatter_chart", "fc.scatter"),
+    "Area": ("fc.area_chart", "fc.area"),
+    "Histogram": ("fc.histogram_chart", "fc.histogram"),
+    "Bar": ("fc.bar_chart", "fc.bar"),
+    "Column": ("fc.column_chart", "fc.column"),
     "Grouped bars": ('mode="grouped"', "fc.bar_chart", "fc.bar"),
     "Stacked bars": ('mode="stacked"', "fc.bar_chart", "fc.bar"),
     "Normalized bars": ('mode="normalized"', "fc.bar_chart", "fc.bar"),
     "Horizontal bars": ('orientation="horizontal"', "fc.bar_chart", "fc.bar"),
-    "Heatmap": ("Figure().heatmap", "fc.heatmap_chart", "fc.heatmap"),
+    "Heatmap": ("fc.heatmap_chart", "fc.heatmap"),
 }
 
 
@@ -152,14 +152,13 @@ def test_api_examples_document_alpha_api_stability_boundary() -> None:
     text = " ".join(API_EXAMPLES.read_text(encoding="utf-8").split())
     required = [
         "API Stability Notes",
-        "Use the fluent `Figure` API for the most stable alpha surface today",
-        "Use the composition API when you want Reflex-shaped",
+        "one public chart-building API: the declarative composition API",
         "column-name resolution through `data=`",
         "`on_hover` / `on_select` callbacks",
         "core composition contract is now stabilizing",
         "CSS/Tailwind-friendly DOM hooks",
-        "same notebook/static export methods as `Figure`",
         "Callback payload details and future adapter packages may still evolve before 1.0",
+        "`chart.figure()` as an advanced escape hatch",
         '`width="100%"`',
         "Standalone `to_html(...)` needs no browser dependency",
         '`to_png(..., engine="chromium")` needs a local Chrome/Chromium executable',
@@ -185,7 +184,8 @@ def test_reflex_shaped_api_doc_tracks_locked_composition_contract() -> None:
     text = " ".join(REFLEX_SHAPED_API_DOC.read_text(encoding="utf-8").split())
     required = [
         "Compatibility Contract",
-        "`Figure` fluent API",
+        "single public chart-building surface",
+        "internal `_figure.Figure` fluent API is no longer public",
         "`Chart.figure()`",
         "`Chart.widget()`",
         "`Chart.show()`",
@@ -217,7 +217,6 @@ def test_api_examples_quick_reference_covers_registered_composition_marks() -> N
 
     rows = "\n".join(_quick_reference_rows().values())
     for mark in sorted(_MARK_APPLIERS):
-        assert f"Figure().{mark}" in rows or mark == "histogram"
         assert f"fc.{mark}" in rows
         assert f"fc.{mark}_chart" in rows or mark in {"bar"}
 
@@ -244,11 +243,11 @@ def test_readme_documents_stability_and_backend_contract() -> None:
         "Stable enough to build on today",
         "Still experimental and expected to change before 1.0",
         "| Surface | Current status | Notes |",
-        "Fluent `Figure` API",
         "Stable alpha",
         "Composition API",
+        "single public chart-building API",
         "Stabilizing alpha",
-        "Declarative `fc.chart(...children)`",
+        "declarative `fc.chart(...children)`",
         "CSS/Tailwind hooks",
         "Reflex integration",
         "Adaptive drilldown internals",
@@ -295,8 +294,8 @@ def test_readme_getting_started_includes_small_business_chart() -> None:
         "Create a small business chart",
         "Revenue vs pipeline",
         "USD thousands",
-        "fig.line(months, revenue",
-        "fig.line(months, pipeline",
+        "fc.line(months, revenue",
+        "fc.line(months, pipeline",
     ]
     for marker in required:
         assert marker in text

--- a/tests/test_figure.py
+++ b/tests/test_figure.py
@@ -13,11 +13,10 @@ import numpy as np
 import pytest
 
 import fastcharts.export as export_module
-from fastcharts import Figure
+from fastcharts._figure import DECIMATION_THRESHOLD, PROTOCOL_VERSION, Figure
 from fastcharts.columns import ColumnStore
 from fastcharts.config import MAX_SCREEN_DIM
 from fastcharts.export import _javascript_for_inline_script, _json_for_inline_script
-from fastcharts.figure import DECIMATION_THRESHOLD, PROTOCOL_VERSION
 
 
 def _payload_col(spec, blob, ref):

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -17,7 +17,7 @@ HEAVY_MODULES = {
     "fastcharts.channel",
     "fastcharts.columns",
     "fastcharts.components",
-    "fastcharts.figure",
+    "fastcharts._figure",
     "fastcharts.interaction",
     "fastcharts.marks",
     "fastcharts.kernels",
@@ -75,7 +75,8 @@ def test_public_metadata_and_dir_are_lazy() -> None:
 
         names = dir(fastcharts)
         assert "__version__" in fastcharts.__all__
-        assert "Figure" in names
+        assert "Figure" not in names
+        assert "Figure" not in fastcharts.__all__
         assert "scatter_chart" in names
         assert fastcharts.__version__
 
@@ -127,7 +128,7 @@ def test_star_import_matches_public_all() -> None:
         )
         assert exported == sorted(fastcharts.__all__)
         assert extras == []
-        assert ns["Figure"] is fastcharts.Figure
+        assert "Figure" not in ns
         assert ns["scatter_chart"] is fastcharts.scatter_chart
         """
     )
@@ -141,15 +142,14 @@ def test_lazy_public_exports_still_work() -> None:
         import fastcharts
         assert "numpy" not in sys.modules
 
-        from fastcharts import Column, Figure, scatter, scatter_chart
+        from fastcharts import Column, scatter, scatter_chart
 
         assert Column is fastcharts.Column
-        assert Figure is fastcharts.Figure
         assert callable(scatter)
         assert callable(scatter_chart)
         assert callable(fastcharts.column)
         assert fastcharts.column(x=["a"], y=[1]).kind == "column"
-        assert "fastcharts.figure" in sys.modules
+        assert "fastcharts._figure" in sys.modules
         assert "numpy" in sys.modules
 
         heavy = {sorted(HEAVY_MODULES)!r}
@@ -159,28 +159,29 @@ def test_lazy_public_exports_still_work() -> None:
     )
 
 
-def test_figure_api_is_the_compute_import_boundary() -> None:
+def test_figure_is_not_public_and_denial_stays_light() -> None:
+    """`Figure` is internal now: the public attribute must raise, and the
+    failed lookup must not drag in the compute stack as a side effect."""
     _run_fresh(
         """
         import sys
 
         import fastcharts
         assert "numpy" not in sys.modules
-        assert "fastcharts.figure" not in sys.modules
+
+        try:
+            fastcharts.Figure
+        except AttributeError:
+            pass
+        else:
+            raise AssertionError("fastcharts.Figure must not be public")
+
+        assert "Figure" not in fastcharts.__all__
+        assert "numpy" not in sys.modules
+        assert "fastcharts._figure" not in sys.modules
         assert "fastcharts.kernels" not in sys.modules
         assert "fastcharts.widget" not in sys.modules
         assert "anywidget" not in sys.modules
-
-        Figure = fastcharts.Figure
-
-        assert Figure.__name__ == "Figure"
-        assert "fastcharts.figure" in sys.modules
-        assert "fastcharts.kernels" in sys.modules
-        assert "numpy" in sys.modules
-        assert "fastcharts._native" in sys.modules
-        assert "fastcharts.widget" not in sys.modules
-        assert "anywidget" not in sys.modules
-        assert "traitlets" not in sys.modules
         """
     )
 
@@ -197,7 +198,7 @@ def test_composition_api_loads_compute_without_widget_stack() -> None:
 
         assert callable(scatter)
         assert "fastcharts.components" in sys.modules
-        assert "fastcharts.figure" in sys.modules
+        assert "fastcharts._figure" in sys.modules
         assert "fastcharts.kernels" in sys.modules
         assert "numpy" in sys.modules
         assert "fastcharts.widget" not in sys.modules
@@ -224,7 +225,7 @@ def test_dom_slot_contract_loads_without_compute_or_widget_stack() -> None:
         assert "tooltip" in slots
         assert "fastcharts.dom" in sys.modules
         assert "fastcharts.components" not in sys.modules
-        assert "fastcharts.figure" not in sys.modules
+        assert "fastcharts._figure" not in sys.modules
         assert "fastcharts.kernels" not in sys.modules
         assert "fastcharts.widget" not in sys.modules
         assert "numpy" not in sys.modules
@@ -239,14 +240,14 @@ def test_html_export_does_not_load_widget_stack() -> None:
         """
         import sys
 
-        import fastcharts
+        import fastcharts as fc
 
-        fig = fastcharts.Figure(title="lazy boundary").line([0, 1], [1, 2])
+        chart = fc.line_chart(fc.line(x=[0, 1], y=[1, 2]), title="lazy boundary")
         assert "fastcharts.widget" not in sys.modules
         assert "anywidget" not in sys.modules
         assert "traitlets" not in sys.modules
 
-        html = fig.to_html()
+        html = chart.to_html()
 
         assert "lazy boundary" in html
         assert "fastcharts.widget" not in sys.modules
@@ -306,17 +307,17 @@ def test_widget_method_is_the_widget_import_boundary() -> None:
         """
         import sys
 
-        import fastcharts
+        import fastcharts as fc
 
-        fig = fastcharts.Figure(title="widget boundary").line([0, 1], [1, 2])
-        fig.to_html()
+        chart = fc.line_chart(fc.line(x=[0, 1], y=[1, 2]), title="widget boundary")
+        chart.to_html()
         assert "fastcharts.widget" not in sys.modules
         assert "anywidget" not in sys.modules
         assert "traitlets" not in sys.modules
 
-        widget = fig.widget()
+        widget = chart.widget()
 
-        assert widget is fig.widget()
+        assert widget is chart.widget()
         assert "fastcharts.widget" in sys.modules
         assert "anywidget" in sys.modules
         assert "traitlets" in sys.modules

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -172,6 +172,36 @@ def test_min_max(impl):
     assert impl.min_max(np.array([], dtype=np.float64)) is None
 
 
+# -- sorted-ingest predicate --------------------------------------------------
+
+
+def test_is_sorted_matches_numpy_diff_predicate(impl):
+    cases = [
+        np.array([], dtype=np.float64),
+        np.array([3.0]),
+        np.array([np.nan]),
+        np.array([1.0, 1.0, 2.0]),
+        np.array([-np.inf, 0.0, np.inf]),
+        np.array([2.0, 1.0]),
+        np.array([1.0, np.nan, 3.0]),
+        np.array([1.0, 2.0, np.nan]),
+        np.array([np.nan, 1.0, 2.0]),
+        np.array([0.0, 1.0, 5.0, 4.0, 9.0]),
+        np.arange(10_000, dtype=np.float64),
+    ]
+    for data in cases:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            expected = bool(np.all(np.diff(data) >= 0))
+        assert impl.is_sorted(data) is expected, data
+
+
+def test_is_sorted_accepts_convertible_input(impl):
+    assert impl.is_sorted(np.arange(8, dtype=np.float32)) is True
+    assert impl.is_sorted([0, 1, 2]) is True
+    assert impl.is_sorted([2, 1]) is False
+
+
 # -- 2D density binning (§5 Tier 2) ------------------------------------------
 
 

--- a/tests/test_lod.py
+++ b/tests/test_lod.py
@@ -73,7 +73,8 @@ def test_plan_view_lod_supports_non_scatter_representations() -> None:
 
 
 def test_scatter_density_view_routes_through_shared_lod_primitives(monkeypatch) -> None:
-    from fastcharts import Figure, interaction
+    from fastcharts import interaction
+    from fastcharts._figure import Figure
 
     calls: dict[str, list[object]] = {
         "request": [],
@@ -141,7 +142,8 @@ def test_scatter_density_view_routes_through_shared_lod_primitives(monkeypatch) 
 
 
 def test_density_view_rejects_bad_viewport_before_mutating_drill_state(monkeypatch) -> None:
-    from fastcharts import Figure, interaction
+    from fastcharts import interaction
+    from fastcharts._figure import Figure
 
     monkeypatch.setattr(interaction, "SCATTER_DENSITY_THRESHOLD", 80)
     monkeypatch.setattr(interaction, "PYRAMID_MIN_POINTS", 1_000_000)
@@ -165,7 +167,8 @@ def test_density_view_rejects_bad_viewport_before_mutating_drill_state(monkeypat
 
 
 def test_line_area_decimate_view_routes_through_shared_buffer_writer(monkeypatch) -> None:
-    from fastcharts import Figure, interaction
+    from fastcharts import interaction
+    from fastcharts._figure import Figure
     from fastcharts.config import DECIMATION_THRESHOLD
 
     calls: list[dict[str, object]] = []

--- a/tests/test_png_export.py
+++ b/tests/test_png_export.py
@@ -9,7 +9,8 @@ import struct
 
 import numpy as np
 
-from fastcharts import Figure, _png, _raster
+from fastcharts import _png, _raster
+from fastcharts._figure import Figure
 
 
 def _ihdr(png: bytes) -> tuple[int, int, int]:

--- a/tests/test_property_figure.py
+++ b/tests/test_property_figure.py
@@ -34,7 +34,7 @@ hyp = pytest.importorskip("hypothesis")
 from hypothesis import given, settings  # noqa: E402
 from hypothesis import strategies as st  # noqa: E402
 
-from fastcharts import Figure  # noqa: E402
+from fastcharts._figure import Figure  # noqa: E402
 
 # Bounded so the whole module stays CI-cheap (< ~30s).
 COMMON = settings(max_examples=60, deadline=None)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -71,7 +71,9 @@ def test_fresh_import_budget_splits_third_party_and_fastcharts_modules(
         return subprocess.CompletedProcess(
             args=[],
             returncode=0,
-            stdout=_fresh_import_stdout(eager=["numpy", "fastcharts.figure", "fastcharts.kernels"]),
+            stdout=_fresh_import_stdout(
+                eager=["numpy", "fastcharts._figure", "fastcharts.kernels"]
+            ),
             stderr="",
         )
 
@@ -82,7 +84,7 @@ def test_fresh_import_budget_splits_third_party_and_fastcharts_modules(
     assert any("third-party" in error and "numpy" in error for error in errors)
     assert any(
         "fastcharts submodules" in error
-        and "fastcharts.figure" in error
+        and "fastcharts._figure" in error
         and "fastcharts.kernels" in error
         for error in errors
     )

--- a/tests/test_scatter.py
+++ b/tests/test_scatter.py
@@ -8,10 +8,9 @@ import json
 import numpy as np
 import pytest
 
-from fastcharts import Figure
 from fastcharts import channels as ch
+from fastcharts._figure import DENSITY_GRID, SCATTER_DENSITY_THRESHOLD, Figure
 from fastcharts.config import DENSITY_SAMPLE_TARGET, MAX_SCREEN_DIM
-from fastcharts.figure import DENSITY_GRID, SCATTER_DENSITY_THRESHOLD
 from fastcharts.interaction import _decode_log_u8
 
 
@@ -616,7 +615,7 @@ def test_drill_hysteresis_holds_points_mode_near_boundary():
 
 
 def test_huge_scatter_with_channels_warns_and_drops():
-    from fastcharts.figure import DIRECT_SOFT_CEILING
+    from fastcharts._figure import DIRECT_SOFT_CEILING
 
     n = DIRECT_SOFT_CEILING + 1
     x = np.zeros(n)
@@ -763,7 +762,7 @@ def test_density_false_is_honored():
 
 
 def test_density_false_above_ceiling_warns():
-    from fastcharts.figure import DIRECT_SOFT_CEILING
+    from fastcharts._figure import DIRECT_SOFT_CEILING
 
     n = DIRECT_SOFT_CEILING + 1
     x = np.zeros(n)

--- a/tests/test_scatter_matrix.py
+++ b/tests/test_scatter_matrix.py
@@ -11,8 +11,7 @@ import numpy as np
 import pytest
 
 import fastcharts as fc
-from fastcharts import Figure
-from fastcharts.figure import DIRECT_SOFT_CEILING, SCATTER_DENSITY_THRESHOLD
+from fastcharts._figure import DIRECT_SOFT_CEILING, SCATTER_DENSITY_THRESHOLD, Figure
 from fastcharts.interaction import _decode_log_u8
 
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -7,9 +7,8 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from fastcharts import Figure
+from fastcharts._figure import SCATTER_DENSITY_THRESHOLD, Figure
 from fastcharts.columns import ZONE_CHUNK, ColumnStore
-from fastcharts.figure import SCATTER_DENSITY_THRESHOLD
 
 # --------------------------------------------------------------------------
 # Column.append — the data layer

--- a/tests/test_svg_export.py
+++ b/tests/test_svg_export.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import numpy as np
 
 import fastcharts as fc
-from fastcharts import Figure
+from fastcharts._figure import Figure
 from fastcharts._svg import COLORMAP_STOPS
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_type_surface.py
+++ b/tests/test_type_surface.py
@@ -9,8 +9,8 @@ import numpy as np
 import pytest
 
 import fastcharts as fc
+import fastcharts._figure as figure_module
 import fastcharts.components as components
-import fastcharts.figure as figure_module
 
 ROOT = Path(__file__).resolve().parents[1]
 

--- a/tests/test_verify_wheel.py
+++ b/tests/test_verify_wheel.py
@@ -12,8 +12,8 @@ import pytest
 
 INIT_PY = """
 __version__ = "0.1.0"
-_EXPORTS = {"Figure": ".figure"}
-__all__ = ["Figure", "__version__"]
+_EXPORTS = {"Selection": "._figure"}
+__all__ = ["Selection", "__version__"]
 def __getattr__(name):
     raise AttributeError(name)
 """
@@ -145,7 +145,7 @@ def _write_wheel(
             data: bytes | str = replacements.get(name, "")
             if name == "fastcharts/__init__.py" and name not in replacements:
                 data = INIT_PY
-            elif name == "fastcharts/figure.py" and name not in replacements:
+            elif name == "fastcharts/_figure.py" and name not in replacements:
                 data = FIGURE_PY
             elif name == "fastcharts/marks.py" and name not in replacements:
                 data = MARKS_PY
@@ -300,7 +300,7 @@ def test_verify_wheel_rejects_stale_figure_export_surface(tmp_path: Path) -> Non
     _write_wheel(
         whl,
         replacements={
-            "fastcharts/figure.py": """
+            "fastcharts/_figure.py": """
 from . import marks as _marks
 class Figure:
     line = _marks.line

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from fastcharts import Figure
-from fastcharts.figure import DECIMATION_THRESHOLD
+from fastcharts._figure import DECIMATION_THRESHOLD, Figure
 from fastcharts.widget import FigureWidget
 
 


### PR DESCRIPTION
## What

The declarative composition API (`fc.chart(...)`, `fc.scatter_chart(...)`, …) is now the **single public chart-building surface**, per the approved declarative-pivot plan (Part A).

- `figure.py` → `_figure.py`: `Figure` becomes the internal scene object composed charts compile to. It is no longer exported from `fastcharts` — `fc.Figure` raises `AttributeError` without importing NumPy or dlopening the native core.
- `Selection` stays public; `Chart.figure()` remains as the documented advanced escape hatch.
- All consumers migrated: 21 test files, every benchmark, docs/README/CHANGELOG, the Reflex example app, the demo notebook, and the smoke/verify scripts.
- `test_api_parity` now pins composition-factory ↔ engine drift (same five checks, one public dialect).

## Performance (hard requirement: zero regression)

Verified with **interleaved A/B runs** against a worktree build of the previous main — plain before/after suite runs drift 1.2–1.9x from machine state on sub-ms rows, so every flagged row was settled with a tight best-of-N microbench of the exact shape.

| Scenario | old → new |
|---|---|
| Bar build, 1k / 10k categories | **−29% / −37%** |
| Histogram build+payload, 10k / 1M | **−18% / −25%** |
| Area 100k | **−10%** |
| Ingest (numpy f64 contiguous) | −7% |
| HTML / SVG export (1M line) | −5% / −4% |
| Everything else | 0.98–1.03x (noise) |
| Wire bytes / payload specs | byte-identical |

Wins landed:
1. **New native kernel `fc_is_sorted`** (ABI v10 → v11): allocation-free, early-exit replacement for the `np.all(np.diff(x) >= 0)` sorted-ingest predicate on the line/area hot path, identical NaN-poisoning semantics (Rust + ctypes + abi_smoke + hypothesis-style parity tests).
2. **Single-conversion data resolution**: the composition probes converted Python lists up to 4× per chart; now exactly once, with a unicode fast path that skips the per-element `category_label` pass on string category axes.
3. **Cheaper ctypes boundary**: bindings take `c_void_p` + raw buffer addresses instead of `data_as(POINTER(...))` objects — ~2× cheaper per pointer, ~46 pointers per small build.

## Bug fixes found along the way

- Composed charts crashed on **pyarrow arrays with nulls** (`ArrowInvalid` from the zero-copy dtype probe); fixed with an O(1) empty-slice probe — no extra copy in the timed ingest path (copy oracles unchanged).

## Verification

- 944 tests green; `verify_local.py --full` (13 checks incl. cargo test/clippy, JS bundle freshness, ABI smoke), plus security / errors / claims / import-budget / benchmark-harness / CI-workflow gates.
- Headless-Chromium render smoke: full probe matrix OK.
- README performance claims untouched; claim guardrails green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)