### PR TITLE
Remove remaining runtime Matplotlib imports

### DIFF
--- a/python/xy/pyplot/__init__.py
+++ b/python/xy/pyplot/__init__.py
@@ -372,28 +372,24 @@ class _ColormapRegistry:
         return Cmap(name)
 
     def __iter__(self):
-        fallback = (
-            "viridis",
-            "plasma",
-            "inferno",
-            "magma",
-            "cividis",
-            "gray",
-            "turbo",
-            "coolwarm",
-            "RdBu",
-            "bwr",
-            "Blues",
-            "RdYlGn",
-            "rainbow",
-            "Spectral",
+        return iter(
+            (
+                "viridis",
+                "plasma",
+                "inferno",
+                "magma",
+                "cividis",
+                "gray",
+                "turbo",
+                "coolwarm",
+                "RdBu",
+                "bwr",
+                "Blues",
+                "RdYlGn",
+                "rainbow",
+                "Spectral",
+            )
         )
-        try:
-            _matplotlib = __import__("matplotlib")
-
-            return iter(tuple(_matplotlib.colormaps))
-        except (ImportError, AttributeError):
-            return iter(fallback)
 
 
 colormaps = _ColormapRegistry()

--- a/python/xy/pyplot/_artists.py
+++ b/python/xy/pyplot/_artists.py
@@ -8,12 +8,39 @@ dominant mutation idioms without reproducing matplotlib's artist graph.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from itertools import pairwise
 from typing import Any, Optional
 
 import numpy as np
 
 from ._colors import resolve_color
+
+
+@dataclass(frozen=True)
+class Bbox:
+    """Dependency-free subset of ``matplotlib.transforms.Bbox`` used by the shim."""
+
+    x0: float
+    y0: float
+    x1: float
+    y1: float
+
+    @classmethod
+    def from_bounds(cls, x0: float, y0: float, width: float, height: float) -> "Bbox":
+        return cls(float(x0), float(y0), float(x0 + width), float(y0 + height))
+
+    @property
+    def width(self) -> float:
+        return self.x1 - self.x0
+
+    @property
+    def height(self) -> float:
+        return self.y1 - self.y0
+
+    @property
+    def bounds(self) -> tuple[float, float, float, float]:
+        return (self.x0, self.y0, self.width, self.height)
 
 
 class Artist:
@@ -536,8 +563,6 @@ class Text(Artist):
 
     def get_window_extent(self, renderer: Any = None) -> Any:
         del renderer
-        Bbox = __import__("matplotlib.transforms", fromlist=["Bbox"]).Bbox
-
         x, y, text = self._entry["args"]
         width = max(0.05, len(str(text)) * 0.018)
         return Bbox.from_bounds(float(x) - width / 2, float(y) - 0.04, width, 0.08)

--- a/python/xy/pyplot/_axes.py
+++ b/python/xy/pyplot/_axes.py
@@ -18,8 +18,17 @@ import numpy as np
 
 import xy as fc
 
-from ._artists import Artist, AxesImage, BarContainer, Line2D, PathCollection, PolyCollection, Text
-from ._colors import PROP_CYCLE, resolve_cmap, resolve_color
+from ._artists import (
+    Artist,
+    AxesImage,
+    BarContainer,
+    Bbox,
+    Line2D,
+    PathCollection,
+    PolyCollection,
+    Text,
+)
+from ._colors import PROP_CYCLE, Cmap, resolve_cmap, resolve_color, to_rgba
 from ._fmt import parse_fmt
 from ._plot_types import PlotTypeMixin
 from ._rc import rcParams
@@ -45,22 +54,6 @@ _MPL_GRID_COLOR = "#b0b0b0"
 # core once, not once per figure (the perf guardrail in tests/pyplot counts
 # on this staying O(1) per process).
 _component_cache: dict[tuple, Any] = {}
-_identity_transform_class: Any = None
-_identity_transform_checked = False
-
-
-def _identity_transform() -> Any:
-    """Return Matplotlib's identity transform when available, without retrying imports."""
-    global _identity_transform_checked, _identity_transform_class
-    if not _identity_transform_checked:
-        try:
-            _identity_transform_class = __import__(
-                "matplotlib.transforms", fromlist=["IdentityTransform"]
-            ).IdentityTransform
-        except ImportError:
-            _identity_transform_class = False
-        _identity_transform_checked = True
-    return _identity_transform_class() if _identity_transform_class else "data"
 
 
 class _AxisProxy:
@@ -137,10 +130,8 @@ class Axes(PlotTypeMixin):
         self._chart: Any = None
         self._twin: Optional[Axes] = None
         self._y2_of = y2_of  # when set, our marks target axis id "y2" on the host
-        self.transAxes = _identity_transform()
-        self.transData = _identity_transform()
-        if self.transAxes == "data":
-            self.transAxes = "axes fraction"
+        self.transAxes = "axes fraction"
+        self.transData = "data"
         self.xaxis = _AxisProxy(self, "x")
         self.yaxis = _AxisProxy(self, "y")
         self.spines = _SpineProxy()
@@ -751,14 +742,7 @@ class Axes(PlotTypeMixin):
             mapped = np.ma.asarray(norm(grid), dtype=np.float64)
             cmap_callable = cmap if callable(cmap) else None
             if cmap_callable is None:
-                try:
-                    mpl_colormaps = __import__("matplotlib", fromlist=["colormaps"]).colormaps
-
-                    cmap_callable = mpl_colormaps.get_cmap(cmap or rcParams["image.cmap"])
-                except (ImportError, ValueError):
-                    from ._colors import Cmap
-
-                    cmap_callable = Cmap(cmap or rcParams["image.cmap"])
+                cmap_callable = Cmap(cmap or rcParams["image.cmap"])
             rgba = np.asarray(cmap_callable(mapped), dtype=np.float64)
             mask = np.ma.getmaskarray(mapped) | ~np.isfinite(grid)
             if rgba.shape[-1] == 3:
@@ -766,8 +750,6 @@ class Axes(PlotTypeMixin):
             rgba[..., 3] = np.where(mask, 0.0, rgba[..., 3])
             grid, truecolor = rgba, True
         if not truecolor and has_extremes:
-            to_rgba = __import__("matplotlib.colors", fromlist=["to_rgba"]).to_rgba
-
             from xy._svg import _lut
 
             finite = grid[np.isfinite(grid)]
@@ -1134,8 +1116,6 @@ class Axes(PlotTypeMixin):
         return (hi, lo) if self._axis_props("y").get("reverse") else (lo, hi)
 
     def get_position(self) -> Any:
-        Bbox = __import__("matplotlib.transforms", fromlist=["Bbox"]).Bbox
-
         return Bbox.from_bounds(0.125, 0.11, 0.775, 0.77)
 
     def set_position(self, position: Any) -> None:

--- a/python/xy/pyplot/_colors.py
+++ b/python/xy/pyplot/_colors.py
@@ -156,6 +156,21 @@ def resolve_color(value: object) -> Optional[str]:
     return f"rgb({level},{level},{level})"
 
 
+def to_rgba(value: object, alpha: object = None) -> tuple[float, float, float, float]:
+    """Convert the shim's color vocabulary to normalized RGBA without Matplotlib."""
+    if isinstance(value, tuple) and len(value) == 2 and isinstance(value[0], str):
+        value, stored_alpha = value
+        if alpha is None:
+            alpha = stored_alpha
+    from xy._raster import _parse_color
+
+    css = resolve_color(value)
+    rgba = np.asarray(_parse_color(css or "transparent"), dtype=np.float64) / 255.0
+    if alpha is not None:
+        rgba[3] = np.asarray(alpha, dtype=np.float64).item()
+    return (float(rgba[0]), float(rgba[1]), float(rgba[2]), float(rgba[3]))
+
+
 def resolve_cmap(name: object) -> str:
     """A matplotlib cmap (name or object) → engine colormap name."""
     text = getattr(name, "name", name)

--- a/python/xy/pyplot/_plot_types.py
+++ b/python/xy/pyplot/_plot_types.py
@@ -31,7 +31,7 @@ from ._artists import (
     Text,
     Wedge,
 )
-from ._colors import PROP_CYCLE, resolve_cmap, resolve_color
+from ._colors import PROP_CYCLE, Cmap, resolve_cmap, resolve_color
 from ._fmt import parse_fmt
 from ._translate import (
     LINESTYLE_TO_DASH,
@@ -2536,14 +2536,7 @@ class PlotTypeMixin:
                 mapped = np.ma.asarray(norm(z), dtype=np.float64)
                 cmap_callable = cmap if callable(cmap) else None
                 if cmap_callable is None:
-                    try:
-                        mpl_colormaps = __import__("matplotlib", fromlist=["colormaps"]).colormaps
-
-                        cmap_callable = mpl_colormaps.get_cmap(cmap or "viridis")
-                    except (ImportError, ValueError):
-                        from ._colors import Cmap
-
-                        cmap_callable = Cmap(cmap or "viridis")
+                    cmap_callable = Cmap(cmap or "viridis")
                 rendered_z = np.asarray(cmap_callable(mapped), dtype=np.float64)
                 mask = np.ma.getmaskarray(mapped) | ~np.isfinite(z)
                 if rendered_z.shape[-1] == 3:
@@ -3536,61 +3529,25 @@ class PlotTypeMixin:
         mapped_color: Any = None
         mapped_width: Any = None
         arrow_count = 0
-        try:
-            # The compatibility layer can reuse Matplotlib's well-tested
-            # integrator without using its renderer.  This preserves explicit
-            # seeds, masks, adaptive controls, and per-segment scalar values;
-            # the resulting paths still render entirely through xy.
-            MatplotlibFigure = __import__("matplotlib.figure", fromlist=["Figure"]).Figure
+        from xy import kernels
 
-            mpl_ax = MatplotlibFigure().subplots()
-            mpl_kwargs: dict[str, Any] = {
-                "density": density,
-                "linewidth": linewidth,
-                "color": color,
-                "cmap": cmap,
-                "norm": norm,
-                "arrowsize": arrowsize,
-                "arrowstyle": arrowstyle,
-                "minlength": minlength,
-                "start_points": start_points,
-                "maxlength": maxlength,
-                "integration_direction": integration_direction,
-                "broken_streamlines": broken_streamlines,
-                "integration_max_step_scale": integration_max_step_scale,
-                "integration_max_error_scale": integration_max_error_scale,
-                "num_arrows": num_arrows,
-            }
-            mpl_kwargs = {key: value for key, value in mpl_kwargs.items() if value is not None}
-            mpl_result = mpl_ax.streamplot(x_values, y_values, u_values, v_values, **mpl_kwargs)
-            source_segments = [
-                np.asarray(segment, dtype=np.float64)
-                for segment in mpl_result.lines.get_segments()
-                if len(segment) >= 2
-            ]
-            mapped_color = mpl_result.lines.get_array()
-            mapped_width = np.asarray(mpl_result.lines.get_linewidths(), dtype=np.float64)
-            arrow_count = len(mpl_result.arrows.get_paths())
-        except (ImportError, TypeError, ValueError):
-            from xy import kernels
-
-            density_value = float(np.max(np.asarray(density, dtype=np.float64)))
-            max_steps = max(1, min(100_000, int(float(maxlength) * max(u_values.shape) * 8)))
-            kx0, kx1, ky0, ky1 = kernels.streamlines(
-                x_values,
-                y_values,
-                u_values,
-                v_values,
-                density=density_value,
-                max_steps=max_steps,
-            )
-            source_segments = [
-                np.asarray([[sx, sy], [ex, ey]], dtype=np.float64)
-                for sx, ex, sy, ey in zip(kx0, kx1, ky0, ky1, strict=True)
-            ]
-            arrow_count = max(
-                1, min(len(source_segments), int(30 * float(np.max(np.asarray(density)))))
-            )
+        density_value = float(np.max(np.asarray(density, dtype=np.float64)))
+        max_steps = max(1, min(100_000, int(float(maxlength) * max(u_values.shape) * 8)))
+        kx0, kx1, ky0, ky1 = kernels.streamlines(
+            x_values,
+            y_values,
+            u_values,
+            v_values,
+            density=density_value,
+            max_steps=max_steps,
+        )
+        source_segments = [
+            np.asarray([[sx, sy], [ex, ey]], dtype=np.float64)
+            for sx, ex, sy, ey in zip(kx0, kx1, ky0, ky1, strict=True)
+        ]
+        arrow_count = max(
+            1, min(len(source_segments), int(30 * float(np.max(np.asarray(density)))))
+        )
 
         x0_values: list[float] = []
         y0_values: list[float] = []

--- a/tests/pyplot/test_boundaries.py
+++ b/tests/pyplot/test_boundaries.py
@@ -73,7 +73,7 @@ def test_shim_import_stays_light() -> None:
     )
 
 
-def test_shim_never_imports_real_matplotlib_statically() -> None:
+def test_shim_contains_no_real_matplotlib_imports() -> None:
     shim = PACKAGE / "pyplot"
     for path in shim.rglob("*.py"):
         tree = ast.parse(path.read_text(), filename=str(path))
@@ -82,3 +82,43 @@ def test_shim_never_imports_real_matplotlib_statically() -> None:
                 assert not any(a.name.split(".")[0] == "matplotlib" for a in node.names), path
             if isinstance(node, ast.ImportFrom):
                 assert (node.module or "").split(".")[0] != "matplotlib", path
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "__import__"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+            ):
+                assert node.args[0].value.split(".")[0] != "matplotlib", path
+
+
+def test_runtime_paths_never_import_real_matplotlib() -> None:
+    _run_fresh(
+        """
+        import sys
+        import numpy as np
+
+        class RejectMatplotlib:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname.split(".")[0] == "matplotlib":
+                    raise AssertionError(f"xy attempted to import {fullname}")
+                return None
+
+        sys.meta_path.insert(0, RejectMatplotlib())
+
+        import xy.pyplot as plt
+
+        fig = plt.figure(facecolor="rgba(12,34,56,0.5)")
+        ax = fig.add_axes([0.1, 0.1, 0.8, 0.8])
+        cmap = plt.get_cmap("viridis").with_extremes(
+            under="yellow", over="limegreen", bad="transparent"
+        )
+        ax.imshow(np.array([[-2.0, 0.0, 2.0, np.nan]]), cmap=cmap, vmin=-1.0, vmax=1.0)
+        assert ax.get_position().bounds == (0.125, 0.11, 0.775, 0.77)
+        extent = ax.text(0.5, 0.5, "label").get_window_extent()
+        assert extent.width > 0 and extent.height > 0
+        assert fig._to_png().startswith(b"\\x89PNG\\r\\n\\x1a\\n")
+        assert not any(name.split(".")[0] == "matplotlib" for name in sys.modules)
+        """
+    )

--- a/tests/pyplot/test_launch_compat.py
+++ b/tests/pyplot/test_launch_compat.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from importlib.util import find_spec
 from io import BytesIO
 
 import numpy as np
@@ -248,17 +247,10 @@ def test_streamplot_preserves_explicit_seeds_scalar_colors_and_widths() -> None:
         cmap="viridis",
     )
     entries = [entry for entry in ax._entries if entry.get("factory") == "segments"]
-    has_matplotlib = find_spec("matplotlib") is not None
-    if has_matplotlib:
-        assert len(entries) > 1  # optional integrator retains varying widths
-    else:
-        assert entries  # dependency-free fallback still renders streamlines
+    assert entries
     assert all(len(entry["args"][0]) > 0 for entry in entries)
     assert all(entry["kwargs"].get("domain") == (-1.0, 1.0) for entry in entries)
-    if has_matplotlib:
-        assert any(np.ptp(np.asarray(entry["kwargs"]["color"])) > 0 for entry in entries)
-    else:
-        assert all("color" in entry["kwargs"] for entry in entries)
+    assert all("color" in entry["kwargs"] for entry in entries)
 
 
 def test_log_locator_contours_and_labels_use_real_contour_geometry() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #33 based on the P0 findings in the Matplotlib fidelity audit.

- replace every remaining shipped pyplot dynamic Matplotlib import with xy-native behavior
- add dependency-free RGBA conversion and bounds objects
- make colormap lookup, transforms, normalized images, pcolormesh, and streamlines environment-independent
- add static and fresh-process regression guards that reject attempted Matplotlib imports

## Root cause

The pyplot shim contained several runtime `__import__("matplotlib…")` calls. They escaped the existing AST guard and made behavior depend on whether Matplotlib happened to be installed, contradicting the shim's dependency-free boundary.

The affected paths included colormap extremes and normalized images, `Axes.get_position()`, `Text.get_window_extent()`, transform setup, colormap enumeration, pcolormesh normalization, and streamplot integration. The `_grid.py` absolute-export case and package metadata were fixed by #33.

## Validation

- `uv run pytest tests/pyplot -q` — 158 passed, 7 skipped
- fresh-process test blocks every top-level `matplotlib` import while exercising absolute-axis PNG export, colormap extremes, bounds, and text extents
- static AST guard rejects literal `__import__("matplotlib…")` calls
- `uv run --with pre-commit pre-commit run --all-files`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check python/xy/pyplot/_colors.py`