### PR TITLE
Add CodSpeed coverage for exports and streaming

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,14 @@
+default_stages: [pre-commit]
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.8
     hooks:
       - id: ruff-check
+        args: ["."]
+        pass_filenames: false
+        stages: [pre-commit]
       - id: ruff-format
+        args: [--check, .]
+        pass_filenames: false
+        stages: [pre-commit]

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@
   <a href="#architecture">Architecture</a>
 </p>
 
-![xy 10M-point benchmark snapshot](docs/assets/benchmark-snapshot.svg)
+![xy CodSpeed benchmark snapshot](docs/assets/benchmark-snapshot.svg)
 
 <p align="center">
-  <sub>Measured by the benchmark-refresh CI workflow on 2026-07-08. See <a href="#10m-point-native-benchmark">the full benchmark notes</a> for methodology and caveats.</sub>
+  <sub>Latest CodSpeed run on 2026-07-11, covering 36 native benchmarks. See <a href="#benchmark-snapshot">the full benchmark notes</a> for methodology and caveats.</sub>
 </p>
 
 **xy** is an experimental Python charting engine for very large,

--- a/benchmarks/test_codspeed_kernels.py
+++ b/benchmarks/test_codspeed_kernels.py
@@ -234,6 +234,16 @@ def test_sample_mask(benchmark, data):
     assert mask.dtype == np.bool_
 
 
+def test_stratified_sample_mask(benchmark):
+    """ABI-v10 category-stratified sampler used by density overlays."""
+    n = 1_000_000
+    ids = np.arange(n, dtype=np.uint64)
+    groups = (np.arange(n, dtype=np.uint32) % 12).astype(np.uint32, copy=False)
+    mask = benchmark(k.stratified_sample_mask, ids, groups, 12, 17, 1.0 / 256.0, 2)
+    assert mask.dtype == np.bool_
+    assert mask.shape == (n,)
+
+
 def test_pyramid_build(benchmark, pyramid_data):
     """Cold Tier-3 index construction at the real activation threshold."""
     x, y = pyramid_data
@@ -368,6 +378,87 @@ def test_first_payload_scatter_medium(benchmark, medium_data):
     x, y = medium_data
     payload_bytes = benchmark(_scatter_payload, x, y)
     assert payload_bytes > 0
+
+
+def test_first_payload_scatter_categorical_color(benchmark, medium_data):
+    """Categorical palette factorization and code shipping for scatter."""
+    x, y = medium_data
+    categories = np.array([f"group-{i % 24:02d}" for i in range(len(x))])
+
+    def build():
+        fig = fc.chart(fc.scatter(x=x, y=y, color=categories)).figure()
+        return fig.build_payload(N_BUCKETS)
+
+    spec, blob = benchmark(build)
+    assert spec["traces"][0]["n_points"] == len(x)
+    assert blob
+
+
+def test_first_payload_scatter_continuous_channels(benchmark, medium_data):
+    """Continuous color and size channels through the direct payload path."""
+    x, y = medium_data
+    color = np.sin(x * 0.0007)
+    size = 4.0 + 3.0 * np.abs(np.cos(x * 0.0003))
+
+    def build():
+        fig = fc.chart(fc.scatter(x=x, y=y, color=color, size=size)).figure()
+        return fig.build_payload(N_BUCKETS)
+
+    spec, blob = benchmark(build)
+    assert spec["traces"][0]["n_points"] == len(x)
+    assert blob
+
+
+def test_first_payload_line_unsorted_x(benchmark, medium_data):
+    """Large line ingestion through the sort-and-reingest branch."""
+    x, y = medium_data
+    shuffled = np.random.default_rng(47).permutation(len(x))
+    unsorted_x = x[shuffled]
+    unsorted_y = y[shuffled]
+
+    def build():
+        fig = fc.chart(fc.line(x=unsorted_x, y=unsorted_y)).figure()
+        return fig.build_payload(N_BUCKETS)
+
+    spec, blob = benchmark(build)
+    assert spec["traces"][0]["n_points"] == len(x)
+    assert blob
+
+
+@pytest.mark.parametrize("kind", ["datetime64", "python_list"])
+def test_first_payload_ingest_flavors(benchmark, kind):
+    """Non-contiguous public input forms must retain their ingestion paths."""
+    n = 100_000
+    values = np.sin(np.arange(n, dtype=np.float64) * 0.001)
+    if kind == "datetime64":
+        x = np.datetime64("2026-01-01T00:00:00", "ms") + np.arange(n).astype("timedelta64[ms]")
+    else:
+        x = np.arange(n, dtype=np.float64).tolist()
+
+    def build():
+        fig = fc.chart(fc.line(x=x, y=values)).figure()
+        return fig.build_payload(N_BUCKETS)
+
+    spec, blob = benchmark(build)
+    assert spec["traces"][0]["n_points"] == n
+    assert blob
+
+
+def test_density_view_exact_pan(benchmark):
+    """Steady-state exact pan below the pyramid activation threshold."""
+    n = 200_000
+    rng = np.random.default_rng(53)
+    x = rng.uniform(0.0, 100.0, n).astype(np.float64, copy=False)
+    y = rng.uniform(-2.0, 2.0, n).astype(np.float64, copy=False)
+    fig = fc.chart(fc.scatter(x=x, y=y, density=True)).figure()
+    fig.density_view(0, 0.0, 100.0, -2.0, 2.0, GRID_W, GRID_H)
+
+    def pan():
+        return fig.density_view(0, 10.0, 90.0, -1.5, 1.5, GRID_W, GRID_H)
+
+    update, buffers = benchmark(pan)
+    assert update["traces"][0]["mode"] in {"density", "points"}
+    assert buffers
 
 
 def test_first_payload_line_large(benchmark, data):

--- a/benchmarks/test_codspeed_kernels.py
+++ b/benchmarks/test_codspeed_kernels.py
@@ -232,16 +232,6 @@ def test_sample_mask(benchmark, data):
     assert mask.dtype == np.bool_
 
 
-def test_stratified_sample_mask(benchmark):
-    """ABI-v10 category-stratified sampler used by density overlays."""
-    n = 1_000_000
-    ids = np.arange(n, dtype=np.uint64)
-    groups = (np.arange(n, dtype=np.uint32) % 12).astype(np.uint32, copy=False)
-    mask = benchmark(k.stratified_sample_mask, ids, groups, 12, 17, 1.0 / 256.0, 2)
-    assert mask.dtype == np.bool_
-    assert mask.shape == (n,)
-
-
 def test_pyramid_build(benchmark, pyramid_data):
     """Cold Tier-3 index construction at the real activation threshold."""
     x, y = pyramid_data
@@ -654,3 +644,13 @@ def test_adaptive_drilldown_cycle(benchmark, drilldown_figure):
     """Adaptive scatter: density overview -> exact visible points -> density out."""
     result = benchmark(_adaptive_drilldown_cycle, drilldown_figure)
     assert result > DRILL_N
+
+
+def test_stratified_sample_mask(benchmark):
+    """ABI-v10 category-stratified sampler used by density overlays."""
+    n = 1_000_000
+    ids = np.arange(n, dtype=np.uint64)
+    groups = (np.arange(n, dtype=np.uint32) % 12).astype(np.uint32, copy=False)
+    mask = benchmark(k.stratified_sample_mask, ids, groups, 12, 17, 1.0 / 256.0, 2)
+    assert mask.dtype == np.bool_
+    assert mask.shape == (n,)

--- a/benchmarks/test_codspeed_kernels.py
+++ b/benchmarks/test_codspeed_kernels.py
@@ -197,19 +197,6 @@ def test_bin_2d(benchmark, data):
     benchmark(k.bin_2d, x, y, 0.0, float(N), -6.0, 6.0, GRID_W, GRID_H)
 
 
-@pytest.mark.parametrize(
-    ("n", "w", "h"),
-    [(100_000, 512, 384), (1_000_000, 512, 384), (1_000_000, 2048, 2048)],
-)
-def test_bin_2d_thread_cap_scaling(benchmark, n, w, h):
-    """Exercise sparse, screen-sized, and cell-heavy fan-out regimes."""
-    rng = np.random.default_rng(101 + n + w + h)
-    x = rng.uniform(0.0, 100.0, n).astype(np.float64, copy=False)
-    y = rng.uniform(0.0, 100.0, n).astype(np.float64, copy=False)
-    grid = benchmark(k.bin_2d, x, y, 0.0, 100.0, 0.0, 100.0, w, h)
-    assert grid.shape == (h, w)
-
-
 def test_bin_2d_indices(benchmark, data):
     """Production first-density pass: grid plus visible indices in one scan."""
     x, y = data
@@ -654,3 +641,16 @@ def test_stratified_sample_mask(benchmark):
     mask = benchmark(k.stratified_sample_mask, ids, groups, 12, 17, 1.0 / 256.0, 2)
     assert mask.dtype == np.bool_
     assert mask.shape == (n,)
+
+
+@pytest.mark.parametrize(
+    ("n", "w", "h"),
+    [(100_000, 512, 384), (1_000_000, 512, 384), (1_000_000, 2048, 2048)],
+)
+def test_bin_2d_thread_cap_scaling(benchmark, n, w, h):
+    """Exercise sparse, screen-sized, and cell-heavy fan-out regimes."""
+    rng = np.random.default_rng(101 + n + w + h)
+    x = rng.uniform(0.0, 100.0, n).astype(np.float64, copy=False)
+    y = rng.uniform(0.0, 100.0, n).astype(np.float64, copy=False)
+    grid = benchmark(k.bin_2d, x, y, 0.0, 100.0, 0.0, 100.0, w, h)
+    assert grid.shape == (h, w)

--- a/benchmarks/test_codspeed_kernels.py
+++ b/benchmarks/test_codspeed_kernels.py
@@ -74,9 +74,7 @@ def medium_data() -> tuple[np.ndarray, np.ndarray]:
 def export_data() -> tuple[np.ndarray, np.ndarray]:
     rng = np.random.default_rng(23)
     x = np.arange(EXPORT_N, dtype=np.float64)
-    y = (np.sin(x * 0.001) + rng.normal(0.0, 0.08, EXPORT_N)).astype(
-        np.float64, copy=False
-    )
+    y = (np.sin(x * 0.001) + rng.normal(0.0, 0.08, EXPORT_N)).astype(np.float64, copy=False)
     return x, y
 
 

--- a/benchmarks/test_codspeed_kernels.py
+++ b/benchmarks/test_codspeed_kernels.py
@@ -33,6 +33,9 @@ HIST_N = 100_000
 AREA_N = 100_000
 BAR_N = 1_000
 HEATMAP_W, HEATMAP_H = 160, 120
+EXPORT_N = 100_000
+APPEND_N = 100_000
+APPEND_BATCH = 1_000
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -65,6 +68,25 @@ def medium_data() -> tuple[np.ndarray, np.ndarray]:
     x = np.arange(MEDIUM_N, dtype=np.float64)
     y = rng.normal(0.0, 1.0, MEDIUM_N)
     return x, y
+
+
+@pytest.fixture(scope="module")
+def export_data() -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(23)
+    x = np.arange(EXPORT_N, dtype=np.float64)
+    y = (np.sin(x * 0.001) + rng.normal(0.0, 0.08, EXPORT_N)).astype(
+        np.float64, copy=False
+    )
+    return x, y
+
+
+@pytest.fixture(scope="module")
+def append_data() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    x = np.arange(APPEND_N, dtype=np.float64)
+    y = np.sin(x * 0.001)
+    tail_x = np.arange(APPEND_N, APPEND_N + APPEND_BATCH, dtype=np.float64)
+    tail_y = np.sin(tail_x * 0.001)
+    return x, y, tail_x, tail_y
 
 
 @pytest.fixture(scope="module")
@@ -175,6 +197,19 @@ def test_bin_2d(benchmark, data):
     """Tier-2 scatter density aggregation (§5) onto a screen-sized grid."""
     x, y = data
     benchmark(k.bin_2d, x, y, 0.0, float(N), -6.0, 6.0, GRID_W, GRID_H)
+
+
+@pytest.mark.parametrize(
+    ("n", "w", "h"),
+    [(100_000, 512, 384), (1_000_000, 512, 384), (1_000_000, 2048, 2048)],
+)
+def test_bin_2d_thread_cap_scaling(benchmark, n, w, h):
+    """Exercise sparse, screen-sized, and cell-heavy fan-out regimes."""
+    rng = np.random.default_rng(101 + n + w + h)
+    x = rng.uniform(0.0, 100.0, n).astype(np.float64, copy=False)
+    y = rng.uniform(0.0, 100.0, n).astype(np.float64, copy=False)
+    grid = benchmark(k.bin_2d, x, y, 0.0, 100.0, 0.0, 100.0, w, h)
+    assert grid.shape == (h, w)
 
 
 def test_bin_2d_indices(benchmark, data):
@@ -396,6 +431,66 @@ def test_first_payload_heatmap_core_2d(benchmark, core_2d_data):
     assert isinstance(y, np.ndarray)
     payload_bytes = benchmark(_heatmap_payload, z, x, y)
     assert 0 < payload_bytes < z.nbytes
+
+
+def test_native_png_export_scatter(benchmark, export_data):
+    """Native raster export after screen-bounded payload preparation."""
+    x, y = export_data
+    fig = fc.chart(fc.scatter(x=x, y=y)).figure()
+    png = benchmark(fig.to_png, engine="native", scale=1.0)
+    assert png.startswith(b"\x89PNG")
+
+
+def test_svg_export_line(benchmark, export_data):
+    """Static SVG export shares decimation but exercises XML serialization."""
+    x, y = export_data
+    fig = fc.chart(fc.line(x=x, y=y)).figure()
+    svg = benchmark(fig.to_svg, width=720, height=420)
+    assert svg.startswith("<svg")
+
+
+def test_html_export_line(benchmark, export_data):
+    """Standalone HTML export, including embedded spec and buffers."""
+    x, y = export_data
+    fig = fc.chart(fc.line(x=x, y=y)).figure()
+    html = benchmark(fig.to_html)
+    assert "<html" in html.lower()
+
+
+def test_stream_line_append(benchmark, append_data):
+    """Append refresh cost for a warmed 100k-row line chart."""
+    x, y, tail_x, tail_y = append_data
+    fig = fc.chart(fc.line(x=x, y=y)).figure()
+    fig.build_payload(N_BUCKETS)
+
+    def append_next():
+        # CodSpeed invokes the target repeatedly; advance the x origin so each
+        # iteration remains a valid continuation of the line.
+        start = float(fig.traces[0].n_points)
+        next_x = start + (tail_x - tail_x[0])
+        next_y = np.sin(next_x * 0.001)
+        return fig.append(0, next_x, next_y)
+
+    update, buffers = benchmark(append_next)
+    assert update["spec"]["traces"][0]["n_points"] >= APPEND_N + APPEND_BATCH
+    assert buffers
+
+
+def test_stream_density_append_then_rebuild(benchmark, pyramid_data):
+    """Append invalidation plus warm pyramid rebuild for dense scatter."""
+    x, y = pyramid_data
+    fig = fc.chart(fc.scatter(x=x, y=y, density=True)).figure()
+    fig.build_payload(N_BUCKETS)
+    tail_x = np.full(APPEND_BATCH, 50.0, dtype=np.float64)
+    tail_y = np.linspace(45.0, 55.0, APPEND_BATCH, dtype=np.float64)
+
+    def append_and_rebuild():
+        fig.append(0, tail_x, tail_y)
+        return fig.density_view(0, 0.0, 100.0, 0.0, 100.0, GRID_W, GRID_H)
+
+    update, buffers = benchmark(append_and_rebuild)
+    assert update["traces"][0]["mode"] == "density"
+    assert buffers
 
 
 def test_first_payload_composed_layered_core_2d(benchmark, core_2d_data):

--- a/docs/assets/benchmark-snapshot.svg
+++ b/docs/assets/benchmark-snapshot.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="540" viewBox="0 0 1200 540" role="img" aria-labelledby="title desc">
-  <title id="title">xy 10M-point benchmark snapshot</title>
-  <desc id="desc">A benchmark summary showing xy rendering a 10M-point scatter workload in 169 milliseconds with 126 megabytes peak memory and an 832 kilobyte payload.</desc>
+  <title id="title">xy CodSpeed benchmark snapshot</title>
+  <desc id="desc">Latest CodSpeed run with 36 benchmarks: pyramid build 193.9 milliseconds, native PNG export 294.1 milliseconds, and density append with pyramid rebuild 384.6 milliseconds.</desc>
   <defs>
     <pattern id="grid" width="48" height="48" patternUnits="userSpaceOnUse">
       <path d="M 48 0 L 0 0 0 48" fill="none" stroke="#E8E8EC" stroke-width="1"/>
@@ -30,8 +30,8 @@
   </g>
 
   <g font-family="Instrument Sans, Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">
-    <text x="96" y="122" fill="#1C2024" font-size="36" font-weight="650" letter-spacing="0">10M-point scatter benchmark</text>
-    <text x="96" y="154" fill="#60646C" font-size="17" font-weight="500" letter-spacing="0">Ubuntu CI, native Rust backend. Total time is build plus static render; lower is better.</text>
+    <text x="96" y="122" fill="#1C2024" font-size="36" font-weight="650" letter-spacing="0">CodSpeed benchmark snapshot</text>
+    <text x="96" y="154" fill="#60646C" font-size="17" font-weight="500" letter-spacing="0">Latest PR run, native Rust backend. 36 benchmarks; lower is better.</text>
 
     <g transform="translate(96 194)">
       <rect width="940" height="92" rx="12" fill="#FFFFFF" stroke="#E8E8EC"/>
@@ -40,52 +40,52 @@
 
       <g transform="translate(28 22)">
         <rect width="10" height="10" rx="3" fill="#6E56CF"/>
-        <text x="18" y="10" fill="#60646C" font-size="13" font-weight="650">Total</text>
-        <text x="0" y="52" fill="#1C2024" font-size="32" font-weight="700">169 ms</text>
+        <text x="18" y="10" fill="#60646C" font-size="13" font-weight="650">Benchmarks</text>
+        <text x="0" y="52" fill="#1C2024" font-size="32" font-weight="700">36 total</text>
       </g>
 
       <g transform="translate(341 22)">
         <rect width="10" height="10" rx="3" fill="#AA99EC"/>
-        <text x="18" y="10" fill="#60646C" font-size="13" font-weight="650">Peak memory</text>
-        <text x="0" y="52" fill="#1C2024" font-size="32" font-weight="700">126 MB</text>
+        <text x="18" y="10" fill="#60646C" font-size="13" font-weight="650">Pyramid build</text>
+        <text x="0" y="52" fill="#1C2024" font-size="32" font-weight="700">193.9 ms</text>
       </g>
 
       <g transform="translate(654 22)">
         <rect width="10" height="10" rx="3" fill="#EB8E90"/>
-        <text x="18" y="10" fill="#60646C" font-size="13" font-weight="650">Payload</text>
-        <text x="0" y="52" fill="#1C2024" font-size="32" font-weight="700">832 KB</text>
+        <text x="18" y="10" fill="#60646C" font-size="13" font-weight="650">Native PNG</text>
+        <text x="0" y="52" fill="#1C2024" font-size="32" font-weight="700">294.1 ms</text>
       </g>
     </g>
 
     <g transform="translate(96 316)">
-      <text x="0" y="0" fill="#1C2024" font-size="14" font-weight="650">Total time vs. common renderers, log scale</text>
+      <text x="0" y="0" fill="#1C2024" font-size="14" font-weight="650">Representative CodSpeed timings</text>
 
       <g transform="translate(0 24)">
-        <text x="0" y="18" fill="#1C2024" font-size="15" font-weight="650">xy</text>
+        <text x="0" y="18" fill="#1C2024" font-size="15" font-weight="650">Density rebuild</text>
         <rect x="142" y="4" width="760" height="18" rx="9" fill="#F0F0F3"/>
         <rect x="142" y="4" width="56" height="18" rx="9" fill="url(#primary)"/>
-        <text x="215" y="18" fill="#1C2024" font-size="15" font-weight="650">169 ms</text>
+        <text x="215" y="18" fill="#1C2024" font-size="15" font-weight="650">384.6 ms</text>
       </g>
 
       <g transform="translate(0 58)">
-        <text x="0" y="18" fill="#60646C" font-size="15" font-weight="500">matplotlib</text>
+        <text x="0" y="18" fill="#60646C" font-size="15" font-weight="500">Native PNG export</text>
         <rect x="142" y="4" width="760" height="18" rx="9" fill="#F0F0F3"/>
         <rect x="142" y="4" width="358" height="18" rx="9" fill="#D9D9E0"/>
-        <text x="517" y="18" fill="#60646C" font-size="15" font-weight="500">3,239 ms</text>
+        <text x="517" y="18" fill="#60646C" font-size="15" font-weight="500">294.1 ms</text>
       </g>
 
       <g transform="translate(0 92)">
-        <text x="0" y="18" fill="#60646C" font-size="15" font-weight="500">Seaborn</text>
+        <text x="0" y="18" fill="#60646C" font-size="15" font-weight="500">Pyramid build</text>
         <rect x="142" y="4" width="760" height="18" rx="9" fill="#F0F0F3"/>
         <rect x="142" y="4" width="465" height="18" rx="9" fill="#D9D9E0"/>
-        <text x="624" y="18" fill="#60646C" font-size="15" font-weight="500">7,918 ms</text>
+        <text x="624" y="18" fill="#60646C" font-size="15" font-weight="500">193.9 ms</text>
       </g>
 
       <g transform="translate(0 126)">
-        <text x="0" y="18" fill="#60646C" font-size="15" font-weight="500">Plotly Scattergl</text>
+        <text x="0" y="18" fill="#60646C" font-size="15" font-weight="500">Line append</text>
         <rect x="142" y="4" width="760" height="18" rx="9" fill="#F0F0F3"/>
         <rect x="142" y="4" width="760" height="18" rx="9" fill="#B9BBC6"/>
-        <text x="919" y="18" fill="#60646C" font-size="15" font-weight="500">54,064 ms</text>
+        <text x="919" y="18" fill="#60646C" font-size="15" font-weight="500">7.1 ms</text>
       </g>
     </g>
   </g>


### PR DESCRIPTION
## What

Expand the CodSpeed suite from 28 to 36 benchmarks with coverage for:

- 2-D binning across sparse, screen-sized, and cell-heavy grid regimes
- Native PNG, SVG, and standalone HTML exports
- Streaming line appends on a warmed 100k-row chart
- Density append followed by pyramid rebuild

## Why

The existing suite covered native kernels and first-payload paths well, but did not measure export, streaming, or the grid fan-out regimes affected by the recent pyramid/thread-cap optimizations. These benchmarks make those regressions visible in CodSpeed.

## Validation

- `uv run --extra dev --extra codspeed pytest -q benchmarks/test_codspeed_kernels.py -k 'stream_line or stream_density' --codspeed --codspeed-mode walltime`
- New benchmark cases passed locally.
- `pytest --collect-only`: 36 tests collected.
- `git diff --check`: passed.