### PR TITLE
perf: tile-pyramid fast paths + interpreter-overhead cuts in the payload path

### DIFF
--- a/python/xy/_figure.py
+++ b/python/xy/_figure.py
@@ -554,7 +554,17 @@ class Figure(AnnotationsMixin, PayloadMixin):
             return arr.tolist()
         return [channels.category_label(raw) for raw in arr.astype(object)]
 
+    @staticmethod
+    def _materialize_sequence(values: Any) -> Any:
+        """Convert a plain list/tuple to an ndarray once, so the category
+        probe and label extraction below don't each re-run the same O(n)
+        conversion (`np.asarray` of an ndarray is free)."""
+        if isinstance(values, (list, tuple)):
+            return np.asarray(values)
+        return values
+
     def _axis_positions(self, values: Any, axis: str, *, commit: bool = True) -> np.ndarray:
+        values = self._materialize_sequence(values)
         if not self._is_category_like(values):
             return self._as_1d_float(values, f"{axis} values")
         raw_labels = self._category_axis_labels(values, axis)
@@ -563,20 +573,58 @@ class Figure(AnnotationsMixin, PayloadMixin):
             if commit
             else list(self._axis_categories.get(axis, []))
         )
-        lookup = {label: i for i, label in enumerate(labels)}
-        out = np.empty(len(raw_labels), dtype=np.float64)
-        for i, label in enumerate(raw_labels):
-            pos = lookup.get(label)
-            if pos is None:
-                pos = len(labels)
-                labels.append(label)
-                lookup[label] = pos
-            out[i] = float(pos)
-        return out
+        return self._category_positions(raw_labels, labels)
+
+    @staticmethod
+    def _category_positions(raw_labels: list[str], labels: list[str]) -> np.ndarray:
+        """Positions for `raw_labels` against `labels`, provisioning new labels
+        onto `labels` in first-appearance order (the category-axis contract)."""
+        lookup = dict(zip(labels, range(len(labels)), strict=True))
+        try:
+            # Layered charts resolve the same categories once per mark, so the
+            # every-label-known case is the hot one; it runs at C speed.
+            return np.fromiter(
+                map(lookup.__getitem__, raw_labels), np.float64, count=len(raw_labels)
+            )
+        except KeyError:
+            pass
+        # `dict.fromkeys` dedupes at C speed preserving first appearance, so
+        # provisioning touches each distinct new label once.
+        new_labels = [label for label in dict.fromkeys(raw_labels) if label not in lookup]
+        start = len(labels)
+        lookup.update(zip(new_labels, range(start, start + len(new_labels)), strict=True))
+        labels.extend(new_labels)
+        return np.fromiter(map(lookup.__getitem__, raw_labels), np.float64, count=len(raw_labels))
+
+    def _axis_positions_with_labels(
+        self, values: Any, axis: str
+    ) -> tuple[np.ndarray, Optional[list[str]]]:
+        """Uncommitted positions plus the normalized labels (None for numeric
+        values), so validate-then-commit callers replay the commit as a label
+        merge instead of re-running the O(n) conversion."""
+        values = self._materialize_sequence(values)
+        if not self._is_category_like(values):
+            return self._as_1d_float(values, f"{axis} values"), None
+        raw_labels = self._category_axis_labels(values, axis)
+        return self._category_positions(raw_labels, list(self._axis_categories.get(axis, []))), (
+            raw_labels
+        )
+
+    def _commit_category_labels(self, raw_labels: list[str], axis: str) -> None:
+        labels = self._axis_categories.setdefault(axis, [])
+        # Insertion-ordered union: existing labels first, then new ones in
+        # first-appearance order — identical to the provisioning loop above.
+        merged = dict.fromkeys(labels)
+        merged.update(dict.fromkeys(raw_labels))
+        if len(merged) > len(labels):
+            labels[:] = merged
 
     def _commit_axis_positions(self, values: Any, axis: str) -> None:
-        if values is not None and self._is_category_like(values):
-            self._axis_positions(values, axis, commit=True)
+        if values is None:
+            return
+        values = self._materialize_sequence(values)
+        if self._is_category_like(values):
+            self._commit_category_labels(self._category_axis_labels(values, axis), axis)
 
     @staticmethod
     def _broadcast_base(base: Any, n: int, kind: str) -> np.ndarray:
@@ -590,6 +638,7 @@ class Figure(AnnotationsMixin, PayloadMixin):
     def _heatmap_axis_positions(self, values: Any, n: int, axis: str) -> np.ndarray:
         if values is None:
             return np.arange(n, dtype=np.float64)
+        values = self._materialize_sequence(values)
         is_category = self._is_category_like(values)
         pos = self._axis_positions(values, axis, commit=False)
         if len(pos) != n:

--- a/python/xy/_native.py
+++ b/python/xy/_native.py
@@ -373,31 +373,34 @@ def zone_maps(
             empty_f.copy(),
             empty_f.copy(),
         )
-    mins = np.empty(n_chunks, dtype=np.float64)
-    maxs = np.empty(n_chunks, dtype=np.float64)
-    counts = np.empty(n_chunks, dtype=np.uint64)
-    nulls = np.empty(n_chunks, dtype=np.uint64)
-    sums = np.empty(n_chunks, dtype=np.float64)
-    sum_sqs = np.empty(n_chunks, dtype=np.float64)
-    positive_mins = np.empty(n_chunks, dtype=np.float64)
-    positive_maxs = np.empty(n_chunks, dtype=np.float64)
+    # Two block allocations (6 f64 rows + 2 u64 rows) instead of eight
+    # scattered ones: zone maps run on every ingest, and the allocator +
+    # `.ctypes` round-trips were a measurable slice of small-chart builds.
+    # Row views stay C-contiguous, and both dtypes are 8 bytes wide.
+    f64_rows = np.empty((6, n_chunks), dtype=np.float64)
+    u64_rows = np.empty((2, n_chunks), dtype=np.uint64)
+    f64_ptr = f64_rows.ctypes.data
+    u64_ptr = u64_rows.ctypes.data
+    row_bytes = n_chunks * 8
     written = _lib.fc_zone_maps(
         _ptr_f64(data),
         n,
         chunk_size,
-        _ptr_f64(mins),
-        _ptr_f64(maxs),
-        counts.ctypes.data,
-        nulls.ctypes.data,
-        _ptr_f64(sums),
-        _ptr_f64(sum_sqs),
-        _ptr_f64(positive_mins),
-        _ptr_f64(positive_maxs),
+        f64_ptr,  # mins
+        f64_ptr + row_bytes,  # maxs
+        u64_ptr,  # counts
+        u64_ptr + row_bytes,  # null counts
+        f64_ptr + 2 * row_bytes,  # sums
+        f64_ptr + 3 * row_bytes,  # sum_sqs
+        f64_ptr + 4 * row_bytes,  # positive_mins
+        f64_ptr + 5 * row_bytes,  # positive_maxs
     )
     if written == _USIZE_MAX:
         raise ValueError("invalid zone_maps arguments")
     if written != n_chunks:
         raise RuntimeError(f"xy native zone_maps wrote {written} chunks, expected {n_chunks}")
+    mins, maxs, sums, sum_sqs, positive_mins, positive_maxs = f64_rows
+    counts, nulls = u64_rows
     return mins, maxs, counts, nulls, sums, sum_sqs, positive_mins, positive_maxs
 
 

--- a/python/xy/_payload.py
+++ b/python/xy/_payload.py
@@ -94,15 +94,26 @@ class PayloadMixin(_Host):
         reduction is recorded in the spec — no silent quality changes (§28).
         """
         pw = _PayloadWriter()
+        # `_range` is an O(traces x chunks) autorange scan and is invariant
+        # while this build runs (emitters only touch shipped_sel/drill state),
+        # so each axis pays for it once even when many traces share an axis.
+        ranges: dict[str, tuple[float, float]] = {}
+
+        def axis_range(axis_id: str) -> tuple[float, float]:
+            r = ranges.get(axis_id)
+            if r is None:
+                ranges[axis_id] = r = self._range(axis_id)
+            return r
+
         spec_traces = []
         for t in self.traces:
-            xr = self._range(t.x_axis)
-            yr = self._range(t.y_axis)
+            xr = axis_range(t.x_axis)
+            yr = axis_range(t.y_axis)
             spec_traces.append(
                 self._emit_trace(t, pw, (min(xr), max(xr)), (min(yr), max(yr)), px_width)
             )
         axis_specs = {
-            axis_id: self._axis_spec(axis_id, self._range(axis_id)) for axis_id in self.axis_options
+            axis_id: self._axis_spec(axis_id, axis_range(axis_id)) for axis_id in self.axis_options
         }
 
         spec = {

--- a/python/xy/_validate.py
+++ b/python/xy/_validate.py
@@ -15,6 +15,7 @@ raises `ValueError` (occasionally `TypeError`) naming `label`.
 from __future__ import annotations
 
 import itertools
+from functools import lru_cache
 from typing import Any, Optional
 
 import numpy as np
@@ -171,7 +172,11 @@ _CSS_ERROR_REASONS = {
 }
 
 
+@lru_cache(maxsize=1024)
 def _css_check(kind: int, value: str, prop: str = "") -> int:
+    # Pure function of its string arguments (the native grammar is static),
+    # so the verdict is memoized — dashboards re-validate the same palette
+    # colors and style declarations on every chart build.
     # Lazy import: these validators run at chart-build time, inside the
     # compute import boundary (§33) — but this module itself must stay
     # importable without loading the native core.

--- a/python/xy/columns.py
+++ b/python/xy/columns.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import datetime as dt
 from dataclasses import dataclass
+from functools import cached_property
 from typing import Any
 
 import numpy as np
@@ -45,33 +46,38 @@ class ZoneMaps:
     positive_mins: npt.NDArray[np.float64]
     positive_maxs: npt.NDArray[np.float64]
 
-    @property
+    # The folded reductions are cached: instances are replaced wholesale when a
+    # column changes (`Column.append` builds a fresh ZoneMaps), never mutated in
+    # place, so the fold is a pure function of construction-time state. Autorange
+    # and offset selection read min/max several times per payload build.
+
+    @cached_property
     def min(self) -> float:
         valid = self.mins[self.counts > 0]
         # numpy's .min()/.max() stub mis-resolves the overload for the mask-indexed
         # f64 view; the reduction is a finite scalar at runtime.
         return float(valid.min()) if len(valid) else float("nan")  # ty: ignore[invalid-argument-type]
 
-    @property
+    @cached_property
     def max(self) -> float:
         valid = self.maxs[self.counts > 0]
         return float(valid.max()) if len(valid) else float("nan")  # ty: ignore[invalid-argument-type]
 
-    @property
+    @cached_property
     def positive_min(self) -> float:
         valid = self.positive_mins[np.isfinite(self.positive_mins)]
         return float(valid.min()) if len(valid) else float("nan")
 
-    @property
+    @cached_property
     def positive_max(self) -> float:
         valid = self.positive_maxs[np.isfinite(self.positive_maxs)]
         return float(valid.max()) if len(valid) else float("nan")
 
-    @property
+    @cached_property
     def count(self) -> int:
         return int(self.counts.sum())
 
-    @property
+    @cached_property
     def null_count(self) -> int:
         return int(self.null_counts.sum())
 

--- a/python/xy/components.py
+++ b/python/xy/components.py
@@ -1798,7 +1798,9 @@ def _looks_like_css(s: str) -> bool:
     string."""
     from . import kernels
 
-    return kernels.css_check(kernels.CSS_COLOR, s)[0] > 0
+    # Routed through `_validate._css_check` for its verdict memo — the same
+    # constant colors are re-classified on every chart build.
+    return _validate._css_check(kernels.CSS_COLOR, s) > 0
 
 
 # ---------------------------------------------------------------------------

--- a/python/xy/marks.py
+++ b/python/xy/marks.py
@@ -53,7 +53,7 @@ def _bar_like(
     if orientation not in {"vertical", "horizontal"}:
         raise ValueError(f"{kind} orientation must be 'vertical' or 'horizontal'")
     category_axis = "x" if orientation == "vertical" else "y"
-    pos = self._axis_positions(x, category_axis, commit=False)
+    pos, category_labels = self._axis_positions_with_labels(x, category_axis)
     vals = self._bar_value_matrix(y, len(pos), kind)
     if mode == "normalized":
         if np.any(vals < 0):
@@ -71,7 +71,8 @@ def _bar_like(
     series_colors = self._series_colors(color, colors, vals.shape[0])
     checkpoint = self._checkpoint()
     try:
-        self._commit_axis_positions(x, category_axis)
+        if category_labels is not None:
+            self._commit_category_labels(category_labels, category_axis)
         half = width / 2.0
         if vals.shape[0] == 1:
             self._append_bar_rect(

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -50,23 +50,35 @@ pub fn build(x: &[f64], y: &[f64], x0: f64, x1: f64, y0: f64, y1: f64, base_dim:
     dims.push(base_dim);
     let mut dim = base_dim;
     while dim > 1 {
-        let next = dim / 2;
         let prev = levels.last().expect("at least one level");
-        let mut lvl = vec![0u32; next * next];
-        for cy in 0..next {
-            for cx in 0..next {
-                let a = prev[(2 * cy) * dim + 2 * cx] as u64
-                    + prev[(2 * cy) * dim + 2 * cx + 1] as u64
-                    + prev[(2 * cy + 1) * dim + 2 * cx] as u64
-                    + prev[(2 * cy + 1) * dim + 2 * cx + 1] as u64;
-                lvl[cy * next + cx] = a.min(u32::MAX as u64) as u32;
-            }
-        }
+        let lvl = reduce_level(prev, dim);
+        dim /= 2;
         levels.push(lvl);
-        dims.push(next);
-        dim = next;
+        dims.push(dim);
     }
     Some(Pyramid { levels, dims, x0, x1, y0, y1 })
+}
+
+/// 4→1 exact reduction of one square level: each output cell is the u64 sum
+/// of its 2×2 source block, saturating to u32 (§5 — every level conserves the
+/// total exactly, up to saturation). Row slices + `chunks_exact(2)` keep the
+/// inner loop free of bounds checks so it autovectorizes.
+fn reduce_level(prev: &[u32], dim: usize) -> Vec<u32> {
+    let next = dim / 2;
+    let mut lvl = vec![0u32; next * next];
+    for (cy, out_row) in lvl.chunks_exact_mut(next).enumerate() {
+        let top = &prev[2 * cy * dim..2 * cy * dim + dim];
+        let bot = &prev[(2 * cy + 1) * dim..(2 * cy + 1) * dim + dim];
+        for ((o, t), b) in out_row
+            .iter_mut()
+            .zip(top.chunks_exact(2))
+            .zip(bot.chunks_exact(2))
+        {
+            let a = t[0] as u64 + t[1] as u64 + b[0] as u64 + b[1] as u64;
+            *o = a.min(u32::MAX as u64) as u32;
+        }
+    }
+    lvl
 }
 
 /// Cell-index range [lo, hi) of a level whose cell CENTERS fall inside the
@@ -85,12 +97,16 @@ pub fn count(p: &Pyramid, lo_x: f64, hi_x: f64, lo_y: f64, hi_y: f64) -> f64 {
     let dim = p.dims[0];
     let (cx0, cx1) = center_range(lo_x, hi_x, p.x0, p.x1, dim);
     let (cy0, cy1) = center_range(lo_y, hi_y, p.y0, p.y1, dim);
+    if cx1 <= cx0 || cy1 <= cy0 {
+        return 0.0;
+    }
     let mut total = 0u64;
     let lvl = &p.levels[0];
     for cy in cy0..cy1 {
-        for cx in cx0..cx1 {
-            total += lvl[cy * dim + cx] as u64;
-        }
+        // Per-row slice so the u32→u64 widen-add autovectorizes; integer sums
+        // are order-independent, so the total is unchanged.
+        let row = &lvl[cy * dim + cx0..cy * dim + cx1];
+        total += row.iter().map(|&c| c as u64).sum::<u64>();
     }
     total as f64
 }
@@ -149,17 +165,29 @@ pub fn compose(
     let sy = h as f64 / (hi_y - lo_y);
     let (cx0, cx1) = center_range(lo_x, hi_x, p.x0, p.x1, dim);
     let (cy0, cy1) = center_range(lo_y, hi_y, p.y0, p.y1, dim);
-    for cy in cy0..cy1 {
-        let ycen = p.y0 + (cy as f64 + 0.5) * cell_y;
-        let oy = (((ycen - lo_y) * sy) as usize).min(h - 1);
-        for cx in cx0..cx1 {
-            let c = lvl[cy * dim + cx];
-            if c == 0 {
-                continue;
+    // center_range can yield cx1 < cx0 for windows astronomically past the
+    // domain (the isize+1 in it wraps); the indexed loop iterated that as
+    // empty, but slicing would panic — keep the empty-window behavior.
+    if cx0 < cx1 {
+        // ox depends only on cx: hoist the center→output-bin math (same f64
+        // expression, so identical bins) out of the per-row loop.
+        let ox_of: Vec<u32> = (cx0..cx1)
+            .map(|cx| {
+                let xcen = p.x0 + (cx as f64 + 0.5) * cell_x;
+                (((xcen - lo_x) * sx) as usize).min(w - 1) as u32
+            })
+            .collect();
+        for cy in cy0..cy1 {
+            let ycen = p.y0 + (cy as f64 + 0.5) * cell_y;
+            let oy = (((ycen - lo_y) * sy) as usize).min(h - 1);
+            let row = &lvl[cy * dim + cx0..cy * dim + cx1];
+            let out_row = &mut out[oy * w..(oy + 1) * w];
+            for (&c, &ox) in row.iter().zip(ox_of.iter()) {
+                if c == 0 {
+                    continue;
+                }
+                out_row[ox as usize] += c as f32;
             }
-            let xcen = p.x0 + (cx as f64 + 0.5) * cell_x;
-            let ox = (((xcen - lo_x) * sx) as usize).min(w - 1);
-            out[oy * w + ox] += c as f32;
         }
     }
     Some(level)
@@ -283,6 +311,61 @@ mod tests {
         // deeper than level 0 can resolve at 2x upsample -> refused
         let mut tiny = vec![0.0f32; 512 * 512];
         assert!(compose(&p, 50.0, 51.0, 50.0, 51.0, 512, 512, &mut tiny).is_none());
+    }
+
+    #[test]
+    fn reduce_level_sums_blocks_and_saturates() {
+        // 4x4 of 0..16 -> 2x2: each output is the exact sum of its 2x2 block,
+        // e.g. top-left block {0, 1, 4, 5} sums to 10.
+        let prev: Vec<u32> = (0..16).collect();
+        assert_eq!(reduce_level(&prev, 4), vec![10, 18, 42, 50]);
+        // Block sums accumulate in u64 and clamp to u32::MAX — never wrap.
+        let big = vec![u32::MAX; 4];
+        assert_eq!(reduce_level(&big, 2), vec![u32::MAX]);
+        let mixed = vec![u32::MAX, 1, 0, 0];
+        assert_eq!(reduce_level(&mixed, 2), vec![u32::MAX]);
+    }
+
+    #[test]
+    fn count_matches_scalar_reference_and_handles_reversed_window() {
+        let (x, y) = cross(5000);
+        let p = build(&x, &y, 0.0, 100.0, 0.0, 100.0, 64).unwrap();
+        let dim = p.dims[0];
+        let (cx0, cx1) = center_range(13.0, 87.5, p.x0, p.x1, dim);
+        let (cy0, cy1) = center_range(22.4, 61.0, p.y0, p.y1, dim);
+        let mut reference = 0u64;
+        for cy in cy0..cy1 {
+            for cx in cx0..cx1 {
+                reference += p.levels[0][cy * dim + cx] as u64;
+            }
+        }
+        assert_eq!(count(&p, 13.0, 87.5, 22.4, 61.0), reference as f64);
+        // degenerate/reversed windows count zero cells, never panic
+        assert_eq!(count(&p, 90.0, 10.0, 0.0, 100.0), 0.0);
+        assert_eq!(count(&p, 50.0, 50.0, 0.0, 100.0), 0.0);
+    }
+
+    // Release-only: in debug builds center_range's `as isize + 1` panics on
+    // these magnitudes (pre-existing, caught by ffi_guard at the ABI); the
+    // wrap to cx1 < cx0 that reaches compose's row slicing only occurs in
+    // release, where the old indexed loop silently iterated it as empty.
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn compose_window_astronomically_past_domain_is_empty_not_panic() {
+        let (x, y) = cross(4000);
+        let p = build(&x, &y, 0.0, 100.0, 0.0, 100.0, 64).unwrap();
+        // hi so far past the domain that center_range saturates and wraps:
+        // cx range comes back reversed (cx0=32, cx1=0). Must compose to an
+        // all-zero grid with a level, exactly like the pre-slicing code.
+        let (w, h) = (2, 2);
+        let mut g = vec![7.0f32; w * h];
+        let level = compose(&p, 50.0, 1.0e21, 0.0, 100.0, w, h, &mut g);
+        assert!(level.is_some());
+        assert!(g.iter().all(|&c| c == 0.0), "wrapped window composes empty");
+        // nanosecond-epoch-scale garbage coordinates over a small domain
+        // (realistic bad input) must also never panic.
+        let mut g2 = vec![0.0f32; w * h];
+        let _ = compose(&p, 1.0e18, 1.75e18, 0.0, 100.0, w, h, &mut g2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two independent, output-identical optimizations for the CodSpeed-tracked hot paths. Every payload, grid, count, and spec produced by this branch is byte-for-byte identical to main — these changes remove work, not behavior. Rebased onto `fba9629` after #17 merged; `reduce_level` applies directly to #17's u32 base grids, so the two changes compose.

**1. Tile pyramid fast paths (`src/tiles.rs`)**

The three indexed hot loops paid a bounds check and index multiply per cell and defeated autovectorization:

- `build()`'s 4→1 level reduction (5.6M cells at the 2048 base dim) now walks top/bottom row slices with `chunks_exact(2)`, so the u32→u64 widen-add vectorizes and bounds checks vanish. Saturation semantics unchanged (u64 accumulate, clamp to `u32::MAX`).
- `compose()` hoists the per-cell `cx → output bin` float math into a per-compose lookup table (dim ≤ 2048 entries); the inner loop becomes skip-zero + table-indexed add. Identical f64 expressions and accumulation order, so identical f32 grids.
- `count()` sums row slices via iterators instead of per-cell indexing.

`compose()` additionally guards its new row slicing against wrapped center ranges: for windows astronomically past the domain (e.g. nanosecond-epoch coordinates against a [0,100] domain), `center_range`'s `as isize + 1` wraps in release builds and yields `cx1 < cx0`. The old indexed loop iterated that as empty; slicing would have panicked. The guard preserves the old empty-window behavior exactly, with a release-mode regression test.

**2. Interpreter-overhead cuts in the figure→payload path (`python/xy/`)**

Profile-guided (cProfile on the small-scatter and composed-layered builds); the changes replace per-label interpreted loops with C-level `dict(zip)` / `dict.fromkeys` / `np.fromiter`, eliminate duplicate O(n) label conversions and N+1 redundant autorange scans, cache zone-map folds that were recomputed 4–5× per column per build, cut redundant allocations and `.ctypes` round-trips per ingest, and memoize the CSS-grammar FFI verdicts.

## Measured

Local walltime (Apple Silicon), full 28-benchmark suite against post-#17 main (`fba9629`), 2 serialized interleaved rounds per side, per-iteration `min_ns`, min-of-rounds per benchmark:

| Benchmark | main | branch | delta |
| --- | --- | --- | --- |
| `test_pyramid_count` | 381.9µs | 147.2µs | **−61%** |
| `test_first_payload_bar_core_2d` | 506.3µs | 247.1µs | **−51%** |
| `test_memory_report_composed_layered_core_2d` | 959.2µs | 552.2µs | **−42%** |
| `test_first_payload_composed_layered_core_2d` | 1.01ms | 582.1µs | **−42%** |
| `test_pyramid_compose` | 883.7µs | 672.3µs | **−24%** |
| `test_adaptive_drilldown_cycle` | 2.97ms | 2.36ms | **−21%** |
| `test_first_payload_histogram_core_2d` | 221.7µs | 187.8µs | **−15%** |
| `test_first_payload_scatter_small` | 96.9µs | 83.5µs | **−14%** |
| `test_pyramid_build` | 8.51ms | 7.47ms | **−12%** |
| `test_first_payload_heatmap_core_2d` | 108.7µs | 98.4µs | **−10%** |

The remaining 18 benchmarks land between −6% and +2% (untouched code paths; within round-to-round noise on this machine). Local walltime is a proxy: this PR's CodSpeed simulation run is the ground truth. All the Rust wins are single-threaded straight-line instruction cuts (no thread-count changes) and the Python wins remove interpreter bytecode from the measured region, so both should translate directly to simulation mode.

## Verification

- **Byte-identity**: `(spec, blob)` hashes identical to post-#17 main across scatter (small/density), line 1M, histogram, area, bar, heatmap, composed-layered, and `memory_report` — plus two independent adversarial batteries (~32 chart shapes: grouped/stacked/horizontal bars, categorical heatmaps, cross-mark category merges, NaN/Inf floods, log/reversed/time axes, streaming appends, chunk-boundary splices, partial-commit failure rollback) all hash-identical.
- **Pyramid bit-exactness**: composed grids and counts SHA-identical to main across ~200 windows × 5 grid shapes, including unaligned windows, domain-edge/corner points, `nextafter` boundaries, 20M duplicate points (f32 cap), `base_dim=2`, `w=h=1`, and a full level sweep; degenerate garbage windows (reversed, 1e21-scale, ns-epoch coords) compose empty exactly like main instead of panicking.
- **Gates**: `cargo test` (debug + release, incl. new reduction/count/compose-guard tests), `cargo clippy --all-targets -- -D warnings`, full `pytest` (1055 passed on the rebase), `ruff check` + `ruff format --check` clean on every changed file, `ty check` clean.
- Dossier invariants hold: no float-accumulation reassociation, NaN semantics unchanged (§19), u32 saturation preserved, no wire-format changes (§29), no ABI signature changes, no new crates, `benchmarks/` and `tests/` untouched.

## Notes

- Composes with #21 (grid-aware thread cap in the 2-D binning kernels): #21 cuts the `bin_2d_counts` fan-out cost that dominates `pyramid_build`; this PR cuts the level reduction and the compose/count read paths. No overlapping lines.
- A hard-serial variant of #21's idea was implemented and verified during this work but deliberately dropped: correct and simulation-positive, it cost 2–3× wall-clock on many-core desktops. #21's graduated cap is the right form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
