### PR TITLE
Fix density sample overlay persistence and sync roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ in the README).
   assembly retains encoded arrays until the final blob join instead of copying
   every column through `tobytes()` first. Payload bytes and sampling decisions
   remain parity-tested and unchanged.
+- **Stable hybrid density overlays.** Pyramid-served pan/zoom updates now keep
+  the retained deterministic point sample when they omit a replacement,
+  instead of making the first-paint overlay disappear on interaction. Exact
+  scans still replace it with their view-specific sample.
 - **View-change callback windows** now reject non-finite bounds and normalize
   inverted ranges before callbacks receive them, matching selection and
   autorange window semantics.

--- a/docs/chart-roadmap.md
+++ b/docs/chart-roadmap.md
@@ -352,33 +352,26 @@ interaction-latency comparison, not assumed.
 
 ## Recommended Sequence
 
-The first breadth milestone — **histogram, bar/column, area, heatmap** — is
-**done** (core primitives + styling). Candlestick/OHLC + finance overlays are
-**prototyped on the closed finance exploration PR** and need a fresh landing. That clears the rectangle-,
-polygon-, and grid-texture foundations, so the next block is statistical
-breadth on top of them, then the two "completeness" charts users ask for first.
+The first breadth milestone — **histogram, bar/column, area, heatmap** — and
+the first statistical block — **box, violin, ECDF, error bars/bands, hexbin,
+contour, steps/stairs/stems, and facets** — are done. The engine and packaging
+gates are ready for the first alpha; the next sequence is therefore product
+integration and compatibility depth, not re-implementing shipped primitives.
 
-1. **Box + violin** — the highest-value missing statistical charts.
-   - Compute quartiles/outliers (box) and a bounded KDE/density grid (violin)
-     from canonical f64 columns kernel-side; ship tiny geometry (a few verts
-     per group), not raw points.
-   - Grouped/categorical axis reuse; exact hover summary (q1/median/q3/whiskers).
-
-2. **Error bars / bands** — needed for science, forecasting, experiment dashboards.
-   - Error bars as instanced line segments; bands as a filled area around a line
-     (reuse the area polygon path). Pairs naturally with a confidence-interval
-     helper on line/scatter.
-
-3. **2D density / hexbin** — makes dense scatter honest as a *named* chart.
-   - Generalize the existing Tier-2 density path: expose counts, log color
-     scaling, and hover readout as `fc.hexbin(...)` / `density_heatmap`.
-
-4. **Pie / donut** — low performance differentiation but a top dashboard ask;
-   implement for completeness (arc geometry + label placement).
-
-5. **Re-land the finance surface** (fresh PR from the closed exploration
-   branch, rebased onto current primitives), then extend rank-35 breadth
-   (depth chart, Heikin-Ashi, Renko) on the `FinanceLayer` system.
+1. **Ship and stabilize the `0.1.x` alpha.** Keep correctness, interaction,
+   packaging, and benchmark gates green while real users exercise the public
+   composition and `xy.pyplot` surfaces.
+2. **Reflex-first reactive API.** Bind charts to Reflex state/data keys through
+   the transport-neutral channel dispatcher without manual payload rebuilds or
+   a hard Reflex dependency in core `xy`.
+3. **Statistical compatibility depth.** Add strip/swarm/boxen/rug,
+   regression/diagnostic helpers, richer density hover/readout, and
+   scatter-matrix/joint-plot composition on the shipped primitives.
+4. **Pie / donut.** Low performance differentiation but a top dashboard ask;
+   implement for completeness with bounded arc geometry and label placement.
+5. **Re-land the finance surface.** Open a fresh PR from the closed exploration
+   branch, rebased onto current composition/LOD primitives, then extend the
+   `FinanceLayer` system with depth charts, Heikin-Ashi, and Renko.
 
 Parallel, non-chart-type tracks:
 
@@ -389,9 +382,8 @@ Parallel, non-chart-type tracks:
   fast truecolor PNGs, and a baked bitmap font for text. `optimize=True`
   retains the slower indexed-palette path for smaller files;
   `engine="chromium"` stays for a pixel-exact WebGL screenshot.
-- **Reflex-first reactive API**: the one deliberately-deferred product
-  requirement — a reactive/data-key-driven surface so charts bind to Reflex
-  state without manual payload rebuilds. Now the main remaining non-breadth track.
+- **Reflex-first reactive API** — now the primary post-alpha product track, as
+  described in step 2 above.
 
 ## Near-Term API Sketch
 
@@ -403,13 +395,13 @@ fc.histogram_chart(fc.hist(values, bins=512, density=False, cumulative=False))
 fc.bar_chart(fc.bar(categories, values, mode="grouped", orientation="vertical"))
 fc.area_chart(fc.area(x, y, base=0.0))     # + fill=linear-gradient, curve, dash
 fc.heatmap_chart(fc.heatmap(z, x=None, y=None, colormap="viridis"))
-fc.candlestick_chart(fc.candlestick(x, open, high, low, close))  # prototyped (closed finance PR)
-
-# next
 fc.box_chart(fc.box(values, group=None))
 fc.violin_chart(fc.violin(values, group=None, bandwidth="auto"))
 fc.chart(fc.errorbar(x, y, yerr=..., xerr=...))
 fc.chart(fc.hexbin(x, y, gridsize=50, color_scale="log"))
+fc.candlestick_chart(fc.candlestick(x, open, high, low, close))  # prototyped (closed finance PR)
+
+# next
 fc.pie_chart(fc.pie(values, labels=..., donut=0.0))
 ```
 
@@ -418,10 +410,9 @@ New chart kinds land as composition marks plus a family container
 
 ## Decision Summary
 
-The rectangle / polygon / grid-texture foundations and full mark styling are
-in place, and finance (candlestick + indicators) is prototyped on a closed
-exploration PR awaiting a fresh landing. The next regular
-2D work is **statistical breadth** — box, violin, error bars/bands, hexbin —
-followed by **pie/donut** for dashboard completeness. In parallel, the **native
-PNG rasterizer** (perf) and the **Reflex-first reactive API** (the last deferred
-product requirement) are the two non-chart-type tracks.
+The rectangle/polygon/grid-texture foundations, statistical breadth block,
+full mark styling, and native PNG rasterizer are in place. The next product
+track is the **Reflex-first reactive API**, followed by statistical
+compatibility depth and **pie/donut** completeness. Finance (candlestick plus
+indicators) remains prototyped on a closed exploration branch awaiting a fresh
+landing.

--- a/docs/chart-roadmap.md
+++ b/docs/chart-roadmap.md
@@ -267,8 +267,10 @@ and drill updates emit the same wire shape.
 
 - *Hybrid overlay* — exact-scan density views now render a density background
   plus a deterministic stratified sample of real points, with an explicit
-  "sampled n of N" badge. Remaining work: make pyramid-served density views
-  produce tile-aware sampled overlays without rescanning raw rows.
+  "sampled n of N" badge. Pyramid-served views retain and viewport-clip that
+  deterministic overlay instead of dropping it on the first interaction.
+  Remaining work: make pyramid-served density views produce tile-aware sampled
+  overlays without rescanning raw rows.
 - *Standalone (kernel-less) refinement* — **shipped.** A `to_html` export used
   to stretch the overview texture on zoom; it now re-bins the retained sample
   in a bundled Web Worker (off the main thread, `worker-src blob:` CSP),

--- a/examples/matplotlib_shim.ipynb
+++ b/examples/matplotlib_shim.ipynb
@@ -464,7 +464,7 @@
     "axes[1].set_title(\"barbs\")\n",
     "\n",
     "stream = axes[2].streamplot(vx, vy, u, v, density=0.8, maxlength=3.0, color=\"tab:green\")\n",
-    "assert stream.lines is stream.arrows\n",
+    "assert stream.lines is not stream.arrows\n",
     "axes[2].set_title(\"native streamplot\")\n",
     "fig.tight_layout()\n",
     "fig"

--- a/js/src/45_lod.js
+++ b/js/src/45_lod.js
@@ -415,7 +415,14 @@ function lodApplyDensityUpdate(view, g, upd, buffers) {
     tex: view._uploadGrid(grid, d.w, d.h, normMax),
     lut: g.density.lut,
   };
-  view._applyDensitySample(g, d.sample, buffers);
+  // Exact scans include a view-specific sample and replace the overlay.
+  // Pyramid responses intentionally omit one until tile-aware sampling lands;
+  // preserve the retained deterministic sample in that case so the hybrid
+  // overlay does not disappear after the first pan/zoom (#24). The draw path
+  // already clips it to its recorded window.
+  if (Object.prototype.hasOwnProperty.call(d, "sample")) {
+    view._applyDensitySample(g, d.sample, buffers);
+  }
   lodStartNormAnim(view, g, normMax, d.max);
   lodRememberDensity(view, g, g.density);
 }

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -1296,7 +1296,9 @@ grid,
 tex: view._uploadGrid(grid, d.w, d.h, normMax),
 lut: g.density.lut,
 };
+if (Object.prototype.hasOwnProperty.call(d, "sample")) {
 view._applyDensitySample(g, d.sample, buffers);
+}
 lodStartNormAnim(view, g, normMax, d.max);
 lodRememberDensity(view, g, g.density);
 }

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -1297,7 +1297,9 @@ grid,
 tex: view._uploadGrid(grid, d.w, d.h, normMax),
 lut: g.density.lut,
 };
+if (Object.prototype.hasOwnProperty.call(d, "sample")) {
 view._applyDensitySample(g, d.sample, buffers);
+}
 lodStartNormAnim(view, g, normMax, d.max);
 lodRememberDensity(view, g, g.density);
 }

--- a/tests/test_static_client_security.py
+++ b/tests/test_static_client_security.py
@@ -344,6 +344,7 @@ def test_client_refreshes_and_destroys_density_sample_overlays() -> None:
     )
     for path in lod_files:
         text = path.read_text(encoding="utf-8")
+        assert 'Object.prototype.hasOwnProperty.call(d, "sample")' in text
         assert "view._applyDensitySample(g, d.sample, buffers);" in text
 
 


### PR DESCRIPTION
## Summary

- preserve the deterministic density sample overlay when pyramid LOD updates omit a replacement sample
- keep explicit exact-scan samples authoritative when a response includes one
- add static-client regression coverage and rebuild the checked-in browser bundles
- sync the chart roadmap with the now-shipped statistical surface
- correct the Matplotlib shim notebook's streamplot collection assertion

## Root cause

The initial density payload includes a deterministic sample overlay, while pyramid-served updates intentionally omit `sample`. The client treated that omission as an empty replacement and destroyed the retained overlay after the first pan or zoom.

The update path now distinguishes an omitted sample from an explicitly supplied sample.

## Validation

- `make check-full` — 1,318 Python tests passed, 7 skipped; 99 Rust tests passed; ABI smoke 121 passed; 13 required checks passed (type diagnostics remain advisory)
- `make check-examples` — 74 passed
- focused density and streamplot tests — 5 passed
- `pre-commit run --all-files` — ruff check and format passed

Closes #24