### PR TITLE
perf: eliminate payload copy overhead on ABI v32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ in the README).
   contract without importing the widget stack.
 
 ### Changed
+- **Payload copy elimination (native ABI v32).** Partial-view density sampling
+  now hashes native `u32` row selections without first widening the full array
+  to `u64`; exact-full index buffers avoid a trailing-slice copy; and payload
+  assembly retains encoded arrays until the final blob join instead of copying
+  every column through `tobytes()` first. Payload bytes and sampling decisions
+  remain parity-tested and unchanged.
 - **View-change callback windows** now reject non-finite bounds and normalize
   inverted ranges before callbacks receive them, matching selection and
   autorange window semantics.

--- a/python/xy/_native.py
+++ b/python/xy/_native.py
@@ -24,7 +24,7 @@ import numpy.typing as npt
 
 from .config import MAX_CONTOUR_WORK, MAX_SCREEN_DIM
 
-ABI_VERSION = 31
+ABI_VERSION = 32
 
 # Rust reports invalid arguments (and, via the ffi_guard panic shield, any
 # internal panic) by returning `usize::MAX` from size-returning entry points.
@@ -505,6 +505,8 @@ def _load() -> ctypes.CDLL:
         ctypes.c_uint64,
         ctypes.c_void_p,
     ]
+    lib.fc_sample_mask_u32.restype = ctypes.c_int32
+    lib.fc_sample_mask_u32.argtypes = list(lib.fc_sample_mask.argtypes)
     lib.fc_sample_range_indices.restype = ctypes.c_size_t
     lib.fc_sample_range_indices.argtypes = [
         ctypes.c_size_t,
@@ -547,6 +549,8 @@ def _load() -> ctypes.CDLL:
         ctypes.c_uint64,  # min_count
         ctypes.c_void_p,  # out
     ]
+    lib.fc_stratified_sample_mask_u32.restype = ctypes.c_int32
+    lib.fc_stratified_sample_mask_u32.argtypes = list(lib.fc_stratified_sample_mask.argtypes)
     lib.fc_pyramid_build.restype = ctypes.c_uint64
     lib.fc_pyramid_build.argtypes = [
         ctypes.c_void_p,
@@ -1951,7 +1955,10 @@ def bin_2d_indices(
     )
     if written == _USIZE_MAX:
         raise ValueError("invalid bin_2d_indices arguments")
-    return grid, idx[:written].copy()
+    # First paint autoranges to the data extent, so every finite row is
+    # usually in range: avoid duplicating the full selection when no slack
+    # needs trimming.
+    return grid, idx if written == len(idx) else idx[:written].copy()
 
 
 def bin_2d_sample_range(
@@ -2243,7 +2250,7 @@ def range_indices(
     )
     if written == _USIZE_MAX:
         raise ValueError("invalid range_indices arguments")
-    return out[:written].copy()
+    return out if written == len(out) else out[:written].copy()
 
 
 def sample_mask(
@@ -2255,14 +2262,21 @@ def sample_mask(
 
     Bit-identical to `lod.hash_row_ids(ids, seed=seed) <= threshold` (the
     NumPy reference, asserted by the parity test), fused into one native pass
-    with no full-width u64 temporaries.
+    with no full-width u64 temporaries. uint32 ids dispatch to an entry point
+    that widens each id in-register instead of copying the full selection.
     """
-    ids = np.ascontiguousarray(ids, dtype=np.uint64)
+    ids = np.asarray(ids)
+    if ids.dtype == np.uint32:
+        ids = np.ascontiguousarray(ids)
+        fn = _lib.fc_sample_mask_u32
+    else:
+        ids = np.ascontiguousarray(ids, dtype=np.uint64)
+        fn = _lib.fc_sample_mask
     if ids.ndim != 1:
         raise ValueError("ids must be a one-dimensional uint64 array")
     out = np.empty(len(ids), dtype=np.uint8)
     if len(ids):
-        ok = _lib.fc_sample_mask(
+        ok = fn(
             ids.ctypes.data,
             len(ids),
             ctypes.c_uint64(int(seed)),
@@ -2392,8 +2406,15 @@ def stratified_sample_mask(
     with a `min_count` lowest-hash floor per category. Bit-identical to the
     per-category NumPy reference in `xy.lod` (asserted by the parity
     test), fused into one native pass instead of O(n · n_groups) rescans.
+    uint32 ids dispatch to the in-register widening entry point.
     """
-    ids = np.ascontiguousarray(ids, dtype=np.uint64)
+    ids = np.asarray(ids)
+    if ids.dtype == np.uint32:
+        ids = np.ascontiguousarray(ids)
+        fn = _lib.fc_stratified_sample_mask_u32
+    else:
+        ids = np.ascontiguousarray(ids, dtype=np.uint64)
+        fn = _lib.fc_stratified_sample_mask
     groups = np.ascontiguousarray(groups, dtype=np.uint32)
     if ids.ndim != 1 or groups.ndim != 1:
         raise ValueError("ids and groups must be one-dimensional arrays")
@@ -2410,7 +2431,7 @@ def stratified_sample_mask(
         raise ValueError("min_count must be a non-negative integer")
     out = np.empty(len(ids), dtype=np.uint8)
     if len(ids):
-        ok = _lib.fc_stratified_sample_mask(
+        ok = fn(
             ids.ctypes.data,
             groups.ctypes.data,
             len(ids),

--- a/python/xy/_payload.py
+++ b/python/xy/_payload.py
@@ -42,7 +42,7 @@ class _PayloadWriter:
 
     def __init__(self, *, borrow_heatmaps: bool = False) -> None:
         self.columns: list[dict[str, Any]] = []
-        self._chunks: list[bytes] = []
+        self._chunks: list[bytes | np.ndarray] = []
         self._pos = 0
         self.borrow_heatmaps = borrow_heatmaps
         self.borrowed: list[np.ndarray] = []
@@ -68,11 +68,10 @@ class _PayloadWriter:
     def ship_u8(self, values: np.ndarray) -> int:
         """Raw byte column, padded so every later f32 column stays aligned."""
         enc = np.ascontiguousarray(values, dtype=np.uint8).reshape(-1)
-        raw = enc.tobytes()
         index = len(self.columns)
         self.columns.append({"byte_offset": self._pos, "len": int(len(enc)), "dtype": "u8"})
-        self._chunks.append(raw)
-        self._pos += len(raw)
+        self._chunks.append(enc)
+        self._pos += enc.nbytes
         padding = (-self._pos) % 4
         if padding:
             self._chunks.append(bytes(padding))
@@ -102,14 +101,20 @@ class _PayloadWriter:
         return self._append(encoded.values, encoded.meta)
 
     def _append(self, enc: np.ndarray, meta: dict[str, Any]) -> int:
-        raw = enc.tobytes()
+        # Retain the encoded array until blob assembly so each column is copied
+        # once into the final bytes object, rather than once in `tobytes()` and
+        # again by `join`.
+        enc = np.ascontiguousarray(enc)
         self.columns.append({"byte_offset": self._pos, "len": int(len(enc)), **meta})
-        self._chunks.append(raw)
-        self._pos += len(raw)
+        self._chunks.append(enc)
+        self._pos += enc.nbytes
         return len(self.columns) - 1
 
     def blob(self) -> bytes:
-        return b"".join(self._chunks)
+        return b"".join(
+            chunk if isinstance(chunk, bytes) else memoryview(chunk).cast("B")
+            for chunk in self._chunks
+        )
 
 
 class PayloadMixin(_Host):

--- a/python/xy/lod.py
+++ b/python/xy/lod.py
@@ -274,6 +274,7 @@ def _float_param(
 
 
 def _row_ids(row_ids: Any, label: str = "row_ids") -> np.ndarray:
+    """Validate unsigned row ids without widening native u32 selections."""
     ids = np.asarray(row_ids)
     if ids.ndim != 1:
         raise ValueError(f"{label} must be a one-dimensional integer array")
@@ -284,6 +285,8 @@ def _row_ids(row_ids: Any, label: str = "row_ids") -> np.ndarray:
             raise ValueError(f"{label} must not contain negative values")
         return ids.astype(np.uint64, copy=False)
     if ids.dtype.kind == "u":
+        if ids.dtype == np.uint32:
+            return ids
         return ids.astype(np.uint64, copy=False)
     raise ValueError(f"{label} must be a one-dimensional integer array")
 

--- a/scripts/abi_smoke.py
+++ b/scripts/abi_smoke.py
@@ -210,6 +210,14 @@ def load() -> ctypes.CDLL:
         ctypes.c_uint64,
         ctypes.POINTER(ctypes.c_uint8),
     ]
+    lib.fc_sample_mask_u32.restype = ctypes.c_int32
+    lib.fc_sample_mask_u32.argtypes = [
+        U32P,
+        ctypes.c_size_t,
+        ctypes.c_uint64,
+        ctypes.c_uint64,
+        ctypes.POINTER(ctypes.c_uint8),
+    ]
     lib.fc_sample_range_indices.restype = ctypes.c_size_t
     lib.fc_sample_range_indices.argtypes = [
         ctypes.c_size_t,
@@ -244,6 +252,17 @@ def load() -> ctypes.CDLL:
     lib.fc_stratified_sample_mask.restype = ctypes.c_int32
     lib.fc_stratified_sample_mask.argtypes = [
         U64P,
+        U32P,
+        ctypes.c_size_t,
+        ctypes.c_size_t,
+        ctypes.c_uint64,
+        ctypes.c_double,
+        ctypes.c_uint64,
+        ctypes.POINTER(ctypes.c_uint8),
+    ]
+    lib.fc_stratified_sample_mask_u32.restype = ctypes.c_int32
+    lib.fc_stratified_sample_mask_u32.argtypes = [
+        U32P,
         U32P,
         ctypes.c_size_t,
         ctypes.c_size_t,
@@ -798,6 +817,24 @@ def main() -> None:
         == 1,
         "sample_mask empty/null ok status",
     )
+    ids32 = array("I", [0, 1, 2, 3])
+    mask32 = array("B", [9, 9, 9, 9])
+    lib.fc_sample_mask_u32(
+        _ptr(ids32, ctypes.c_uint32),
+        1,
+        ctypes.c_uint64(0),
+        ctypes.c_uint64(0xE220A8397B1DCDAF),
+        _ptr(mask32, ctypes.c_uint8),
+    )
+    ok(mask32[0] == 1, "sample_mask_u32 matches the u64 reference vector")
+    lib.fc_sample_mask_u32(
+        _ptr(ids32, ctypes.c_uint32),
+        4,
+        ctypes.c_uint64(0),
+        ctypes.c_uint64(0),
+        _ptr(mask32, ctypes.c_uint8),
+    )
+    ok(list(mask32) == [0, 0, 0, 0], "sample_mask_u32 threshold=0 keeps none")
     sampled = array("I", [999]) * 4
     written = lib.fc_sample_range_indices(
         4,
@@ -934,6 +971,21 @@ def main() -> None:
     ok(
         status == 1 and sum(smask) == 2 and smask[3] == 1,
         "stratified_sample_mask floor pins one row per category",
+    )
+    smask32 = array("B", [9, 9, 9, 9])
+    status = lib.fc_stratified_sample_mask_u32(
+        _ptr(ids32, ctypes.c_uint32),
+        _ptr(sgroups, ctypes.c_uint32),
+        4,
+        2,
+        ctypes.c_uint64(0),
+        ctypes.c_double(1e-18),
+        ctypes.c_uint64(1),
+        _ptr(smask32, ctypes.c_uint8),
+    )
+    ok(
+        status == 1 and list(smask32) == list(smask),
+        "stratified_sample_mask_u32 matches u64 ids",
     )
     smask_bad = array("B", [7, 7, 7, 7])
     bad_groups = array("I", [0, 0, 0, 5])  # 5 >= n_groups

--- a/src/kernels.rs
+++ b/src/kernels.rs
@@ -3419,8 +3419,14 @@ fn sample_expected_capacity(size: usize, threshold: u64) -> usize {
 /// Deterministic sampling mask: `out[i] = splitmix64(ids[i], seed) <= threshold`.
 /// One fused pass — the NumPy expression allocates five full-width u64
 /// temporaries (~80 MB each at 10M rows) and dominated the density payload
-/// build; this reads ids once and writes the byte mask once.
-pub fn sample_mask(ids: &[u64], seed: u64, threshold: u64, out: &mut [u8]) {
+/// build; this reads ids once and writes the byte mask once. u32 ids widen
+/// in-register, avoiding a caller-side u64 selection copy.
+pub fn sample_mask<T: Copy + Sync + Into<u64>>(
+    ids: &[T],
+    seed: u64,
+    threshold: u64,
+    out: &mut [u8],
+) {
     assert_eq!(ids.len(), out.len());
     sample_mask_impl(ids, seed, threshold, par_threads(ids.len()), out)
 }
@@ -3833,10 +3839,16 @@ fn bin_2d_stratified_sample_range_u8_impl(
     complete_stratified_sample_range(groups, counts, seed, min_count, selected, &kept)
 }
 
-fn sample_mask_impl(ids: &[u64], seed: u64, threshold: u64, threads: usize, out: &mut [u8]) {
+fn sample_mask_impl<T: Copy + Sync + Into<u64>>(
+    ids: &[T],
+    seed: u64,
+    threshold: u64,
+    threads: usize,
+    out: &mut [u8],
+) {
     if threads <= 1 || ids.len() < 2 {
         for (o, &id) in out.iter_mut().zip(ids) {
-            *o = u8::from(splitmix64(id, seed) <= threshold);
+            *o = u8::from(splitmix64(id.into(), seed) <= threshold);
         }
         return;
     }
@@ -3845,7 +3857,7 @@ fn sample_mask_impl(ids: &[u64], seed: u64, threshold: u64, threads: usize, out:
         for (seg_ids, seg_out) in ids.chunks(per).zip(out.chunks_mut(per)) {
             s.spawn(move || {
                 for (o, &id) in seg_out.iter_mut().zip(seg_ids) {
-                    *o = u8::from(splitmix64(id, seed) <= threshold);
+                    *o = u8::from(splitmix64(id.into(), seed) <= threshold);
                 }
             });
         }
@@ -3879,8 +3891,8 @@ fn sample_threshold(fraction: f64) -> u64 {
 ///
 /// `groups[i]` must be `< n_groups`; returns false (output undefined) on an
 /// out-of-range code.
-pub fn stratified_sample_mask(
-    ids: &[u64],
+pub fn stratified_sample_mask<T: Copy + Sync + Into<u64>>(
+    ids: &[T],
     groups: &[u32],
     n_groups: usize,
     seed: u64,
@@ -3924,7 +3936,7 @@ pub fn stratified_sample_mask(
                 s.spawn(move || {
                     let mut kept = vec![0u64; n_groups];
                     for ((o, &id), &g) in seg_out.iter_mut().zip(seg_ids).zip(seg_groups) {
-                        let keep = splitmix64(id, seed) <= thresholds_ref[g as usize];
+                        let keep = splitmix64(id.into(), seed) <= thresholds_ref[g as usize];
                         *o = u8::from(keep);
                         kept[g as usize] += u64::from(keep);
                     }
@@ -3955,7 +3967,7 @@ pub fn stratified_sample_mask(
         let mut pools: Vec<Vec<(u64, usize)>> = vec![Vec::new(); n_groups];
         for (i, (&id, &g)) in ids.iter().zip(groups).enumerate() {
             if deficient[g as usize] {
-                pools[g as usize].push((splitmix64(id, seed), i));
+                pools[g as usize].push((splitmix64(id.into(), seed), i));
             }
         }
         for (g, pool) in pools.iter_mut().enumerate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ unsafe fn borrowed_byte_spans<'a>(
 /// ABI version — bumped on any signature change. The Python wrapper checks this
 /// at load time and refuses a mismatched library loudly (§33 comm-versioning
 /// rule, applied to the in-process boundary).
-pub const ABI_VERSION: u32 = 31;
+pub const ABI_VERSION: u32 = 32;
 const FACTORIZE_CAPACITY_EXCEEDED: usize = usize::MAX - 1;
 
 #[no_mangle]
@@ -2249,6 +2249,33 @@ pub unsafe extern "C" fn fc_sample_mask(
     })
 }
 
+/// `fc_sample_mask` over u32 row indices: each id widens to u64 in-register,
+/// bit-identical to widening the full array first without that allocation.
+///
+/// # Safety
+/// `ids` must point to `len` readable u32s; `out` to `len` writable u8s.
+#[no_mangle]
+pub unsafe extern "C" fn fc_sample_mask_u32(
+    ids: *const u32,
+    len: usize,
+    seed: u64,
+    threshold: u64,
+    out: *mut u8,
+) -> i32 {
+    if len == 0 {
+        return 1;
+    }
+    if ids.is_null() || out.is_null() {
+        return 0;
+    }
+    let ids = std::slice::from_raw_parts(ids, len);
+    let out = std::slice::from_raw_parts_mut(out, len);
+    ffi_guard(0, || {
+        kernels::sample_mask(ids, seed, threshold, out);
+        1
+    })
+}
+
 /// Deterministically sample implicit row ids `0..size`. Returns the required
 /// output length; values are written only when `capacity` is sufficient.
 /// `usize::MAX` reports an invalid size/pointer combination.
@@ -2393,6 +2420,45 @@ pub unsafe extern "C" fn fc_stratified_sample_range_u8_counted(
 #[allow(clippy::too_many_arguments)]
 pub unsafe extern "C" fn fc_stratified_sample_mask(
     ids: *const u64,
+    groups: *const u32,
+    len: usize,
+    n_groups: usize,
+    seed: u64,
+    fraction: f64,
+    min_count: u64,
+    out: *mut u8,
+) -> i32 {
+    if len == 0 {
+        return 1;
+    }
+    if ids.is_null()
+        || groups.is_null()
+        || out.is_null()
+        || n_groups == 0
+        || !fraction.is_finite()
+        || fraction <= 0.0
+    {
+        return 0;
+    }
+    let ids = std::slice::from_raw_parts(ids, len);
+    let groups = std::slice::from_raw_parts(groups, len);
+    let out = std::slice::from_raw_parts_mut(out, len);
+    ffi_guard(0, || {
+        kernels::stratified_sample_mask(ids, groups, n_groups, seed, fraction, min_count, out)
+            as i32
+    })
+}
+
+/// `fc_stratified_sample_mask` over u32 row indices, with the same in-register
+/// widening contract as [`fc_sample_mask_u32`].
+///
+/// # Safety
+/// `ids` and `groups` must point to `len` readable u32s; `out` to `len`
+/// writable u8s.
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn fc_stratified_sample_mask_u32(
+    ids: *const u32,
     groups: *const u32,
     len: usize,
     n_groups: usize,

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -837,6 +837,19 @@ def test_sample_mask_matches_numpy_hash_reference(impl):
         np.testing.assert_array_equal(got, ref)
 
 
+def test_sample_mask_u32_ids_match_widened_u64(impl):
+    from xy import lod
+
+    rng = np.random.default_rng(13)
+    ids32 = rng.integers(0, 2**32, size=100_000, dtype=np.uint64).astype(np.uint32)
+    for seed, fraction in [(0, 0.5), (7, 0.001), (2**40, 0.25)]:
+        threshold = int(lod._sample_threshold(fraction))
+        np.testing.assert_array_equal(
+            impl.sample_mask(ids32, seed, threshold),
+            impl.sample_mask(ids32.astype(np.uint64), seed, threshold),
+        )
+
+
 def test_density_log_u8_matches_wire_reference(impl):
     grid = np.array([0, 1, 2, 3, 9, 100, 10_000], dtype=np.float32)
     encoded, maximum = impl.density_log_u8(grid)
@@ -890,6 +903,18 @@ def test_stratified_sample_mask_matches_numpy_reference(impl):
         got = impl.stratified_sample_mask(ids, groups, 4, 9, fraction, min_count)
         assert got.dtype == np.bool_
         np.testing.assert_array_equal(got, reference(fraction, min_count))
+
+
+def test_stratified_sample_mask_u32_ids_match_widened_u64(impl):
+    rng = np.random.default_rng(17)
+    n = 50_000
+    ids32 = rng.permutation(n).astype(np.uint32)
+    groups = rng.choice(4, size=n, p=[0.9, 0.06, 0.039, 0.001]).astype(np.uint32)
+    for fraction, min_count in [(1 / 4096, 1), (1 / 64, 5), (0.5, 0)]:
+        np.testing.assert_array_equal(
+            impl.stratified_sample_mask(ids32, groups, 4, 9, fraction, min_count),
+            impl.stratified_sample_mask(ids32.astype(np.uint64), groups, 4, 9, fraction, min_count),
+        )
 
 
 def test_stratified_sample_mask_edges(impl):


### PR DESCRIPTION
## Summary

Ports the payload-copy elimination work onto the current native core (ABI v32) after the large performance-ceiling merge:

- `sample_mask` and `stratified_sample_mask` accept native `u32` row selections and widen each ID in-register, avoiding a source-sized `u64` copy on partial density views.
- `bin_2d_indices` and `range_indices` return the exact full allocation directly when no trailing slack needs trimming.
- `_PayloadWriter` retains encoded arrays and copies each column once into the final blob, including aligned `u8` payloads and borrowed heatmap spans.
- ABI, Rust, Python, and smoke parity coverage asserts that `u32` and widened `u64` sampling are identical.

## Why

PR #29 introduced faster fused full-domain paths, but partial selections still produced `u32` IDs that were widened through a full allocation, while multi-column payload assembly still copied each encoded array through `tobytes()` before the final join.

## Current-main measurements

Apple Silicon, same process shape and current `main` baseline:

- 10M-row `u32` sample mask median: **1.70 ms → 0.62 ms** (~2.7× faster).
- Five-column payload writer (5 × 5M f32 values) median: **3.17 ms → 1.61 ms** (~2× faster).
- Fresh 10M-point full-domain density compose/build remains effectively unchanged: **4.37 ms → 4.16 ms** (the newer fused path already handles this case).

Payload bytes and sampling decisions are unchanged.

## Validation

- `cargo test` — 99 passed
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `pytest -q tests/test_kernels.py tests/test_scatter.py` — 171 passed
- `python scripts/abi_smoke.py` — 121 checks
- repository pre-commit, Ruff lint, and Ruff format gates
