### PR TITLE
Ship first paint as per-column split buffers (§29)

### DIFF
--- a/benchmarks/test_codspeed_kernels.py
+++ b/benchmarks/test_codspeed_kernels.py
@@ -65,6 +65,7 @@ def warm_lazy_modules() -> None:
     y = np.array([0.0, 1.0, 0.0, 1.0])
     fig = fc.chart(fc.scatter(x=x, y=y), fc.line(x=x, y=y)).figure()
     fig.build_payload(N_BUCKETS)
+    fig.build_payload_split(N_BUCKETS)
     fig.to_svg(width=64, height=48)
     fig.to_png(engine="native", scale=1.0)
     fig.to_html()
@@ -580,16 +581,22 @@ def test_range_indices(benchmark, data):
     benchmark(k.range_indices, x, y, N * 0.45, N * 0.55, -2.0, 2.0)
 
 
+# The first-payload helpers measure the production widget first paint, which
+# ships the split buffer layout (§29): per-column borrowed buffers, no join
+# copy. Repointing them from build_payload created a one-time step improvement
+# in these series; the packed layout stays tracked by test_build_payload and
+# the export benchmarks (to_png/to_svg/to_html), which are its remaining
+# production consumers.
 def _scatter_payload(x: np.ndarray, y: np.ndarray, *, density: bool | None = None) -> int:
     fig = fc.chart(fc.scatter(x=x, y=y, density=density)).figure()
-    _spec, blob = fig.build_payload(N_BUCKETS)
-    return len(blob)
+    _spec, buffers = fig.build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
 
 
 def _line_payload(x: np.ndarray, y: np.ndarray) -> int:
     fig = fc.chart(fc.line(x=x, y=y)).figure()
-    _spec, blob = fig.build_payload(N_BUCKETS)
-    return len(blob)
+    _spec, buffers = fig.build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
 
 
 def _density_memory_report(x: np.ndarray, y: np.ndarray) -> dict[str, object]:
@@ -599,26 +606,26 @@ def _density_memory_report(x: np.ndarray, y: np.ndarray) -> dict[str, object]:
 
 def _histogram_payload(values: np.ndarray) -> int:
     fig = fc.chart(fc.histogram(values, bins=200)).figure()
-    _spec, blob = fig.build_payload(N_BUCKETS)
-    return len(blob)
+    _spec, buffers = fig.build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
 
 
 def _area_payload(x: np.ndarray, y: np.ndarray) -> int:
     fig = fc.chart(fc.area(x, y)).figure()
-    _spec, blob = fig.build_payload(N_BUCKETS)
-    return len(blob)
+    _spec, buffers = fig.build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
 
 
 def _bar_payload(categories: list[str], values: np.ndarray) -> int:
     fig = fc.chart(fc.bar(categories, values)).figure()
-    _spec, blob = fig.build_payload(N_BUCKETS)
-    return len(blob)
+    _spec, buffers = fig.build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
 
 
 def _heatmap_payload(z: np.ndarray, x: np.ndarray, y: np.ndarray) -> int:
     fig = fc.chart(fc.heatmap(z, x=x, y=y)).figure()
-    _spec, blob = fig.build_payload(N_BUCKETS)
-    return len(blob)
+    _spec, buffers = fig.build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
 
 
 def _statistical_payload(values: list[np.ndarray]) -> int:
@@ -626,28 +633,28 @@ def _statistical_payload(values: list[np.ndarray]) -> int:
         fc.box(values=values, name="box"),
         fc.violin(values=values, bins=64, name="violin"),
     ).figure()
-    _spec, blob = fig.build_payload(N_BUCKETS)
-    return len(blob)
+    _spec, buffers = fig.build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
 
 
 def _hexbin_payload(x: np.ndarray, y: np.ndarray) -> int:
     fig = fc.chart(fc.hexbin(x=x, y=y, gridsize=128)).figure()
-    _spec, blob = fig.build_payload(N_BUCKETS)
-    return len(blob)
+    _spec, buffers = fig.build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
 
 
 def _contour_payload(z: np.ndarray) -> int:
     fig = fc.chart(fc.contour(z=z, levels=12, filled=True)).figure()
-    _spec, blob = fig.build_payload(N_BUCKETS)
-    return len(blob)
+    _spec, buffers = fig.build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
 
 
 def _errorbar_payload(x: np.ndarray, y: np.ndarray) -> int:
     fig = fc.chart(fc.errorbar(x=x, y=y, yerr=1.0)).figure()
-    spec, blob = fig.build_payload(N_BUCKETS)
+    spec, buffers = fig.build_payload_split(N_BUCKETS)
     # The point of this bench is the segment-emission decimation branch.
     assert spec["traces"][0]["tier"] == "decimated"
-    return len(blob)
+    return sum(b.nbytes for b in buffers)
 
 
 def _composed_layered_payload(data: dict[str, object]) -> int:
@@ -672,8 +679,8 @@ def _composed_layered_payload(data: dict[str, object]) -> int:
         class_names={"legend": "fc-legend", "tooltip": "fc-tooltip"},
         style={"--fc-accent": "#2563eb"},
     )
-    _spec, blob = chart.figure().build_payload(N_BUCKETS)
-    return len(blob)
+    _spec, buffers = chart.figure().build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
 
 
 def _composed_layered_memory_report(data: dict[str, object]) -> dict[str, object]:
@@ -711,9 +718,9 @@ def test_first_payload_scatter_categorical_color(benchmark, medium_data):
 
     def build():
         fig = fc.chart(fc.scatter(x=x, y=y, color=categories)).figure()
-        return fig.build_payload(N_BUCKETS)
+        return fig.build_payload_split(N_BUCKETS)
 
-    spec, blob = benchmark(build)
+    spec, buffers = benchmark(build)
     trace = spec["traces"][0]
     color = trace["color"]
     color_meta = spec["columns"][color["buf"]]
@@ -721,7 +728,7 @@ def test_first_payload_scatter_categorical_color(benchmark, medium_data):
     assert color["dtype"] == "u8" and color_meta["dtype"] == "u8"
     # Two f32 geometry columns plus one byte code: the compact categorical
     # transport is a hard benchmark invariant, not merely an implementation detail.
-    assert len(blob) == 9 * len(x)
+    assert sum(b.nbytes for b in buffers) == 9 * len(x)
 
 
 def test_first_payload_scatter_continuous_channels(benchmark, medium_data):
@@ -732,11 +739,11 @@ def test_first_payload_scatter_continuous_channels(benchmark, medium_data):
 
     def build():
         fig = fc.chart(fc.scatter(x=x, y=y, color=color, size=size)).figure()
-        return fig.build_payload(N_BUCKETS)
+        return fig.build_payload_split(N_BUCKETS)
 
-    spec, blob = benchmark(build)
+    spec, buffers = benchmark(build)
     assert spec["traces"][0]["n_points"] == len(x)
-    assert blob
+    assert sum(b.nbytes for b in buffers) == 4 * len(x) * 4
 
 
 def test_first_payload_line_unsorted_x(benchmark, medium_data):
@@ -748,11 +755,11 @@ def test_first_payload_line_unsorted_x(benchmark, medium_data):
 
     def build():
         fig = fc.chart(fc.line(x=unsorted_x, y=unsorted_y)).figure()
-        return fig.build_payload(N_BUCKETS)
+        return fig.build_payload_split(N_BUCKETS)
 
-    spec, blob = benchmark(build)
+    spec, buffers = benchmark(build)
     assert spec["traces"][0]["n_points"] == len(x)
-    assert blob
+    assert buffers
 
 
 @pytest.mark.parametrize("kind", ["datetime64", "python_list"])
@@ -767,11 +774,11 @@ def test_first_payload_ingest_flavors(benchmark, kind):
 
     def build():
         fig = fc.chart(fc.line(x=x, y=values)).figure()
-        return fig.build_payload(N_BUCKETS)
+        return fig.build_payload_split(N_BUCKETS)
 
-    spec, blob = benchmark(build)
+    spec, buffers = benchmark(build)
     assert spec["traces"][0]["n_points"] == n
-    assert blob
+    assert buffers
 
 
 def test_density_view_exact_pan(benchmark):

--- a/js/src/50_chartview.js
+++ b/js/src/50_chartview.js
@@ -1031,9 +1031,8 @@ class ChartView {
     if (t.tier === "density") {
       const d = t.density;
       const meta = this.spec.columns[d.buf];
-      const grid = d.enc === "log-u8"
-        ? lodDecodeLogU8(new Uint8Array(buffer, meta.byte_offset, meta.len), d.max)
-        : new Float32Array(buffer, meta.byte_offset, d.w * d.h);
+      const raw = this._columnView(buffer, meta);
+      const grid = d.enc === "log-u8" ? lodDecodeLogU8(raw, d.max) : raw;
       g.densityNormMax = d.max;
       g.density = {
         w: d.w, h: d.h, max: d.max, normMax: d.max, colormap: d.colormap,
@@ -1575,8 +1574,22 @@ class ChartView {
   // (heatmap, histogram) reuse them instead of copy-pasting.
 
   _columnView(buffer, meta) {
-    if (meta.dtype === "u8") return new Uint8Array(buffer, meta.byte_offset, meta.len);
-    return new Float32Array(buffer, meta.byte_offset, meta.len);
+    // Packed layout: one blob, columns addressed by global byte_offset.
+    // Split layout (§29 first paint): `buffer` is a list of per-column
+    // ArrayBuffers and the column entry carries `buf`, its list index. A
+    // disagreement between spec and transport is a bug — fail loudly rather
+    // than render from misaligned bytes.
+    const split = Array.isArray(buffer);
+    if (split !== Number.isInteger(meta.buf)) {
+      throw new Error(
+        split
+          ? "xy: transport delivered a buffer list but the spec column has no wire-buffer index"
+          : "xy: spec column carries a wire-buffer index but the transport delivered one blob",
+      );
+    }
+    const src = split ? buffer[meta.buf] : buffer;
+    if (meta.dtype === "u8") return new Uint8Array(src, meta.byte_offset, meta.len);
+    return new Float32Array(src, meta.byte_offset, meta.len);
   }
 
   _upload(view) {

--- a/js/src/60_entries.js
+++ b/js/src/60_entries.js
@@ -10,9 +10,26 @@ function bytesToArrayBuffer(b) {
   throw new Error("unsupported buffer type");
 }
 
+/** First-paint buffers in the shape the spec declares (§29): packed is one
+ * blob; split is one ArrayBuffer per column — slicing each incoming frame
+ * separately also guarantees Float32Array alignment. A spec/transport
+ * disagreement is a bug, never a fallback. */
+function payloadBuffers(spec, raw) {
+  if (spec.buffer_layout === "split") {
+    if (!Array.isArray(raw)) {
+      throw new Error("xy: spec says buffer_layout=split but the transport delivered one buffer");
+    }
+    return raw.map(bytesToArrayBuffer);
+  }
+  if (Array.isArray(raw)) {
+    throw new Error("xy: transport delivered a buffer list but the spec is not split-layout");
+  }
+  return bytesToArrayBuffer(raw);
+}
+
 function render({ model, el }) {
   const spec = model.get("spec");
-  const buffer = bytesToArrayBuffer(model.get("buffers"));
+  const buffer = payloadBuffers(spec, model.get("buffers"));
   const comm = {
     send: (msg) => model.send(msg),
     onMessage: (cb) => {

--- a/python/xy/_payload.py
+++ b/python/xy/_payload.py
@@ -40,10 +40,16 @@ class _PayloadWriter:
     means calling these, not re-implementing the encoding.
     """
 
-    def __init__(self, *, borrow_heatmaps: bool = False) -> None:
+    def __init__(self, *, split: bool = False, borrow_heatmaps: bool = False) -> None:
+        # split=True: every column ships as its own wire buffer — spec entries
+        # carry `buf` (the wire-buffer index) with byte_offset 0, and
+        # `buffers()` returns per-column views with no join copy. Packed mode
+        # keeps the single `blob()` with global byte offsets (standalone
+        # export, streaming-refresh reopen state).
         self.columns: list[dict[str, Any]] = []
         self._chunks: list[bytes | np.ndarray] = []
         self._pos = 0
+        self._split = split
         self.borrow_heatmaps = borrow_heatmaps
         self.borrowed: list[np.ndarray] = []
 
@@ -69,6 +75,18 @@ class _PayloadWriter:
         """Raw byte column, padded so every later f32 column stays aligned."""
         enc = np.ascontiguousarray(values, dtype=np.uint8).reshape(-1)
         index = len(self.columns)
+        if self._split:
+            # One buffer per column: fold the alignment padding into the u8
+            # buffer itself (spec `len` still counts only real values), so the
+            # split layout stays a byte-identical repack of the packed blob.
+            padding = (-len(enc)) % 4
+            padded = np.concatenate([enc, np.zeros(padding, np.uint8)]) if padding else enc
+            self.columns.append(
+                {"buf": len(self._chunks), "byte_offset": 0, "len": int(len(enc)), "dtype": "u8"}
+            )
+            self._chunks.append(padded)
+            self._pos += padded.nbytes
+            return index
         self.columns.append({"byte_offset": self._pos, "len": int(len(enc)), "dtype": "u8"})
         self._chunks.append(enc)
         self._pos += enc.nbytes
@@ -103,18 +121,31 @@ class _PayloadWriter:
     def _append(self, enc: np.ndarray, meta: dict[str, Any]) -> int:
         # Retain the encoded array until blob assembly so each column is copied
         # once into the final bytes object, rather than once in `tobytes()` and
-        # again by `join`.
+        # again by `join` — and split mode ships these views with no copy at all.
         enc = np.ascontiguousarray(enc)
-        self.columns.append({"byte_offset": self._pos, "len": int(len(enc)), **meta})
+        idx = len(self.columns)
+        if self._split:
+            # `buf` indexes the wire buffer list (== `_chunks`), which can
+            # drift from the column table (`borrow_f64` columns own no chunk).
+            self.columns.append(
+                {"buf": len(self._chunks), "byte_offset": 0, "len": int(len(enc)), **meta}
+            )
+        else:
+            self.columns.append({"byte_offset": self._pos, "len": int(len(enc)), **meta})
         self._chunks.append(enc)
         self._pos += enc.nbytes
-        return len(self.columns) - 1
+        return idx
 
     def blob(self) -> bytes:
         return b"".join(
             chunk if isinstance(chunk, bytes) else memoryview(chunk).cast("B")
             for chunk in self._chunks
         )
+
+    def buffers(self) -> list[memoryview]:
+        """Per-column wire buffers (split mode): zero-copy views over the
+        encoded chunks, ready to ship as separate binary comm frames."""
+        return [memoryview(c).cast("B") for c in self._chunks]
 
 
 class PayloadMixin(_Host):
@@ -127,18 +158,37 @@ class PayloadMixin(_Host):
         (§5 Tier 1); dense scatter ships a density grid (§5 Tier 2). Every
         reduction is recorded in the spec — no silent quality changes (§28).
         """
-        spec, blob, _borrowed = self._build_payload(px_width, borrow_heatmaps=False)
-        return spec, blob
+        pw = _PayloadWriter()
+        spec = self._payload_spec(pw, self._resolve_px_width(px_width))
+        return spec, pw.blob()
+
+    def build_payload_split(
+        self, px_width: Optional[int] = None
+    ) -> tuple[dict[str, Any], list[memoryview]]:
+        """`build_payload` with per-column wire buffers instead of one blob.
+
+        Same emitters, same encoded bytes — but the columns ship as a list of
+        borrowed buffer views, skipping the join copy (the single largest
+        allocation of a direct-tier build). The spec says so explicitly:
+        `buffer_layout: "split"`, and each column entry carries `buf`, its
+        index into the buffer list (§29 — the comm protocol already carries
+        multi-buffer messages on the update path; this extends it to first
+        paint).
+        """
+        pw = _PayloadWriter(split=True)
+        spec = self._payload_spec(pw, self._resolve_px_width(px_width))
+        spec["buffer_layout"] = "split"
+        return spec, pw.buffers()
 
     def _build_raster_payload(
         self, px_width: Optional[int] = None
     ) -> tuple[dict[str, Any], bytes, tuple[np.ndarray, ...]]:
         """Private static-export payload with borrowed canonical heatmap spans."""
-        return self._build_payload(px_width, borrow_heatmaps=True)
+        pw = _PayloadWriter(borrow_heatmaps=True)
+        spec = self._payload_spec(pw, self._resolve_px_width(px_width))
+        return spec, pw.blob(), tuple(pw.borrowed)
 
-    def _build_payload(
-        self, px_width: Optional[int], *, borrow_heatmaps: bool
-    ) -> tuple[dict[str, Any], bytes, tuple[np.ndarray, ...]]:
+    def _resolve_px_width(self, px_width: Optional[int]) -> int:
         if px_width is None:
             # A concrete chart should pay for the pixels it can display, not
             # the historical 2048px fluid-layout fallback. Responsive charts
@@ -151,7 +201,9 @@ class PayloadMixin(_Host):
                 else 2048
             )
         px_width, _ = lod.screen_shape(px_width, 16)
-        pw = _PayloadWriter(borrow_heatmaps=borrow_heatmaps)
+        return px_width
+
+    def _payload_spec(self, pw: "_PayloadWriter", px_width: int) -> dict[str, Any]:
         # `_range` is an O(traces x chunks) autorange scan and is invariant
         # while this build runs (emitters only touch shipped_sel/drill state),
         # so each axis pays for it once even when many traces share an axis.
@@ -211,7 +263,7 @@ class PayloadMixin(_Host):
         annotations = self._annotation_specs()
         if annotations:
             spec["annotations"] = annotations
-        return spec, pw.blob(), tuple(pw.borrowed)
+        return spec
 
     def _emit_trace(
         self, t: Trace, pw: "_PayloadWriter", xr: tuple, yr: tuple, px_width: int

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -2320,9 +2320,8 @@ yAxis: typeof t.y_axis === "string" ? t.y_axis : "y",
 if (t.tier === "density") {
 const d = t.density;
 const meta = this.spec.columns[d.buf];
-const grid = d.enc === "log-u8"
-? lodDecodeLogU8(new Uint8Array(buffer, meta.byte_offset, meta.len), d.max)
-: new Float32Array(buffer, meta.byte_offset, d.w * d.h);
+const raw = this._columnView(buffer, meta);
+const grid = d.enc === "log-u8" ? lodDecodeLogU8(raw, d.max) : raw;
 g.densityNormMax = d.max;
 g.density = {
 w: d.w, h: d.h, max: d.max, normMax: d.max, colormap: d.colormap,
@@ -2806,8 +2805,17 @@ gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 return tex;
 }
 _columnView(buffer, meta) {
-if (meta.dtype === "u8") return new Uint8Array(buffer, meta.byte_offset, meta.len);
-return new Float32Array(buffer, meta.byte_offset, meta.len);
+const split = Array.isArray(buffer);
+if (split !== Number.isInteger(meta.buf)) {
+throw new Error(
+split
+? "xy: transport delivered a buffer list but the spec column has no wire-buffer index"
+: "xy: spec column carries a wire-buffer index but the transport delivered one blob",
+);
+}
+const src = split ? buffer[meta.buf] : buffer;
+if (meta.dtype === "u8") return new Uint8Array(src, meta.byte_offset, meta.len);
+return new Float32Array(src, meta.byte_offset, meta.len);
 }
 _upload(view) {
 const gl = this.gl;
@@ -5505,9 +5513,22 @@ return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength);
 }
 throw new Error("unsupported buffer type");
 }
+
+function payloadBuffers(spec, raw) {
+if (spec.buffer_layout === "split") {
+if (!Array.isArray(raw)) {
+throw new Error("xy: spec says buffer_layout=split but the transport delivered one buffer");
+}
+return raw.map(bytesToArrayBuffer);
+}
+if (Array.isArray(raw)) {
+throw new Error("xy: transport delivered a buffer list but the spec is not split-layout");
+}
+return bytesToArrayBuffer(raw);
+}
 function render({ model, el }) {
 const spec = model.get("spec");
-const buffer = bytesToArrayBuffer(model.get("buffers"));
+const buffer = payloadBuffers(spec, model.get("buffers"));
 const comm = {
 send: (msg) => model.send(msg),
 onMessage: (cb) => {

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -2321,9 +2321,8 @@ yAxis: typeof t.y_axis === "string" ? t.y_axis : "y",
 if (t.tier === "density") {
 const d = t.density;
 const meta = this.spec.columns[d.buf];
-const grid = d.enc === "log-u8"
-? lodDecodeLogU8(new Uint8Array(buffer, meta.byte_offset, meta.len), d.max)
-: new Float32Array(buffer, meta.byte_offset, d.w * d.h);
+const raw = this._columnView(buffer, meta);
+const grid = d.enc === "log-u8" ? lodDecodeLogU8(raw, d.max) : raw;
 g.densityNormMax = d.max;
 g.density = {
 w: d.w, h: d.h, max: d.max, normMax: d.max, colormap: d.colormap,
@@ -2807,8 +2806,17 @@ gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 return tex;
 }
 _columnView(buffer, meta) {
-if (meta.dtype === "u8") return new Uint8Array(buffer, meta.byte_offset, meta.len);
-return new Float32Array(buffer, meta.byte_offset, meta.len);
+const split = Array.isArray(buffer);
+if (split !== Number.isInteger(meta.buf)) {
+throw new Error(
+split
+? "xy: transport delivered a buffer list but the spec column has no wire-buffer index"
+: "xy: spec column carries a wire-buffer index but the transport delivered one blob",
+);
+}
+const src = split ? buffer[meta.buf] : buffer;
+if (meta.dtype === "u8") return new Uint8Array(src, meta.byte_offset, meta.len);
+return new Float32Array(src, meta.byte_offset, meta.len);
 }
 _upload(view) {
 const gl = this.gl;
@@ -5506,9 +5514,22 @@ return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength);
 }
 throw new Error("unsupported buffer type");
 }
+
+function payloadBuffers(spec, raw) {
+if (spec.buffer_layout === "split") {
+if (!Array.isArray(raw)) {
+throw new Error("xy: spec says buffer_layout=split but the transport delivered one buffer");
+}
+return raw.map(bytesToArrayBuffer);
+}
+if (Array.isArray(raw)) {
+throw new Error("xy: transport delivered a buffer list but the spec is not split-layout");
+}
+return bytesToArrayBuffer(raw);
+}
 function render({ model, el }) {
 const spec = model.get("spec");
-const buffer = bytesToArrayBuffer(model.get("buffers"));
+const buffer = payloadBuffers(spec, model.get("buffers"));
 const comm = {
 send: (msg) => model.send(msg),
 onMessage: (cb) => {

--- a/python/xy/widget.py
+++ b/python/xy/widget.py
@@ -44,10 +44,12 @@ class FigureWidget(anywidget.AnyWidget):
 
     # Data-less spec (§9) — tiny JSON, sync'd as a trait.
     spec = traitlets.Dict().tag(sync=True)
-    # Encoded columns — one binary blob, transported as a raw buffer by the
-    # widget protocol (ipywidgets serializes Bytes traits as binary buffers,
-    # never JSON).
-    buffers = traitlets.Bytes().tag(sync=True)
+    # Encoded columns — raw binary, never JSON. First paint ships the split
+    # layout: a list of per-column memoryviews, each transported as its own
+    # binary comm frame with no join copy (§29). Streaming-refresh reopen
+    # state re-syncs a single packed blob, so the trait is Any: the client
+    # picks the layout from `spec.buffer_layout`, not the trait shape.
+    buffers = traitlets.Any().tag(sync=True)
 
     def __init__(
         self,
@@ -68,8 +70,8 @@ class FigureWidget(anywidget.AnyWidget):
             on_select=on_select,
             on_view_change=on_view_change,
         )
-        spec, blob = figure.build_payload()
-        super().__init__(spec=spec, buffers=blob, **kwargs)
+        spec, bufs = figure.build_payload_split()
+        super().__init__(spec=spec, buffers=bufs, **kwargs)
         self.on_msg(self._on_custom_msg)
 
     def append(self, trace_id: int, x: Any, y: Any, *, color: Any = None, size: Any = None) -> None:

--- a/scripts/render_smoke_nonumpy.py
+++ b/scripts/render_smoke_nonumpy.py
@@ -744,6 +744,23 @@ try{{
     if (dv1.gpuTraces) for (const gg of dv1.gpuTraces) gg._densityNormAnim = null;
     if (dv2.gpuTraces) for (const gg of dv2.gpuTraces) gg._densityNormAnim = null;
     const pixdet = pixhash(dv1) === pixhash(dv2) ? 1 : 0;
+    // Split first-paint layout (§29): the same payload delivered as one
+    // ArrayBuffer per column must hash pixel-identical to the packed render,
+    // and a spec/transport shape disagreement must throw, never mis-render.
+    const splitSpec = JSON.parse(JSON.stringify(spec));
+    splitSpec.buffer_layout = "split";
+    splitSpec.columns = splitSpec.columns.map((c, i) => ({{ ...c, buf: i, byte_offset: 0 }}));
+    const splitBufs = spec.columns.map((c) =>
+      bytes.buffer.slice(c.byte_offset, c.byte_offset + c.len * 4));
+    const sv1 = new xy.ChartView(mk(), splitSpec, splitBufs, null);
+    sv1._sampleRebinDisabled = true;
+    if (sv1.gpuTraces) for (const gg of sv1.gpuTraces) gg._densityNormAnim = null;
+    const splitPix = pixhash(sv1) === pixhash(dv1) ? 1 : 0;
+    const splitLoud =
+      (throws(() => new xy.ChartView(mk(), splitSpec, bytes.buffer, null)) &&
+       throws(() => new xy.ChartView(mk(), JSON.parse(JSON.stringify(spec)), splitBufs, null)))
+        ? 1 : 0;
+    const splitbuf = (splitPix && splitLoud) ? 1 : 0;
     // Streaming append (rust-engine §5): the affected trace rebuilds from the
     // fresh payload and the view follows the data — refit when at home, hold
     // when zoomed into history, slide when pinned to the live right edge.
@@ -864,7 +881,7 @@ try{{
     const gLn=vSm.gpuTraces[0], gAr=vSm.gpuTraces[1];
     const msmooth=(gLn.n===65 && gLn._cpu.x.length===5 && gAr.n===65 && gAr._cpu.base.length===5)?1:0;
     vSm.destroy();holderSm.remove();
-    const base=`FC_OK lit=${{lit}} total=${{w*h}} labels=${{labels}} pick=${{hits}} row=${{hasXY}} selAll=${{selAll}} selSome=${{selSome}} active=${{active}} btns=${{btns}} zin=${{zin}} smooth=${{smooth}} labelThrottle=${{labelThrottle}} hoverSkip=${{hoverSkip}} zanch=${{zanch}} retarget=${{retarget}} nosnap=${{nosnap}} prefetch=${{prefetch}} maxwait=${{maxwait}} box=${{boxOk}} zmode=${{zmode}} densityLit=${{densityLit}} drill=${{drilled}} pending=${{pending}} dblend=${{dblend}} dseq=${{dseq}} hov=${{hov}} sstale=${{sstale}} sfresh=${{sfresh}} plut=${{plut}} reg=${{reg}} refresh=${{refresh}} dpick=${{dpick}} hold=${{hold}} zoomout=${{zoomout}} broad=${{broadfallback}} dying=${{dying}} dback=${{dback}} dnorm=${{dnorm}} dnormDone=${{dnormDone}} stale=${{stale}} thrash=${{thrash}} qwire=${{qwire}} stream=${{stream}} tj=${{Math.round(maxJump*100)}} td=${{Math.round(reviveDip*100)}} malformed=${{malformed}} pixdet=${{pixdet}} barBase=${{barBase}} histBase=${{histBase}} edgepad=${{edgepad}} mgrad=${{mgrad}} axisontop=${{axisontop}} mtipbase=${{mtipbase}} mcorner=${{mcorner}} mstroke=${{mstroke}} bgrad=${{bgrad}} bcorner=${{bcorner}} msmooth=${{msmooth}}`;
+    const base=`FC_OK lit=${{lit}} total=${{w*h}} labels=${{labels}} pick=${{hits}} row=${{hasXY}} selAll=${{selAll}} selSome=${{selSome}} active=${{active}} btns=${{btns}} zin=${{zin}} smooth=${{smooth}} labelThrottle=${{labelThrottle}} hoverSkip=${{hoverSkip}} zanch=${{zanch}} retarget=${{retarget}} nosnap=${{nosnap}} prefetch=${{prefetch}} maxwait=${{maxwait}} box=${{boxOk}} zmode=${{zmode}} densityLit=${{densityLit}} drill=${{drilled}} pending=${{pending}} dblend=${{dblend}} dseq=${{dseq}} hov=${{hov}} sstale=${{sstale}} sfresh=${{sfresh}} plut=${{plut}} reg=${{reg}} refresh=${{refresh}} dpick=${{dpick}} hold=${{hold}} zoomout=${{zoomout}} broad=${{broadfallback}} dying=${{dying}} dback=${{dback}} dnorm=${{dnorm}} dnormDone=${{dnormDone}} stale=${{stale}} thrash=${{thrash}} qwire=${{qwire}} stream=${{stream}} tj=${{Math.round(maxJump*100)}} td=${{Math.round(reviveDip*100)}} malformed=${{malformed}} pixdet=${{pixdet}} splitbuf=${{splitbuf}} barBase=${{barBase}} histBase=${{histBase}} edgepad=${{edgepad}} mgrad=${{mgrad}} axisontop=${{axisontop}} mtipbase=${{mtipbase}} mcorner=${{mcorner}} mstroke=${{mstroke}} bgrad=${{bgrad}} bcorner=${{bcorner}} msmooth=${{msmooth}}`;
     // Responsive: 100%-by-100% chart in a 400x300 container tracks its parent;
     // growing the container must fire the ResizeObserver and re-render bigger.
     const spec2=JSON.parse(JSON.stringify(spec));
@@ -1074,6 +1091,7 @@ try{{
     stream = int(re.search(r"stream=(\d+)", title).group(1))
     malformed = int(re.search(r"malformed=(\d+)", title).group(1))
     pixdet = int(re.search(r"pixdet=(\d+)", title).group(1))
+    splitbuf = int(re.search(r"splitbuf=(\d+)", title).group(1))
     ctxloss = int(re.search(r"ctxloss=(\d+)", title).group(1))
     ctxcycles = int(re.search(r"ctxcycles=(\d+)", title).group(1))
     ctxquiet = int(re.search(r"ctxquiet=(\d+)", title).group(1))
@@ -1200,6 +1218,11 @@ try{{
         raise SystemExit("chart was not interactive and nonblank after context restoration")
     if pixdet != 1:
         raise SystemExit("pixel determinism failed (render path must be RNG/time-free)")
+    if splitbuf != 1:
+        raise SystemExit(
+            "split buffer layout failed (per-column first paint must render "
+            "pixel-identical to packed and reject spec/transport mismatches)"
+        )
     if qwire != 1:
         raise SystemExit("log-u8 density decode failed (quantized wire)")
     if stream != 1:

--- a/tests/test_figure.py
+++ b/tests/test_figure.py
@@ -70,6 +70,70 @@ def test_spec_is_dataless_json():
     assert len(blob) == 2 * 1000 * 4  # two f32 columns
 
 
+def test_build_payload_split_matches_packed():
+    # Split layout (§29 multi-buffer first paint) is a transport repack, never
+    # a re-encode: same spec, same bytes, delivered one borrowed buffer per
+    # column instead of one joined blob.
+    rng = np.random.default_rng(5)
+    x = np.arange(5000, dtype=np.float64)
+    fig = Figure().scatter(x, rng.normal(size=5000), color=np.sin(x * 0.01), size=2 + x % 7)
+    fig.line(x, np.cos(x * 0.01))
+
+    spec_p, blob = fig.build_payload()
+    spec_s, bufs = fig.build_payload_split()
+
+    assert spec_s["buffer_layout"] == "split"
+    assert isinstance(bufs, list)
+    assert all(isinstance(b, memoryview) for b in bufs)
+    assert len(bufs) == len(spec_s["columns"])
+    assert b"".join(bytes(b) for b in bufs) == blob
+    for i, (col_p, col_s) in enumerate(zip(spec_p["columns"], spec_s["columns"], strict=True)):
+        assert col_s["buf"] == i
+        assert col_s["byte_offset"] == 0
+        assert bufs[i].nbytes == col_p["len"] * 4
+        drop_p = {k: v for k, v in col_p.items() if k != "byte_offset"}
+        drop_s = {k: v for k, v in col_s.items() if k not in ("buf", "byte_offset")}
+        assert drop_s == drop_p
+    strip_p = {k: v for k, v in spec_p.items() if k != "columns"}
+    strip_s = {k: v for k, v in spec_s.items() if k not in ("columns", "buffer_layout")}
+    assert strip_s == strip_p
+    assert json.dumps(spec_s)  # spec must stay data-less JSON either way (§9)
+
+
+def test_build_payload_split_density_tier():
+    # The density tier ships grid + sampled-overlay columns; the split repack
+    # must cover those column shapes too, byte-for-byte.
+    rng = np.random.default_rng(6)
+    fig = Figure().scatter(rng.normal(size=20_000), rng.normal(size=20_000), density=True)
+    spec_p, blob = fig.build_payload()
+    spec_s, bufs = fig.build_payload_split()
+    assert spec_p["traces"][0]["tier"] == "density"
+    assert b"".join(bytes(b) for b in bufs) == blob
+    sample = spec_s["traces"][0]["density"].get("sample")
+    if sample is not None:
+        assert sample["x"]["buf"] == sample["x"]["col"]
+        assert sample["x"]["byte_offset"] == 0
+
+
+def test_build_payload_split_folds_u8_alignment_padding_into_column_buffer():
+    fig = Figure().scatter(
+        np.arange(5.0),
+        np.arange(5.0),
+        color=np.array(["a", "b", "a", "b", "a"]),
+    )
+
+    _spec_p, blob = fig.build_payload()
+    spec_s, bufs = fig.build_payload_split()
+    color_col = spec_s["traces"][0]["color"]["buf"]
+    meta = spec_s["columns"][color_col]
+
+    assert meta["dtype"] == "u8"
+    assert meta["len"] == 5
+    assert meta["byte_offset"] == 0
+    assert bufs[meta["buf"]].nbytes == 8
+    assert b"".join(bytes(buf) for buf in bufs) == blob
+
+
 def test_offset_encoding_roundtrip():
     x = 1.6e12 + np.arange(5000, dtype=np.float64)  # ms timestamps
     y = np.sin(np.arange(5000) * 0.01)

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -20,6 +20,37 @@ def _capturing_widget(fig: Figure, **kwargs):
     return widget, sent
 
 
+def test_widget_first_paint_ships_split_buffers_zero_copy():
+    # First paint uses the split layout (§29): one binary comm frame per
+    # column, each a borrowed memoryview over the writer's encoded chunk —
+    # the joined blob (and its payload-sized copy) never exists.
+    fig = Figure().scatter(np.arange(100.0), np.arange(100.0))
+    widget, _sent = _capturing_widget(fig)
+
+    assert widget.spec["buffer_layout"] == "split"
+    assert isinstance(widget.buffers, list)
+    assert len(widget.buffers) == len(widget.spec["columns"])
+    for view in widget.buffers:
+        assert isinstance(view, memoryview)
+        assert isinstance(view.obj, np.ndarray)  # borrowed, not copied
+
+    spec, blob = fig.build_payload()
+    assert b"".join(bytes(b) for b in widget.buffers) == blob
+
+
+def test_widget_append_resyncs_packed_reopen_state():
+    # Streaming append refreshes the synced traits with the packed layout
+    # (spec without buffer_layout + one blob) — reopen state must stay
+    # self-consistent with whichever layout the spec declares.
+    fig = Figure().scatter(np.arange(10.0), np.arange(10.0))
+    widget, sent = _capturing_widget(fig)
+    widget.append(fig.traces[0].id, np.arange(10.0, 15.0), np.arange(10.0, 15.0))
+
+    assert "buffer_layout" not in widget.spec
+    assert isinstance(widget.buffers, bytes)
+    assert len(sent) == 1
+
+
 def test_widget_drops_malformed_view_messages():
     n = DECIMATION_THRESHOLD + 1
     fig = Figure().line(np.arange(n, dtype=np.float64), np.arange(n, dtype=np.float64))


### PR DESCRIPTION
## What

First paint now ships the payload as one wire buffer per column instead of a single joined blob. The joined blob was the single largest allocation of a direct-tier build — after #27 removed the encode copy, the `b"".join` at `blob()` was the last payload-sized copy on the path.

- **`_PayloadWriter`** grows a `split=True` mode: column spec entries carry `buf` (wire-buffer index) with `byte_offset: 0`, and `buffers()` returns zero-copy memoryviews over the encoded chunks. u8 alignment padding folds into the u8 column's own buffer, so the split layout stays a **byte-identical repack** of the packed blob — asserted in tests, never a re-encode. Build entry points are factored so `build_payload`, `build_payload_split`, and `_build_raster_payload` are thin wrappers over one `_payload_spec`.
- **`FigureWidget.buffers`** becomes an `Any` trait: a list of memoryviews on first paint (ipywidgets ships each as its own binary comm frame, verified zero-copy), a single packed blob after a streaming-append re-sync. The client picks the layout from `spec.buffer_layout`, never from the transport shape.
- **JS** `_columnView` reads either layout and throws loudly on a spec/transport disagreement; slicing each incoming frame also guarantees `Float32Array` alignment. The log-u8 density grid decode now routes through it. `static/` regenerated.
- **Packed mode is unchanged** and remains the layout for standalone HTML export, raster export, and reopen state.

## Numbers (mode-scoped per §2)

Payload build, median of 7, this machine:

| Scenario | Payload | Packed | Split | Peak alloc |
|---|---|---|---|---|
| scatter 200k direct, 4 channels | 3.2 MB | 0.98 ms | 0.87 ms | 6.4 → 3.4 MB |
| scatter 2M forced direct | 16 MB | 14.4 ms | 3.0 ms | 32 → 18 MB |
| scatter 10M forced direct | 80 MB | 78.7 ms | 23.2 ms | 160 → 90 MB |
| heatmap 2000×2000 | 16 MB | 2.8 ms | 1.1 ms | 32 → 16 MB |
| scatter 2M density tier (default) | 0.26 MB | 5.4 ms | 5.3 ms | unchanged |

The win is scoped to large direct-tier payloads (forced direct, heatmaps, many traces): 3–5× faster builds and ~half the peak allocation, which also softens the §5 F3 allocation-cliff failure mode. Default density-tier charts are unaffected.

## CodSpeed

The `test_first_payload_*` benchmarks are repointed at `build_payload_split` — they measure the widget first-paint scenario, which now ships split in production. Expect a one-time step improvement (~37–42% wall time on the medium scatter builds). The packed layout keeps coverage via `test_build_payload` and the export benchmarks.

## Testing

- Byte-identity contract tests (split joined == packed blob, incl. u8 padding fold and density-tier sample columns)
- Widget transport tests: zero-copy memoryview frames on first paint, packed re-sync after append
- Chromium render smoke gains a `splitbuf` probe: split render must hash pixel-identical to packed, and both spec/transport mismatch directions must throw
- Full suite: 1338 pytest passed, ABI smoke 121 checks, render smoke, ruff + pre-commit clean. No Rust/ABI change.