### PR TITLE
Add compact draggable chart toolbar and editable lasso selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ in the README).
   to the internal engine object.
 
 ### Added
+- **Compact chart toolbar and editable lasso selection.** The client toolbar
+  appears on chart hover or keyboard focus, can be dragged within the chart,
+  groups zoom and selection modes into accessible menus, and exports PNG, SVG,
+  or resident data as CSV. Completed lasso selections expose up to 16 adaptive
+  RDP handles for range adjustment, and client SVG/PNG export snapshots the
+  chart's computed theme tokens and typography so host light/dark themes carry
+  into downloaded images.
 - `xy.pyplot.FacetGrid`: a seaborn-shaped row/column facet grid running
   entirely on the shim (seaborn's `map` contract: subset → activate panel →
   call the pyplot function), with shared domains, edge-only axis labels,

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -232,6 +232,15 @@ Set them on `.xy` or any ancestor:
 | `--chart-annotation-text` | Annotation label color | falls back to `--chart-text` |
 | `--chart-cursor` / `--chart-cursor-pan` | Plot cursor (box-zoom / pan) | `crosshair` / `grab` |
 
+The compact toolbar appears while the chart is hovered or one of its controls
+has keyboard focus. Drag its grip to move it within the chart. Zoom and
+selection modes are grouped into menus; completed lasso selections expose up
+to 16 adaptively simplified handles that can be dragged to refine the selected
+range. The grip's menu exports PNG, SVG, or the chart's resident data as CSV.
+Client PNG and SVG export snapshot the chart's computed `--chart-*` tokens,
+text color, and font styles so themes inherited from a host application are
+preserved in the downloaded image.
+
 ## Standalone HTML
 
 `to_html(fig, custom_css=...)` inlines the same client and your stylesheet into a

--- a/js/src/20_theme.js
+++ b/js/src/20_theme.js
@@ -88,6 +88,9 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
 :where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
 :where(.xy [data-fc-modebar-drag-handle]){cursor:move}
+:where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:58px;gap:2px;padding:0 6px;font-size:11px;font-variant-numeric:tabular-nums}
+:where(.xy [data-fc-modebar-menu-indicator]){display:flex;transition:transform .15s}
+:where(.xy [data-fc-modebar-menu-indicator] svg){width:11px;height:11px}
 :where(.xy [data-fc-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}
 :where(.xy [data-fc-modebar-menu-item]){width:100%;height:28px;justify-content:flex-start;padding:0 9px;border-radius:4px;text-align:left;white-space:nowrap}
 :where(.xy [data-fc-modebar-menu-item]:hover,.xy [data-fc-modebar-menu-item]:focus-visible){background:var(--chart-modebar-active,rgba(128,128,128,.18));outline:none}

--- a/js/src/20_theme.js
+++ b/js/src/20_theme.js
@@ -89,8 +89,6 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar_button"]){width:24px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
 :where(.xy [data-fc-modebar-drag-handle]){position:relative;width:22px;margin-right:2px;cursor:move}
 :where(.xy [data-fc-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-1px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
-:where(.xy [data-fc-slot="modebar"][data-fc-collapsed="true"]>[data-fc-modebar-drag-handle]){margin-right:0}
-:where(.xy [data-fc-slot="modebar"][data-fc-collapsed="true"]>[data-fc-modebar-drag-handle])::after{display:none}
 :where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:52px;gap:1px;padding:0 4px;font-size:11px;font-variant-numeric:tabular-nums}
 :where(.xy [data-fc-modebar-select-trigger]){width:auto;min-width:30px;gap:0;padding:0 2px}
 :where(.xy [data-fc-modebar-menu-indicator]){display:flex;transition:transform .15s}

--- a/js/src/20_theme.js
+++ b/js/src/20_theme.js
@@ -99,7 +99,6 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-modebar-menu-item][data-fc-separator]){margin-top:3px;border-top:1px solid rgba(128,128,128,.2);border-radius:0 0 4px 4px}
 :where(.xy [data-fc-modebar-menu-icon]){display:flex;width:16px;margin-right:7px}
 :where(.xy [data-fc-modebar-menu-icon] svg){width:14px;height:14px}
-:where(.xy [data-fc-modebar-menu-shortcut]){margin-left:auto;padding-left:20px;color:var(--chart-axis,currentColor);font-size:10px;opacity:.72}
 :where(.xy [data-fc-slot="modebar_button"].fc-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
 :where(.xy [data-fc-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-fc-slot="selection"][data-fc-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}

--- a/js/src/20_theme.js
+++ b/js/src/20_theme.js
@@ -87,6 +87,7 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="badge_item"]){padding:3px 6px;border-radius:4px;color:var(--chart-badge-text,#0f172a);background:var(--chart-badge-bg,rgba(255,255,255,.82));box-shadow:0 1px 4px rgba(15,23,42,.14)}
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
 :where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
+:where(.xy [data-fc-modebar-drag-handle]){cursor:move}
 :where(.xy [data-fc-slot="modebar_button"].fc-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
 :where(.xy [data-fc-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-fc-slot="selection"][data-fc-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}

--- a/js/src/20_theme.js
+++ b/js/src/20_theme.js
@@ -87,7 +87,10 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="badge_item"]){padding:3px 6px;border-radius:4px;color:var(--chart-badge-text,#0f172a);background:var(--chart-badge-bg,rgba(255,255,255,.82));box-shadow:0 1px 4px rgba(15,23,42,.14)}
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
 :where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
-:where(.xy [data-fc-modebar-drag-handle]){cursor:move}
+:where(.xy [data-fc-modebar-drag-handle]){position:relative;margin-right:3px;cursor:move}
+:where(.xy [data-fc-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-2px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
+:where(.xy [data-fc-slot="modebar"][data-fc-collapsed="true"]>[data-fc-modebar-drag-handle]){margin-right:0}
+:where(.xy [data-fc-slot="modebar"][data-fc-collapsed="true"]>[data-fc-modebar-drag-handle])::after{display:none}
 :where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:58px;gap:2px;padding:0 6px;font-size:11px;font-variant-numeric:tabular-nums}
 :where(.xy [data-fc-modebar-select-trigger]){width:auto;min-width:35px;gap:0;padding:0 4px}
 :where(.xy [data-fc-modebar-menu-indicator]){display:flex;transition:transform .15s}

--- a/js/src/20_theme.js
+++ b/js/src/20_theme.js
@@ -87,9 +87,9 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="badge_item"]){padding:3px 6px;border-radius:4px;color:var(--chart-badge-text,#0f172a);background:var(--chart-badge-bg,rgba(255,255,255,.82));box-shadow:0 1px 4px rgba(15,23,42,.14)}
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
 :where(.xy [data-fc-slot="modebar_button"]){width:24px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
-:where(.xy [data-fc-modebar-drag-handle]){position:relative;width:22px;margin-right:2px;cursor:move}
-:where(.xy [data-fc-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-1px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
-:where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:52px;gap:1px;padding:0 4px;font-size:11px;font-variant-numeric:tabular-nums}
+:where(.xy [data-fc-modebar-drag-handle]){position:relative;width:22px;margin-right:4px;cursor:move}
+:where(.xy [data-fc-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-3px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
+:where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:48px;gap:1px;padding:0 4px;font-size:11px;font-variant-numeric:tabular-nums}
 :where(.xy [data-fc-modebar-select-trigger]){width:auto;min-width:30px;gap:0;padding:0 2px}
 :where(.xy [data-fc-modebar-menu-indicator]){display:flex;transition:transform .15s}
 :where(.xy [data-fc-modebar-menu-indicator] svg){width:11px;height:11px}

--- a/js/src/20_theme.js
+++ b/js/src/20_theme.js
@@ -89,6 +89,7 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
 :where(.xy [data-fc-modebar-drag-handle]){cursor:move}
 :where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:58px;gap:2px;padding:0 6px;font-size:11px;font-variant-numeric:tabular-nums}
+:where(.xy [data-fc-modebar-select-trigger]){width:auto;min-width:35px;gap:0;padding:0 4px}
 :where(.xy [data-fc-modebar-menu-indicator]){display:flex;transition:transform .15s}
 :where(.xy [data-fc-modebar-menu-indicator] svg){width:11px;height:11px}
 :where(.xy [data-fc-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}
@@ -101,6 +102,7 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar_button"].fc-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
 :where(.xy [data-fc-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-fc-slot="selection"][data-fc-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}
+:where(.xy [data-fc-selection-lasso]){fill:var(--chart-selection-fill,rgba(90,140,240,.15));stroke:var(--chart-selection,rgba(90,140,240,.9));stroke-width:1.5;stroke-linejoin:round}
 :where(.xy [data-fc-slot="crosshair_x"],.xy [data-fc-slot="crosshair_y"]){background:var(--chart-crosshair,rgba(15,23,42,.42))}
 :where(.xy [data-fc-slot="tick_label"]){color:var(--chart-text,inherit)}
 :where(.xy [data-fc-slot="axis_title"]){color:var(--chart-text,inherit);font-size:12px}

--- a/js/src/20_theme.js
+++ b/js/src/20_theme.js
@@ -88,6 +88,11 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
 :where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
 :where(.xy [data-fc-modebar-drag-handle]){cursor:move}
+:where(.xy [data-fc-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}
+:where(.xy [data-fc-modebar-menu-item]){width:100%;height:28px;justify-content:space-between;padding:0 9px;border-radius:4px;text-align:left;white-space:nowrap}
+:where(.xy [data-fc-modebar-menu-item]:hover,.xy [data-fc-modebar-menu-item]:focus-visible){background:var(--chart-modebar-active,rgba(128,128,128,.18));outline:none}
+:where(.xy [data-fc-modebar-menu-item][data-fc-separator]){margin-top:3px;border-top:1px solid rgba(128,128,128,.2);border-radius:0 0 4px 4px}
+:where(.xy [data-fc-modebar-menu-shortcut]){margin-left:20px;color:var(--chart-axis,currentColor);font-size:10px;opacity:.72}
 :where(.xy [data-fc-slot="modebar_button"].fc-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
 :where(.xy [data-fc-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-fc-slot="selection"][data-fc-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}

--- a/js/src/20_theme.js
+++ b/js/src/20_theme.js
@@ -89,10 +89,12 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
 :where(.xy [data-fc-modebar-drag-handle]){cursor:move}
 :where(.xy [data-fc-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}
-:where(.xy [data-fc-modebar-menu-item]){width:100%;height:28px;justify-content:space-between;padding:0 9px;border-radius:4px;text-align:left;white-space:nowrap}
+:where(.xy [data-fc-modebar-menu-item]){width:100%;height:28px;justify-content:flex-start;padding:0 9px;border-radius:4px;text-align:left;white-space:nowrap}
 :where(.xy [data-fc-modebar-menu-item]:hover,.xy [data-fc-modebar-menu-item]:focus-visible){background:var(--chart-modebar-active,rgba(128,128,128,.18));outline:none}
 :where(.xy [data-fc-modebar-menu-item][data-fc-separator]){margin-top:3px;border-top:1px solid rgba(128,128,128,.2);border-radius:0 0 4px 4px}
-:where(.xy [data-fc-modebar-menu-shortcut]){margin-left:20px;color:var(--chart-axis,currentColor);font-size:10px;opacity:.72}
+:where(.xy [data-fc-modebar-menu-icon]){display:flex;width:16px;margin-right:7px}
+:where(.xy [data-fc-modebar-menu-icon] svg){width:14px;height:14px}
+:where(.xy [data-fc-modebar-menu-shortcut]){margin-left:auto;padding-left:20px;color:var(--chart-axis,currentColor);font-size:10px;opacity:.72}
 :where(.xy [data-fc-slot="modebar_button"].fc-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
 :where(.xy [data-fc-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-fc-slot="selection"][data-fc-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}

--- a/js/src/20_theme.js
+++ b/js/src/20_theme.js
@@ -103,7 +103,9 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar_button"].fc-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
 :where(.xy [data-fc-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-fc-slot="selection"][data-fc-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}
-:where(.xy [data-fc-selection-lasso]){fill:var(--chart-selection-fill,rgba(90,140,240,.15));stroke:var(--chart-selection,rgba(90,140,240,.9));stroke-width:1.5;stroke-linejoin:round}
+:where(.xy [data-fc-selection-lasso]){fill:var(--chart-selection-fill,rgba(90,140,240,.15));stroke:var(--chart-selection,rgba(90,140,240,.9));stroke-width:1.5;stroke-linejoin:round;pointer-events:none}
+:where(.xy [data-fc-selection-lasso-handle]){fill:var(--chart-bg,#fff);stroke:var(--chart-selection,rgba(90,140,240,.9));stroke-width:1.5;cursor:grab;pointer-events:all}
+:where(.xy [data-fc-selection-lasso-handle][data-fc-active]){cursor:grabbing;fill:var(--chart-selection,rgba(90,140,240,.9))}
 :where(.xy [data-fc-slot="crosshair_x"],.xy [data-fc-slot="crosshair_y"]){background:var(--chart-crosshair,rgba(15,23,42,.42))}
 :where(.xy [data-fc-slot="tick_label"]){color:var(--chart-text,inherit)}
 :where(.xy [data-fc-slot="axis_title"]){color:var(--chart-text,inherit);font-size:12px}

--- a/js/src/20_theme.js
+++ b/js/src/20_theme.js
@@ -86,13 +86,13 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="badge"]){gap:3px;font-size:11px;line-height:1.2}
 :where(.xy [data-fc-slot="badge_item"]){padding:3px 6px;border-radius:4px;color:var(--chart-badge-text,#0f172a);background:var(--chart-badge-bg,rgba(255,255,255,.82));box-shadow:0 1px 4px rgba(15,23,42,.14)}
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
-:where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
-:where(.xy [data-fc-modebar-drag-handle]){position:relative;margin-right:3px;cursor:move}
-:where(.xy [data-fc-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-2px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
+:where(.xy [data-fc-slot="modebar_button"]){width:24px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
+:where(.xy [data-fc-modebar-drag-handle]){position:relative;width:22px;margin-right:2px;cursor:move}
+:where(.xy [data-fc-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-1px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
 :where(.xy [data-fc-slot="modebar"][data-fc-collapsed="true"]>[data-fc-modebar-drag-handle]){margin-right:0}
 :where(.xy [data-fc-slot="modebar"][data-fc-collapsed="true"]>[data-fc-modebar-drag-handle])::after{display:none}
-:where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:58px;gap:2px;padding:0 6px;font-size:11px;font-variant-numeric:tabular-nums}
-:where(.xy [data-fc-modebar-select-trigger]){width:auto;min-width:35px;gap:0;padding:0 4px}
+:where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:52px;gap:1px;padding:0 4px;font-size:11px;font-variant-numeric:tabular-nums}
+:where(.xy [data-fc-modebar-select-trigger]){width:auto;min-width:30px;gap:0;padding:0 2px}
 :where(.xy [data-fc-modebar-menu-indicator]){display:flex;transition:transform .15s}
 :where(.xy [data-fc-modebar-menu-indicator] svg){width:11px;height:11px}
 :where(.xy [data-fc-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}

--- a/js/src/50_chartview.js
+++ b/js/src/50_chartview.js
@@ -2032,6 +2032,7 @@ class ChartView {
   // frame invalidates (§17 — steady hover must not re-render N-point picks).
   draw(keepPick = false) {
     if (this._destroyed || this._glLost || !this.gl) return;
+    this._updateZoomMenuLabel?.();
     if (this._raf) {
       this._rafKeepPick = this._rafKeepPick && keepPick;
       return;

--- a/js/src/50_chartview.js
+++ b/js/src/50_chartview.js
@@ -148,7 +148,8 @@ class ChartView {
     this._hoverTarget = null;
     this._viewEventRaf = null;
     this._linkedSource = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
-    this.dragMode = "pan"; // "pan" | "zoom" | "select"; toggled via the modebar
+    // pan | zoom | select (box) | select-lasso | select-x | select-y
+    this.dragMode = "pan";
 
     // Responsive size: "100%" means the *container* owns that axis — measure
     // it now, track it with a ResizeObserver below. Numeric sizes are fixed.

--- a/js/src/50_chartview.js
+++ b/js/src/50_chartview.js
@@ -2076,6 +2076,7 @@ class ChartView {
     if (!this._rafKeepPick) this._pickDirty = true;
     this._rafKeepPick = false;
     this._drawChrome();
+    this._renderLassoSelection?.();
   }
 
   // Centralized clock seam for animation state machines. Production uses the

--- a/js/src/50_chartview.js
+++ b/js/src/50_chartview.js
@@ -148,7 +148,7 @@ class ChartView {
     this._hoverTarget = null;
     this._viewEventRaf = null;
     this._linkedSource = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
-    this.dragMode = "pan"; // "pan" | "zoom" (box zoom); toggled via the modebar
+    this.dragMode = "pan"; // "pan" | "zoom" | "select"; toggled via the modebar
 
     // Responsive size: "100%" means the *container* owns that axis — measure
     // it now, track it with a ResizeObserver below. Numeric sizes are fixed.

--- a/js/src/53_interaction.js
+++ b/js/src/53_interaction.js
@@ -398,6 +398,7 @@ Object.assign(ChartView.prototype, {
     bar.dataset.fcCollapsed = "false";
     let setZoomMenuOpen = () => {};
     let setSelectMenuOpen = () => {};
+    let setExportMenuOpen = () => {};
 
     const setVisible = (visible) => {
       const show = visible || this._modebarDragging || bar.contains(document.activeElement);
@@ -409,6 +410,7 @@ Object.assign(ChartView.prototype, {
       setVisible(false);
       setZoomMenuOpen(false);
       setSelectMenuOpen(false);
+      setExportMenuOpen(false);
     });
     this._listen(bar, "focusin", () => setVisible(true));
     this._listen(bar, "focusout", () => {
@@ -440,6 +442,7 @@ Object.assign(ChartView.prototype, {
       if (collapsed) {
         setZoomMenuOpen(false);
         setSelectMenuOpen(false);
+        setExportMenuOpen(false);
       }
       for (const button of bar.querySelectorAll("button")) {
         if (button !== grip) {
@@ -485,6 +488,7 @@ Object.assign(ChartView.prototype, {
         bar.style.transition = "none";
         setZoomMenuOpen(false);
         setSelectMenuOpen(false);
+        setExportMenuOpen(false);
         try { grip.setPointerCapture(e.pointerId); } catch (_err) { /* synthetic event */ }
       }
       const rootRect = root.getBoundingClientRect();
@@ -572,6 +576,14 @@ Object.assign(ChartView.prototype, {
       selectTrigger.appendChild(selectIndicator);
       this._selectMenuButton = selectTrigger;
     }
+    const exportTrigger = mk("more", "Export options", () => {
+      setExportMenuOpen(!this._exportMenuOpen);
+    });
+    exportTrigger.dataset.fcModebarExport = "";
+    exportTrigger.dataset.fcModebarExportTrigger = "";
+    exportTrigger.setAttribute("aria-label", "Export options");
+    exportTrigger.setAttribute("aria-haspopup", "menu");
+    exportTrigger.setAttribute("aria-expanded", "false");
 
     const zoomMenu = document.createElement("div");
     zoomMenu.dataset.fcModebarMenu = "";
@@ -669,9 +681,59 @@ Object.assign(ChartView.prototype, {
       mkSelectItem("selecty", "Y Range", "Y", "select-y");
     }
 
+    const exportMenu = document.createElement("div");
+    exportMenu.dataset.fcModebarMenu = "";
+    exportMenu.dataset.fcModebarExportMenu = "";
+    exportMenu.setAttribute("role", "menu");
+    exportMenu.setAttribute("aria-label", "Export options");
+    exportMenu.style.cssText =
+      "position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
+    bar.appendChild(exportMenu);
+    const exportMenuItems = [];
+    const mkExportItem = (name, label, onClick, separator = false) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.tabIndex = -1;
+      button.dataset.fcModebarMenuItem = name;
+      button.dataset.fcModebarExportItem = name;
+      if (separator) button.dataset.fcSeparator = "";
+      button.setAttribute("role", "menuitem");
+      button.style.cssText = "display:flex;align-items:center;pointer-events:auto;";
+      this._applySlot(button, "modebar_button");
+      const icon = document.createElement("span");
+      icon.dataset.fcModebarMenuIcon = "";
+      icon.innerHTML = this._icon(name);
+      button.appendChild(icon);
+      const text = document.createElement("span");
+      text.textContent = label;
+      button.appendChild(text);
+      this._listen(button, "pointerdown", (e) => e.stopPropagation());
+      this._listen(button, "click", (e) => {
+        e.stopPropagation();
+        setExportMenuOpen(false, true);
+        Promise.resolve(onClick()).catch((error) => console.error(`xy: ${label} failed`, error));
+      });
+      exportMenu.appendChild(button);
+      exportMenuItems.push(button);
+      return button;
+    };
+    const themeItem = mkExportItem("moon", "Dark Mode", () => this._toggleColorMode());
+    themeItem.dataset.fcModebarThemeToggle = "";
+    themeItem.setAttribute("role", "menuitemcheckbox");
+    themeItem.setAttribute("aria-checked", "false");
+    this._themeMenuItem = themeItem;
+    this._colorMode = "light";
+    this._updateColorModeItem();
+    mkExportItem("png", "Export PNG", () => this._exportPng(), true);
+    mkExportItem("svg", "Export SVG", () => this._exportSvg());
+    mkExportItem("csv", "Export CSV", () => this._exportCsv());
+
     setZoomMenuOpen = (open, restoreFocus = false) => {
       const show = Boolean(open) && !this._modebarCollapsed;
-      if (show) setSelectMenuOpen(false);
+      if (show) {
+        setSelectMenuOpen(false);
+        setExportMenuOpen(false);
+      }
       this._zoomMenuOpen = show;
       zoomTrigger.setAttribute("aria-expanded", String(show));
       if (!show) {
@@ -701,7 +763,10 @@ Object.assign(ChartView.prototype, {
     setSelectMenuOpen = (open, restoreFocus = false) => {
       if (!selectTrigger) return;
       const show = Boolean(open) && !this._modebarCollapsed;
-      if (show) setZoomMenuOpen(false);
+      if (show) {
+        setZoomMenuOpen(false);
+        setExportMenuOpen(false);
+      }
       this._selectMenuOpen = show;
       selectTrigger.setAttribute("aria-expanded", String(show));
       if (!show) {
@@ -728,13 +793,45 @@ Object.assign(ChartView.prototype, {
       selectMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
       selectMenu.style.visibility = "visible";
     };
+    setExportMenuOpen = (open, restoreFocus = false) => {
+      const show = Boolean(open) && !this._modebarCollapsed;
+      if (show) {
+        setZoomMenuOpen(false);
+        setSelectMenuOpen(false);
+      }
+      this._exportMenuOpen = show;
+      exportTrigger.setAttribute("aria-expanded", String(show));
+      if (!show) {
+        exportMenu.style.display = "none";
+        if (restoreFocus) exportTrigger.focus();
+        return;
+      }
+      exportMenu.style.display = "flex";
+      exportMenu.style.visibility = "hidden";
+      const rootRect = root.getBoundingClientRect();
+      const barRect = bar.getBoundingClientRect();
+      const rootLeft = barRect.left - rootRect.left;
+      const rootTop = barRect.top - rootRect.top;
+      const below = bar.offsetHeight + 6;
+      const above = -exportMenu.offsetHeight - 6;
+      const preferredTop = barRect.bottom + 6 + exportMenu.offsetHeight <= rootRect.bottom
+        ? below
+        : above;
+      const maxLeft = root.clientWidth - rootLeft - exportMenu.offsetWidth;
+      const maxTop = root.clientHeight - rootTop - exportMenu.offsetHeight;
+      exportMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, exportTrigger.offsetLeft))}px`;
+      exportMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
+      exportMenu.style.visibility = "visible";
+    };
     this._closeModebarMenu = () => {
       setZoomMenuOpen(false);
       setSelectMenuOpen(false);
+      setExportMenuOpen(false);
     };
     this._listen(document, "pointerdown", (e) => {
       if (this._zoomMenuOpen && !bar.contains(e.target)) setZoomMenuOpen(false);
       if (this._selectMenuOpen && !bar.contains(e.target)) setSelectMenuOpen(false);
+      if (this._exportMenuOpen && !bar.contains(e.target)) setExportMenuOpen(false);
     });
     this._listen(zoomTrigger, "keydown", (e) => {
       if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
@@ -786,6 +883,31 @@ Object.assign(ChartView.prototype, {
         selectMenuItems[next].focus();
       });
     }
+    this._listen(exportTrigger, "keydown", (e) => {
+      if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+      e.preventDefault();
+      e.stopPropagation();
+      setExportMenuOpen(true);
+      const index = e.key === "ArrowDown" ? 0 : exportMenuItems.length - 1;
+      exportMenuItems[index].focus();
+    });
+    this._listen(exportMenu, "keydown", (e) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        setExportMenuOpen(false, true);
+        return;
+      }
+      if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(e.key)) return;
+      e.preventDefault();
+      const current = exportMenuItems.indexOf(document.activeElement);
+      let next = e.key === "Home" ? 0 : e.key === "End" ? exportMenuItems.length - 1 : current;
+      if (e.key === "ArrowDown") next = (current + 1) % exportMenuItems.length;
+      if (e.key === "ArrowUp") {
+        next = (current - 1 + exportMenuItems.length) % exportMenuItems.length;
+      }
+      exportMenuItems[next].focus();
+    });
     root.appendChild(bar);
     this._fitModebar();
     // The pointer may already be over a chart that mounted beneath it, in
@@ -1013,6 +1135,221 @@ Object.assign(ChartView.prototype, {
     this._setView({ x0, x1, y0, y1 }, { animate });
   },
 
+  _updateColorModeItem() {
+    if (!this._themeMenuItem) return;
+    const dark = this._colorMode === "dark";
+    const icon = this._themeMenuItem.querySelector("[data-fc-modebar-menu-icon]");
+    const label = icon?.nextElementSibling;
+    if (icon) icon.innerHTML = this._icon(dark ? "sun" : "moon");
+    if (label) label.textContent = dark ? "Light Mode" : "Dark Mode";
+    this._themeMenuItem.dataset.fcModebarExportItem = dark ? "light" : "dark";
+    this._themeMenuItem.setAttribute("aria-checked", String(dark));
+  },
+
+  _setColorMode(mode) {
+    const dark = mode === "dark";
+    this._colorMode = dark ? "dark" : "light";
+    this.root.dataset.fcColorMode = this._colorMode;
+    const colors = dark ? {
+      color: "#e5e7eb",
+      background: "#0b1220",
+      "--chart-bg": "#111827",
+      "--chart-grid": "rgba(226,232,240,.14)",
+      "--chart-axis": "#94a3b8",
+      "--chart-text": "#e5e7eb",
+      "--chart-legend-bg": "rgba(30,41,59,.84)",
+      "--chart-modebar-bg": "rgba(15,23,42,.94)",
+      "--chart-modebar-active": "rgba(148,163,184,.24)",
+      "--chart-tooltip-bg": "rgba(2,6,23,.96)",
+      "--chart-tooltip-text": "#f8fafc",
+      "--chart-badge-bg": "rgba(30,41,59,.9)",
+      "--chart-badge-text": "#e2e8f0",
+    } : {
+      color: "#1f2937",
+      background: "#ffffff",
+      "--chart-bg": "#ffffff",
+      "--chart-grid": "rgba(15,23,42,.12)",
+      "--chart-axis": "#64748b",
+      "--chart-text": "#1f2937",
+      "--chart-legend-bg": "rgba(241,245,249,.88)",
+      "--chart-modebar-bg": "rgba(255,255,255,.94)",
+      "--chart-modebar-active": "rgba(100,116,139,.18)",
+      "--chart-tooltip-bg": "rgba(20,24,33,.94)",
+      "--chart-tooltip-text": "#ffffff",
+      "--chart-badge-bg": "rgba(255,255,255,.9)",
+      "--chart-badge-text": "#0f172a",
+    };
+    for (const [name, value] of Object.entries(colors)) {
+      if (name === "color" || name === "background") this.root.style[name] = value;
+      else this.root.style.setProperty(name, value);
+    }
+    this._updateColorModeItem();
+    this.refreshTheme();
+  },
+
+  _toggleColorMode() {
+    this._setColorMode(this._colorMode === "dark" ? "light" : "dark");
+  },
+
+  _exportFilename(extension) {
+    const title = String(this.spec.title || "xy-chart")
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "xy-chart";
+    return `${title}.${extension}`;
+  },
+
+  _downloadExport(blob, filename) {
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    link.style.display = "none";
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+  },
+
+  _exportSvgMarkup() {
+    this._drawNow?.();
+    this.gl?.finish?.();
+    const width = this.size.w;
+    const height = this.size.h;
+    const clone = this.root.cloneNode(true);
+    clone.style.width = `${width}px`;
+    clone.style.height = `${height}px`;
+    clone.style.margin = "0";
+    clone.setAttribute("xmlns", "http://www.w3.org/1999/xhtml");
+
+    const sourceCanvases = [...this.root.querySelectorAll("canvas")];
+    const clonedCanvases = [...clone.querySelectorAll("canvas")];
+    for (let i = 0; i < clonedCanvases.length; i++) {
+      const source = sourceCanvases[i];
+      const target = clonedCanvases[i];
+      if (!source || !target) continue;
+      const image = document.createElement("img");
+      image.setAttribute("src", source.toDataURL("image/png"));
+      image.setAttribute("alt", "");
+      image.setAttribute("style", target.getAttribute("style") || "");
+      image.setAttribute("width", String(source.clientWidth || source.width));
+      image.setAttribute("height", String(source.clientHeight || source.height));
+      for (const attr of target.attributes) {
+        if (attr.name.startsWith("data-")) image.setAttribute(attr.name, attr.value);
+      }
+      target.replaceWith(image);
+    }
+
+    clone.querySelectorAll(
+      '[data-fc-slot="modebar"],[data-fc-slot="tooltip"],' +
+      '[data-fc-slot="selection"],[data-fc-selection-lasso],' +
+      '[data-fc-slot="crosshair_x"],[data-fc-slot="crosshair_y"]'
+    ).forEach((node) => node.remove());
+    const stylesheet = document.createElement("style");
+    stylesheet.textContent = FC_CHROME_CSS;
+    clone.prepend(stylesheet);
+    const content = new XMLSerializer().serializeToString(clone);
+    return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" ` +
+      `viewBox="0 0 ${width} ${height}"><foreignObject width="100%" height="100%">` +
+      `${content}</foreignObject></svg>`;
+  },
+
+  _exportSvg() {
+    const svg = this._exportSvgMarkup();
+    this._downloadExport(
+      new Blob([svg], { type: "image/svg+xml;charset=utf-8" }),
+      this._exportFilename("svg")
+    );
+  },
+
+  _exportPng() {
+    const svg = this._exportSvgMarkup();
+    const sourceUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+    const image = new Image();
+    return new Promise((resolve, reject) => {
+      image.onload = () => {
+        const scale = Math.max(1, window.devicePixelRatio || 1);
+        const canvas = document.createElement("canvas");
+        canvas.width = Math.round(this.size.w * scale);
+        canvas.height = Math.round(this.size.h * scale);
+        const ctx = canvas.getContext("2d");
+        ctx.scale(scale, scale);
+        ctx.drawImage(image, 0, 0, this.size.w, this.size.h);
+        canvas.toBlob((blob) => {
+          if (!blob) {
+            reject(new Error("PNG encoding returned no data"));
+            return;
+          }
+          this._downloadExport(blob, this._exportFilename("png"));
+          resolve();
+        }, "image/png");
+      };
+      image.onerror = () => {
+        reject(new Error("chart SVG could not be rasterized"));
+      };
+      image.src = sourceUrl;
+    });
+  },
+
+  _exportCsvText() {
+    const columns = ["trace", "name", "kind", "index", "x", "y", "x0", "x1", "y0", "y1", "value"];
+    const rows = [columns];
+    const clean = (value) => Number.isFinite(value) ? value : "";
+    for (const g of this.gpuTraces || []) {
+      const trace = g.trace || {};
+      const prefix = [trace.id ?? "", trace.name ?? "", trace.kind ?? ""];
+      if (g._cpuRect) {
+        const r = g._cpuRect;
+        const n = Math.min(r.x0.length, r.x1.length, r.y0.length, r.y1.length);
+        for (let i = 0; i < n; i++) {
+          rows.push([...prefix, i, "", "",
+            clean(this._decodeValue(r.x0, r.x0Meta, i)),
+            clean(this._decodeValue(r.x1, r.x1Meta, i)),
+            clean(this._decodeValue(r.y0, r.y0Meta, i)),
+            clean(this._decodeValue(r.y1, r.y1Meta, i)), ""]);
+        }
+        continue;
+      }
+      if (g.heatmap && g._cpuHeatmap) {
+        const h = g.heatmap;
+        for (let i = 0; i < g._cpuHeatmap.grid.length; i++) {
+          const row = Math.floor(i / h.w);
+          const col = i % h.w;
+          const x = h.xRange[0] + (col + 0.5) * ((h.xRange[1] - h.xRange[0]) / h.w);
+          const y = h.yRange[0] + (row + 0.5) * ((h.yRange[1] - h.yRange[0]) / h.h);
+          const value = this._denormalizeUnit(g._cpuHeatmap.grid[i], trace.color?.domain);
+          rows.push([...prefix, i, clean(x), clean(y), "", "", "", "", clean(value)]);
+        }
+        continue;
+      }
+      const cpu = g._cpu;
+      if (!cpu?.x || !cpu?.y) continue;
+      const n = Math.min(cpu.x.length, cpu.y.length, g.n || Infinity);
+      for (let i = 0; i < n; i++) {
+        rows.push([...prefix, i,
+          clean(this._decodeValue(cpu.x, cpu.xMeta || g.xMeta, i)),
+          clean(this._decodeValue(cpu.y, cpu.yMeta || g.yMeta, i)),
+          "", "", "", "", ""]);
+      }
+    }
+    const quote = (value) => {
+      const text = String(value ?? "");
+      const escaped = text.split('"').join('""');
+      return text.includes(",") || text.includes('"') || text.includes("\r") || text.includes("\n")
+        ? `"${escaped}"`
+        : text;
+    };
+    return rows.map((row) => row.map(quote).join(",")).join("\r\n") + "\r\n";
+  },
+
+  _exportCsv() {
+    this._downloadExport(
+      new Blob([this._exportCsvText()], { type: "text/csv;charset=utf-8" }),
+      this._exportFilename("csv")
+    );
+  },
+
   _icon(name) {
     // Inline stroke SVGs (currentColor) — no external assets (§33 no supply chain).
     const svg = (body) =>
@@ -1051,6 +1388,25 @@ Object.assign(ChartView.prototype, {
           '<path d="M10 6 V14 M10 6 L8 8 M10 6 L12 8 M10 14 L8 12 M10 14 L12 12"/>');
       case "chevrondown":
         return svg('<path d="M6 8 L10 12 L14 8"/>');
+      case "more":
+        return svg('<circle cx="5" cy="10" r="1" fill="currentColor" stroke="none"/>' +
+          '<circle cx="10" cy="10" r="1" fill="currentColor" stroke="none"/>' +
+          '<circle cx="15" cy="10" r="1" fill="currentColor" stroke="none"/>');
+      case "moon":
+        return svg('<path d="M14.8 13.8 A6.5 6.5 0 0 1 6.2 5.2 A6.5 6.5 0 1 0 14.8 13.8 Z"/>');
+      case "sun":
+        return svg('<circle cx="10" cy="10" r="3"/><path d="M10 2 V4 M10 16 V18 ' +
+          'M2 10 H4 M16 10 H18 M4.3 4.3 L5.7 5.7 M14.3 14.3 L15.7 15.7 ' +
+          'M15.7 4.3 L14.3 5.7 M5.7 14.3 L4.3 15.7"/>');
+      case "png":
+        return svg('<path d="M5 2.5 H12 L15.5 6 V17.5 H5 Z"/><path d="M12 2.5 V6 H15.5"/>' +
+          '<path d="M7 13 L9 10.5 L11 12 L13.5 9 V15 H7 Z"/>');
+      case "svg":
+        return svg('<path d="M5 2.5 H12 L15.5 6 V17.5 H5 Z"/><path d="M12 2.5 V6 H15.5"/>' +
+          '<path d="M7 13 L9 9 L11 14 L13.5 10"/>');
+      case "csv":
+        return svg('<path d="M5 2.5 H12 L15.5 6 V17.5 H5 Z"/><path d="M12 2.5 V6 H15.5"/>' +
+          '<path d="M7 9 H13 M7 12 H13 M7 15 H13 M9 8 V16"/>');
       case "reset":
         return svg('<path d="M4 10 a6 6 0 1 1 1.8 4.3"/><path d="M4 6 V10 H8"/>');
       case "drag":

--- a/js/src/53_interaction.js
+++ b/js/src/53_interaction.js
@@ -36,10 +36,10 @@ Object.assign(ChartView.prototype, {
 
     this._listen(c, "pointerdown", (e) => {
       this._cancelViewAnimation();
-      // Shift-drag box-selects (§34); a "zoom" modebar toggle turns a plain drag
-      // into a box-zoom; otherwise a plain drag pans.
+      // Shift-drag box-selects (§34); the modebar can make selection or box-zoom
+      // the default plain-drag gesture; otherwise a plain drag pans.
       const canBrush = this._interactionFlag("brush", true) && this._interactionFlag("select", true);
-      const mode = e.shiftKey && canBrush && this._pickable ? "select"
+      const mode = (e.shiftKey || this.dragMode === "select") && canBrush && this._pickable ? "select"
         : this.dragMode === "zoom" ? "zoom" : null;
       if (mode) {
         band = { mode, sx: e.clientX, sy: e.clientY, d0: dataAt(e.clientX, e.clientY) };
@@ -444,6 +444,15 @@ Object.assign(ChartView.prototype, {
     zoomTrigger.setAttribute("aria-haspopup", "menu");
     zoomTrigger.setAttribute("aria-expanded", "false");
     mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
+    const canSelect = this._pickable
+      && this._interactionFlag("brush", true)
+      && this._interactionFlag("select", true);
+    if (canSelect) {
+      const selectButton = mk(
+        "select", "Select points", () => this._setDragMode("select"), "select"
+      );
+      selectButton.dataset.fcModebarSelect = "";
+    }
 
     const zoomMenu = document.createElement("div");
     zoomMenu.dataset.fcModebarMenu = "";
@@ -793,6 +802,11 @@ Object.assign(ChartView.prototype, {
       case "zoom":
         return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
           'stroke-dasharray="3 2"/>');
+      case "select":
+        return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
+          'stroke-dasharray="2.5 2"/><circle cx="7" cy="7" r="1" fill="currentColor" ' +
+          'stroke="none"/><circle cx="12.5" cy="9" r="1" fill="currentColor" stroke="none"/>' +
+          '<circle cx="9.5" cy="13" r="1" fill="currentColor" stroke="none"/>');
       case "chevrondown":
         return svg('<path d="M6 8 L10 12 L14 8"/>');
       case "reset":

--- a/js/src/53_interaction.js
+++ b/js/src/53_interaction.js
@@ -18,10 +18,61 @@ Object.assign(ChartView.prototype, {
     this.selLasso = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     this.selLasso.style.cssText =
       "position:absolute;display:none;pointer-events:none;z-index:4;overflow:visible;";
+    this.selLasso.dataset.fcSelectionLassoOverlay = "";
     this.selLassoPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
     this.selLassoPath.dataset.fcSelectionLasso = "";
     this.selLasso.appendChild(this.selLassoPath);
+    this.selLassoHandles = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    this.selLassoHandles.dataset.fcSelectionLassoHandles = "";
+    this.selLasso.appendChild(this.selLassoHandles);
     this.root.appendChild(this.selLasso);
+    this._lassoPolygon = null;
+    let lassoHandleDrag = null;
+
+    const moveLassoHandle = (e) => {
+      if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId) return;
+      const rect = c.getBoundingClientRect();
+      const cssX = Math.max(0, Math.min(rect.width, e.clientX - rect.left));
+      const cssY = Math.max(0, Math.min(rect.height, e.clientY - rect.top));
+      this._lassoPolygon[lassoHandleDrag.index] = this._dataFromCanvas(cssX, cssY);
+      this._renderLassoSelection();
+      e.preventDefault();
+      e.stopPropagation();
+    };
+    this._listen(this.selLasso, "pointerdown", (e) => {
+      const handle = e.target.closest?.("[data-fc-selection-lasso-handle]");
+      if (!handle || !this._lassoPolygon) return;
+      const index = Number(handle.dataset.fcSelectionLassoHandle);
+      if (!Number.isInteger(index) || !this._lassoPolygon[index]) return;
+      lassoHandleDrag = {
+        index,
+        pointerId: e.pointerId,
+        original: [...this._lassoPolygon[index]],
+        handle,
+      };
+      handle.dataset.fcActive = "";
+      this.tooltip.style.display = "none";
+      try { this.selLasso.setPointerCapture(e.pointerId); } catch (_err) { /* synthetic event */ }
+      e.preventDefault();
+      e.stopPropagation();
+    });
+    this._listen(this.selLasso, "pointermove", moveLassoHandle);
+    this._listen(this.selLasso, "pointerup", (e) => {
+      if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId) return;
+      moveLassoHandle(e);
+      const handle = lassoHandleDrag.handle;
+      lassoHandleDrag = null;
+      delete handle.dataset.fcActive;
+      this._sendSelectPolygon(this._lassoPolygon);
+    });
+    this._listen(this.selLasso, "pointercancel", (e) => {
+      if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId) return;
+      this._lassoPolygon[lassoHandleDrag.index] = lassoHandleDrag.original;
+      delete lassoHandleDrag.handle.dataset.fcActive;
+      lassoHandleDrag = null;
+      this._renderLassoSelection();
+      e.stopPropagation();
+    });
 
     if (this._interactionFlag("crosshair")) {
       this.crosshairX = document.createElement("div");
@@ -40,6 +91,16 @@ Object.assign(ChartView.prototype, {
       const r = c.getBoundingClientRect();
       return this._dataFromCanvas(clientX - r.left, clientY - r.top);
     };
+    const lassoPointAt = (clientX, clientY) => {
+      const r = c.getBoundingClientRect();
+      const cssX = Math.max(0, Math.min(r.width, clientX - r.left));
+      const cssY = Math.max(0, Math.min(r.height, clientY - r.top));
+      return {
+        x: r.left + cssX,
+        y: r.top + cssY,
+        data: this._dataFromCanvas(cssX, cssY),
+      };
+    };
 
     this._listen(c, "pointerdown", (e) => {
       this._cancelViewAnimation();
@@ -51,10 +112,16 @@ Object.assign(ChartView.prototype, {
         ? (e.shiftKey ? "select" : selectMode)
         : this.dragMode === "zoom" ? "zoom" : null;
       if (mode) {
-        const d0 = dataAt(e.clientX, e.clientY);
+        const previousLasso = mode.startsWith("select") && this._lassoPolygon
+          ? this._lassoPolygon.map((point) => [...point])
+          : null;
+        if (mode.startsWith("select")) this._clearLassoOverlay();
+        const firstLassoPoint = mode === "select-lasso" ? lassoPointAt(e.clientX, e.clientY) : null;
+        const d0 = firstLassoPoint ? firstLassoPoint.data : dataAt(e.clientX, e.clientY);
         band = {
           mode, sx: e.clientX, sy: e.clientY, d0,
-          points: mode === "select-lasso" ? [{ x: e.clientX, y: e.clientY, data: d0 }] : null,
+          points: firstLassoPoint ? [firstLassoPoint] : null,
+          previousLasso,
         };
         c.setPointerCapture(e.pointerId);
         this.tooltip.style.display = "none";
@@ -98,7 +165,8 @@ Object.assign(ChartView.prototype, {
         if (moved) {
           if (band.mode === "zoom") this._zoomToBox(band.d0, d1, true);
           else if (band.mode === "select-lasso" && band.points.length >= 3) {
-            this._sendSelectPolygon(band.points.map((point) => point.data));
+            const editable = this._simplifyLassoPoints(band.points);
+            this._sendSelectPolygon(editable.map((point) => point.data));
           } else {
             let d0 = band.d0;
             if (band.mode === "select-x") {
@@ -111,6 +179,9 @@ Object.assign(ChartView.prototype, {
             this._sendSelect(d0, d1);
           }
           this._ignoreNextClick = true;
+        } else if (band.previousLasso) {
+          this._lassoPolygon = band.previousLasso;
+          this._renderLassoSelection();
         }
         band = null;
         return;
@@ -123,6 +194,10 @@ Object.assign(ChartView.prototype, {
     this._listen(c, "pointercancel", () => {
       this.selRect.style.display = "none";
       this.selLasso.style.display = "none";
+      if (band?.previousLasso) {
+        this._lassoPolygon = band.previousLasso;
+        this._renderLassoSelection();
+      }
       band = null;
       drag = null;
     });
@@ -217,11 +292,13 @@ Object.assign(ChartView.prototype, {
     const rootRect = this.root.getBoundingClientRect();
     if (band.mode === "select-lasso") {
       const previous = band.points[band.points.length - 1];
+      const cssX = Math.max(0, Math.min(rect.width, e.clientX - rect.left));
+      const cssY = Math.max(0, Math.min(rect.height, e.clientY - rect.top));
+      const clientX = rect.left + cssX;
+      const clientY = rect.top + cssY;
       if (band.points.length < 2048
-          && Math.hypot(e.clientX - previous.x, e.clientY - previous.y) >= 3) {
-        band.points.push({ x: e.clientX, y: e.clientY, data: this._dataFromCanvas(
-          e.clientX - rect.left, e.clientY - rect.top
-        ) });
+          && Math.hypot(clientX - previous.x, clientY - previous.y) >= 3) {
+        band.points.push({ x: clientX, y: clientY, data: this._dataFromCanvas(cssX, cssY) });
       }
       const points = band.points.map((point) => [
         Math.max(this.plot.x, Math.min(this.plot.x + this.plot.w, point.x - rootRect.left)),
@@ -261,7 +338,113 @@ Object.assign(ChartView.prototype, {
     void rect;
   },
 
+  _simplifyLassoPoints(points, tolerance = 6, maxPoints = 16) {
+    const source = points.filter((point) => point && Number.isFinite(point.x) && Number.isFinite(point.y));
+    if (source.length > 3) {
+      const first = source[0], last = source[source.length - 1];
+      if (Math.hypot(first.x - last.x, first.y - last.y) <= tolerance) source.pop();
+    }
+    if (source.length <= 3) return source.slice();
+
+    const distanceToSegmentSq = (point, start, end) => {
+      const dx = end.x - start.x, dy = end.y - start.y;
+      if (dx === 0 && dy === 0) {
+        return (point.x - start.x) ** 2 + (point.y - start.y) ** 2;
+      }
+      const t = Math.max(0, Math.min(1,
+        ((point.x - start.x) * dx + (point.y - start.y) * dy) / (dx * dx + dy * dy)
+      ));
+      const x = start.x + t * dx, y = start.y + t * dy;
+      return (point.x - x) ** 2 + (point.y - y) ** 2;
+    };
+    const keep = new Uint8Array(source.length);
+    keep[0] = 1;
+    keep[source.length - 1] = 1;
+    const stack = [[0, source.length - 1]];
+    const toleranceSq = tolerance * tolerance;
+    while (stack.length) {
+      const [start, end] = stack.pop();
+      let furthest = -1, furthestDistance = toleranceSq;
+      for (let i = start + 1; i < end; i++) {
+        const distance = distanceToSegmentSq(source[i], source[start], source[end]);
+        if (distance > furthestDistance) {
+          furthest = i;
+          furthestDistance = distance;
+        }
+      }
+      if (furthest >= 0) {
+        keep[furthest] = 1;
+        stack.push([start, furthest], [furthest, end]);
+      }
+    }
+    let simplified = source.filter((_point, index) => keep[index]);
+    if (simplified.length < 3) {
+      simplified = [source[0], source[Math.floor(source.length / 2)], source[source.length - 1]];
+    }
+    if (simplified.length > maxPoints) {
+      simplified = Array.from({ length: maxPoints }, (_value, index) => (
+        simplified[Math.round(index * (simplified.length - 1) / (maxPoints - 1))]
+      ));
+    }
+    return simplified;
+  },
+
+  _clearLassoOverlay() {
+    this._lassoPolygon = null;
+    if (!this.selLasso) return;
+    this.selLasso.style.display = "none";
+    this.selLassoPath?.removeAttribute("d");
+    this.selLassoHandles?.replaceChildren();
+  },
+
+  _renderLassoSelection() {
+    const polygon = this._lassoPolygon;
+    if (!this.selLasso || !this.selLassoPath || !this.selLassoHandles
+        || !Array.isArray(polygon) || polygon.length < 3) return;
+    const [x0, x1] = this._axisRange("x");
+    const [y0, y1] = this._axisRange("y");
+    const xAxis = this._axis("x"), yAxis = this._axis("y");
+    const cx0 = this._axisCoord(xAxis, x0), cx1 = this._axisCoord(xAxis, x1);
+    const cy0 = this._axisCoord(yAxis, y0), cy1 = this._axisCoord(yAxis, y1);
+    if (![cx0, cx1, cy0, cy1].every(Number.isFinite) || cx0 === cx1 || cy0 === cy1) return;
+    const points = polygon.map((point) => {
+      const cx = this._axisCoord(xAxis, point[0]);
+      const cy = this._axisCoord(yAxis, point[1]);
+      const x = this.plot.x + ((cx - cx0) / (cx1 - cx0)) * this.plot.w;
+      const y = this.plot.y + ((cy1 - cy) / (cy1 - cy0)) * this.plot.h;
+      return [
+        Math.max(this.plot.x, Math.min(this.plot.x + this.plot.w, x)),
+        Math.max(this.plot.y, Math.min(this.plot.y + this.plot.h, y)),
+      ];
+    });
+    if (!points.flat().every(Number.isFinite)) return;
+
+    this.selLasso.style.display = "block";
+    this.selLasso.style.inset = "0";
+    this.selLasso.setAttribute("width", String(this.root.clientWidth));
+    this.selLasso.setAttribute("height", String(this.root.clientHeight));
+    this.selLassoPath.setAttribute(
+      "d", points.map((point, index) => `${index ? "L" : "M"}${point[0]} ${point[1]}`).join(" ") + " Z"
+    );
+    while (this.selLassoHandles.childElementCount < points.length) {
+      const handle = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+      handle.dataset.fcSelectionLassoHandle = "";
+      handle.setAttribute("r", "4");
+      this.selLassoHandles.appendChild(handle);
+    }
+    while (this.selLassoHandles.childElementCount > points.length) {
+      this.selLassoHandles.lastElementChild.remove();
+    }
+    [...this.selLassoHandles.children].forEach((handle, index) => {
+      handle.dataset.fcSelectionLassoHandle = String(index);
+      handle.setAttribute("cx", String(points[index][0]));
+      handle.setAttribute("cy", String(points[index][1]));
+      handle.setAttribute("aria-label", `Lasso point ${index + 1}`);
+    });
+  },
+
   _sendSelect(d0, d1) {
+    this._clearLassoOverlay();
     const x0 = Math.min(d0[0], d1[0]), x1 = Math.max(d0[0], d1[0]);
     const y0 = Math.min(d0[1], d1[1]), y1 = Math.max(d0[1], d1[1]);
     const range = { x0, x1, y0, y1 };
@@ -276,6 +459,9 @@ Object.assign(ChartView.prototype, {
   _sendSelectPolygon(points) {
     if (!Array.isArray(points) || points.length < 3) return;
     const polygon = points.map((point) => [point[0], point[1]]);
+    if (!polygon.every((point) => point.every(Number.isFinite))) return;
+    this._lassoPolygon = polygon;
+    this._renderLassoSelection();
     this._dispatchChartEvent("brush", {
       polygon,
       view: this._eventView("brush"),
@@ -359,6 +545,7 @@ Object.assign(ChartView.prototype, {
   },
 
   _clearSelection() {
+    this._clearLassoOverlay();
     for (const g of this.gpuTraces) {
       g.selActive = false;
       if (g.drill) g.drill.selActive = false;
@@ -1140,7 +1327,7 @@ Object.assign(ChartView.prototype, {
 
     clone.querySelectorAll(
       '[data-fc-slot="modebar"],[data-fc-slot="tooltip"],' +
-      '[data-fc-slot="selection"],[data-fc-selection-lasso],' +
+      '[data-fc-slot="selection"],[data-fc-selection-lasso-overlay],' +
       '[data-fc-slot="crosshair_x"],[data-fc-slot="crosshair_y"]'
     ).forEach((node) => node.remove());
     const stylesheet = document.createElement("style");

--- a/js/src/53_interaction.js
+++ b/js/src/53_interaction.js
@@ -567,7 +567,6 @@ Object.assign(ChartView.prototype, {
     this._zoomMenuLabel = zoomPercent;
     zoomTrigger.setAttribute("aria-haspopup", "menu");
     zoomTrigger.setAttribute("aria-expanded", "false");
-    mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
     const canSelect = this._pickable
       && this._interactionFlag("brush", true)
       && this._interactionFlag("select", true);
@@ -587,6 +586,7 @@ Object.assign(ChartView.prototype, {
       selectTrigger.appendChild(selectIndicator);
       this._selectMenuButton = selectTrigger;
     }
+    mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
     const zoomMenu = document.createElement("div");
     zoomMenu.dataset.fcModebarMenu = "";
     zoomMenu.setAttribute("role", "menu");

--- a/js/src/53_interaction.js
+++ b/js/src/53_interaction.js
@@ -399,6 +399,7 @@ Object.assign(ChartView.prototype, {
     let setZoomMenuOpen = () => {};
     let setSelectMenuOpen = () => {};
     let setExportMenuOpen = () => {};
+    let updateCollapseItem = () => {};
 
     const setVisible = (visible) => {
       const show = visible || this._modebarDragging || bar.contains(document.activeElement);
@@ -417,15 +418,18 @@ Object.assign(ChartView.prototype, {
       if (!root.matches(":hover")) setVisible(false);
     });
 
-    // A dedicated grip keeps button clicks distinct from toolbar movement.
-    // Pointer capture lets a drag finish cleanly even if it leaves the chart;
-    // the coordinates are still clamped to the chart root below.
+    // One combined grip/menu control avoids a second, visually redundant dots
+    // button. Click opens toolbar options, drag moves, and double-click keeps
+    // the quick collapse shortcut; Collapse/Expand is also a menu action.
     const grip = document.createElement("button");
     grip.type = "button";
-    grip.title = "Double-click to collapse; drag to move";
-    grip.setAttribute("aria-label", "Collapse toolbar");
-    grip.setAttribute("aria-expanded", "true");
+    grip.title = "Click for toolbar options; drag to move; double-click to collapse";
+    grip.setAttribute("aria-label", "Toolbar options");
+    grip.setAttribute("aria-haspopup", "menu");
+    grip.setAttribute("aria-expanded", "false");
     grip.dataset.fcModebarDragHandle = "";
+    grip.dataset.fcModebarExport = "";
+    grip.dataset.fcModebarExportTrigger = "";
     grip.innerHTML = this._icon("drag");
     grip.style.cssText =
       "display:flex;align-items:center;justify-content:center;pointer-events:auto;touch-action:none;";
@@ -436,6 +440,7 @@ Object.assign(ChartView.prototype, {
     const DRAG_THRESHOLD_PX = 6;
     let modebarDrag = null;
     let lastGripDown = 0;
+    let suppressGripClickUntil = 0;
     const setCollapsed = (collapsed) => {
       this._modebarCollapsed = collapsed;
       bar.dataset.fcCollapsed = String(collapsed);
@@ -444,17 +449,18 @@ Object.assign(ChartView.prototype, {
         setSelectMenuOpen(false);
         setExportMenuOpen(false);
       }
-      for (const button of bar.querySelectorAll("button")) {
+      // Only collapse top-level controls. Menu items stay available because
+      // this same grip is the only visible control in the collapsed state.
+      for (const button of bar.querySelectorAll(":scope > button")) {
         if (button !== grip) {
           button.hidden = collapsed;
           button.style.display = collapsed ? "none" : "flex";
         }
       }
       grip.title = collapsed
-        ? "Double-click to expand; drag to move"
-        : "Double-click to collapse; drag to move";
-      grip.setAttribute("aria-label", collapsed ? "Expand toolbar" : "Collapse toolbar");
-      grip.setAttribute("aria-expanded", String(!collapsed));
+        ? "Click for toolbar options; drag to move; double-click to expand"
+        : "Click for toolbar options; drag to move; double-click to collapse";
+      updateCollapseItem();
       this._fitModebar();
     };
     const toggleModebar = () => setCollapsed(!this._modebarCollapsed);
@@ -474,7 +480,10 @@ Object.assign(ChartView.prototype, {
         moved: false,
       };
       setVisible(true);
-      if (doubleClick) toggleModebar();
+      if (doubleClick) {
+        suppressGripClickUntil = performance.now() + 100;
+        toggleModebar();
+      }
     });
     this._listen(grip, "pointermove", (e) => {
       if (!modebarDrag || e.pointerId !== modebarDrag.pointerId) return;
@@ -506,20 +515,22 @@ Object.assign(ChartView.prototype, {
       setVisible(root.matches(":hover"));
       if (moved || cancelled) {
         lastGripDown = 0;
+        suppressGripClickUntil = performance.now() + 100;
       }
     };
     this._listen(grip, "pointerup", endModebarDrag);
     this._listen(grip, "pointercancel", endModebarDrag);
-    this._listen(grip, "click", (e) => e.stopPropagation());
+    this._listen(grip, "click", (e) => {
+      e.stopPropagation();
+      if (performance.now() <= suppressGripClickUntil) {
+        suppressGripClickUntil = 0;
+        return;
+      }
+      setExportMenuOpen(!this._exportMenuOpen);
+    });
     this._listen(grip, "dblclick", (e) => {
       e.preventDefault();
       e.stopPropagation();
-    });
-    this._listen(grip, "keydown", (e) => {
-      if (e.repeat || (e.key !== "Enter" && e.key !== " ")) return;
-      e.preventDefault();
-      e.stopPropagation();
-      toggleModebar();
     });
 
     const mk = (name, title, onClick, toggles) => {
@@ -576,15 +587,6 @@ Object.assign(ChartView.prototype, {
       selectTrigger.appendChild(selectIndicator);
       this._selectMenuButton = selectTrigger;
     }
-    const exportTrigger = mk("more", "Export options", () => {
-      setExportMenuOpen(!this._exportMenuOpen);
-    });
-    exportTrigger.dataset.fcModebarExport = "";
-    exportTrigger.dataset.fcModebarExportTrigger = "";
-    exportTrigger.setAttribute("aria-label", "Export options");
-    exportTrigger.setAttribute("aria-haspopup", "menu");
-    exportTrigger.setAttribute("aria-expanded", "false");
-
     const zoomMenu = document.createElement("div");
     zoomMenu.dataset.fcModebarMenu = "";
     zoomMenu.setAttribute("role", "menu");
@@ -685,17 +687,18 @@ Object.assign(ChartView.prototype, {
     exportMenu.dataset.fcModebarMenu = "";
     exportMenu.dataset.fcModebarExportMenu = "";
     exportMenu.setAttribute("role", "menu");
-    exportMenu.setAttribute("aria-label", "Export options");
+    exportMenu.setAttribute("aria-label", "Toolbar options");
     exportMenu.style.cssText =
       "position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
     bar.appendChild(exportMenu);
     const exportMenuItems = [];
-    const mkExportItem = (name, label, onClick) => {
+    const mkExportItem = (name, label, onClick, separator = false) => {
       const button = document.createElement("button");
       button.type = "button";
       button.tabIndex = -1;
       button.dataset.fcModebarMenuItem = name;
       button.dataset.fcModebarExportItem = name;
+      if (separator) button.dataset.fcSeparator = "";
       button.setAttribute("role", "menuitem");
       button.style.cssText = "display:flex;align-items:center;pointer-events:auto;";
       this._applySlot(button, "modebar_button");
@@ -716,7 +719,18 @@ Object.assign(ChartView.prototype, {
       exportMenuItems.push(button);
       return button;
     };
-    mkExportItem("png", "Export PNG", () => this._exportPng());
+    const collapseItem = mkExportItem("collapse", "Collapse Toolbar", toggleModebar);
+    collapseItem.dataset.fcModebarCollapseItem = "";
+    updateCollapseItem = () => {
+      const collapsed = this._modebarCollapsed;
+      const icon = collapseItem.querySelector("[data-fc-modebar-menu-icon]");
+      const label = icon?.nextElementSibling;
+      if (icon) icon.innerHTML = this._icon(collapsed ? "expand" : "collapse");
+      if (label) label.textContent = collapsed ? "Expand Toolbar" : "Collapse Toolbar";
+      collapseItem.dataset.fcModebarExportItem = collapsed ? "expand" : "collapse";
+    };
+    updateCollapseItem();
+    mkExportItem("png", "Export PNG", () => this._exportPng(), true);
     mkExportItem("svg", "Export SVG", () => this._exportSvg());
     mkExportItem("csv", "Export CSV", () => this._exportCsv());
 
@@ -786,16 +800,16 @@ Object.assign(ChartView.prototype, {
       selectMenu.style.visibility = "visible";
     };
     setExportMenuOpen = (open, restoreFocus = false) => {
-      const show = Boolean(open) && !this._modebarCollapsed;
+      const show = Boolean(open);
       if (show) {
         setZoomMenuOpen(false);
         setSelectMenuOpen(false);
       }
       this._exportMenuOpen = show;
-      exportTrigger.setAttribute("aria-expanded", String(show));
+      grip.setAttribute("aria-expanded", String(show));
       if (!show) {
         exportMenu.style.display = "none";
-        if (restoreFocus) exportTrigger.focus();
+        if (restoreFocus) grip.focus();
         return;
       }
       exportMenu.style.display = "flex";
@@ -811,7 +825,7 @@ Object.assign(ChartView.prototype, {
         : above;
       const maxLeft = root.clientWidth - rootLeft - exportMenu.offsetWidth;
       const maxTop = root.clientHeight - rootTop - exportMenu.offsetHeight;
-      exportMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, exportTrigger.offsetLeft))}px`;
+      exportMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, grip.offsetLeft))}px`;
       exportMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
       exportMenu.style.visibility = "visible";
     };
@@ -875,7 +889,7 @@ Object.assign(ChartView.prototype, {
         selectMenuItems[next].focus();
       });
     }
-    this._listen(exportTrigger, "keydown", (e) => {
+    this._listen(grip, "keydown", (e) => {
       if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
       e.preventDefault();
       e.stopPropagation();
@@ -1324,10 +1338,10 @@ Object.assign(ChartView.prototype, {
           '<path d="M10 6 V14 M10 6 L8 8 M10 6 L12 8 M10 14 L8 12 M10 14 L12 12"/>');
       case "chevrondown":
         return svg('<path d="M6 8 L10 12 L14 8"/>');
-      case "more":
-        return svg('<circle cx="5" cy="10" r="1" fill="currentColor" stroke="none"/>' +
-          '<circle cx="10" cy="10" r="1" fill="currentColor" stroke="none"/>' +
-          '<circle cx="15" cy="10" r="1" fill="currentColor" stroke="none"/>');
+      case "collapse":
+        return svg('<path d="M4 5 H16 M4 15 H16 M7 8 L10 11 L13 8"/>');
+      case "expand":
+        return svg('<path d="M4 5 H16 M4 15 H16 M7 12 L10 9 L13 12"/>');
       case "png":
         return svg('<path d="M5 2.5 H12 L15.5 6 V17.5 H5 Z"/><path d="M12 2.5 V6 H15.5"/>' +
           '<path d="M7 13 L9 10.5 L11 12 L13.5 9 V15 H7 Z"/>');

--- a/js/src/53_interaction.js
+++ b/js/src/53_interaction.js
@@ -431,6 +431,16 @@ Object.assign(ChartView.prototype, {
     });
     this._zoomMenuButton = zoomTrigger;
     zoomTrigger.dataset.fcModebarMenuTrigger = "";
+    zoomTrigger.replaceChildren();
+    const zoomPercent = document.createElement("span");
+    zoomPercent.dataset.fcModebarZoomPercent = "";
+    zoomPercent.textContent = "100%";
+    zoomTrigger.appendChild(zoomPercent);
+    const zoomIndicator = document.createElement("span");
+    zoomIndicator.dataset.fcModebarMenuIndicator = "";
+    zoomIndicator.innerHTML = this._icon("chevrondown");
+    zoomTrigger.appendChild(zoomIndicator);
+    this._zoomMenuLabel = zoomPercent;
     zoomTrigger.setAttribute("aria-haspopup", "menu");
     zoomTrigger.setAttribute("aria-expanded", "false");
     mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
@@ -491,6 +501,7 @@ Object.assign(ChartView.prototype, {
       zoomTrigger.setAttribute("aria-expanded", String(show));
       if (!show) {
         zoomMenu.style.display = "none";
+        zoomIndicator.style.transform = "none";
         if (restoreFocus) zoomTrigger.focus();
         return;
       }
@@ -505,6 +516,7 @@ Object.assign(ChartView.prototype, {
       const preferredTop = barRect.bottom + 6 + zoomMenu.offsetHeight <= rootRect.bottom
         ? below
         : above;
+      zoomIndicator.style.transform = preferredTop === above ? "rotate(180deg)" : "none";
       const maxLeft = root.clientWidth - rootLeft - zoomMenu.offsetWidth;
       const maxTop = root.clientHeight - rootTop - zoomMenu.offsetHeight;
       zoomMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, zoomTrigger.offsetLeft))}px`;
@@ -580,6 +592,27 @@ Object.assign(ChartView.prototype, {
       btn.classList.toggle("fc-active", name === mode);
     }
     this._zoomMenuButton?.classList.toggle("fc-active", mode === "zoom");
+  },
+
+  _updateZoomMenuLabel() {
+    if (!this._zoomMenuLabel || !this.view || !this.view0) return;
+    const axisPercent = (axisId, lo, hi, homeLo, homeHi) => {
+      const axis = this._axis(axisId);
+      const span = Math.abs(this._axisCoord(axis, hi) - this._axisCoord(axis, lo));
+      const homeSpan = Math.abs(
+        this._axisCoord(axis, homeHi) - this._axisCoord(axis, homeLo)
+      );
+      return Number.isFinite(span) && span > 0 && Number.isFinite(homeSpan) && homeSpan > 0
+        ? (homeSpan / span) * 100
+        : null;
+    };
+    const percent = axisPercent("x", this.view.x0, this.view.x1, this.view0.x0, this.view0.x1)
+      ?? axisPercent("y", this.view.y0, this.view.y1, this.view0.y0, this.view0.y1)
+      ?? 100;
+    const text = percent < 1 ? "<1%" : `${Math.round(percent)}%`;
+    this._zoomMenuLabel.textContent = text;
+    this._zoomMenuButton.title = `Zoom controls (${text})`;
+    this._zoomMenuButton.setAttribute("aria-label", `Zoom controls, ${text}`);
   },
 
   _prefersReducedMotion() {
@@ -760,9 +793,8 @@ Object.assign(ChartView.prototype, {
       case "zoom":
         return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
           'stroke-dasharray="3 2"/>');
-      case "zoommenu":
-        return svg('<circle cx="8" cy="8" r="4.5"/><path d="M11.5 11.5 L15 15"/>' +
-          '<path d="M16 7 L18 9 L16 11"/>');
+      case "chevrondown":
+        return svg('<path d="M6 8 L10 12 L14 8"/>');
       case "reset":
         return svg('<path d="M4 10 a6 6 0 1 1 1.8 4.3"/><path d="M4 6 V10 H8"/>');
       case "drag":

--- a/js/src/53_interaction.js
+++ b/js/src/53_interaction.js
@@ -690,13 +690,12 @@ Object.assign(ChartView.prototype, {
       "position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
     bar.appendChild(exportMenu);
     const exportMenuItems = [];
-    const mkExportItem = (name, label, onClick, separator = false) => {
+    const mkExportItem = (name, label, onClick) => {
       const button = document.createElement("button");
       button.type = "button";
       button.tabIndex = -1;
       button.dataset.fcModebarMenuItem = name;
       button.dataset.fcModebarExportItem = name;
-      if (separator) button.dataset.fcSeparator = "";
       button.setAttribute("role", "menuitem");
       button.style.cssText = "display:flex;align-items:center;pointer-events:auto;";
       this._applySlot(button, "modebar_button");
@@ -717,14 +716,7 @@ Object.assign(ChartView.prototype, {
       exportMenuItems.push(button);
       return button;
     };
-    const themeItem = mkExportItem("moon", "Dark Mode", () => this._toggleColorMode());
-    themeItem.dataset.fcModebarThemeToggle = "";
-    themeItem.setAttribute("role", "menuitemcheckbox");
-    themeItem.setAttribute("aria-checked", "false");
-    this._themeMenuItem = themeItem;
-    this._colorMode = "light";
-    this._updateColorModeItem();
-    mkExportItem("png", "Export PNG", () => this._exportPng(), true);
+    mkExportItem("png", "Export PNG", () => this._exportPng());
     mkExportItem("svg", "Export SVG", () => this._exportSvg());
     mkExportItem("csv", "Export CSV", () => this._exportCsv());
 
@@ -1135,62 +1127,6 @@ Object.assign(ChartView.prototype, {
     this._setView({ x0, x1, y0, y1 }, { animate });
   },
 
-  _updateColorModeItem() {
-    if (!this._themeMenuItem) return;
-    const dark = this._colorMode === "dark";
-    const icon = this._themeMenuItem.querySelector("[data-fc-modebar-menu-icon]");
-    const label = icon?.nextElementSibling;
-    if (icon) icon.innerHTML = this._icon(dark ? "sun" : "moon");
-    if (label) label.textContent = dark ? "Light Mode" : "Dark Mode";
-    this._themeMenuItem.dataset.fcModebarExportItem = dark ? "light" : "dark";
-    this._themeMenuItem.setAttribute("aria-checked", String(dark));
-  },
-
-  _setColorMode(mode) {
-    const dark = mode === "dark";
-    this._colorMode = dark ? "dark" : "light";
-    this.root.dataset.fcColorMode = this._colorMode;
-    const colors = dark ? {
-      color: "#e5e7eb",
-      background: "#0b1220",
-      "--chart-bg": "#111827",
-      "--chart-grid": "rgba(226,232,240,.14)",
-      "--chart-axis": "#94a3b8",
-      "--chart-text": "#e5e7eb",
-      "--chart-legend-bg": "rgba(30,41,59,.84)",
-      "--chart-modebar-bg": "rgba(15,23,42,.94)",
-      "--chart-modebar-active": "rgba(148,163,184,.24)",
-      "--chart-tooltip-bg": "rgba(2,6,23,.96)",
-      "--chart-tooltip-text": "#f8fafc",
-      "--chart-badge-bg": "rgba(30,41,59,.9)",
-      "--chart-badge-text": "#e2e8f0",
-    } : {
-      color: "#1f2937",
-      background: "#ffffff",
-      "--chart-bg": "#ffffff",
-      "--chart-grid": "rgba(15,23,42,.12)",
-      "--chart-axis": "#64748b",
-      "--chart-text": "#1f2937",
-      "--chart-legend-bg": "rgba(241,245,249,.88)",
-      "--chart-modebar-bg": "rgba(255,255,255,.94)",
-      "--chart-modebar-active": "rgba(100,116,139,.18)",
-      "--chart-tooltip-bg": "rgba(20,24,33,.94)",
-      "--chart-tooltip-text": "#ffffff",
-      "--chart-badge-bg": "rgba(255,255,255,.9)",
-      "--chart-badge-text": "#0f172a",
-    };
-    for (const [name, value] of Object.entries(colors)) {
-      if (name === "color" || name === "background") this.root.style[name] = value;
-      else this.root.style.setProperty(name, value);
-    }
-    this._updateColorModeItem();
-    this.refreshTheme();
-  },
-
-  _toggleColorMode() {
-    this._setColorMode(this._colorMode === "dark" ? "light" : "dark");
-  },
-
   _exportFilename(extension) {
     const title = String(this.spec.title || "xy-chart")
       .trim()
@@ -1392,12 +1328,6 @@ Object.assign(ChartView.prototype, {
         return svg('<circle cx="5" cy="10" r="1" fill="currentColor" stroke="none"/>' +
           '<circle cx="10" cy="10" r="1" fill="currentColor" stroke="none"/>' +
           '<circle cx="15" cy="10" r="1" fill="currentColor" stroke="none"/>');
-      case "moon":
-        return svg('<path d="M14.8 13.8 A6.5 6.5 0 0 1 6.2 5.2 A6.5 6.5 0 1 0 14.8 13.8 Z"/>');
-      case "sun":
-        return svg('<circle cx="10" cy="10" r="3"/><path d="M10 2 V4 M10 16 V18 ' +
-          'M2 10 H4 M16 10 H18 M4.3 4.3 L5.7 5.7 M14.3 14.3 L15.7 15.7 ' +
-          'M15.7 4.3 L14.3 5.7 M5.7 14.3 L4.3 15.7"/>');
       case "png":
         return svg('<path d="M5 2.5 H12 L15.5 6 V17.5 H5 Z"/><path d="M12 2.5 V6 H15.5"/>' +
           '<path d="M7 13 L9 10.5 L11 12 L13.5 9 V15 H7 Z"/>');

--- a/js/src/53_interaction.js
+++ b/js/src/53_interaction.js
@@ -267,20 +267,141 @@ Object.assign(ChartView.prototype, {
     }
   },
 
+  _clampModebar(left, top) {
+    const bar = this._modebar;
+    if (!bar || !this.root) return;
+    const currentLeft = left ?? (Number.parseFloat(bar.style.left) || 0);
+    const currentTop = top ?? (Number.parseFloat(bar.style.top) || 0);
+    const maxLeft = Math.max(0, this.root.clientWidth - bar.offsetWidth);
+    const maxTop = Math.max(0, this.root.clientHeight - bar.offsetHeight);
+    bar.style.left = `${Math.max(0, Math.min(maxLeft, currentLeft))}px`;
+    bar.style.top = `${Math.max(0, Math.min(maxTop, currentTop))}px`;
+  },
+
   _buildModebar(root) {
     if (this.spec.show_modebar === false) return;
     const bar = document.createElement("div");
-    // Visible by default, then stronger on hover. At .25 opacity the controls
-    // were technically present but easy to miss in embedded dashboards. Layout
-    // + opacity state stay inline; the box styling is in the stylesheet.
+    // The modebar is chrome, so keep it out of the way until the chart is
+    // hovered (or a keyboard user focuses one of its controls). Layout +
+    // visibility state stay inline; the box styling is in the stylesheet.
     bar.style.cssText =
       `position:absolute;top:${this.plot.y + 4}px;left:${this.plot.x + 4}px;z-index:6;` +
-      "display:flex;opacity:.72;transition:opacity .15s;";
+      "display:flex;opacity:0;pointer-events:none;transition:opacity .15s;";
     this._applySlot(bar, "modebar");
-    this._listen(root, "pointerenter", () => { bar.style.opacity = "1"; });
-    this._listen(root, "pointerleave", () => { bar.style.opacity = ".72"; });
     this._modebar = bar;
     this._modeBtns = {};
+    this._modebarCollapsed = false;
+    this._modebarMoved = false;
+    bar.dataset.fcCollapsed = "false";
+
+    const setVisible = (visible) => {
+      const show = visible || this._modebarDragging || bar.contains(document.activeElement);
+      bar.style.opacity = show ? "1" : "0";
+      bar.style.pointerEvents = show ? "auto" : "none";
+    };
+    this._listen(root, "pointerenter", () => setVisible(true));
+    this._listen(root, "pointerleave", () => setVisible(false));
+    this._listen(bar, "focusin", () => setVisible(true));
+    this._listen(bar, "focusout", () => {
+      if (!root.matches(":hover")) setVisible(false);
+    });
+
+    // A dedicated grip keeps button clicks distinct from toolbar movement.
+    // Pointer capture lets a drag finish cleanly even if it leaves the chart;
+    // the coordinates are still clamped to the chart root below.
+    const grip = document.createElement("button");
+    grip.type = "button";
+    grip.title = "Double-click to collapse; drag to move";
+    grip.setAttribute("aria-label", "Collapse toolbar");
+    grip.setAttribute("aria-expanded", "true");
+    grip.dataset.fcModebarDragHandle = "";
+    grip.innerHTML = this._icon("drag");
+    grip.style.cssText =
+      "display:flex;align-items:center;justify-content:center;pointer-events:auto;touch-action:none;";
+    this._applySlot(grip, "modebar_button");
+    bar.appendChild(grip);
+
+    const DOUBLE_CLICK_MS = 500;
+    const DRAG_THRESHOLD_PX = 6;
+    let modebarDrag = null;
+    let lastGripDown = 0;
+    const setCollapsed = (collapsed) => {
+      this._modebarCollapsed = collapsed;
+      bar.dataset.fcCollapsed = String(collapsed);
+      for (const button of bar.querySelectorAll("button")) {
+        if (button !== grip) {
+          button.hidden = collapsed;
+          button.style.display = collapsed ? "none" : "flex";
+        }
+      }
+      grip.title = collapsed
+        ? "Double-click to expand; drag to move"
+        : "Double-click to collapse; drag to move";
+      grip.setAttribute("aria-label", collapsed ? "Expand toolbar" : "Collapse toolbar");
+      grip.setAttribute("aria-expanded", String(!collapsed));
+      this._fitModebar();
+    };
+    const toggleModebar = () => setCollapsed(!this._modebarCollapsed);
+    this._listen(grip, "pointerdown", (e) => {
+      if (e.pointerType === "mouse" && e.button !== 0) return;
+      e.stopPropagation();
+      const now = e.timeStamp || performance.now();
+      const doubleClick = lastGripDown > 0 && now - lastGripDown <= DOUBLE_CLICK_MS;
+      lastGripDown = doubleClick ? 0 : now;
+      const barRect = bar.getBoundingClientRect();
+      modebarDrag = {
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+        dx: e.clientX - barRect.left,
+        dy: e.clientY - barRect.top,
+        moved: false,
+      };
+      setVisible(true);
+      if (doubleClick) toggleModebar();
+    });
+    this._listen(grip, "pointermove", (e) => {
+      if (!modebarDrag || e.pointerId !== modebarDrag.pointerId) return;
+      const distance = Math.hypot(e.clientX - modebarDrag.startX, e.clientY - modebarDrag.startY);
+      if (!modebarDrag.moved) {
+        if (distance < DRAG_THRESHOLD_PX) return;
+        modebarDrag.moved = true;
+        lastGripDown = 0;
+        this._modebarDragging = true;
+        this._modebarMoved = true;
+        bar.style.transition = "none";
+        try { grip.setPointerCapture(e.pointerId); } catch (_err) { /* synthetic event */ }
+      }
+      const rootRect = root.getBoundingClientRect();
+      const left = e.clientX - rootRect.left - modebarDrag.dx;
+      const top = e.clientY - rootRect.top - modebarDrag.dy;
+      this._clampModebar(left, top);
+    });
+    const endModebarDrag = (e) => {
+      if (!modebarDrag || e.pointerId !== modebarDrag.pointerId) return;
+      const moved = modebarDrag.moved;
+      const cancelled = e.type === "pointercancel";
+      modebarDrag = null;
+      this._modebarDragging = false;
+      bar.style.transition = "opacity .15s";
+      setVisible(root.matches(":hover"));
+      if (moved || cancelled) {
+        lastGripDown = 0;
+      }
+    };
+    this._listen(grip, "pointerup", endModebarDrag);
+    this._listen(grip, "pointercancel", endModebarDrag);
+    this._listen(grip, "click", (e) => e.stopPropagation());
+    this._listen(grip, "dblclick", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    });
+    this._listen(grip, "keydown", (e) => {
+      if (e.repeat || (e.key !== "Enter" && e.key !== " ")) return;
+      e.preventDefault();
+      e.stopPropagation();
+      toggleModebar();
+    });
 
     const mk = (name, title, onClick, toggles) => {
       const b = document.createElement("button");
@@ -309,6 +430,9 @@ Object.assign(ChartView.prototype, {
     });
     root.appendChild(bar);
     this._fitModebar();
+    // The pointer may already be over a chart that mounted beneath it, in
+    // which case no pointerenter fires after these listeners are installed.
+    setVisible(root.matches(":hover"));
     this._setDragMode(this.dragMode);
   },
 
@@ -319,12 +443,18 @@ Object.assign(ChartView.prototype, {
   _fitModebar() {
     const bar = this._modebar;
     if (!bar) return;
-    bar.style.top = `${this.plot.y + 4}px`;
-    bar.style.left = `${this.plot.x + 4}px`;
+    if (!this._modebarMoved) {
+      bar.style.top = `${this.plot.y + 4}px`;
+      bar.style.left = `${this.plot.x + 4}px`;
+    }
     bar.style.display = "flex"; // measurable before the verdict
     const fits =
       bar.offsetWidth + 8 <= this.plot.w && bar.offsetHeight + 8 <= this.plot.h;
-    if (!fits) bar.style.display = "none";
+    if (!fits) {
+      bar.style.display = "none";
+      return;
+    }
+    this._clampModebar();
   },
 
   _setDragMode(mode) {
@@ -520,6 +650,13 @@ Object.assign(ChartView.prototype, {
           'stroke-dasharray="3 2"/>');
       case "reset":
         return svg('<path d="M4 10 a6 6 0 1 1 1.8 4.3"/><path d="M4 6 V10 H8"/>');
+      case "drag":
+        return svg('<circle cx="7" cy="5" r=".8" fill="currentColor" stroke="none"/>' +
+          '<circle cx="13" cy="5" r=".8" fill="currentColor" stroke="none"/>' +
+          '<circle cx="7" cy="10" r=".8" fill="currentColor" stroke="none"/>' +
+          '<circle cx="13" cy="10" r=".8" fill="currentColor" stroke="none"/>' +
+          '<circle cx="7" cy="15" r=".8" fill="currentColor" stroke="none"/>' +
+          '<circle cx="13" cy="15" r=".8" fill="currentColor" stroke="none"/>');
       default:
         return svg("");
     }

--- a/js/src/53_interaction.js
+++ b/js/src/53_interaction.js
@@ -393,13 +393,10 @@ Object.assign(ChartView.prototype, {
     this._applySlot(bar, "modebar");
     this._modebar = bar;
     this._modeBtns = {};
-    this._modebarCollapsed = false;
     this._modebarMoved = false;
-    bar.dataset.fcCollapsed = "false";
     let setZoomMenuOpen = () => {};
     let setSelectMenuOpen = () => {};
     let setExportMenuOpen = () => {};
-    let updateCollapseItem = () => {};
 
     const setVisible = (visible) => {
       const show = visible || this._modebarDragging || bar.contains(document.activeElement);
@@ -419,11 +416,10 @@ Object.assign(ChartView.prototype, {
     });
 
     // One combined grip/menu control avoids a second, visually redundant dots
-    // button. Click opens toolbar options, drag moves, and double-click keeps
-    // the quick collapse shortcut; Collapse/Expand is also a menu action.
+    // button. Click opens toolbar options and drag moves the toolbar.
     const grip = document.createElement("button");
     grip.type = "button";
-    grip.title = "Click for toolbar options; drag to move; double-click to collapse";
+    grip.title = "Click for toolbar options; drag to move";
     grip.setAttribute("aria-label", "Toolbar options");
     grip.setAttribute("aria-haspopup", "menu");
     grip.setAttribute("aria-expanded", "false");
@@ -436,40 +432,12 @@ Object.assign(ChartView.prototype, {
     this._applySlot(grip, "modebar_button");
     bar.appendChild(grip);
 
-    const DOUBLE_CLICK_MS = 500;
     const DRAG_THRESHOLD_PX = 6;
     let modebarDrag = null;
-    let lastGripDown = 0;
     let suppressGripClickUntil = 0;
-    const setCollapsed = (collapsed) => {
-      this._modebarCollapsed = collapsed;
-      bar.dataset.fcCollapsed = String(collapsed);
-      if (collapsed) {
-        setZoomMenuOpen(false);
-        setSelectMenuOpen(false);
-        setExportMenuOpen(false);
-      }
-      // Only collapse top-level controls. Menu items stay available because
-      // this same grip is the only visible control in the collapsed state.
-      for (const button of bar.querySelectorAll(":scope > button")) {
-        if (button !== grip) {
-          button.hidden = collapsed;
-          button.style.display = collapsed ? "none" : "flex";
-        }
-      }
-      grip.title = collapsed
-        ? "Click for toolbar options; drag to move; double-click to expand"
-        : "Click for toolbar options; drag to move; double-click to collapse";
-      updateCollapseItem();
-      this._fitModebar();
-    };
-    const toggleModebar = () => setCollapsed(!this._modebarCollapsed);
     this._listen(grip, "pointerdown", (e) => {
       if (e.pointerType === "mouse" && e.button !== 0) return;
       e.stopPropagation();
-      const now = e.timeStamp || performance.now();
-      const doubleClick = lastGripDown > 0 && now - lastGripDown <= DOUBLE_CLICK_MS;
-      lastGripDown = doubleClick ? 0 : now;
       const barRect = bar.getBoundingClientRect();
       modebarDrag = {
         pointerId: e.pointerId,
@@ -480,10 +448,6 @@ Object.assign(ChartView.prototype, {
         moved: false,
       };
       setVisible(true);
-      if (doubleClick) {
-        suppressGripClickUntil = performance.now() + 100;
-        toggleModebar();
-      }
     });
     this._listen(grip, "pointermove", (e) => {
       if (!modebarDrag || e.pointerId !== modebarDrag.pointerId) return;
@@ -491,7 +455,6 @@ Object.assign(ChartView.prototype, {
       if (!modebarDrag.moved) {
         if (distance < DRAG_THRESHOLD_PX) return;
         modebarDrag.moved = true;
-        lastGripDown = 0;
         this._modebarDragging = true;
         this._modebarMoved = true;
         bar.style.transition = "none";
@@ -514,7 +477,6 @@ Object.assign(ChartView.prototype, {
       bar.style.transition = "opacity .15s";
       setVisible(root.matches(":hover"));
       if (moved || cancelled) {
-        lastGripDown = 0;
         suppressGripClickUntil = performance.now() + 100;
       }
     };
@@ -527,10 +489,6 @@ Object.assign(ChartView.prototype, {
         return;
       }
       setExportMenuOpen(!this._exportMenuOpen);
-    });
-    this._listen(grip, "dblclick", (e) => {
-      e.preventDefault();
-      e.stopPropagation();
     });
 
     const mk = (name, title, onClick, toggles) => {
@@ -719,23 +677,12 @@ Object.assign(ChartView.prototype, {
       exportMenuItems.push(button);
       return button;
     };
-    const collapseItem = mkExportItem("collapse", "Collapse Toolbar", toggleModebar);
-    collapseItem.dataset.fcModebarCollapseItem = "";
-    updateCollapseItem = () => {
-      const collapsed = this._modebarCollapsed;
-      const icon = collapseItem.querySelector("[data-fc-modebar-menu-icon]");
-      const label = icon?.nextElementSibling;
-      if (icon) icon.innerHTML = this._icon(collapsed ? "expand" : "collapse");
-      if (label) label.textContent = collapsed ? "Expand Toolbar" : "Collapse Toolbar";
-      collapseItem.dataset.fcModebarExportItem = collapsed ? "expand" : "collapse";
-    };
-    updateCollapseItem();
-    mkExportItem("png", "Export PNG", () => this._exportPng(), true);
+    mkExportItem("png", "Export PNG", () => this._exportPng());
     mkExportItem("svg", "Export SVG", () => this._exportSvg());
     mkExportItem("csv", "Export CSV", () => this._exportCsv());
 
     setZoomMenuOpen = (open, restoreFocus = false) => {
-      const show = Boolean(open) && !this._modebarCollapsed;
+      const show = Boolean(open);
       if (show) {
         setSelectMenuOpen(false);
         setExportMenuOpen(false);
@@ -768,7 +715,7 @@ Object.assign(ChartView.prototype, {
     };
     setSelectMenuOpen = (open, restoreFocus = false) => {
       if (!selectTrigger) return;
-      const show = Boolean(open) && !this._modebarCollapsed;
+      const show = Boolean(open);
       if (show) {
         setZoomMenuOpen(false);
         setExportMenuOpen(false);

--- a/js/src/53_interaction.js
+++ b/js/src/53_interaction.js
@@ -30,7 +30,8 @@ Object.assign(ChartView.prototype, {
     let lassoHandleDrag = null;
 
     const moveLassoHandle = (e) => {
-      if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId) return;
+      if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId
+          || !this._lassoPolygon) return;
       const rect = c.getBoundingClientRect();
       const cssX = Math.max(0, Math.min(rect.width, e.clientX - rect.left));
       const cssY = Math.max(0, Math.min(rect.height, e.clientY - rect.top));
@@ -63,14 +64,16 @@ Object.assign(ChartView.prototype, {
       const handle = lassoHandleDrag.handle;
       lassoHandleDrag = null;
       delete handle.dataset.fcActive;
-      this._sendSelectPolygon(this._lassoPolygon);
+      if (this._lassoPolygon) this._sendSelectPolygon(this._lassoPolygon);
     });
     this._listen(this.selLasso, "pointercancel", (e) => {
       if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId) return;
-      this._lassoPolygon[lassoHandleDrag.index] = lassoHandleDrag.original;
+      if (this._lassoPolygon) {
+        this._lassoPolygon[lassoHandleDrag.index] = lassoHandleDrag.original;
+      }
       delete lassoHandleDrag.handle.dataset.fcActive;
       lassoHandleDrag = null;
-      this._renderLassoSelection();
+      if (this._lassoPolygon) this._renderLassoSelection();
       e.stopPropagation();
     });
 
@@ -164,9 +167,14 @@ Object.assign(ChartView.prototype, {
         const moved = Math.abs(e.clientX - band.sx) > 3 || Math.abs(e.clientY - band.sy) > 3;
         if (moved) {
           if (band.mode === "zoom") this._zoomToBox(band.d0, d1, true);
-          else if (band.mode === "select-lasso" && band.points.length >= 3) {
-            const editable = this._simplifyLassoPoints(band.points);
-            this._sendSelectPolygon(editable.map((point) => point.data));
+          else if (band.mode === "select-lasso") {
+            if (band.points.length >= 3) {
+              const editable = this._simplifyLassoPoints(band.points);
+              this._sendSelectPolygon(editable.map((point) => point.data));
+            } else if (band.previousLasso) {
+              this._lassoPolygon = band.previousLasso;
+              this._renderLassoSelection();
+            }
           } else {
             let d0 = band.d0;
             if (band.mode === "select-x") {
@@ -357,34 +365,56 @@ Object.assign(ChartView.prototype, {
       const x = start.x + t * dx, y = start.y + t * dy;
       return (point.x - x) ** 2 + (point.y - y) ** 2;
     };
-    const keep = new Uint8Array(source.length);
-    keep[0] = 1;
-    keep[source.length - 1] = 1;
-    const stack = [[0, source.length - 1]];
-    const toleranceSq = tolerance * tolerance;
-    while (stack.length) {
-      const [start, end] = stack.pop();
-      let furthest = -1, furthestDistance = toleranceSq;
-      for (let i = start + 1; i < end; i++) {
-        const distance = distanceToSegmentSq(source[i], source[start], source[end]);
-        if (distance > furthestDistance) {
-          furthest = i;
-          furthestDistance = distance;
+    const simplifyAt = (currentTolerance) => {
+      const keep = new Uint8Array(source.length);
+      keep[0] = 1;
+      keep[source.length - 1] = 1;
+      const stack = [[0, source.length - 1]];
+      const toleranceSq = currentTolerance * currentTolerance;
+      while (stack.length) {
+        const [start, end] = stack.pop();
+        let furthest = -1, furthestDistance = toleranceSq;
+        for (let i = start + 1; i < end; i++) {
+          const distance = distanceToSegmentSq(source[i], source[start], source[end]);
+          if (distance > furthestDistance) {
+            furthest = i;
+            furthestDistance = distance;
+          }
+        }
+        if (furthest >= 0) {
+          keep[furthest] = 1;
+          stack.push([start, furthest], [furthest, end]);
         }
       }
-      if (furthest >= 0) {
-        keep[furthest] = 1;
-        stack.push([start, furthest], [furthest, end]);
-      }
-    }
-    let simplified = source.filter((_point, index) => keep[index]);
+      return source.filter((_point, index) => keep[index]);
+    };
+    let simplified = simplifyAt(tolerance);
     if (simplified.length < 3) {
       simplified = [source[0], source[Math.floor(source.length / 2)], source[source.length - 1]];
     }
     if (simplified.length > maxPoints) {
-      simplified = Array.from({ length: maxPoints }, (_value, index) => (
-        simplified[Math.round(index * (simplified.length - 1) / (maxPoints - 1))]
-      ));
+      // Raise the RDP tolerance until the handle budget is met. Unlike uniform
+      // re-sampling, this continues to preserve the polygon's most significant
+      // corners as the editable overlay becomes simpler.
+      let low = tolerance;
+      let high = Math.max(tolerance, 1);
+      for (let i = 0; i < 16 && simplified.length > maxPoints; i++) {
+        low = high;
+        high *= 2;
+        simplified = simplifyAt(high);
+      }
+      for (let i = 0; i < 12; i++) {
+        const middle = (low + high) / 2;
+        const candidate = simplifyAt(middle);
+        if (candidate.length > maxPoints) low = middle;
+        else {
+          high = middle;
+          simplified = candidate;
+        }
+      }
+      if (simplified.length < 3) {
+        simplified = [source[0], source[Math.floor(source.length / 2)], source[source.length - 1]];
+      }
     }
     return simplified;
   },
@@ -474,6 +504,10 @@ Object.assign(ChartView.prototype, {
   },
 
   _selectLocalPolygon(points) {
+    const xs = points.map((point) => point[0]);
+    const ys = points.map((point) => point[1]);
+    const minX = Math.min(...xs), maxX = Math.max(...xs);
+    const minY = Math.min(...ys), maxY = Math.max(...ys);
     const inside = (x, y) => {
       let hit = false;
       for (let i = 0, j = points.length - 1; i < points.length; j = i++) {
@@ -493,7 +527,12 @@ Object.assign(ChartView.prototype, {
       const mask = new Float32Array(g.n);
       let count = 0;
       for (let i = 0; i < g.n; i++) {
-        if (inside(cx[i] / sx + ox, cy[i] / sy + oy)) { mask[i] = 1; count++; }
+        const x = cx[i] / sx + ox;
+        const y = cy[i] / sy + oy;
+        if (x >= minX && x <= maxX && y >= minY && y <= maxY && inside(x, y)) {
+          mask[i] = 1;
+          count++;
+        }
       }
       this._applySelMask(g, mask);
       total += count;
@@ -598,8 +637,8 @@ Object.assign(ChartView.prototype, {
       setExportMenuOpen(false);
     });
     this._listen(bar, "focusin", () => setVisible(true));
-    this._listen(bar, "focusout", () => {
-      if (!root.matches(":hover")) setVisible(false);
+    this._listen(bar, "focusout", (e) => {
+      if (!bar.contains(e.relatedTarget) && !root.matches(":hover")) setVisible(false);
     });
 
     // One combined grip/menu control avoids a second, visually redundant dots
@@ -634,6 +673,7 @@ Object.assign(ChartView.prototype, {
         dy: e.clientY - barRect.top,
         moved: false,
       };
+      try { grip.setPointerCapture(e.pointerId); } catch (_err) { /* synthetic event */ }
       setVisible(true);
     });
     this._listen(grip, "pointermove", (e) => {
@@ -648,7 +688,6 @@ Object.assign(ChartView.prototype, {
         setZoomMenuOpen(false);
         setSelectMenuOpen(false);
         setExportMenuOpen(false);
-        try { grip.setPointerCapture(e.pointerId); } catch (_err) { /* synthetic event */ }
       }
       const rootRect = root.getBoundingClientRect();
       const left = e.clientX - rootRect.left - modebarDrag.dx;
@@ -740,7 +779,7 @@ Object.assign(ChartView.prototype, {
       "position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
     bar.appendChild(zoomMenu);
     const zoomMenuItems = [];
-    const mkZoomItem = (name, label, shortcut, onClick, toggles, separator = false) => {
+    const mkZoomItem = (name, label, onClick, toggles, separator = false) => {
       const button = document.createElement("button");
       button.type = "button";
       button.tabIndex = -1;
@@ -757,10 +796,6 @@ Object.assign(ChartView.prototype, {
       const text = document.createElement("span");
       text.textContent = label;
       button.appendChild(text);
-      const hint = document.createElement("span");
-      hint.dataset.fcModebarMenuShortcut = "";
-      hint.textContent = shortcut;
-      button.appendChild(hint);
       this._listen(button, "pointerdown", (e) => e.stopPropagation());
       this._listen(button, "click", (e) => {
         e.stopPropagation();
@@ -777,10 +812,10 @@ Object.assign(ChartView.prototype, {
       this._clearSelection();
       this._setView(this.view0, { animate: true });
     };
-    mkZoomItem("zoomin", "Zoom In", "+", () => this._zoomBy(0.5, true));
-    mkZoomItem("zoomout", "Zoom Out", "−", () => this._zoomBy(2, true));
-    mkZoomItem("zoom", "Box Zoom", "B", () => this._setDragMode("zoom"), "zoom");
-    mkZoomItem("reset", "Reset View", "0", resetView, null, true);
+    mkZoomItem("zoomin", "Zoom In", () => this._zoomBy(0.5, true));
+    mkZoomItem("zoomout", "Zoom Out", () => this._zoomBy(2, true));
+    mkZoomItem("zoom", "Box Zoom", () => this._setDragMode("zoom"), "zoom");
+    mkZoomItem("reset", "Reset View", resetView, null, true);
 
     const selectMenu = document.createElement("div");
     selectMenu.dataset.fcModebarMenu = "";
@@ -791,7 +826,7 @@ Object.assign(ChartView.prototype, {
       "position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
     bar.appendChild(selectMenu);
     const selectMenuItems = [];
-    const mkSelectItem = (name, label, shortcut, mode) => {
+    const mkSelectItem = (name, label, mode) => {
       const button = document.createElement("button");
       button.type = "button";
       button.tabIndex = -1;
@@ -807,10 +842,6 @@ Object.assign(ChartView.prototype, {
       const text = document.createElement("span");
       text.textContent = label;
       button.appendChild(text);
-      const hint = document.createElement("span");
-      hint.dataset.fcModebarMenuShortcut = "";
-      hint.textContent = shortcut;
-      button.appendChild(hint);
       this._listen(button, "pointerdown", (e) => e.stopPropagation());
       this._listen(button, "click", (e) => {
         e.stopPropagation();
@@ -822,10 +853,10 @@ Object.assign(ChartView.prototype, {
       this._modeBtns[mode] = button;
     };
     if (canSelect) {
-      mkSelectItem("select", "Box Select", "B", "select");
-      mkSelectItem("lasso", "Lasso Select", "L", "select-lasso");
-      mkSelectItem("selectx", "X Range", "X", "select-x");
-      mkSelectItem("selecty", "Y Range", "Y", "select-y");
+      mkSelectItem("select", "Box Select", "select");
+      mkSelectItem("lasso", "Lasso Select", "select-lasso");
+      mkSelectItem("selectx", "X Range", "select-x");
+      mkSelectItem("selecty", "Y Range", "select-y");
     }
 
     const exportMenu = document.createElement("div");
@@ -1111,6 +1142,8 @@ Object.assign(ChartView.prototype, {
     const rounded = Math.round(percent);
     const exactText = percent < 1 ? "<1%" : `${rounded}%`;
     const displayText = rounded > 999 ? `${String(rounded).slice(0, 3)}…%` : exactText;
+    if (this._zoomMenuLabel.dataset.fcZoomExact === exactText
+        && this._zoomMenuLabel.textContent === displayText) return;
     this._zoomMenuLabel.textContent = displayText;
     this._zoomMenuLabel.dataset.fcZoomExact = exactText;
     this._zoomMenuButton.title = `Zoom controls (${exactText})`;
@@ -1306,6 +1339,32 @@ Object.assign(ChartView.prototype, {
     clone.style.height = `${height}px`;
     clone.style.margin = "0";
     clone.setAttribute("xmlns", "http://www.w3.org/1999/xhtml");
+
+    // The clone is detached from its host, so inherited theme tokens and text
+    // styles must be made explicit before it is serialized for SVG/PNG export.
+    const computed = getComputedStyle(this.root);
+    const inheritedProperties = [
+      "color", "font-family", "font-size", "font-style", "font-weight",
+      "letter-spacing", "line-height",
+    ];
+    const chartTokens = [
+      "--chart-bg", "--chart-text", "--chart-grid", "--chart-axis",
+      "--chart-tooltip-bg", "--chart-tooltip-text", "--chart-legend-bg",
+      "--chart-badge-bg", "--chart-badge-text", "--chart-modebar-bg",
+      "--chart-modebar-active", "--chart-selection", "--chart-selection-fill",
+      "--chart-zoom-selection", "--chart-zoom-selection-fill", "--chart-crosshair",
+      "--chart-annotation-text", "--chart-cursor", "--chart-cursor-pan",
+    ];
+    for (let i = 0; i < computed.length; i++) {
+      const property = computed.item(i);
+      if (!property.startsWith("--")) continue;
+      const value = computed.getPropertyValue(property).trim();
+      if (value) clone.style.setProperty(property, value);
+    }
+    for (const property of [...inheritedProperties, ...chartTokens]) {
+      const value = computed.getPropertyValue(property).trim();
+      if (value) clone.style.setProperty(property, value);
+    }
 
     const sourceCanvases = [...this.root.querySelectorAll("canvas")];
     const clonedCanvases = [...clone.querySelectorAll("canvas")];

--- a/js/src/53_interaction.js
+++ b/js/src/53_interaction.js
@@ -453,6 +453,10 @@ Object.assign(ChartView.prototype, {
       button.style.cssText =
         "display:flex;align-items:center;pointer-events:auto;";
       this._applySlot(button, "modebar_button");
+      const icon = document.createElement("span");
+      icon.dataset.fcModebarMenuIcon = "";
+      icon.innerHTML = this._icon(name);
+      button.appendChild(icon);
       const text = document.createElement("span");
       text.textContent = label;
       button.appendChild(text);

--- a/js/src/53_interaction.js
+++ b/js/src/53_interaction.js
@@ -15,6 +15,13 @@ Object.assign(ChartView.prototype, {
     this.selRect.style.cssText = "position:absolute;display:none;pointer-events:none;z-index:4;";
     this._applySlot(this.selRect, "selection");
     this.root.appendChild(this.selRect);
+    this.selLasso = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    this.selLasso.style.cssText =
+      "position:absolute;display:none;pointer-events:none;z-index:4;overflow:visible;";
+    this.selLassoPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    this.selLassoPath.dataset.fcSelectionLasso = "";
+    this.selLasso.appendChild(this.selLassoPath);
+    this.root.appendChild(this.selLasso);
 
     if (this._interactionFlag("crosshair")) {
       this.crosshairX = document.createElement("div");
@@ -39,10 +46,16 @@ Object.assign(ChartView.prototype, {
       // Shift-drag box-selects (§34); the modebar can make selection or box-zoom
       // the default plain-drag gesture; otherwise a plain drag pans.
       const canBrush = this._interactionFlag("brush", true) && this._interactionFlag("select", true);
-      const mode = (e.shiftKey || this.dragMode === "select") && canBrush && this._pickable ? "select"
+      const selectMode = this.dragMode.startsWith("select") ? this.dragMode : null;
+      const mode = (e.shiftKey || selectMode) && canBrush && this._pickable
+        ? (e.shiftKey ? "select" : selectMode)
         : this.dragMode === "zoom" ? "zoom" : null;
       if (mode) {
-        band = { mode, sx: e.clientX, sy: e.clientY, d0: dataAt(e.clientX, e.clientY) };
+        const d0 = dataAt(e.clientX, e.clientY);
+        band = {
+          mode, sx: e.clientX, sy: e.clientY, d0,
+          points: mode === "select-lasso" ? [{ x: e.clientX, y: e.clientY, data: d0 }] : null,
+        };
         c.setPointerCapture(e.pointerId);
         this.tooltip.style.display = "none";
         return;
@@ -79,11 +92,24 @@ Object.assign(ChartView.prototype, {
     const end = (e) => {
       if (band) {
         this.selRect.style.display = "none";
+        this.selLasso.style.display = "none";
         const d1 = dataAt(e.clientX, e.clientY);
         const moved = Math.abs(e.clientX - band.sx) > 3 || Math.abs(e.clientY - band.sy) > 3;
         if (moved) {
           if (band.mode === "zoom") this._zoomToBox(band.d0, d1, true);
-          else this._sendSelect(band.d0, d1);
+          else if (band.mode === "select-lasso" && band.points.length >= 3) {
+            this._sendSelectPolygon(band.points.map((point) => point.data));
+          } else {
+            let d0 = band.d0;
+            if (band.mode === "select-x") {
+              d0 = [band.d0[0], this.view.y0];
+              d1[1] = this.view.y1;
+            } else if (band.mode === "select-y") {
+              d0 = [this.view.x0, band.d0[1]];
+              d1[0] = this.view.x1;
+            }
+            this._sendSelect(d0, d1);
+          }
           this._ignoreNextClick = true;
         }
         band = null;
@@ -94,7 +120,12 @@ Object.assign(ChartView.prototype, {
       drag = null;
     };
     this._listen(c, "pointerup", end);
-    this._listen(c, "pointercancel", () => { this.selRect.style.display = "none"; band = null; drag = null; });
+    this._listen(c, "pointercancel", () => {
+      this.selRect.style.display = "none";
+      this.selLasso.style.display = "none";
+      band = null;
+      drag = null;
+    });
     this._listen(c, "pointerleave", () => {
       const hadHover = this._hoverId !== -1;
       this._hoverId = -1;
@@ -184,6 +215,27 @@ Object.assign(ChartView.prototype, {
   _updateBand(band, e) {
     const rect = this.canvas.getBoundingClientRect();
     const rootRect = this.root.getBoundingClientRect();
+    if (band.mode === "select-lasso") {
+      const previous = band.points[band.points.length - 1];
+      if (band.points.length < 2048
+          && Math.hypot(e.clientX - previous.x, e.clientY - previous.y) >= 3) {
+        band.points.push({ x: e.clientX, y: e.clientY, data: this._dataFromCanvas(
+          e.clientX - rect.left, e.clientY - rect.top
+        ) });
+      }
+      const points = band.points.map((point) => [
+        Math.max(this.plot.x, Math.min(this.plot.x + this.plot.w, point.x - rootRect.left)),
+        Math.max(this.plot.y, Math.min(this.plot.y + this.plot.h, point.y - rootRect.top)),
+      ]);
+      this.selLasso.style.display = "block";
+      this.selLasso.style.inset = "0";
+      this.selLasso.setAttribute("width", String(this.root.clientWidth));
+      this.selLasso.setAttribute("height", String(this.root.clientHeight));
+      this.selLassoPath.setAttribute(
+        "d", points.map((point, i) => `${i ? "L" : "M"}${point[0]} ${point[1]}`).join(" ") + " Z"
+      );
+      return;
+    }
     const x = Math.min(band.sx, e.clientX) - rootRect.left;
     const y = Math.min(band.sy, e.clientY) - rootRect.top;
     const w = Math.abs(e.clientX - band.sx);
@@ -191,7 +243,10 @@ Object.assign(ChartView.prototype, {
     // clamp to plot area
     const px = this.plot.x, py = this.plot.y;
     const x2 = Math.min(x + w, px + this.plot.w), y2 = Math.min(y + h, py + this.plot.h);
-    const cx = Math.max(x, px), cy = Math.max(y, py);
+    let cx = Math.max(x, px), cy = Math.max(y, py);
+    let bx2 = x2, by2 = y2;
+    if (band.mode === "select-x") { cy = py; by2 = py + this.plot.h; }
+    if (band.mode === "select-y") { cx = px; bx2 = px + this.plot.w; }
     // Band paint (border/background) is a defeatable :where() default keyed on
     // data-fc-band, NOT pinned inline — otherwise a `class_names={"selection":…}`
     // utility (or `styles[selection]`) would lose to the inline style, breaking
@@ -201,8 +256,8 @@ Object.assign(ChartView.prototype, {
     this.selRect.style.display = "block";
     this.selRect.style.left = cx + "px";
     this.selRect.style.top = cy + "px";
-    this.selRect.style.width = Math.max(0, x2 - cx) + "px";
-    this.selRect.style.height = Math.max(0, y2 - cy) + "px";
+    this.selRect.style.width = Math.max(0, bx2 - cx) + "px";
+    this.selRect.style.height = Math.max(0, by2 - cy) + "px";
     void rect;
   },
 
@@ -216,6 +271,54 @@ Object.assign(ChartView.prototype, {
     } else {
       this._selectLocal(x0, x1, y0, y1); // standalone: compute from resident f32
     }
+  },
+
+  _sendSelectPolygon(points) {
+    if (!Array.isArray(points) || points.length < 3) return;
+    const polygon = points.map((point) => [point[0], point[1]]);
+    this._dispatchChartEvent("brush", {
+      polygon,
+      view: this._eventView("brush"),
+    });
+    if (this.comm) {
+      this.comm.send({ type: "select_polygon", points: polygon });
+    } else {
+      this._selectLocalPolygon(polygon);
+    }
+  },
+
+  _selectLocalPolygon(points) {
+    const inside = (x, y) => {
+      let hit = false;
+      for (let i = 0, j = points.length - 1; i < points.length; j = i++) {
+        const [xi, yi] = points[i], [xj, yj] = points[j];
+        if ((yi > y) !== (yj > y) && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) hit = !hit;
+      }
+      return hit;
+    };
+    let total = 0;
+    for (const g of this.gpuTraces) {
+      if (!g._cpu || g.tier === "density") continue;
+      const cx = g._cpu.x, cy = g._cpu.y;
+      const xMeta = g._cpu.xMeta || g.xMeta;
+      const yMeta = g._cpu.yMeta || g.yMeta;
+      const ox = xMeta.offset, sx = xMeta.scale || 1;
+      const oy = yMeta.offset, sy = yMeta.scale || 1;
+      const mask = new Float32Array(g.n);
+      let count = 0;
+      for (let i = 0; i < g.n; i++) {
+        if (inside(cx[i] / sx + ox, cy[i] / sy + oy)) { mask[i] = 1; count++; }
+      }
+      this._applySelMask(g, mask);
+      total += count;
+    }
+    this._selectionCount = total;
+    this.draw();
+    this._dispatchChartEvent("select", {
+      total,
+      polygon: points,
+      view: this._eventView("select"),
+    });
   },
 
   // Standalone selection (no kernel): mask the retained CPU f32 columns (§37).
@@ -294,6 +397,7 @@ Object.assign(ChartView.prototype, {
     this._modebarMoved = false;
     bar.dataset.fcCollapsed = "false";
     let setZoomMenuOpen = () => {};
+    let setSelectMenuOpen = () => {};
 
     const setVisible = (visible) => {
       const show = visible || this._modebarDragging || bar.contains(document.activeElement);
@@ -304,6 +408,7 @@ Object.assign(ChartView.prototype, {
     this._listen(root, "pointerleave", () => {
       setVisible(false);
       setZoomMenuOpen(false);
+      setSelectMenuOpen(false);
     });
     this._listen(bar, "focusin", () => setVisible(true));
     this._listen(bar, "focusout", () => {
@@ -332,7 +437,10 @@ Object.assign(ChartView.prototype, {
     const setCollapsed = (collapsed) => {
       this._modebarCollapsed = collapsed;
       bar.dataset.fcCollapsed = String(collapsed);
-      if (collapsed) setZoomMenuOpen(false);
+      if (collapsed) {
+        setZoomMenuOpen(false);
+        setSelectMenuOpen(false);
+      }
       for (const button of bar.querySelectorAll("button")) {
         if (button !== grip) {
           button.hidden = collapsed;
@@ -376,6 +484,7 @@ Object.assign(ChartView.prototype, {
         this._modebarMoved = true;
         bar.style.transition = "none";
         setZoomMenuOpen(false);
+        setSelectMenuOpen(false);
         try { grip.setPointerCapture(e.pointerId); } catch (_err) { /* synthetic event */ }
       }
       const rootRect = root.getBoundingClientRect();
@@ -447,11 +556,21 @@ Object.assign(ChartView.prototype, {
     const canSelect = this._pickable
       && this._interactionFlag("brush", true)
       && this._interactionFlag("select", true);
+    let selectTrigger = null;
+    let selectIndicator = null;
     if (canSelect) {
-      const selectButton = mk(
-        "select", "Select points", () => this._setDragMode("select"), "select"
-      );
-      selectButton.dataset.fcModebarSelect = "";
+      selectTrigger = mk("select", "Selection controls", () => {
+        setSelectMenuOpen(!this._selectMenuOpen);
+      });
+      selectTrigger.dataset.fcModebarSelect = "";
+      selectTrigger.dataset.fcModebarSelectTrigger = "";
+      selectTrigger.setAttribute("aria-haspopup", "menu");
+      selectTrigger.setAttribute("aria-expanded", "false");
+      selectIndicator = document.createElement("span");
+      selectIndicator.dataset.fcModebarMenuIndicator = "";
+      selectIndicator.innerHTML = this._icon("chevrondown");
+      selectTrigger.appendChild(selectIndicator);
+      this._selectMenuButton = selectTrigger;
     }
 
     const zoomMenu = document.createElement("div");
@@ -504,8 +623,55 @@ Object.assign(ChartView.prototype, {
     mkZoomItem("zoom", "Box Zoom", "B", () => this._setDragMode("zoom"), "zoom");
     mkZoomItem("reset", "Reset View", "0", resetView, null, true);
 
+    const selectMenu = document.createElement("div");
+    selectMenu.dataset.fcModebarMenu = "";
+    selectMenu.dataset.fcModebarSelectMenu = "";
+    selectMenu.setAttribute("role", "menu");
+    selectMenu.setAttribute("aria-label", "Selection controls");
+    selectMenu.style.cssText =
+      "position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
+    bar.appendChild(selectMenu);
+    const selectMenuItems = [];
+    const mkSelectItem = (name, label, shortcut, mode) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.tabIndex = -1;
+      button.dataset.fcModebarMenuItem = name;
+      button.dataset.fcModebarSelectItem = mode;
+      button.setAttribute("role", "menuitem");
+      button.style.cssText = "display:flex;align-items:center;pointer-events:auto;";
+      this._applySlot(button, "modebar_button");
+      const icon = document.createElement("span");
+      icon.dataset.fcModebarMenuIcon = "";
+      icon.innerHTML = this._icon(name);
+      button.appendChild(icon);
+      const text = document.createElement("span");
+      text.textContent = label;
+      button.appendChild(text);
+      const hint = document.createElement("span");
+      hint.dataset.fcModebarMenuShortcut = "";
+      hint.textContent = shortcut;
+      button.appendChild(hint);
+      this._listen(button, "pointerdown", (e) => e.stopPropagation());
+      this._listen(button, "click", (e) => {
+        e.stopPropagation();
+        setSelectMenuOpen(false, true);
+        this._setDragMode(mode);
+      });
+      selectMenu.appendChild(button);
+      selectMenuItems.push(button);
+      this._modeBtns[mode] = button;
+    };
+    if (canSelect) {
+      mkSelectItem("select", "Box Select", "B", "select");
+      mkSelectItem("lasso", "Lasso Select", "L", "select-lasso");
+      mkSelectItem("selectx", "X Range", "X", "select-x");
+      mkSelectItem("selecty", "Y Range", "Y", "select-y");
+    }
+
     setZoomMenuOpen = (open, restoreFocus = false) => {
       const show = Boolean(open) && !this._modebarCollapsed;
+      if (show) setSelectMenuOpen(false);
       this._zoomMenuOpen = show;
       zoomTrigger.setAttribute("aria-expanded", String(show));
       if (!show) {
@@ -532,9 +698,43 @@ Object.assign(ChartView.prototype, {
       zoomMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
       zoomMenu.style.visibility = "visible";
     };
-    this._closeModebarMenu = () => setZoomMenuOpen(false);
+    setSelectMenuOpen = (open, restoreFocus = false) => {
+      if (!selectTrigger) return;
+      const show = Boolean(open) && !this._modebarCollapsed;
+      if (show) setZoomMenuOpen(false);
+      this._selectMenuOpen = show;
+      selectTrigger.setAttribute("aria-expanded", String(show));
+      if (!show) {
+        selectMenu.style.display = "none";
+        selectIndicator.style.transform = "none";
+        if (restoreFocus) selectTrigger.focus();
+        return;
+      }
+      selectMenu.style.display = "flex";
+      selectMenu.style.visibility = "hidden";
+      const rootRect = root.getBoundingClientRect();
+      const barRect = bar.getBoundingClientRect();
+      const rootLeft = barRect.left - rootRect.left;
+      const rootTop = barRect.top - rootRect.top;
+      const below = bar.offsetHeight + 6;
+      const above = -selectMenu.offsetHeight - 6;
+      const preferredTop = barRect.bottom + 6 + selectMenu.offsetHeight <= rootRect.bottom
+        ? below
+        : above;
+      selectIndicator.style.transform = preferredTop === above ? "rotate(180deg)" : "none";
+      const maxLeft = root.clientWidth - rootLeft - selectMenu.offsetWidth;
+      const maxTop = root.clientHeight - rootTop - selectMenu.offsetHeight;
+      selectMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, selectTrigger.offsetLeft))}px`;
+      selectMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
+      selectMenu.style.visibility = "visible";
+    };
+    this._closeModebarMenu = () => {
+      setZoomMenuOpen(false);
+      setSelectMenuOpen(false);
+    };
     this._listen(document, "pointerdown", (e) => {
       if (this._zoomMenuOpen && !bar.contains(e.target)) setZoomMenuOpen(false);
+      if (this._selectMenuOpen && !bar.contains(e.target)) setSelectMenuOpen(false);
     });
     this._listen(zoomTrigger, "keydown", (e) => {
       if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
@@ -559,6 +759,33 @@ Object.assign(ChartView.prototype, {
       if (e.key === "ArrowUp") next = (current - 1 + zoomMenuItems.length) % zoomMenuItems.length;
       zoomMenuItems[next].focus();
     });
+    if (selectTrigger) {
+      this._listen(selectTrigger, "keydown", (e) => {
+        if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+        e.preventDefault();
+        e.stopPropagation();
+        setSelectMenuOpen(true);
+        const index = e.key === "ArrowDown" ? 0 : selectMenuItems.length - 1;
+        selectMenuItems[index].focus();
+      });
+      this._listen(selectMenu, "keydown", (e) => {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          e.stopPropagation();
+          setSelectMenuOpen(false, true);
+          return;
+        }
+        if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(e.key)) return;
+        e.preventDefault();
+        const current = selectMenuItems.indexOf(document.activeElement);
+        let next = e.key === "Home" ? 0 : e.key === "End" ? selectMenuItems.length - 1 : current;
+        if (e.key === "ArrowDown") next = (current + 1) % selectMenuItems.length;
+        if (e.key === "ArrowUp") {
+          next = (current - 1 + selectMenuItems.length) % selectMenuItems.length;
+        }
+        selectMenuItems[next].focus();
+      });
+    }
     root.appendChild(bar);
     this._fitModebar();
     // The pointer may already be over a chart that mounted beneath it, in
@@ -601,6 +828,7 @@ Object.assign(ChartView.prototype, {
       btn.classList.toggle("fc-active", name === mode);
     }
     this._zoomMenuButton?.classList.toggle("fc-active", mode === "zoom");
+    this._selectMenuButton?.classList.toggle("fc-active", mode.startsWith("select"));
   },
 
   _updateZoomMenuLabel() {
@@ -618,10 +846,13 @@ Object.assign(ChartView.prototype, {
     const percent = axisPercent("x", this.view.x0, this.view.x1, this.view0.x0, this.view0.x1)
       ?? axisPercent("y", this.view.y0, this.view.y1, this.view0.y0, this.view0.y1)
       ?? 100;
-    const text = percent < 1 ? "<1%" : `${Math.round(percent)}%`;
-    this._zoomMenuLabel.textContent = text;
-    this._zoomMenuButton.title = `Zoom controls (${text})`;
-    this._zoomMenuButton.setAttribute("aria-label", `Zoom controls, ${text}`);
+    const rounded = Math.round(percent);
+    const exactText = percent < 1 ? "<1%" : `${rounded}%`;
+    const displayText = rounded > 999 ? `${String(rounded).slice(0, 3)}…%` : exactText;
+    this._zoomMenuLabel.textContent = displayText;
+    this._zoomMenuLabel.dataset.fcZoomExact = exactText;
+    this._zoomMenuButton.title = `Zoom controls (${exactText})`;
+    this._zoomMenuButton.setAttribute("aria-label", `Zoom controls, ${exactText}`);
   },
 
   _prefersReducedMotion() {
@@ -807,6 +1038,17 @@ Object.assign(ChartView.prototype, {
           'stroke-dasharray="2.5 2"/><circle cx="7" cy="7" r="1" fill="currentColor" ' +
           'stroke="none"/><circle cx="12.5" cy="9" r="1" fill="currentColor" stroke="none"/>' +
           '<circle cx="9.5" cy="13" r="1" fill="currentColor" stroke="none"/>');
+      case "lasso":
+        return svg('<path d="M4 6 C6 2 15 3 16 8 C17 13 11 17 6 14 C2 12 2 8 4 6 Z" ' +
+          'stroke-dasharray="2.5 2"/><circle cx="6" cy="8" r="1" fill="currentColor" ' +
+          'stroke="none"/><circle cx="12" cy="7" r="1" fill="currentColor" stroke="none"/>' +
+          '<circle cx="10" cy="12" r="1" fill="currentColor" stroke="none"/>');
+      case "selectx":
+        return svg('<rect x="3" y="5" width="14" height="10" rx="1" stroke-dasharray="2.5 2"/>' +
+          '<path d="M6 10 H14 M6 10 L8 8 M6 10 L8 12 M14 10 L12 8 M14 10 L12 12"/>');
+      case "selecty":
+        return svg('<rect x="5" y="3" width="10" height="14" rx="1" stroke-dasharray="2.5 2"/>' +
+          '<path d="M10 6 V14 M10 6 L8 8 M10 6 L12 8 M10 14 L8 12 M10 14 L12 12"/>');
       case "chevrondown":
         return svg('<path d="M6 8 L10 12 L14 8"/>');
       case "reset":

--- a/js/src/53_interaction.js
+++ b/js/src/53_interaction.js
@@ -293,6 +293,7 @@ Object.assign(ChartView.prototype, {
     this._modebarCollapsed = false;
     this._modebarMoved = false;
     bar.dataset.fcCollapsed = "false";
+    let setZoomMenuOpen = () => {};
 
     const setVisible = (visible) => {
       const show = visible || this._modebarDragging || bar.contains(document.activeElement);
@@ -300,7 +301,10 @@ Object.assign(ChartView.prototype, {
       bar.style.pointerEvents = show ? "auto" : "none";
     };
     this._listen(root, "pointerenter", () => setVisible(true));
-    this._listen(root, "pointerleave", () => setVisible(false));
+    this._listen(root, "pointerleave", () => {
+      setVisible(false);
+      setZoomMenuOpen(false);
+    });
     this._listen(bar, "focusin", () => setVisible(true));
     this._listen(bar, "focusout", () => {
       if (!root.matches(":hover")) setVisible(false);
@@ -328,6 +332,7 @@ Object.assign(ChartView.prototype, {
     const setCollapsed = (collapsed) => {
       this._modebarCollapsed = collapsed;
       bar.dataset.fcCollapsed = String(collapsed);
+      if (collapsed) setZoomMenuOpen(false);
       for (const button of bar.querySelectorAll("button")) {
         if (button !== grip) {
           button.hidden = collapsed;
@@ -370,6 +375,7 @@ Object.assign(ChartView.prototype, {
         this._modebarDragging = true;
         this._modebarMoved = true;
         bar.style.transition = "none";
+        setZoomMenuOpen(false);
         try { grip.setPointerCapture(e.pointerId); } catch (_err) { /* synthetic event */ }
       }
       const rootRect = root.getBoundingClientRect();
@@ -420,13 +426,113 @@ Object.assign(ChartView.prototype, {
       return b;
     };
 
-    mk("zoomin", "Zoom in", () => this._zoomBy(0.5, true));
-    mk("zoomout", "Zoom out", () => this._zoomBy(2, true));
+    const zoomTrigger = mk("zoommenu", "Zoom controls", () => {
+      setZoomMenuOpen(!this._zoomMenuOpen);
+    });
+    this._zoomMenuButton = zoomTrigger;
+    zoomTrigger.dataset.fcModebarMenuTrigger = "";
+    zoomTrigger.setAttribute("aria-haspopup", "menu");
+    zoomTrigger.setAttribute("aria-expanded", "false");
     mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
-    mk("zoom", "Box zoom", () => this._setDragMode("zoom"), "zoom");
-    mk("reset", "Reset view", () => {
+
+    const zoomMenu = document.createElement("div");
+    zoomMenu.dataset.fcModebarMenu = "";
+    zoomMenu.setAttribute("role", "menu");
+    zoomMenu.setAttribute("aria-label", "Zoom controls");
+    zoomMenu.style.cssText =
+      "position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
+    bar.appendChild(zoomMenu);
+    const zoomMenuItems = [];
+    const mkZoomItem = (name, label, shortcut, onClick, toggles, separator = false) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.tabIndex = -1;
+      button.dataset.fcModebarMenuItem = name;
+      if (separator) button.dataset.fcSeparator = "";
+      button.setAttribute("role", "menuitem");
+      button.style.cssText =
+        "display:flex;align-items:center;pointer-events:auto;";
+      this._applySlot(button, "modebar_button");
+      const text = document.createElement("span");
+      text.textContent = label;
+      button.appendChild(text);
+      const hint = document.createElement("span");
+      hint.dataset.fcModebarMenuShortcut = "";
+      hint.textContent = shortcut;
+      button.appendChild(hint);
+      this._listen(button, "pointerdown", (e) => e.stopPropagation());
+      this._listen(button, "click", (e) => {
+        e.stopPropagation();
+        setZoomMenuOpen(false, true);
+        onClick();
+      });
+      zoomMenu.appendChild(button);
+      zoomMenuItems.push(button);
+      if (toggles) this._modeBtns[toggles] = button;
+      return button;
+    };
+
+    const resetView = () => {
       this._clearSelection();
       this._setView(this.view0, { animate: true });
+    };
+    mkZoomItem("zoomin", "Zoom In", "+", () => this._zoomBy(0.5, true));
+    mkZoomItem("zoomout", "Zoom Out", "−", () => this._zoomBy(2, true));
+    mkZoomItem("zoom", "Box Zoom", "B", () => this._setDragMode("zoom"), "zoom");
+    mkZoomItem("reset", "Reset View", "0", resetView, null, true);
+
+    setZoomMenuOpen = (open, restoreFocus = false) => {
+      const show = Boolean(open) && !this._modebarCollapsed;
+      this._zoomMenuOpen = show;
+      zoomTrigger.setAttribute("aria-expanded", String(show));
+      if (!show) {
+        zoomMenu.style.display = "none";
+        if (restoreFocus) zoomTrigger.focus();
+        return;
+      }
+      zoomMenu.style.display = "flex";
+      zoomMenu.style.visibility = "hidden";
+      const rootRect = root.getBoundingClientRect();
+      const barRect = bar.getBoundingClientRect();
+      const rootLeft = barRect.left - rootRect.left;
+      const rootTop = barRect.top - rootRect.top;
+      const below = bar.offsetHeight + 6;
+      const above = -zoomMenu.offsetHeight - 6;
+      const preferredTop = barRect.bottom + 6 + zoomMenu.offsetHeight <= rootRect.bottom
+        ? below
+        : above;
+      const maxLeft = root.clientWidth - rootLeft - zoomMenu.offsetWidth;
+      const maxTop = root.clientHeight - rootTop - zoomMenu.offsetHeight;
+      zoomMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, zoomTrigger.offsetLeft))}px`;
+      zoomMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
+      zoomMenu.style.visibility = "visible";
+    };
+    this._closeModebarMenu = () => setZoomMenuOpen(false);
+    this._listen(document, "pointerdown", (e) => {
+      if (this._zoomMenuOpen && !bar.contains(e.target)) setZoomMenuOpen(false);
+    });
+    this._listen(zoomTrigger, "keydown", (e) => {
+      if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+      e.preventDefault();
+      e.stopPropagation();
+      setZoomMenuOpen(true);
+      const index = e.key === "ArrowDown" ? 0 : zoomMenuItems.length - 1;
+      zoomMenuItems[index].focus();
+    });
+    this._listen(zoomMenu, "keydown", (e) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        setZoomMenuOpen(false, true);
+        return;
+      }
+      if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(e.key)) return;
+      e.preventDefault();
+      const current = zoomMenuItems.indexOf(document.activeElement);
+      let next = e.key === "Home" ? 0 : e.key === "End" ? zoomMenuItems.length - 1 : current;
+      if (e.key === "ArrowDown") next = (current + 1) % zoomMenuItems.length;
+      if (e.key === "ArrowUp") next = (current - 1 + zoomMenuItems.length) % zoomMenuItems.length;
+      zoomMenuItems[next].focus();
     });
     root.appendChild(bar);
     this._fitModebar();
@@ -443,6 +549,7 @@ Object.assign(ChartView.prototype, {
   _fitModebar() {
     const bar = this._modebar;
     if (!bar) return;
+    this._closeModebarMenu?.();
     if (!this._modebarMoved) {
       bar.style.top = `${this.plot.y + 4}px`;
       bar.style.left = `${this.plot.x + 4}px`;
@@ -468,6 +575,7 @@ Object.assign(ChartView.prototype, {
     for (const [name, btn] of Object.entries(this._modeBtns || {})) {
       btn.classList.toggle("fc-active", name === mode);
     }
+    this._zoomMenuButton?.classList.toggle("fc-active", mode === "zoom");
   },
 
   _prefersReducedMotion() {
@@ -648,6 +756,9 @@ Object.assign(ChartView.prototype, {
       case "zoom":
         return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
           'stroke-dasharray="3 2"/>');
+      case "zoommenu":
+        return svg('<circle cx="8" cy="8" r="4.5"/><path d="M11.5 11.5 L15 15"/>' +
+          '<path d="M16 7 L18 9 L16 11"/>');
       case "reset":
         return svg('<path d="M4 10 a6 6 0 1 1 1.8 4.3"/><path d="M4 6 V10 H8"/>');
       case "drag":

--- a/python/xy/_figure.py
+++ b/python/xy/_figure.py
@@ -1102,6 +1102,10 @@ class Figure(AnnotationsMixin, PayloadMixin):
         """Box-select → canonical indices per scatter trace (§34 Filter Tier A)."""
         return interaction.select_range(self, x0, x1, y0, y1, trace_id)
 
+    def select_polygon(self, points: Any, trace_id: Optional[int] = None) -> dict[int, np.ndarray]:
+        """Lasso-select → canonical indices per scatter trace."""
+        return interaction.select_polygon(self, points, trace_id)
+
     def to_shipped_indices(self, trace_id: int, canonical: np.ndarray) -> np.ndarray:
         """Canonical rows → shipped vertex positions (the client's mask space)."""
         return interaction.to_shipped_indices(self, trace_id, canonical)

--- a/python/xy/channel.py
+++ b/python/xy/channel.py
@@ -89,12 +89,42 @@ class ChannelCallbacks:
 
     on_hover: Optional[Callable[[dict[str, Any]], None]] = None
     on_click: Optional[Callable[[dict[str, Any]], None]] = None
-    on_brush: Optional[Callable[[dict[str, float]], None]] = None
+    on_brush: Optional[Callable[[dict[str, Any]], None]] = None
     on_select: Optional[Callable[[Selection], None]] = None
     on_view_change: Optional[Callable[[dict[str, Any]], None]] = None
 
 
 _NO_CALLBACKS = ChannelCallbacks()
+
+
+def _selection_reply(
+    fig: "Figure",
+    selected: dict[int, Any],
+    callbacks: ChannelCallbacks,
+    brush: dict[str, Any],
+) -> Reply:
+    if callbacks.on_brush is not None:
+        callbacks.on_brush(brush)
+    traces = []
+    out: list[bytes] = []
+    total = 0
+    for tid, idx in selected.items():
+        # The wire mask speaks shipped-vertex positions; callbacks retain
+        # canonical rows (§34 — the GPU and Python have distinct index spaces).
+        wire_idx = fig.to_shipped_indices(tid, idx)
+        traces.append(
+            {
+                "id": tid,
+                "count": int(len(wire_idx)),
+                "buf": len(out),
+                "drill_seq": fig.traces[tid].drill_seq,
+            }
+        )
+        out.append(wire_idx.tobytes())
+        total += len(idx)
+    if callbacks.on_select is not None:
+        callbacks.on_select(Selection(fig, selected))
+    return {"type": "selection", "traces": traces, "total": total}, out
 
 
 def handle_message(
@@ -221,31 +251,20 @@ def handle_message(
             )
         except (KeyError, TypeError, ValueError):
             return None
-        if callbacks.on_brush is not None:
-            callbacks.on_brush({"x0": x0, "x1": x1, "y0": y0, "y1": y1})
-        traces = []
-        out: list[bytes] = []
-        total = 0
-        for tid, idx in sel.items():
-            # The wire mask speaks shipped-vertex positions; the Selection
-            # callback below keeps canonical rows (§34 — callbacks get real
-            # data, the GPU gets its own coordinate space).
-            wire_idx = fig.to_shipped_indices(tid, idx)
-            traces.append(
-                {
-                    "id": tid,
-                    "count": int(len(wire_idx)),
-                    "buf": len(out),
-                    # Which drilled subset this mask speaks for; the client
-                    # drops it if its buffers have moved on (§17).
-                    "drill_seq": fig.traces[tid].drill_seq,
-                }
-            )
-            out.append(wire_idx.tobytes())
-            total += len(idx)
-        if callbacks.on_select is not None:
-            callbacks.on_select(Selection(fig, sel))
-        return {"type": "selection", "traces": traces, "total": total}, out
+        return _selection_reply(
+            fig,
+            sel,
+            callbacks,
+            {"x0": x0, "x1": x1, "y0": y0, "y1": y1},
+        )
+    if kind == "select_polygon":
+        try:
+            points = content["points"]
+            sel = fig.select_polygon(points)
+            polygon = [[float(point[0]), float(point[1])] for point in points]
+        except (IndexError, KeyError, TypeError, ValueError):
+            return None
+        return _selection_reply(fig, sel, callbacks, {"polygon": polygon})
     if kind == "select_clear":
         if callbacks.on_select is not None:
             callbacks.on_select(Selection(fig, {}))

--- a/python/xy/interaction.py
+++ b/python/xy/interaction.py
@@ -142,6 +142,49 @@ def select_range(
     return out
 
 
+def select_polygon(
+    fig: "Figure", points: Any, trace_id: Optional[int] = None
+) -> dict[int, np.ndarray]:
+    """Canonical scatter indices inside a finite lasso polygon.
+
+    The polygon's bounding box first reuses the zone-pruned range predicate;
+    ray casting then runs only on those candidates rather than every row.
+    """
+    polygon = np.asarray(points, dtype=np.float64)
+    if polygon.ndim != 2 or polygon.shape[1:] != (2,) or not 3 <= len(polygon) <= 2048:
+        raise ValueError("selection polygon must contain 3 to 2048 x/y points")
+    if not np.isfinite(polygon).all():
+        raise ValueError("selection polygon must be finite")
+    candidates = select_range(
+        fig,
+        float(polygon[:, 0].min()),
+        float(polygon[:, 0].max()),
+        float(polygon[:, 1].min()),
+        float(polygon[:, 1].max()),
+        trace_id,
+    )
+    out: dict[int, np.ndarray] = {}
+    for tid, rows in candidates.items():
+        if len(rows) == 0:
+            out[tid] = rows
+            continue
+        trace = fig.traces[tid]
+        x = trace.x.values[rows]
+        y = trace.y.values[rows]
+        inside = np.zeros(len(rows), dtype=np.bool_)
+        j = len(polygon) - 1
+        for i in range(len(polygon)):
+            xi, yi = polygon[i]
+            xj, yj = polygon[j]
+            crosses = (yi > y) != (yj > y)
+            with np.errstate(divide="ignore", invalid="ignore"):
+                edge_x = (xj - xi) * (y - yi) / (yj - yi) + xi
+            inside ^= crosses & (x < edge_x)
+            j = i
+        out[tid] = rows[inside]
+    return out
+
+
 def to_shipped_indices(fig: "Figure", trace_id: int, canonical: np.ndarray) -> np.ndarray:
     """Translate canonical row indices to *shipped* vertex positions for a
     trace — the coordinate space the client's per-vertex selection mask uses.

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -241,9 +241,10 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="badge"]){gap:3px;font-size:11px;line-height:1.2}
 :where(.xy [data-fc-slot="badge_item"]){padding:3px 6px;border-radius:4px;color:var(--chart-badge-text,#0f172a);background:var(--chart-badge-bg,rgba(255,255,255,.82));box-shadow:0 1px 4px rgba(15,23,42,.14)}
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
-:where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-axis,currentColor);cursor:pointer}
+:where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
 :where(.xy [data-fc-modebar-drag-handle]){cursor:move}
 :where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:58px;gap:2px;padding:0 6px;font-size:11px;font-variant-numeric:tabular-nums}
+:where(.xy [data-fc-modebar-select-trigger]){width:auto;min-width:35px;gap:0;padding:0 4px}
 :where(.xy [data-fc-modebar-menu-indicator]){display:flex;transition:transform .15s}
 :where(.xy [data-fc-modebar-menu-indicator] svg){width:11px;height:11px}
 :where(.xy [data-fc-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}
@@ -256,6 +257,7 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar_button"].fc-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
 :where(.xy [data-fc-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-fc-slot="selection"][data-fc-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}
+:where(.xy [data-fc-selection-lasso]){fill:var(--chart-selection-fill,rgba(90,140,240,.15));stroke:var(--chart-selection,rgba(90,140,240,.9));stroke-width:1.5;stroke-linejoin:round}
 :where(.xy [data-fc-slot="crosshair_x"],.xy [data-fc-slot="crosshair_y"]){background:var(--chart-crosshair,rgba(15,23,42,.42))}
 :where(.xy [data-fc-slot="tick_label"]){color:var(--chart-text,inherit)}
 :where(.xy [data-fc-slot="axis_title"]){color:var(--chart-text,inherit);font-size:12px}
@@ -5130,12 +5132,29 @@ d.textContent = text;
 const dx = Number.isFinite(Number(ann.dx)) ? Number(ann.dx) : 0;
 const dy = Number.isFinite(Number(ann.dy)) ? Number(ann.dy) : 0;
 const anchor = ann.anchor === "middle" ? "-50%" : ann.anchor === "end" ? "-100%" : "0";
-const va = style.vertical_align;
+const rot = Number.isFinite(Number(style.rotation))
+? ((Number(style.rotation) % 360) + 360) % 360
+: 0;
+const va = String(style.vertical_align || "");
 const vAnchor =
 va === "center" || va === "middle" ? "-50%" : va === "bottom" ? "-100%" : "0";
+let transform = `translate(${anchor},${vAnchor})`;
+if (rot === 90 || rot === 270) {
+const cw = rot === 270;
+const along =
+va === "center" || va === "middle" ? "-50%"
+: va === "top" ? (cw ? "0" : "-100%")
+: va === "bottom" ? (cw ? "-100%" : "0")
+: cw ? "0" : "-100%";
+const cross =
+ann.anchor === "middle" ? "-50%" : ann.anchor === "end" ? (cw ? "0" : "-100%") : cw ? "-100%" : "0";
+transform = `rotate(${cw ? 90 : -90}deg) translate(${along},${cross})`;
+} else if (rot) {
+transform = `rotate(${-rot}deg) translate(${anchor},${vAnchor})`;
+}
 d.style.cssText =
 `position:absolute;left:${px + dx}px;top:${py + dy}px;` +
-`transform:translate(${anchor},${vAnchor});pointer-events:none;` +
+`transform:${transform};transform-origin:0 0;pointer-events:none;` +
 `white-space:pre-line;text-align:center;width:max-content;`;
 this._applySlot(d, "annotation_label");
 this._applyClass(d, ann.class_name);
@@ -5370,6 +5389,13 @@ this.selRect = document.createElement("div");
 this.selRect.style.cssText = "position:absolute;display:none;pointer-events:none;z-index:4;";
 this._applySlot(this.selRect, "selection");
 this.root.appendChild(this.selRect);
+this.selLasso = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+this.selLasso.style.cssText =
+"position:absolute;display:none;pointer-events:none;z-index:4;overflow:visible;";
+this.selLassoPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
+this.selLassoPath.dataset.fcSelectionLasso = "";
+this.selLasso.appendChild(this.selLassoPath);
+this.root.appendChild(this.selLasso);
 if (this._interactionFlag("crosshair")) {
 this.crosshairX = document.createElement("div");
 this.crosshairX.style.cssText =
@@ -5389,10 +5415,16 @@ return this._dataFromCanvas(clientX - r.left, clientY - r.top);
 this._listen(c, "pointerdown", (e) => {
 this._cancelViewAnimation();
 const canBrush = this._interactionFlag("brush", true) && this._interactionFlag("select", true);
-const mode = (e.shiftKey || this.dragMode === "select") && canBrush && this._pickable ? "select"
+const selectMode = this.dragMode.startsWith("select") ? this.dragMode : null;
+const mode = (e.shiftKey || selectMode) && canBrush && this._pickable
+? (e.shiftKey ? "select" : selectMode)
 : this.dragMode === "zoom" ? "zoom" : null;
 if (mode) {
-band = { mode, sx: e.clientX, sy: e.clientY, d0: dataAt(e.clientX, e.clientY) };
+const d0 = dataAt(e.clientX, e.clientY);
+band = {
+mode, sx: e.clientX, sy: e.clientY, d0,
+points: mode === "select-lasso" ? [{ x: e.clientX, y: e.clientY, data: d0 }] : null,
+};
 c.setPointerCapture(e.pointerId);
 this.tooltip.style.display = "none";
 return;
@@ -5429,11 +5461,24 @@ this._hover(e);
 const end = (e) => {
 if (band) {
 this.selRect.style.display = "none";
+this.selLasso.style.display = "none";
 const d1 = dataAt(e.clientX, e.clientY);
 const moved = Math.abs(e.clientX - band.sx) > 3 || Math.abs(e.clientY - band.sy) > 3;
 if (moved) {
 if (band.mode === "zoom") this._zoomToBox(band.d0, d1, true);
-else this._sendSelect(band.d0, d1);
+else if (band.mode === "select-lasso" && band.points.length >= 3) {
+this._sendSelectPolygon(band.points.map((point) => point.data));
+} else {
+let d0 = band.d0;
+if (band.mode === "select-x") {
+d0 = [band.d0[0], this.view.y0];
+d1[1] = this.view.y1;
+} else if (band.mode === "select-y") {
+d0 = [this.view.x0, band.d0[1]];
+d1[0] = this.view.x1;
+}
+this._sendSelect(d0, d1);
+}
 this._ignoreNextClick = true;
 }
 band = null;
@@ -5444,7 +5489,12 @@ if (drag && !drag.moved) this.tooltip.style.display = "none";
 drag = null;
 };
 this._listen(c, "pointerup", end);
-this._listen(c, "pointercancel", () => { this.selRect.style.display = "none"; band = null; drag = null; });
+this._listen(c, "pointercancel", () => {
+this.selRect.style.display = "none";
+this.selLasso.style.display = "none";
+band = null;
+drag = null;
+});
 this._listen(c, "pointerleave", () => {
 const hadHover = this._hoverId !== -1;
 this._hoverId = -1;
@@ -5527,19 +5577,43 @@ this.comm.send(msg);
 _updateBand(band, e) {
 const rect = this.canvas.getBoundingClientRect();
 const rootRect = this.root.getBoundingClientRect();
+if (band.mode === "select-lasso") {
+const previous = band.points[band.points.length - 1];
+if (band.points.length < 2048
+&& Math.hypot(e.clientX - previous.x, e.clientY - previous.y) >= 3) {
+band.points.push({ x: e.clientX, y: e.clientY, data: this._dataFromCanvas(
+e.clientX - rect.left, e.clientY - rect.top
+) });
+}
+const points = band.points.map((point) => [
+Math.max(this.plot.x, Math.min(this.plot.x + this.plot.w, point.x - rootRect.left)),
+Math.max(this.plot.y, Math.min(this.plot.y + this.plot.h, point.y - rootRect.top)),
+]);
+this.selLasso.style.display = "block";
+this.selLasso.style.inset = "0";
+this.selLasso.setAttribute("width", String(this.root.clientWidth));
+this.selLasso.setAttribute("height", String(this.root.clientHeight));
+this.selLassoPath.setAttribute(
+"d", points.map((point, i) => `${i ? "L" : "M"}${point[0]} ${point[1]}`).join(" ") + " Z"
+);
+return;
+}
 const x = Math.min(band.sx, e.clientX) - rootRect.left;
 const y = Math.min(band.sy, e.clientY) - rootRect.top;
 const w = Math.abs(e.clientX - band.sx);
 const h = Math.abs(e.clientY - band.sy);
 const px = this.plot.x, py = this.plot.y;
 const x2 = Math.min(x + w, px + this.plot.w), y2 = Math.min(y + h, py + this.plot.h);
-const cx = Math.max(x, px), cy = Math.max(y, py);
+let cx = Math.max(x, px), cy = Math.max(y, py);
+let bx2 = x2, by2 = y2;
+if (band.mode === "select-x") { cy = py; by2 = py + this.plot.h; }
+if (band.mode === "select-y") { cx = px; bx2 = px + this.plot.w; }
 this.selRect.dataset.fcBand = band.mode === "zoom" ? "zoom" : "select";
 this.selRect.style.display = "block";
 this.selRect.style.left = cx + "px";
 this.selRect.style.top = cy + "px";
-this.selRect.style.width = Math.max(0, x2 - cx) + "px";
-this.selRect.style.height = Math.max(0, y2 - cy) + "px";
+this.selRect.style.width = Math.max(0, bx2 - cx) + "px";
+this.selRect.style.height = Math.max(0, by2 - cy) + "px";
 void rect;
 },
 _sendSelect(d0, d1) {
@@ -5552,6 +5626,52 @@ this.comm.send({ type: "select", x0, x1, y0, y1 });
 } else {
 this._selectLocal(x0, x1, y0, y1);
 }
+},
+_sendSelectPolygon(points) {
+if (!Array.isArray(points) || points.length < 3) return;
+const polygon = points.map((point) => [point[0], point[1]]);
+this._dispatchChartEvent("brush", {
+polygon,
+view: this._eventView("brush"),
+});
+if (this.comm) {
+this.comm.send({ type: "select_polygon", points: polygon });
+} else {
+this._selectLocalPolygon(polygon);
+}
+},
+_selectLocalPolygon(points) {
+const inside = (x, y) => {
+let hit = false;
+for (let i = 0, j = points.length - 1; i < points.length; j = i++) {
+const [xi, yi] = points[i], [xj, yj] = points[j];
+if ((yi > y) !== (yj > y) && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) hit = !hit;
+}
+return hit;
+};
+let total = 0;
+for (const g of this.gpuTraces) {
+if (!g._cpu || g.tier === "density") continue;
+const cx = g._cpu.x, cy = g._cpu.y;
+const xMeta = g._cpu.xMeta || g.xMeta;
+const yMeta = g._cpu.yMeta || g.yMeta;
+const ox = xMeta.offset, sx = xMeta.scale || 1;
+const oy = yMeta.offset, sy = yMeta.scale || 1;
+const mask = new Float32Array(g.n);
+let count = 0;
+for (let i = 0; i < g.n; i++) {
+if (inside(cx[i] / sx + ox, cy[i] / sy + oy)) { mask[i] = 1; count++; }
+}
+this._applySelMask(g, mask);
+total += count;
+}
+this._selectionCount = total;
+this.draw();
+this._dispatchChartEvent("select", {
+total,
+polygon: points,
+view: this._eventView("select"),
+});
 },
 _selectLocal(x0, x1, y0, y1) {
 let total = 0;
@@ -5620,6 +5740,7 @@ this._modebarCollapsed = false;
 this._modebarMoved = false;
 bar.dataset.fcCollapsed = "false";
 let setZoomMenuOpen = () => {};
+let setSelectMenuOpen = () => {};
 const setVisible = (visible) => {
 const show = visible || this._modebarDragging || bar.contains(document.activeElement);
 bar.style.opacity = show ? "1" : "0";
@@ -5629,6 +5750,7 @@ this._listen(root, "pointerenter", () => setVisible(true));
 this._listen(root, "pointerleave", () => {
 setVisible(false);
 setZoomMenuOpen(false);
+setSelectMenuOpen(false);
 });
 this._listen(bar, "focusin", () => setVisible(true));
 this._listen(bar, "focusout", () => {
@@ -5652,7 +5774,10 @@ let lastGripDown = 0;
 const setCollapsed = (collapsed) => {
 this._modebarCollapsed = collapsed;
 bar.dataset.fcCollapsed = String(collapsed);
-if (collapsed) setZoomMenuOpen(false);
+if (collapsed) {
+setZoomMenuOpen(false);
+setSelectMenuOpen(false);
+}
 for (const button of bar.querySelectorAll("button")) {
 if (button !== grip) {
 button.hidden = collapsed;
@@ -5696,6 +5821,7 @@ this._modebarDragging = true;
 this._modebarMoved = true;
 bar.style.transition = "none";
 setZoomMenuOpen(false);
+setSelectMenuOpen(false);
 try { grip.setPointerCapture(e.pointerId); } catch (_err) {   }
 }
 const rootRect = root.getBoundingClientRect();
@@ -5763,11 +5889,21 @@ mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
 const canSelect = this._pickable
 && this._interactionFlag("brush", true)
 && this._interactionFlag("select", true);
+let selectTrigger = null;
+let selectIndicator = null;
 if (canSelect) {
-const selectButton = mk(
-"select", "Select points", () => this._setDragMode("select"), "select"
-);
-selectButton.dataset.fcModebarSelect = "";
+selectTrigger = mk("select", "Selection controls", () => {
+setSelectMenuOpen(!this._selectMenuOpen);
+});
+selectTrigger.dataset.fcModebarSelect = "";
+selectTrigger.dataset.fcModebarSelectTrigger = "";
+selectTrigger.setAttribute("aria-haspopup", "menu");
+selectTrigger.setAttribute("aria-expanded", "false");
+selectIndicator = document.createElement("span");
+selectIndicator.dataset.fcModebarMenuIndicator = "";
+selectIndicator.innerHTML = this._icon("chevrondown");
+selectTrigger.appendChild(selectIndicator);
+this._selectMenuButton = selectTrigger;
 }
 const zoomMenu = document.createElement("div");
 zoomMenu.dataset.fcModebarMenu = "";
@@ -5817,8 +5953,54 @@ mkZoomItem("zoomin", "Zoom In", "+", () => this._zoomBy(0.5, true));
 mkZoomItem("zoomout", "Zoom Out", "−", () => this._zoomBy(2, true));
 mkZoomItem("zoom", "Box Zoom", "B", () => this._setDragMode("zoom"), "zoom");
 mkZoomItem("reset", "Reset View", "0", resetView, null, true);
+const selectMenu = document.createElement("div");
+selectMenu.dataset.fcModebarMenu = "";
+selectMenu.dataset.fcModebarSelectMenu = "";
+selectMenu.setAttribute("role", "menu");
+selectMenu.setAttribute("aria-label", "Selection controls");
+selectMenu.style.cssText =
+"position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
+bar.appendChild(selectMenu);
+const selectMenuItems = [];
+const mkSelectItem = (name, label, shortcut, mode) => {
+const button = document.createElement("button");
+button.type = "button";
+button.tabIndex = -1;
+button.dataset.fcModebarMenuItem = name;
+button.dataset.fcModebarSelectItem = mode;
+button.setAttribute("role", "menuitem");
+button.style.cssText = "display:flex;align-items:center;pointer-events:auto;";
+this._applySlot(button, "modebar_button");
+const icon = document.createElement("span");
+icon.dataset.fcModebarMenuIcon = "";
+icon.innerHTML = this._icon(name);
+button.appendChild(icon);
+const text = document.createElement("span");
+text.textContent = label;
+button.appendChild(text);
+const hint = document.createElement("span");
+hint.dataset.fcModebarMenuShortcut = "";
+hint.textContent = shortcut;
+button.appendChild(hint);
+this._listen(button, "pointerdown", (e) => e.stopPropagation());
+this._listen(button, "click", (e) => {
+e.stopPropagation();
+setSelectMenuOpen(false, true);
+this._setDragMode(mode);
+});
+selectMenu.appendChild(button);
+selectMenuItems.push(button);
+this._modeBtns[mode] = button;
+};
+if (canSelect) {
+mkSelectItem("select", "Box Select", "B", "select");
+mkSelectItem("lasso", "Lasso Select", "L", "select-lasso");
+mkSelectItem("selectx", "X Range", "X", "select-x");
+mkSelectItem("selecty", "Y Range", "Y", "select-y");
+}
 setZoomMenuOpen = (open, restoreFocus = false) => {
 const show = Boolean(open) && !this._modebarCollapsed;
+if (show) setSelectMenuOpen(false);
 this._zoomMenuOpen = show;
 zoomTrigger.setAttribute("aria-expanded", String(show));
 if (!show) {
@@ -5845,9 +6027,43 @@ zoomMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, zoomTrigger.offse
 zoomMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
 zoomMenu.style.visibility = "visible";
 };
-this._closeModebarMenu = () => setZoomMenuOpen(false);
+setSelectMenuOpen = (open, restoreFocus = false) => {
+if (!selectTrigger) return;
+const show = Boolean(open) && !this._modebarCollapsed;
+if (show) setZoomMenuOpen(false);
+this._selectMenuOpen = show;
+selectTrigger.setAttribute("aria-expanded", String(show));
+if (!show) {
+selectMenu.style.display = "none";
+selectIndicator.style.transform = "none";
+if (restoreFocus) selectTrigger.focus();
+return;
+}
+selectMenu.style.display = "flex";
+selectMenu.style.visibility = "hidden";
+const rootRect = root.getBoundingClientRect();
+const barRect = bar.getBoundingClientRect();
+const rootLeft = barRect.left - rootRect.left;
+const rootTop = barRect.top - rootRect.top;
+const below = bar.offsetHeight + 6;
+const above = -selectMenu.offsetHeight - 6;
+const preferredTop = barRect.bottom + 6 + selectMenu.offsetHeight <= rootRect.bottom
+? below
+: above;
+selectIndicator.style.transform = preferredTop === above ? "rotate(180deg)" : "none";
+const maxLeft = root.clientWidth - rootLeft - selectMenu.offsetWidth;
+const maxTop = root.clientHeight - rootTop - selectMenu.offsetHeight;
+selectMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, selectTrigger.offsetLeft))}px`;
+selectMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
+selectMenu.style.visibility = "visible";
+};
+this._closeModebarMenu = () => {
+setZoomMenuOpen(false);
+setSelectMenuOpen(false);
+};
 this._listen(document, "pointerdown", (e) => {
 if (this._zoomMenuOpen && !bar.contains(e.target)) setZoomMenuOpen(false);
+if (this._selectMenuOpen && !bar.contains(e.target)) setSelectMenuOpen(false);
 });
 this._listen(zoomTrigger, "keydown", (e) => {
 if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
@@ -5872,6 +6088,33 @@ if (e.key === "ArrowDown") next = (current + 1) % zoomMenuItems.length;
 if (e.key === "ArrowUp") next = (current - 1 + zoomMenuItems.length) % zoomMenuItems.length;
 zoomMenuItems[next].focus();
 });
+if (selectTrigger) {
+this._listen(selectTrigger, "keydown", (e) => {
+if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+e.preventDefault();
+e.stopPropagation();
+setSelectMenuOpen(true);
+const index = e.key === "ArrowDown" ? 0 : selectMenuItems.length - 1;
+selectMenuItems[index].focus();
+});
+this._listen(selectMenu, "keydown", (e) => {
+if (e.key === "Escape") {
+e.preventDefault();
+e.stopPropagation();
+setSelectMenuOpen(false, true);
+return;
+}
+if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(e.key)) return;
+e.preventDefault();
+const current = selectMenuItems.indexOf(document.activeElement);
+let next = e.key === "Home" ? 0 : e.key === "End" ? selectMenuItems.length - 1 : current;
+if (e.key === "ArrowDown") next = (current + 1) % selectMenuItems.length;
+if (e.key === "ArrowUp") {
+next = (current - 1 + selectMenuItems.length) % selectMenuItems.length;
+}
+selectMenuItems[next].focus();
+});
+}
 root.appendChild(bar);
 this._fitModebar();
 setVisible(root.matches(":hover"));
@@ -5901,6 +6144,7 @@ for (const [name, btn] of Object.entries(this._modeBtns || {})) {
 btn.classList.toggle("fc-active", name === mode);
 }
 this._zoomMenuButton?.classList.toggle("fc-active", mode === "zoom");
+this._selectMenuButton?.classList.toggle("fc-active", mode.startsWith("select"));
 },
 _updateZoomMenuLabel() {
 if (!this._zoomMenuLabel || !this.view || !this.view0) return;
@@ -5917,10 +6161,13 @@ return Number.isFinite(span) && span > 0 && Number.isFinite(homeSpan) && homeSpa
 const percent = axisPercent("x", this.view.x0, this.view.x1, this.view0.x0, this.view0.x1)
 ?? axisPercent("y", this.view.y0, this.view.y1, this.view0.y0, this.view0.y1)
 ?? 100;
-const text = percent < 1 ? "<1%" : `${Math.round(percent)}%`;
-this._zoomMenuLabel.textContent = text;
-this._zoomMenuButton.title = `Zoom controls (${text})`;
-this._zoomMenuButton.setAttribute("aria-label", `Zoom controls, ${text}`);
+const rounded = Math.round(percent);
+const exactText = percent < 1 ? "<1%" : `${rounded}%`;
+const displayText = rounded > 999 ? `${String(rounded).slice(0, 3)}…%` : exactText;
+this._zoomMenuLabel.textContent = displayText;
+this._zoomMenuLabel.dataset.fcZoomExact = exactText;
+this._zoomMenuButton.title = `Zoom controls (${exactText})`;
+this._zoomMenuButton.setAttribute("aria-label", `Zoom controls, ${exactText}`);
 },
 _prefersReducedMotion() {
 return window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches === true;
@@ -6090,6 +6337,17 @@ return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
 'stroke-dasharray="2.5 2"/><circle cx="7" cy="7" r="1" fill="currentColor" ' +
 'stroke="none"/><circle cx="12.5" cy="9" r="1" fill="currentColor" stroke="none"/>' +
 '<circle cx="9.5" cy="13" r="1" fill="currentColor" stroke="none"/>');
+case "lasso":
+return svg('<path d="M4 6 C6 2 15 3 16 8 C17 13 11 17 6 14 C2 12 2 8 4 6 Z" ' +
+'stroke-dasharray="2.5 2"/><circle cx="6" cy="8" r="1" fill="currentColor" ' +
+'stroke="none"/><circle cx="12" cy="7" r="1" fill="currentColor" stroke="none"/>' +
+'<circle cx="10" cy="12" r="1" fill="currentColor" stroke="none"/>');
+case "selectx":
+return svg('<rect x="3" y="5" width="14" height="10" rx="1" stroke-dasharray="2.5 2"/>' +
+'<path d="M6 10 H14 M6 10 L8 8 M6 10 L8 12 M14 10 L12 8 M14 10 L12 12"/>');
+case "selecty":
+return svg('<rect x="5" y="3" width="10" height="14" rx="1" stroke-dasharray="2.5 2"/>' +
+'<path d="M10 6 V14 M10 6 L8 8 M10 6 L12 8 M10 14 L8 12 M10 14 L12 12"/>');
 case "chevrondown":
 return svg('<path d="M6 8 L10 12 L14 8"/>');
 case "reset":

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -244,8 +244,6 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar_button"]){width:24px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
 :where(.xy [data-fc-modebar-drag-handle]){position:relative;width:22px;margin-right:2px;cursor:move}
 :where(.xy [data-fc-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-1px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
-:where(.xy [data-fc-slot="modebar"][data-fc-collapsed="true"]>[data-fc-modebar-drag-handle]){margin-right:0}
-:where(.xy [data-fc-slot="modebar"][data-fc-collapsed="true"]>[data-fc-modebar-drag-handle])::after{display:none}
 :where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:52px;gap:1px;padding:0 4px;font-size:11px;font-variant-numeric:tabular-nums}
 :where(.xy [data-fc-modebar-select-trigger]){width:auto;min-width:30px;gap:0;padding:0 2px}
 :where(.xy [data-fc-modebar-menu-indicator]){display:flex;transition:transform .15s}
@@ -5739,13 +5737,10 @@ bar.style.cssText =
 this._applySlot(bar, "modebar");
 this._modebar = bar;
 this._modeBtns = {};
-this._modebarCollapsed = false;
 this._modebarMoved = false;
-bar.dataset.fcCollapsed = "false";
 let setZoomMenuOpen = () => {};
 let setSelectMenuOpen = () => {};
 let setExportMenuOpen = () => {};
-let updateCollapseItem = () => {};
 const setVisible = (visible) => {
 const show = visible || this._modebarDragging || bar.contains(document.activeElement);
 bar.style.opacity = show ? "1" : "0";
@@ -5764,7 +5759,7 @@ if (!root.matches(":hover")) setVisible(false);
 });
 const grip = document.createElement("button");
 grip.type = "button";
-grip.title = "Click for toolbar options; drag to move; double-click to collapse";
+grip.title = "Click for toolbar options; drag to move";
 grip.setAttribute("aria-label", "Toolbar options");
 grip.setAttribute("aria-haspopup", "menu");
 grip.setAttribute("aria-expanded", "false");
@@ -5776,38 +5771,12 @@ grip.style.cssText =
 "display:flex;align-items:center;justify-content:center;pointer-events:auto;touch-action:none;";
 this._applySlot(grip, "modebar_button");
 bar.appendChild(grip);
-const DOUBLE_CLICK_MS = 500;
 const DRAG_THRESHOLD_PX = 6;
 let modebarDrag = null;
-let lastGripDown = 0;
 let suppressGripClickUntil = 0;
-const setCollapsed = (collapsed) => {
-this._modebarCollapsed = collapsed;
-bar.dataset.fcCollapsed = String(collapsed);
-if (collapsed) {
-setZoomMenuOpen(false);
-setSelectMenuOpen(false);
-setExportMenuOpen(false);
-}
-for (const button of bar.querySelectorAll(":scope > button")) {
-if (button !== grip) {
-button.hidden = collapsed;
-button.style.display = collapsed ? "none" : "flex";
-}
-}
-grip.title = collapsed
-? "Click for toolbar options; drag to move; double-click to expand"
-: "Click for toolbar options; drag to move; double-click to collapse";
-updateCollapseItem();
-this._fitModebar();
-};
-const toggleModebar = () => setCollapsed(!this._modebarCollapsed);
 this._listen(grip, "pointerdown", (e) => {
 if (e.pointerType === "mouse" && e.button !== 0) return;
 e.stopPropagation();
-const now = e.timeStamp || performance.now();
-const doubleClick = lastGripDown > 0 && now - lastGripDown <= DOUBLE_CLICK_MS;
-lastGripDown = doubleClick ? 0 : now;
 const barRect = bar.getBoundingClientRect();
 modebarDrag = {
 pointerId: e.pointerId,
@@ -5818,10 +5787,6 @@ dy: e.clientY - barRect.top,
 moved: false,
 };
 setVisible(true);
-if (doubleClick) {
-suppressGripClickUntil = performance.now() + 100;
-toggleModebar();
-}
 });
 this._listen(grip, "pointermove", (e) => {
 if (!modebarDrag || e.pointerId !== modebarDrag.pointerId) return;
@@ -5829,7 +5794,6 @@ const distance = Math.hypot(e.clientX - modebarDrag.startX, e.clientY - modebarD
 if (!modebarDrag.moved) {
 if (distance < DRAG_THRESHOLD_PX) return;
 modebarDrag.moved = true;
-lastGripDown = 0;
 this._modebarDragging = true;
 this._modebarMoved = true;
 bar.style.transition = "none";
@@ -5852,7 +5816,6 @@ this._modebarDragging = false;
 bar.style.transition = "opacity .15s";
 setVisible(root.matches(":hover"));
 if (moved || cancelled) {
-lastGripDown = 0;
 suppressGripClickUntil = performance.now() + 100;
 }
 };
@@ -5865,10 +5828,6 @@ suppressGripClickUntil = 0;
 return;
 }
 setExportMenuOpen(!this._exportMenuOpen);
-});
-this._listen(grip, "dblclick", (e) => {
-e.preventDefault();
-e.stopPropagation();
 });
 const mk = (name, title, onClick, toggles) => {
 const b = document.createElement("button");
@@ -6050,22 +6009,11 @@ exportMenu.appendChild(button);
 exportMenuItems.push(button);
 return button;
 };
-const collapseItem = mkExportItem("collapse", "Collapse Toolbar", toggleModebar);
-collapseItem.dataset.fcModebarCollapseItem = "";
-updateCollapseItem = () => {
-const collapsed = this._modebarCollapsed;
-const icon = collapseItem.querySelector("[data-fc-modebar-menu-icon]");
-const label = icon?.nextElementSibling;
-if (icon) icon.innerHTML = this._icon(collapsed ? "expand" : "collapse");
-if (label) label.textContent = collapsed ? "Expand Toolbar" : "Collapse Toolbar";
-collapseItem.dataset.fcModebarExportItem = collapsed ? "expand" : "collapse";
-};
-updateCollapseItem();
-mkExportItem("png", "Export PNG", () => this._exportPng(), true);
+mkExportItem("png", "Export PNG", () => this._exportPng());
 mkExportItem("svg", "Export SVG", () => this._exportSvg());
 mkExportItem("csv", "Export CSV", () => this._exportCsv());
 setZoomMenuOpen = (open, restoreFocus = false) => {
-const show = Boolean(open) && !this._modebarCollapsed;
+const show = Boolean(open);
 if (show) {
 setSelectMenuOpen(false);
 setExportMenuOpen(false);
@@ -6098,7 +6046,7 @@ zoomMenu.style.visibility = "visible";
 };
 setSelectMenuOpen = (open, restoreFocus = false) => {
 if (!selectTrigger) return;
-const show = Boolean(open) && !this._modebarCollapsed;
+const show = Boolean(open);
 if (show) {
 setZoomMenuOpen(false);
 setExportMenuOpen(false);

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -243,6 +243,11 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
 :where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-axis,currentColor);cursor:pointer}
 :where(.xy [data-fc-modebar-drag-handle]){cursor:move}
+:where(.xy [data-fc-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}
+:where(.xy [data-fc-modebar-menu-item]){width:100%;height:28px;justify-content:space-between;padding:0 9px;border-radius:4px;text-align:left;white-space:nowrap}
+:where(.xy [data-fc-modebar-menu-item]:hover,.xy [data-fc-modebar-menu-item]:focus-visible){background:var(--chart-modebar-active,rgba(128,128,128,.18));outline:none}
+:where(.xy [data-fc-modebar-menu-item][data-fc-separator]){margin-top:3px;border-top:1px solid rgba(128,128,128,.2);border-radius:0 0 4px 4px}
+:where(.xy [data-fc-modebar-menu-shortcut]){margin-left:20px;color:var(--chart-axis,currentColor);font-size:10px;opacity:.72}
 :where(.xy [data-fc-slot="modebar_button"].fc-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
 :where(.xy [data-fc-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-fc-slot="selection"][data-fc-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}
@@ -5608,13 +5613,17 @@ this._modeBtns = {};
 this._modebarCollapsed = false;
 this._modebarMoved = false;
 bar.dataset.fcCollapsed = "false";
+let setZoomMenuOpen = () => {};
 const setVisible = (visible) => {
 const show = visible || this._modebarDragging || bar.contains(document.activeElement);
 bar.style.opacity = show ? "1" : "0";
 bar.style.pointerEvents = show ? "auto" : "none";
 };
 this._listen(root, "pointerenter", () => setVisible(true));
-this._listen(root, "pointerleave", () => setVisible(false));
+this._listen(root, "pointerleave", () => {
+setVisible(false);
+setZoomMenuOpen(false);
+});
 this._listen(bar, "focusin", () => setVisible(true));
 this._listen(bar, "focusout", () => {
 if (!root.matches(":hover")) setVisible(false);
@@ -5637,6 +5646,7 @@ let lastGripDown = 0;
 const setCollapsed = (collapsed) => {
 this._modebarCollapsed = collapsed;
 bar.dataset.fcCollapsed = String(collapsed);
+if (collapsed) setZoomMenuOpen(false);
 for (const button of bar.querySelectorAll("button")) {
 if (button !== grip) {
 button.hidden = collapsed;
@@ -5679,6 +5689,7 @@ lastGripDown = 0;
 this._modebarDragging = true;
 this._modebarMoved = true;
 bar.style.transition = "none";
+setZoomMenuOpen(false);
 try { grip.setPointerCapture(e.pointerId); } catch (_err) {   }
 }
 const rootRect = root.getBoundingClientRect();
@@ -5725,13 +5736,110 @@ bar.appendChild(b);
 if (toggles) this._modeBtns[toggles] = b;
 return b;
 };
-mk("zoomin", "Zoom in", () => this._zoomBy(0.5, true));
-mk("zoomout", "Zoom out", () => this._zoomBy(2, true));
+const zoomTrigger = mk("zoommenu", "Zoom controls", () => {
+setZoomMenuOpen(!this._zoomMenuOpen);
+});
+this._zoomMenuButton = zoomTrigger;
+zoomTrigger.dataset.fcModebarMenuTrigger = "";
+zoomTrigger.setAttribute("aria-haspopup", "menu");
+zoomTrigger.setAttribute("aria-expanded", "false");
 mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
-mk("zoom", "Box zoom", () => this._setDragMode("zoom"), "zoom");
-mk("reset", "Reset view", () => {
+const zoomMenu = document.createElement("div");
+zoomMenu.dataset.fcModebarMenu = "";
+zoomMenu.setAttribute("role", "menu");
+zoomMenu.setAttribute("aria-label", "Zoom controls");
+zoomMenu.style.cssText =
+"position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
+bar.appendChild(zoomMenu);
+const zoomMenuItems = [];
+const mkZoomItem = (name, label, shortcut, onClick, toggles, separator = false) => {
+const button = document.createElement("button");
+button.type = "button";
+button.tabIndex = -1;
+button.dataset.fcModebarMenuItem = name;
+if (separator) button.dataset.fcSeparator = "";
+button.setAttribute("role", "menuitem");
+button.style.cssText =
+"display:flex;align-items:center;pointer-events:auto;";
+this._applySlot(button, "modebar_button");
+const text = document.createElement("span");
+text.textContent = label;
+button.appendChild(text);
+const hint = document.createElement("span");
+hint.dataset.fcModebarMenuShortcut = "";
+hint.textContent = shortcut;
+button.appendChild(hint);
+this._listen(button, "pointerdown", (e) => e.stopPropagation());
+this._listen(button, "click", (e) => {
+e.stopPropagation();
+setZoomMenuOpen(false, true);
+onClick();
+});
+zoomMenu.appendChild(button);
+zoomMenuItems.push(button);
+if (toggles) this._modeBtns[toggles] = button;
+return button;
+};
+const resetView = () => {
 this._clearSelection();
 this._setView(this.view0, { animate: true });
+};
+mkZoomItem("zoomin", "Zoom In", "+", () => this._zoomBy(0.5, true));
+mkZoomItem("zoomout", "Zoom Out", "−", () => this._zoomBy(2, true));
+mkZoomItem("zoom", "Box Zoom", "B", () => this._setDragMode("zoom"), "zoom");
+mkZoomItem("reset", "Reset View", "0", resetView, null, true);
+setZoomMenuOpen = (open, restoreFocus = false) => {
+const show = Boolean(open) && !this._modebarCollapsed;
+this._zoomMenuOpen = show;
+zoomTrigger.setAttribute("aria-expanded", String(show));
+if (!show) {
+zoomMenu.style.display = "none";
+if (restoreFocus) zoomTrigger.focus();
+return;
+}
+zoomMenu.style.display = "flex";
+zoomMenu.style.visibility = "hidden";
+const rootRect = root.getBoundingClientRect();
+const barRect = bar.getBoundingClientRect();
+const rootLeft = barRect.left - rootRect.left;
+const rootTop = barRect.top - rootRect.top;
+const below = bar.offsetHeight + 6;
+const above = -zoomMenu.offsetHeight - 6;
+const preferredTop = barRect.bottom + 6 + zoomMenu.offsetHeight <= rootRect.bottom
+? below
+: above;
+const maxLeft = root.clientWidth - rootLeft - zoomMenu.offsetWidth;
+const maxTop = root.clientHeight - rootTop - zoomMenu.offsetHeight;
+zoomMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, zoomTrigger.offsetLeft))}px`;
+zoomMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
+zoomMenu.style.visibility = "visible";
+};
+this._closeModebarMenu = () => setZoomMenuOpen(false);
+this._listen(document, "pointerdown", (e) => {
+if (this._zoomMenuOpen && !bar.contains(e.target)) setZoomMenuOpen(false);
+});
+this._listen(zoomTrigger, "keydown", (e) => {
+if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+e.preventDefault();
+e.stopPropagation();
+setZoomMenuOpen(true);
+const index = e.key === "ArrowDown" ? 0 : zoomMenuItems.length - 1;
+zoomMenuItems[index].focus();
+});
+this._listen(zoomMenu, "keydown", (e) => {
+if (e.key === "Escape") {
+e.preventDefault();
+e.stopPropagation();
+setZoomMenuOpen(false, true);
+return;
+}
+if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(e.key)) return;
+e.preventDefault();
+const current = zoomMenuItems.indexOf(document.activeElement);
+let next = e.key === "Home" ? 0 : e.key === "End" ? zoomMenuItems.length - 1 : current;
+if (e.key === "ArrowDown") next = (current + 1) % zoomMenuItems.length;
+if (e.key === "ArrowUp") next = (current - 1 + zoomMenuItems.length) % zoomMenuItems.length;
+zoomMenuItems[next].focus();
 });
 root.appendChild(bar);
 this._fitModebar();
@@ -5741,6 +5849,7 @@ this._setDragMode(this.dragMode);
 _fitModebar() {
 const bar = this._modebar;
 if (!bar) return;
+this._closeModebarMenu?.();
 if (!this._modebarMoved) {
 bar.style.top = `${this.plot.y + 4}px`;
 bar.style.left = `${this.plot.x + 4}px`;
@@ -5760,6 +5869,7 @@ if (this.canvas) this.canvas.dataset.fcDragmode = mode;
 for (const [name, btn] of Object.entries(this._modeBtns || {})) {
 btn.classList.toggle("fc-active", name === mode);
 }
+this._zoomMenuButton?.classList.toggle("fc-active", mode === "zoom");
 },
 _prefersReducedMotion() {
 return window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches === true;
@@ -5924,6 +6034,9 @@ return svg('<path d="M10 3 V17 M3 10 H17"/><path d="M10 3 L8 5 M10 3 L12 5"/>' +
 case "zoom":
 return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
 'stroke-dasharray="3 2"/>');
+case "zoommenu":
+return svg('<circle cx="8" cy="8" r="4.5"/><path d="M11.5 11.5 L15 15"/>' +
+'<path d="M16 7 L18 9 L16 11"/>');
 case "reset":
 return svg('<path d="M4 10 a6 6 0 1 1 1.8 4.3"/><path d="M4 6 V10 H8"/>');
 case "drag":

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -254,7 +254,6 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-modebar-menu-item][data-fc-separator]){margin-top:3px;border-top:1px solid rgba(128,128,128,.2);border-radius:0 0 4px 4px}
 :where(.xy [data-fc-modebar-menu-icon]){display:flex;width:16px;margin-right:7px}
 :where(.xy [data-fc-modebar-menu-icon] svg){width:14px;height:14px}
-:where(.xy [data-fc-modebar-menu-shortcut]){margin-left:auto;padding-left:20px;color:var(--chart-axis,currentColor);font-size:10px;opacity:.72}
 :where(.xy [data-fc-slot="modebar_button"].fc-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
 :where(.xy [data-fc-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-fc-slot="selection"][data-fc-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}
@@ -5407,7 +5406,8 @@ this.root.appendChild(this.selLasso);
 this._lassoPolygon = null;
 let lassoHandleDrag = null;
 const moveLassoHandle = (e) => {
-if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId) return;
+if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId
+|| !this._lassoPolygon) return;
 const rect = c.getBoundingClientRect();
 const cssX = Math.max(0, Math.min(rect.width, e.clientX - rect.left));
 const cssY = Math.max(0, Math.min(rect.height, e.clientY - rect.top));
@@ -5440,14 +5440,16 @@ moveLassoHandle(e);
 const handle = lassoHandleDrag.handle;
 lassoHandleDrag = null;
 delete handle.dataset.fcActive;
-this._sendSelectPolygon(this._lassoPolygon);
+if (this._lassoPolygon) this._sendSelectPolygon(this._lassoPolygon);
 });
 this._listen(this.selLasso, "pointercancel", (e) => {
 if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId) return;
+if (this._lassoPolygon) {
 this._lassoPolygon[lassoHandleDrag.index] = lassoHandleDrag.original;
+}
 delete lassoHandleDrag.handle.dataset.fcActive;
 lassoHandleDrag = null;
-this._renderLassoSelection();
+if (this._lassoPolygon) this._renderLassoSelection();
 e.stopPropagation();
 });
 if (this._interactionFlag("crosshair")) {
@@ -5536,9 +5538,14 @@ const d1 = dataAt(e.clientX, e.clientY);
 const moved = Math.abs(e.clientX - band.sx) > 3 || Math.abs(e.clientY - band.sy) > 3;
 if (moved) {
 if (band.mode === "zoom") this._zoomToBox(band.d0, d1, true);
-else if (band.mode === "select-lasso" && band.points.length >= 3) {
+else if (band.mode === "select-lasso") {
+if (band.points.length >= 3) {
 const editable = this._simplifyLassoPoints(band.points);
 this._sendSelectPolygon(editable.map((point) => point.data));
+} else if (band.previousLasso) {
+this._lassoPolygon = band.previousLasso;
+this._renderLassoSelection();
+}
 } else {
 let d0 = band.d0;
 if (band.mode === "select-x") {
@@ -5714,11 +5721,12 @@ const t = Math.max(0, Math.min(1,
 const x = start.x + t * dx, y = start.y + t * dy;
 return (point.x - x) ** 2 + (point.y - y) ** 2;
 };
+const simplifyAt = (currentTolerance) => {
 const keep = new Uint8Array(source.length);
 keep[0] = 1;
 keep[source.length - 1] = 1;
 const stack = [[0, source.length - 1]];
-const toleranceSq = tolerance * tolerance;
+const toleranceSq = currentTolerance * currentTolerance;
 while (stack.length) {
 const [start, end] = stack.pop();
 let furthest = -1, furthestDistance = toleranceSq;
@@ -5734,14 +5742,32 @@ keep[furthest] = 1;
 stack.push([start, furthest], [furthest, end]);
 }
 }
-let simplified = source.filter((_point, index) => keep[index]);
+return source.filter((_point, index) => keep[index]);
+};
+let simplified = simplifyAt(tolerance);
 if (simplified.length < 3) {
 simplified = [source[0], source[Math.floor(source.length / 2)], source[source.length - 1]];
 }
 if (simplified.length > maxPoints) {
-simplified = Array.from({ length: maxPoints }, (_value, index) => (
-simplified[Math.round(index * (simplified.length - 1) / (maxPoints - 1))]
-));
+let low = tolerance;
+let high = Math.max(tolerance, 1);
+for (let i = 0; i < 16 && simplified.length > maxPoints; i++) {
+low = high;
+high *= 2;
+simplified = simplifyAt(high);
+}
+for (let i = 0; i < 12; i++) {
+const middle = (low + high) / 2;
+const candidate = simplifyAt(middle);
+if (candidate.length > maxPoints) low = middle;
+else {
+high = middle;
+simplified = candidate;
+}
+}
+if (simplified.length < 3) {
+simplified = [source[0], source[Math.floor(source.length / 2)], source[source.length - 1]];
+}
 }
 return simplified;
 },
@@ -5825,6 +5851,10 @@ this._selectLocalPolygon(polygon);
 }
 },
 _selectLocalPolygon(points) {
+const xs = points.map((point) => point[0]);
+const ys = points.map((point) => point[1]);
+const minX = Math.min(...xs), maxX = Math.max(...xs);
+const minY = Math.min(...ys), maxY = Math.max(...ys);
 const inside = (x, y) => {
 let hit = false;
 for (let i = 0, j = points.length - 1; i < points.length; j = i++) {
@@ -5844,7 +5874,12 @@ const oy = yMeta.offset, sy = yMeta.scale || 1;
 const mask = new Float32Array(g.n);
 let count = 0;
 for (let i = 0; i < g.n; i++) {
-if (inside(cx[i] / sx + ox, cy[i] / sy + oy)) { mask[i] = 1; count++; }
+const x = cx[i] / sx + ox;
+const y = cy[i] / sy + oy;
+if (x >= minX && x <= maxX && y >= minY && y <= maxY && inside(x, y)) {
+mask[i] = 1;
+count++;
+}
 }
 this._applySelMask(g, mask);
 total += count;
@@ -5938,8 +5973,8 @@ setSelectMenuOpen(false);
 setExportMenuOpen(false);
 });
 this._listen(bar, "focusin", () => setVisible(true));
-this._listen(bar, "focusout", () => {
-if (!root.matches(":hover")) setVisible(false);
+this._listen(bar, "focusout", (e) => {
+if (!bar.contains(e.relatedTarget) && !root.matches(":hover")) setVisible(false);
 });
 const grip = document.createElement("button");
 grip.type = "button";
@@ -5970,6 +6005,7 @@ dx: e.clientX - barRect.left,
 dy: e.clientY - barRect.top,
 moved: false,
 };
+try { grip.setPointerCapture(e.pointerId); } catch (_err) {   }
 setVisible(true);
 });
 this._listen(grip, "pointermove", (e) => {
@@ -5984,7 +6020,6 @@ bar.style.transition = "none";
 setZoomMenuOpen(false);
 setSelectMenuOpen(false);
 setExportMenuOpen(false);
-try { grip.setPointerCapture(e.pointerId); } catch (_err) {   }
 }
 const rootRect = root.getBoundingClientRect();
 const left = e.clientX - rootRect.left - modebarDrag.dx;
@@ -6072,7 +6107,7 @@ zoomMenu.style.cssText =
 "position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
 bar.appendChild(zoomMenu);
 const zoomMenuItems = [];
-const mkZoomItem = (name, label, shortcut, onClick, toggles, separator = false) => {
+const mkZoomItem = (name, label, onClick, toggles, separator = false) => {
 const button = document.createElement("button");
 button.type = "button";
 button.tabIndex = -1;
@@ -6089,10 +6124,6 @@ button.appendChild(icon);
 const text = document.createElement("span");
 text.textContent = label;
 button.appendChild(text);
-const hint = document.createElement("span");
-hint.dataset.fcModebarMenuShortcut = "";
-hint.textContent = shortcut;
-button.appendChild(hint);
 this._listen(button, "pointerdown", (e) => e.stopPropagation());
 this._listen(button, "click", (e) => {
 e.stopPropagation();
@@ -6108,10 +6139,10 @@ const resetView = () => {
 this._clearSelection();
 this._setView(this.view0, { animate: true });
 };
-mkZoomItem("zoomin", "Zoom In", "+", () => this._zoomBy(0.5, true));
-mkZoomItem("zoomout", "Zoom Out", "−", () => this._zoomBy(2, true));
-mkZoomItem("zoom", "Box Zoom", "B", () => this._setDragMode("zoom"), "zoom");
-mkZoomItem("reset", "Reset View", "0", resetView, null, true);
+mkZoomItem("zoomin", "Zoom In", () => this._zoomBy(0.5, true));
+mkZoomItem("zoomout", "Zoom Out", () => this._zoomBy(2, true));
+mkZoomItem("zoom", "Box Zoom", () => this._setDragMode("zoom"), "zoom");
+mkZoomItem("reset", "Reset View", resetView, null, true);
 const selectMenu = document.createElement("div");
 selectMenu.dataset.fcModebarMenu = "";
 selectMenu.dataset.fcModebarSelectMenu = "";
@@ -6121,7 +6152,7 @@ selectMenu.style.cssText =
 "position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
 bar.appendChild(selectMenu);
 const selectMenuItems = [];
-const mkSelectItem = (name, label, shortcut, mode) => {
+const mkSelectItem = (name, label, mode) => {
 const button = document.createElement("button");
 button.type = "button";
 button.tabIndex = -1;
@@ -6137,10 +6168,6 @@ button.appendChild(icon);
 const text = document.createElement("span");
 text.textContent = label;
 button.appendChild(text);
-const hint = document.createElement("span");
-hint.dataset.fcModebarMenuShortcut = "";
-hint.textContent = shortcut;
-button.appendChild(hint);
 this._listen(button, "pointerdown", (e) => e.stopPropagation());
 this._listen(button, "click", (e) => {
 e.stopPropagation();
@@ -6152,10 +6179,10 @@ selectMenuItems.push(button);
 this._modeBtns[mode] = button;
 };
 if (canSelect) {
-mkSelectItem("select", "Box Select", "B", "select");
-mkSelectItem("lasso", "Lasso Select", "L", "select-lasso");
-mkSelectItem("selectx", "X Range", "X", "select-x");
-mkSelectItem("selecty", "Y Range", "Y", "select-y");
+mkSelectItem("select", "Box Select", "select");
+mkSelectItem("lasso", "Lasso Select", "select-lasso");
+mkSelectItem("selectx", "X Range", "select-x");
+mkSelectItem("selecty", "Y Range", "select-y");
 }
 const exportMenu = document.createElement("div");
 exportMenu.dataset.fcModebarMenu = "";
@@ -6425,6 +6452,8 @@ const percent = axisPercent("x", this.view.x0, this.view.x1, this.view0.x0, this
 const rounded = Math.round(percent);
 const exactText = percent < 1 ? "<1%" : `${rounded}%`;
 const displayText = rounded > 999 ? `${String(rounded).slice(0, 3)}…%` : exactText;
+if (this._zoomMenuLabel.dataset.fcZoomExact === exactText
+&& this._zoomMenuLabel.textContent === displayText) return;
 this._zoomMenuLabel.textContent = displayText;
 this._zoomMenuLabel.dataset.fcZoomExact = exactText;
 this._zoomMenuButton.title = `Zoom controls (${exactText})`;
@@ -6603,6 +6632,29 @@ clone.style.width = `${width}px`;
 clone.style.height = `${height}px`;
 clone.style.margin = "0";
 clone.setAttribute("xmlns", "http://www.w3.org/1999/xhtml");
+const computed = getComputedStyle(this.root);
+const inheritedProperties = [
+"color", "font-family", "font-size", "font-style", "font-weight",
+"letter-spacing", "line-height",
+];
+const chartTokens = [
+"--chart-bg", "--chart-text", "--chart-grid", "--chart-axis",
+"--chart-tooltip-bg", "--chart-tooltip-text", "--chart-legend-bg",
+"--chart-badge-bg", "--chart-badge-text", "--chart-modebar-bg",
+"--chart-modebar-active", "--chart-selection", "--chart-selection-fill",
+"--chart-zoom-selection", "--chart-zoom-selection-fill", "--chart-crosshair",
+"--chart-annotation-text", "--chart-cursor", "--chart-cursor-pan",
+];
+for (let i = 0; i < computed.length; i++) {
+const property = computed.item(i);
+if (!property.startsWith("--")) continue;
+const value = computed.getPropertyValue(property).trim();
+if (value) clone.style.setProperty(property, value);
+}
+for (const property of [...inheritedProperties, ...chartTokens]) {
+const value = computed.getPropertyValue(property).trim();
+if (value) clone.style.setProperty(property, value);
+}
 const sourceCanvases = [...this.root.querySelectorAll("canvas")];
 const clonedCanvases = [...clone.querySelectorAll("canvas")];
 for (let i = 0; i < clonedCanvases.length; i++) {

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -241,7 +241,8 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="badge"]){gap:3px;font-size:11px;line-height:1.2}
 :where(.xy [data-fc-slot="badge_item"]){padding:3px 6px;border-radius:4px;color:var(--chart-badge-text,#0f172a);background:var(--chart-badge-bg,rgba(255,255,255,.82));box-shadow:0 1px 4px rgba(15,23,42,.14)}
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
-:where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
+:where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-axis,currentColor);cursor:pointer}
+:where(.xy [data-fc-modebar-drag-handle]){cursor:move}
 :where(.xy [data-fc-slot="modebar_button"].fc-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
 :where(.xy [data-fc-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-fc-slot="selection"][data-fc-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}
@@ -5118,29 +5119,12 @@ d.textContent = text;
 const dx = Number.isFinite(Number(ann.dx)) ? Number(ann.dx) : 0;
 const dy = Number.isFinite(Number(ann.dy)) ? Number(ann.dy) : 0;
 const anchor = ann.anchor === "middle" ? "-50%" : ann.anchor === "end" ? "-100%" : "0";
-const rot = Number.isFinite(Number(style.rotation))
-? ((Number(style.rotation) % 360) + 360) % 360
-: 0;
-const va = String(style.vertical_align || "");
+const va = style.vertical_align;
 const vAnchor =
 va === "center" || va === "middle" ? "-50%" : va === "bottom" ? "-100%" : "0";
-let transform = `translate(${anchor},${vAnchor})`;
-if (rot === 90 || rot === 270) {
-const cw = rot === 270;
-const along =
-va === "center" || va === "middle" ? "-50%"
-: va === "top" ? (cw ? "0" : "-100%")
-: va === "bottom" ? (cw ? "-100%" : "0")
-: cw ? "0" : "-100%";
-const cross =
-ann.anchor === "middle" ? "-50%" : ann.anchor === "end" ? (cw ? "0" : "-100%") : cw ? "-100%" : "0";
-transform = `rotate(${cw ? 90 : -90}deg) translate(${along},${cross})`;
-} else if (rot) {
-transform = `rotate(${-rot}deg) translate(${anchor},${vAnchor})`;
-}
 d.style.cssText =
 `position:absolute;left:${px + dx}px;top:${py + dy}px;` +
-`transform:${transform};transform-origin:0 0;pointer-events:none;` +
+`transform:translate(${anchor},${vAnchor});pointer-events:none;` +
 `white-space:pre-line;text-align:center;width:max-content;`;
 this._applySlot(d, "annotation_label");
 this._applyClass(d, ann.class_name);
@@ -5602,17 +5586,131 @@ if (this.comm) this.comm.send({ type: "select_clear" });
 this._dispatchChartEvent("select", { total: 0, view: this._eventView("select_clear") });
 }
 },
+_clampModebar(left, top) {
+const bar = this._modebar;
+if (!bar || !this.root) return;
+const currentLeft = left ?? (Number.parseFloat(bar.style.left) || 0);
+const currentTop = top ?? (Number.parseFloat(bar.style.top) || 0);
+const maxLeft = Math.max(0, this.root.clientWidth - bar.offsetWidth);
+const maxTop = Math.max(0, this.root.clientHeight - bar.offsetHeight);
+bar.style.left = `${Math.max(0, Math.min(maxLeft, currentLeft))}px`;
+bar.style.top = `${Math.max(0, Math.min(maxTop, currentTop))}px`;
+},
 _buildModebar(root) {
 if (this.spec.show_modebar === false) return;
 const bar = document.createElement("div");
 bar.style.cssText =
 `position:absolute;top:${this.plot.y + 4}px;left:${this.plot.x + 4}px;z-index:6;` +
-"display:flex;opacity:.72;transition:opacity .15s;";
+"display:flex;opacity:0;pointer-events:none;transition:opacity .15s;";
 this._applySlot(bar, "modebar");
-this._listen(root, "pointerenter", () => { bar.style.opacity = "1"; });
-this._listen(root, "pointerleave", () => { bar.style.opacity = ".72"; });
 this._modebar = bar;
 this._modeBtns = {};
+this._modebarCollapsed = false;
+this._modebarMoved = false;
+bar.dataset.fcCollapsed = "false";
+const setVisible = (visible) => {
+const show = visible || this._modebarDragging || bar.contains(document.activeElement);
+bar.style.opacity = show ? "1" : "0";
+bar.style.pointerEvents = show ? "auto" : "none";
+};
+this._listen(root, "pointerenter", () => setVisible(true));
+this._listen(root, "pointerleave", () => setVisible(false));
+this._listen(bar, "focusin", () => setVisible(true));
+this._listen(bar, "focusout", () => {
+if (!root.matches(":hover")) setVisible(false);
+});
+const grip = document.createElement("button");
+grip.type = "button";
+grip.title = "Double-click to collapse; drag to move";
+grip.setAttribute("aria-label", "Collapse toolbar");
+grip.setAttribute("aria-expanded", "true");
+grip.dataset.fcModebarDragHandle = "";
+grip.innerHTML = this._icon("drag");
+grip.style.cssText =
+"display:flex;align-items:center;justify-content:center;pointer-events:auto;touch-action:none;";
+this._applySlot(grip, "modebar_button");
+bar.appendChild(grip);
+const DOUBLE_CLICK_MS = 500;
+const DRAG_THRESHOLD_PX = 6;
+let modebarDrag = null;
+let lastGripDown = 0;
+const setCollapsed = (collapsed) => {
+this._modebarCollapsed = collapsed;
+bar.dataset.fcCollapsed = String(collapsed);
+for (const button of bar.querySelectorAll("button")) {
+if (button !== grip) {
+button.hidden = collapsed;
+button.style.display = collapsed ? "none" : "flex";
+}
+}
+grip.title = collapsed
+? "Double-click to expand; drag to move"
+: "Double-click to collapse; drag to move";
+grip.setAttribute("aria-label", collapsed ? "Expand toolbar" : "Collapse toolbar");
+grip.setAttribute("aria-expanded", String(!collapsed));
+this._fitModebar();
+};
+const toggleModebar = () => setCollapsed(!this._modebarCollapsed);
+this._listen(grip, "pointerdown", (e) => {
+if (e.pointerType === "mouse" && e.button !== 0) return;
+e.stopPropagation();
+const now = e.timeStamp || performance.now();
+const doubleClick = lastGripDown > 0 && now - lastGripDown <= DOUBLE_CLICK_MS;
+lastGripDown = doubleClick ? 0 : now;
+const barRect = bar.getBoundingClientRect();
+modebarDrag = {
+pointerId: e.pointerId,
+startX: e.clientX,
+startY: e.clientY,
+dx: e.clientX - barRect.left,
+dy: e.clientY - barRect.top,
+moved: false,
+};
+setVisible(true);
+if (doubleClick) toggleModebar();
+});
+this._listen(grip, "pointermove", (e) => {
+if (!modebarDrag || e.pointerId !== modebarDrag.pointerId) return;
+const distance = Math.hypot(e.clientX - modebarDrag.startX, e.clientY - modebarDrag.startY);
+if (!modebarDrag.moved) {
+if (distance < DRAG_THRESHOLD_PX) return;
+modebarDrag.moved = true;
+lastGripDown = 0;
+this._modebarDragging = true;
+this._modebarMoved = true;
+bar.style.transition = "none";
+try { grip.setPointerCapture(e.pointerId); } catch (_err) {   }
+}
+const rootRect = root.getBoundingClientRect();
+const left = e.clientX - rootRect.left - modebarDrag.dx;
+const top = e.clientY - rootRect.top - modebarDrag.dy;
+this._clampModebar(left, top);
+});
+const endModebarDrag = (e) => {
+if (!modebarDrag || e.pointerId !== modebarDrag.pointerId) return;
+const moved = modebarDrag.moved;
+const cancelled = e.type === "pointercancel";
+modebarDrag = null;
+this._modebarDragging = false;
+bar.style.transition = "opacity .15s";
+setVisible(root.matches(":hover"));
+if (moved || cancelled) {
+lastGripDown = 0;
+}
+};
+this._listen(grip, "pointerup", endModebarDrag);
+this._listen(grip, "pointercancel", endModebarDrag);
+this._listen(grip, "click", (e) => e.stopPropagation());
+this._listen(grip, "dblclick", (e) => {
+e.preventDefault();
+e.stopPropagation();
+});
+this._listen(grip, "keydown", (e) => {
+if (e.repeat || (e.key !== "Enter" && e.key !== " ")) return;
+e.preventDefault();
+e.stopPropagation();
+toggleModebar();
+});
 const mk = (name, title, onClick, toggles) => {
 const b = document.createElement("button");
 b.type = "button";
@@ -5637,17 +5735,24 @@ this._setView(this.view0, { animate: true });
 });
 root.appendChild(bar);
 this._fitModebar();
+setVisible(root.matches(":hover"));
 this._setDragMode(this.dragMode);
 },
 _fitModebar() {
 const bar = this._modebar;
 if (!bar) return;
+if (!this._modebarMoved) {
 bar.style.top = `${this.plot.y + 4}px`;
 bar.style.left = `${this.plot.x + 4}px`;
+}
 bar.style.display = "flex";
 const fits =
 bar.offsetWidth + 8 <= this.plot.w && bar.offsetHeight + 8 <= this.plot.h;
-if (!fits) bar.style.display = "none";
+if (!fits) {
+bar.style.display = "none";
+return;
+}
+this._clampModebar();
 },
 _setDragMode(mode) {
 this.dragMode = mode;
@@ -5821,6 +5926,13 @@ return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
 'stroke-dasharray="3 2"/>');
 case "reset":
 return svg('<path d="M4 10 a6 6 0 1 1 1.8 4.3"/><path d="M4 6 V10 H8"/>');
+case "drag":
+return svg('<circle cx="7" cy="5" r=".8" fill="currentColor" stroke="none"/>' +
+'<circle cx="13" cy="5" r=".8" fill="currentColor" stroke="none"/>' +
+'<circle cx="7" cy="10" r=".8" fill="currentColor" stroke="none"/>' +
+'<circle cx="13" cy="10" r=".8" fill="currentColor" stroke="none"/>' +
+'<circle cx="7" cy="15" r=".8" fill="currentColor" stroke="none"/>' +
+'<circle cx="13" cy="15" r=".8" fill="currentColor" stroke="none"/>');
 default:
 return svg("");
 }

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -5898,7 +5898,6 @@ zoomTrigger.appendChild(zoomIndicator);
 this._zoomMenuLabel = zoomPercent;
 zoomTrigger.setAttribute("aria-haspopup", "menu");
 zoomTrigger.setAttribute("aria-expanded", "false");
-mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
 const canSelect = this._pickable
 && this._interactionFlag("brush", true)
 && this._interactionFlag("select", true);
@@ -5918,6 +5917,7 @@ selectIndicator.innerHTML = this._icon("chevrondown");
 selectTrigger.appendChild(selectIndicator);
 this._selectMenuButton = selectTrigger;
 }
+mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
 const zoomMenu = document.createElement("div");
 zoomMenu.dataset.fcModebarMenu = "";
 zoomMenu.setAttribute("role", "menu");

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -241,13 +241,13 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="badge"]){gap:3px;font-size:11px;line-height:1.2}
 :where(.xy [data-fc-slot="badge_item"]){padding:3px 6px;border-radius:4px;color:var(--chart-badge-text,#0f172a);background:var(--chart-badge-bg,rgba(255,255,255,.82));box-shadow:0 1px 4px rgba(15,23,42,.14)}
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
-:where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
-:where(.xy [data-fc-modebar-drag-handle]){position:relative;margin-right:3px;cursor:move}
-:where(.xy [data-fc-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-2px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
+:where(.xy [data-fc-slot="modebar_button"]){width:24px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
+:where(.xy [data-fc-modebar-drag-handle]){position:relative;width:22px;margin-right:2px;cursor:move}
+:where(.xy [data-fc-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-1px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
 :where(.xy [data-fc-slot="modebar"][data-fc-collapsed="true"]>[data-fc-modebar-drag-handle]){margin-right:0}
 :where(.xy [data-fc-slot="modebar"][data-fc-collapsed="true"]>[data-fc-modebar-drag-handle])::after{display:none}
-:where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:58px;gap:2px;padding:0 6px;font-size:11px;font-variant-numeric:tabular-nums}
-:where(.xy [data-fc-modebar-select-trigger]){width:auto;min-width:35px;gap:0;padding:0 4px}
+:where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:52px;gap:1px;padding:0 4px;font-size:11px;font-variant-numeric:tabular-nums}
+:where(.xy [data-fc-modebar-select-trigger]){width:auto;min-width:30px;gap:0;padding:0 2px}
 :where(.xy [data-fc-modebar-menu-indicator]){display:flex;transition:transform .15s}
 :where(.xy [data-fc-modebar-menu-indicator] svg){width:11px;height:11px}
 :where(.xy [data-fc-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -5389,7 +5389,7 @@ return this._dataFromCanvas(clientX - r.left, clientY - r.top);
 this._listen(c, "pointerdown", (e) => {
 this._cancelViewAnimation();
 const canBrush = this._interactionFlag("brush", true) && this._interactionFlag("select", true);
-const mode = e.shiftKey && canBrush && this._pickable ? "select"
+const mode = (e.shiftKey || this.dragMode === "select") && canBrush && this._pickable ? "select"
 : this.dragMode === "zoom" ? "zoom" : null;
 if (mode) {
 band = { mode, sx: e.clientX, sy: e.clientY, d0: dataAt(e.clientX, e.clientY) };
@@ -5760,6 +5760,15 @@ this._zoomMenuLabel = zoomPercent;
 zoomTrigger.setAttribute("aria-haspopup", "menu");
 zoomTrigger.setAttribute("aria-expanded", "false");
 mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
+const canSelect = this._pickable
+&& this._interactionFlag("brush", true)
+&& this._interactionFlag("select", true);
+if (canSelect) {
+const selectButton = mk(
+"select", "Select points", () => this._setDragMode("select"), "select"
+);
+selectButton.dataset.fcModebarSelect = "";
+}
 const zoomMenu = document.createElement("div");
 zoomMenu.dataset.fcModebarMenu = "";
 zoomMenu.setAttribute("role", "menu");
@@ -6076,6 +6085,11 @@ return svg('<path d="M10 3 V17 M3 10 H17"/><path d="M10 3 L8 5 M10 3 L12 5"/>' +
 case "zoom":
 return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
 'stroke-dasharray="3 2"/>');
+case "select":
+return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
+'stroke-dasharray="2.5 2"/><circle cx="7" cy="7" r="1" fill="currentColor" ' +
+'stroke="none"/><circle cx="12.5" cy="9" r="1" fill="currentColor" stroke="none"/>' +
+'<circle cx="9.5" cy="13" r="1" fill="currentColor" stroke="none"/>');
 case "chevrondown":
 return svg('<path d="M6 8 L10 12 L14 8"/>');
 case "reset":

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -243,6 +243,9 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
 :where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-axis,currentColor);cursor:pointer}
 :where(.xy [data-fc-modebar-drag-handle]){cursor:move}
+:where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:58px;gap:2px;padding:0 6px;font-size:11px;font-variant-numeric:tabular-nums}
+:where(.xy [data-fc-modebar-menu-indicator]){display:flex;transition:transform .15s}
+:where(.xy [data-fc-modebar-menu-indicator] svg){width:11px;height:11px}
 :where(.xy [data-fc-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}
 :where(.xy [data-fc-modebar-menu-item]){width:100%;height:28px;justify-content:flex-start;padding:0 9px;border-radius:4px;text-align:left;white-space:nowrap}
 :where(.xy [data-fc-modebar-menu-item]:hover,.xy [data-fc-modebar-menu-item]:focus-visible){background:var(--chart-modebar-active,rgba(128,128,128,.18));outline:none}
@@ -3372,6 +3375,7 @@ gl.uniform1i(u(`${prefix}mode`), this._axisMode(axisId));
 }
 draw(keepPick = false) {
 if (this._destroyed || this._glLost || !this.gl) return;
+this._updateZoomMenuLabel?.();
 if (this._raf) {
 this._rafKeepPick = this._rafKeepPick && keepPick;
 return;
@@ -5743,6 +5747,16 @@ setZoomMenuOpen(!this._zoomMenuOpen);
 });
 this._zoomMenuButton = zoomTrigger;
 zoomTrigger.dataset.fcModebarMenuTrigger = "";
+zoomTrigger.replaceChildren();
+const zoomPercent = document.createElement("span");
+zoomPercent.dataset.fcModebarZoomPercent = "";
+zoomPercent.textContent = "100%";
+zoomTrigger.appendChild(zoomPercent);
+const zoomIndicator = document.createElement("span");
+zoomIndicator.dataset.fcModebarMenuIndicator = "";
+zoomIndicator.innerHTML = this._icon("chevrondown");
+zoomTrigger.appendChild(zoomIndicator);
+this._zoomMenuLabel = zoomPercent;
 zoomTrigger.setAttribute("aria-haspopup", "menu");
 zoomTrigger.setAttribute("aria-expanded", "false");
 mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
@@ -5800,6 +5814,7 @@ this._zoomMenuOpen = show;
 zoomTrigger.setAttribute("aria-expanded", String(show));
 if (!show) {
 zoomMenu.style.display = "none";
+zoomIndicator.style.transform = "none";
 if (restoreFocus) zoomTrigger.focus();
 return;
 }
@@ -5814,6 +5829,7 @@ const above = -zoomMenu.offsetHeight - 6;
 const preferredTop = barRect.bottom + 6 + zoomMenu.offsetHeight <= rootRect.bottom
 ? below
 : above;
+zoomIndicator.style.transform = preferredTop === above ? "rotate(180deg)" : "none";
 const maxLeft = root.clientWidth - rootLeft - zoomMenu.offsetWidth;
 const maxTop = root.clientHeight - rootTop - zoomMenu.offsetHeight;
 zoomMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, zoomTrigger.offsetLeft))}px`;
@@ -5876,6 +5892,26 @@ for (const [name, btn] of Object.entries(this._modeBtns || {})) {
 btn.classList.toggle("fc-active", name === mode);
 }
 this._zoomMenuButton?.classList.toggle("fc-active", mode === "zoom");
+},
+_updateZoomMenuLabel() {
+if (!this._zoomMenuLabel || !this.view || !this.view0) return;
+const axisPercent = (axisId, lo, hi, homeLo, homeHi) => {
+const axis = this._axis(axisId);
+const span = Math.abs(this._axisCoord(axis, hi) - this._axisCoord(axis, lo));
+const homeSpan = Math.abs(
+this._axisCoord(axis, homeHi) - this._axisCoord(axis, homeLo)
+);
+return Number.isFinite(span) && span > 0 && Number.isFinite(homeSpan) && homeSpan > 0
+? (homeSpan / span) * 100
+: null;
+};
+const percent = axisPercent("x", this.view.x0, this.view.x1, this.view0.x0, this.view0.x1)
+?? axisPercent("y", this.view.y0, this.view.y1, this.view0.y0, this.view0.y1)
+?? 100;
+const text = percent < 1 ? "<1%" : `${Math.round(percent)}%`;
+this._zoomMenuLabel.textContent = text;
+this._zoomMenuButton.title = `Zoom controls (${text})`;
+this._zoomMenuButton.setAttribute("aria-label", `Zoom controls, ${text}`);
 },
 _prefersReducedMotion() {
 return window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches === true;
@@ -6040,9 +6076,8 @@ return svg('<path d="M10 3 V17 M3 10 H17"/><path d="M10 3 L8 5 M10 3 L12 5"/>' +
 case "zoom":
 return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
 'stroke-dasharray="3 2"/>');
-case "zoommenu":
-return svg('<circle cx="8" cy="8" r="4.5"/><path d="M11.5 11.5 L15 15"/>' +
-'<path d="M16 7 L18 9 L16 11"/>');
+case "chevrondown":
+return svg('<path d="M6 8 L10 12 L14 8"/>');
 case "reset":
 return svg('<path d="M4 10 a6 6 0 1 1 1.8 4.3"/><path d="M4 6 V10 H8"/>');
 case "drag":

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -258,7 +258,9 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar_button"].fc-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
 :where(.xy [data-fc-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-fc-slot="selection"][data-fc-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}
-:where(.xy [data-fc-selection-lasso]){fill:var(--chart-selection-fill,rgba(90,140,240,.15));stroke:var(--chart-selection,rgba(90,140,240,.9));stroke-width:1.5;stroke-linejoin:round}
+:where(.xy [data-fc-selection-lasso]){fill:var(--chart-selection-fill,rgba(90,140,240,.15));stroke:var(--chart-selection,rgba(90,140,240,.9));stroke-width:1.5;stroke-linejoin:round;pointer-events:none}
+:where(.xy [data-fc-selection-lasso-handle]){fill:var(--chart-bg,#fff);stroke:var(--chart-selection,rgba(90,140,240,.9));stroke-width:1.5;cursor:grab;pointer-events:all}
+:where(.xy [data-fc-selection-lasso-handle][data-fc-active]){cursor:grabbing;fill:var(--chart-selection,rgba(90,140,240,.9))}
 :where(.xy [data-fc-slot="crosshair_x"],.xy [data-fc-slot="crosshair_y"]){background:var(--chart-crosshair,rgba(15,23,42,.42))}
 :where(.xy [data-fc-slot="tick_label"]){color:var(--chart-text,inherit)}
 :where(.xy [data-fc-slot="axis_title"]){color:var(--chart-text,inherit);font-size:12px}
@@ -3411,6 +3413,7 @@ this._drawHoverState();
 if (!this._rafKeepPick) this._pickDirty = true;
 this._rafKeepPick = false;
 this._drawChrome();
+this._renderLassoSelection?.();
 }
 _now() {
 return performance.now();
@@ -5393,10 +5396,60 @@ this.root.appendChild(this.selRect);
 this.selLasso = document.createElementNS("http://www.w3.org/2000/svg", "svg");
 this.selLasso.style.cssText =
 "position:absolute;display:none;pointer-events:none;z-index:4;overflow:visible;";
+this.selLasso.dataset.fcSelectionLassoOverlay = "";
 this.selLassoPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
 this.selLassoPath.dataset.fcSelectionLasso = "";
 this.selLasso.appendChild(this.selLassoPath);
+this.selLassoHandles = document.createElementNS("http://www.w3.org/2000/svg", "g");
+this.selLassoHandles.dataset.fcSelectionLassoHandles = "";
+this.selLasso.appendChild(this.selLassoHandles);
 this.root.appendChild(this.selLasso);
+this._lassoPolygon = null;
+let lassoHandleDrag = null;
+const moveLassoHandle = (e) => {
+if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId) return;
+const rect = c.getBoundingClientRect();
+const cssX = Math.max(0, Math.min(rect.width, e.clientX - rect.left));
+const cssY = Math.max(0, Math.min(rect.height, e.clientY - rect.top));
+this._lassoPolygon[lassoHandleDrag.index] = this._dataFromCanvas(cssX, cssY);
+this._renderLassoSelection();
+e.preventDefault();
+e.stopPropagation();
+};
+this._listen(this.selLasso, "pointerdown", (e) => {
+const handle = e.target.closest?.("[data-fc-selection-lasso-handle]");
+if (!handle || !this._lassoPolygon) return;
+const index = Number(handle.dataset.fcSelectionLassoHandle);
+if (!Number.isInteger(index) || !this._lassoPolygon[index]) return;
+lassoHandleDrag = {
+index,
+pointerId: e.pointerId,
+original: [...this._lassoPolygon[index]],
+handle,
+};
+handle.dataset.fcActive = "";
+this.tooltip.style.display = "none";
+try { this.selLasso.setPointerCapture(e.pointerId); } catch (_err) {   }
+e.preventDefault();
+e.stopPropagation();
+});
+this._listen(this.selLasso, "pointermove", moveLassoHandle);
+this._listen(this.selLasso, "pointerup", (e) => {
+if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId) return;
+moveLassoHandle(e);
+const handle = lassoHandleDrag.handle;
+lassoHandleDrag = null;
+delete handle.dataset.fcActive;
+this._sendSelectPolygon(this._lassoPolygon);
+});
+this._listen(this.selLasso, "pointercancel", (e) => {
+if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId) return;
+this._lassoPolygon[lassoHandleDrag.index] = lassoHandleDrag.original;
+delete lassoHandleDrag.handle.dataset.fcActive;
+lassoHandleDrag = null;
+this._renderLassoSelection();
+e.stopPropagation();
+});
 if (this._interactionFlag("crosshair")) {
 this.crosshairX = document.createElement("div");
 this.crosshairX.style.cssText =
@@ -5413,6 +5466,16 @@ const dataAt = (clientX, clientY) => {
 const r = c.getBoundingClientRect();
 return this._dataFromCanvas(clientX - r.left, clientY - r.top);
 };
+const lassoPointAt = (clientX, clientY) => {
+const r = c.getBoundingClientRect();
+const cssX = Math.max(0, Math.min(r.width, clientX - r.left));
+const cssY = Math.max(0, Math.min(r.height, clientY - r.top));
+return {
+x: r.left + cssX,
+y: r.top + cssY,
+data: this._dataFromCanvas(cssX, cssY),
+};
+};
 this._listen(c, "pointerdown", (e) => {
 this._cancelViewAnimation();
 const canBrush = this._interactionFlag("brush", true) && this._interactionFlag("select", true);
@@ -5421,10 +5484,16 @@ const mode = (e.shiftKey || selectMode) && canBrush && this._pickable
 ? (e.shiftKey ? "select" : selectMode)
 : this.dragMode === "zoom" ? "zoom" : null;
 if (mode) {
-const d0 = dataAt(e.clientX, e.clientY);
+const previousLasso = mode.startsWith("select") && this._lassoPolygon
+? this._lassoPolygon.map((point) => [...point])
+: null;
+if (mode.startsWith("select")) this._clearLassoOverlay();
+const firstLassoPoint = mode === "select-lasso" ? lassoPointAt(e.clientX, e.clientY) : null;
+const d0 = firstLassoPoint ? firstLassoPoint.data : dataAt(e.clientX, e.clientY);
 band = {
 mode, sx: e.clientX, sy: e.clientY, d0,
-points: mode === "select-lasso" ? [{ x: e.clientX, y: e.clientY, data: d0 }] : null,
+points: firstLassoPoint ? [firstLassoPoint] : null,
+previousLasso,
 };
 c.setPointerCapture(e.pointerId);
 this.tooltip.style.display = "none";
@@ -5468,7 +5537,8 @@ const moved = Math.abs(e.clientX - band.sx) > 3 || Math.abs(e.clientY - band.sy)
 if (moved) {
 if (band.mode === "zoom") this._zoomToBox(band.d0, d1, true);
 else if (band.mode === "select-lasso" && band.points.length >= 3) {
-this._sendSelectPolygon(band.points.map((point) => point.data));
+const editable = this._simplifyLassoPoints(band.points);
+this._sendSelectPolygon(editable.map((point) => point.data));
 } else {
 let d0 = band.d0;
 if (band.mode === "select-x") {
@@ -5481,6 +5551,9 @@ d1[0] = this.view.x1;
 this._sendSelect(d0, d1);
 }
 this._ignoreNextClick = true;
+} else if (band.previousLasso) {
+this._lassoPolygon = band.previousLasso;
+this._renderLassoSelection();
 }
 band = null;
 return;
@@ -5493,6 +5566,10 @@ this._listen(c, "pointerup", end);
 this._listen(c, "pointercancel", () => {
 this.selRect.style.display = "none";
 this.selLasso.style.display = "none";
+if (band?.previousLasso) {
+this._lassoPolygon = band.previousLasso;
+this._renderLassoSelection();
+}
 band = null;
 drag = null;
 });
@@ -5580,11 +5657,13 @@ const rect = this.canvas.getBoundingClientRect();
 const rootRect = this.root.getBoundingClientRect();
 if (band.mode === "select-lasso") {
 const previous = band.points[band.points.length - 1];
+const cssX = Math.max(0, Math.min(rect.width, e.clientX - rect.left));
+const cssY = Math.max(0, Math.min(rect.height, e.clientY - rect.top));
+const clientX = rect.left + cssX;
+const clientY = rect.top + cssY;
 if (band.points.length < 2048
-&& Math.hypot(e.clientX - previous.x, e.clientY - previous.y) >= 3) {
-band.points.push({ x: e.clientX, y: e.clientY, data: this._dataFromCanvas(
-e.clientX - rect.left, e.clientY - rect.top
-) });
+&& Math.hypot(clientX - previous.x, clientY - previous.y) >= 3) {
+band.points.push({ x: clientX, y: clientY, data: this._dataFromCanvas(cssX, cssY) });
 }
 const points = band.points.map((point) => [
 Math.max(this.plot.x, Math.min(this.plot.x + this.plot.w, point.x - rootRect.left)),
@@ -5617,7 +5696,108 @@ this.selRect.style.width = Math.max(0, bx2 - cx) + "px";
 this.selRect.style.height = Math.max(0, by2 - cy) + "px";
 void rect;
 },
+_simplifyLassoPoints(points, tolerance = 6, maxPoints = 16) {
+const source = points.filter((point) => point && Number.isFinite(point.x) && Number.isFinite(point.y));
+if (source.length > 3) {
+const first = source[0], last = source[source.length - 1];
+if (Math.hypot(first.x - last.x, first.y - last.y) <= tolerance) source.pop();
+}
+if (source.length <= 3) return source.slice();
+const distanceToSegmentSq = (point, start, end) => {
+const dx = end.x - start.x, dy = end.y - start.y;
+if (dx === 0 && dy === 0) {
+return (point.x - start.x) ** 2 + (point.y - start.y) ** 2;
+}
+const t = Math.max(0, Math.min(1,
+((point.x - start.x) * dx + (point.y - start.y) * dy) / (dx * dx + dy * dy)
+));
+const x = start.x + t * dx, y = start.y + t * dy;
+return (point.x - x) ** 2 + (point.y - y) ** 2;
+};
+const keep = new Uint8Array(source.length);
+keep[0] = 1;
+keep[source.length - 1] = 1;
+const stack = [[0, source.length - 1]];
+const toleranceSq = tolerance * tolerance;
+while (stack.length) {
+const [start, end] = stack.pop();
+let furthest = -1, furthestDistance = toleranceSq;
+for (let i = start + 1; i < end; i++) {
+const distance = distanceToSegmentSq(source[i], source[start], source[end]);
+if (distance > furthestDistance) {
+furthest = i;
+furthestDistance = distance;
+}
+}
+if (furthest >= 0) {
+keep[furthest] = 1;
+stack.push([start, furthest], [furthest, end]);
+}
+}
+let simplified = source.filter((_point, index) => keep[index]);
+if (simplified.length < 3) {
+simplified = [source[0], source[Math.floor(source.length / 2)], source[source.length - 1]];
+}
+if (simplified.length > maxPoints) {
+simplified = Array.from({ length: maxPoints }, (_value, index) => (
+simplified[Math.round(index * (simplified.length - 1) / (maxPoints - 1))]
+));
+}
+return simplified;
+},
+_clearLassoOverlay() {
+this._lassoPolygon = null;
+if (!this.selLasso) return;
+this.selLasso.style.display = "none";
+this.selLassoPath?.removeAttribute("d");
+this.selLassoHandles?.replaceChildren();
+},
+_renderLassoSelection() {
+const polygon = this._lassoPolygon;
+if (!this.selLasso || !this.selLassoPath || !this.selLassoHandles
+|| !Array.isArray(polygon) || polygon.length < 3) return;
+const [x0, x1] = this._axisRange("x");
+const [y0, y1] = this._axisRange("y");
+const xAxis = this._axis("x"), yAxis = this._axis("y");
+const cx0 = this._axisCoord(xAxis, x0), cx1 = this._axisCoord(xAxis, x1);
+const cy0 = this._axisCoord(yAxis, y0), cy1 = this._axisCoord(yAxis, y1);
+if (![cx0, cx1, cy0, cy1].every(Number.isFinite) || cx0 === cx1 || cy0 === cy1) return;
+const points = polygon.map((point) => {
+const cx = this._axisCoord(xAxis, point[0]);
+const cy = this._axisCoord(yAxis, point[1]);
+const x = this.plot.x + ((cx - cx0) / (cx1 - cx0)) * this.plot.w;
+const y = this.plot.y + ((cy1 - cy) / (cy1 - cy0)) * this.plot.h;
+return [
+Math.max(this.plot.x, Math.min(this.plot.x + this.plot.w, x)),
+Math.max(this.plot.y, Math.min(this.plot.y + this.plot.h, y)),
+];
+});
+if (!points.flat().every(Number.isFinite)) return;
+this.selLasso.style.display = "block";
+this.selLasso.style.inset = "0";
+this.selLasso.setAttribute("width", String(this.root.clientWidth));
+this.selLasso.setAttribute("height", String(this.root.clientHeight));
+this.selLassoPath.setAttribute(
+"d", points.map((point, index) => `${index ? "L" : "M"}${point[0]} ${point[1]}`).join(" ") + " Z"
+);
+while (this.selLassoHandles.childElementCount < points.length) {
+const handle = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+handle.dataset.fcSelectionLassoHandle = "";
+handle.setAttribute("r", "4");
+this.selLassoHandles.appendChild(handle);
+}
+while (this.selLassoHandles.childElementCount > points.length) {
+this.selLassoHandles.lastElementChild.remove();
+}
+[...this.selLassoHandles.children].forEach((handle, index) => {
+handle.dataset.fcSelectionLassoHandle = String(index);
+handle.setAttribute("cx", String(points[index][0]));
+handle.setAttribute("cy", String(points[index][1]));
+handle.setAttribute("aria-label", `Lasso point ${index + 1}`);
+});
+},
 _sendSelect(d0, d1) {
+this._clearLassoOverlay();
 const x0 = Math.min(d0[0], d1[0]), x1 = Math.max(d0[0], d1[0]);
 const y0 = Math.min(d0[1], d1[1]), y1 = Math.max(d0[1], d1[1]);
 const range = { x0, x1, y0, y1 };
@@ -5631,6 +5811,9 @@ this._selectLocal(x0, x1, y0, y1);
 _sendSelectPolygon(points) {
 if (!Array.isArray(points) || points.length < 3) return;
 const polygon = points.map((point) => [point[0], point[1]]);
+if (!polygon.every((point) => point.every(Number.isFinite))) return;
+this._lassoPolygon = polygon;
+this._renderLassoSelection();
 this._dispatchChartEvent("brush", {
 polygon,
 view: this._eventView("brush"),
@@ -5708,6 +5891,7 @@ gl.bufferData(gl.ARRAY_BUFFER, maskF32, gl.STATIC_DRAW);
 g.selActive = true;
 },
 _clearSelection() {
+this._clearLassoOverlay();
 for (const g of this.gpuTraces) {
 g.selActive = false;
 if (g.drill) g.drill.selActive = false;
@@ -6438,7 +6622,7 @@ target.replaceWith(image);
 }
 clone.querySelectorAll(
 '[data-fc-slot="modebar"],[data-fc-slot="tooltip"],' +
-'[data-fc-slot="selection"],[data-fc-selection-lasso],' +
+'[data-fc-slot="selection"],[data-fc-selection-lasso-overlay],' +
 '[data-fc-slot="crosshair_x"],[data-fc-slot="crosshair_y"]'
 ).forEach((node) => node.remove());
 const stylesheet = document.createElement("style");

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -5741,6 +5741,7 @@ this._modebarMoved = false;
 bar.dataset.fcCollapsed = "false";
 let setZoomMenuOpen = () => {};
 let setSelectMenuOpen = () => {};
+let setExportMenuOpen = () => {};
 const setVisible = (visible) => {
 const show = visible || this._modebarDragging || bar.contains(document.activeElement);
 bar.style.opacity = show ? "1" : "0";
@@ -5751,6 +5752,7 @@ this._listen(root, "pointerleave", () => {
 setVisible(false);
 setZoomMenuOpen(false);
 setSelectMenuOpen(false);
+setExportMenuOpen(false);
 });
 this._listen(bar, "focusin", () => setVisible(true));
 this._listen(bar, "focusout", () => {
@@ -5777,6 +5779,7 @@ bar.dataset.fcCollapsed = String(collapsed);
 if (collapsed) {
 setZoomMenuOpen(false);
 setSelectMenuOpen(false);
+setExportMenuOpen(false);
 }
 for (const button of bar.querySelectorAll("button")) {
 if (button !== grip) {
@@ -5822,6 +5825,7 @@ this._modebarMoved = true;
 bar.style.transition = "none";
 setZoomMenuOpen(false);
 setSelectMenuOpen(false);
+setExportMenuOpen(false);
 try { grip.setPointerCapture(e.pointerId); } catch (_err) {   }
 }
 const rootRect = root.getBoundingClientRect();
@@ -5905,6 +5909,14 @@ selectIndicator.innerHTML = this._icon("chevrondown");
 selectTrigger.appendChild(selectIndicator);
 this._selectMenuButton = selectTrigger;
 }
+const exportTrigger = mk("more", "Export options", () => {
+setExportMenuOpen(!this._exportMenuOpen);
+});
+exportTrigger.dataset.fcModebarExport = "";
+exportTrigger.dataset.fcModebarExportTrigger = "";
+exportTrigger.setAttribute("aria-label", "Export options");
+exportTrigger.setAttribute("aria-haspopup", "menu");
+exportTrigger.setAttribute("aria-expanded", "false");
 const zoomMenu = document.createElement("div");
 zoomMenu.dataset.fcModebarMenu = "";
 zoomMenu.setAttribute("role", "menu");
@@ -5998,9 +6010,58 @@ mkSelectItem("lasso", "Lasso Select", "L", "select-lasso");
 mkSelectItem("selectx", "X Range", "X", "select-x");
 mkSelectItem("selecty", "Y Range", "Y", "select-y");
 }
+const exportMenu = document.createElement("div");
+exportMenu.dataset.fcModebarMenu = "";
+exportMenu.dataset.fcModebarExportMenu = "";
+exportMenu.setAttribute("role", "menu");
+exportMenu.setAttribute("aria-label", "Export options");
+exportMenu.style.cssText =
+"position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
+bar.appendChild(exportMenu);
+const exportMenuItems = [];
+const mkExportItem = (name, label, onClick, separator = false) => {
+const button = document.createElement("button");
+button.type = "button";
+button.tabIndex = -1;
+button.dataset.fcModebarMenuItem = name;
+button.dataset.fcModebarExportItem = name;
+if (separator) button.dataset.fcSeparator = "";
+button.setAttribute("role", "menuitem");
+button.style.cssText = "display:flex;align-items:center;pointer-events:auto;";
+this._applySlot(button, "modebar_button");
+const icon = document.createElement("span");
+icon.dataset.fcModebarMenuIcon = "";
+icon.innerHTML = this._icon(name);
+button.appendChild(icon);
+const text = document.createElement("span");
+text.textContent = label;
+button.appendChild(text);
+this._listen(button, "pointerdown", (e) => e.stopPropagation());
+this._listen(button, "click", (e) => {
+e.stopPropagation();
+setExportMenuOpen(false, true);
+Promise.resolve(onClick()).catch((error) => console.error(`xy: ${label} failed`, error));
+});
+exportMenu.appendChild(button);
+exportMenuItems.push(button);
+return button;
+};
+const themeItem = mkExportItem("moon", "Dark Mode", () => this._toggleColorMode());
+themeItem.dataset.fcModebarThemeToggle = "";
+themeItem.setAttribute("role", "menuitemcheckbox");
+themeItem.setAttribute("aria-checked", "false");
+this._themeMenuItem = themeItem;
+this._colorMode = "light";
+this._updateColorModeItem();
+mkExportItem("png", "Export PNG", () => this._exportPng(), true);
+mkExportItem("svg", "Export SVG", () => this._exportSvg());
+mkExportItem("csv", "Export CSV", () => this._exportCsv());
 setZoomMenuOpen = (open, restoreFocus = false) => {
 const show = Boolean(open) && !this._modebarCollapsed;
-if (show) setSelectMenuOpen(false);
+if (show) {
+setSelectMenuOpen(false);
+setExportMenuOpen(false);
+}
 this._zoomMenuOpen = show;
 zoomTrigger.setAttribute("aria-expanded", String(show));
 if (!show) {
@@ -6030,7 +6091,10 @@ zoomMenu.style.visibility = "visible";
 setSelectMenuOpen = (open, restoreFocus = false) => {
 if (!selectTrigger) return;
 const show = Boolean(open) && !this._modebarCollapsed;
-if (show) setZoomMenuOpen(false);
+if (show) {
+setZoomMenuOpen(false);
+setExportMenuOpen(false);
+}
 this._selectMenuOpen = show;
 selectTrigger.setAttribute("aria-expanded", String(show));
 if (!show) {
@@ -6057,13 +6121,45 @@ selectMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, selectTrigger.o
 selectMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
 selectMenu.style.visibility = "visible";
 };
+setExportMenuOpen = (open, restoreFocus = false) => {
+const show = Boolean(open) && !this._modebarCollapsed;
+if (show) {
+setZoomMenuOpen(false);
+setSelectMenuOpen(false);
+}
+this._exportMenuOpen = show;
+exportTrigger.setAttribute("aria-expanded", String(show));
+if (!show) {
+exportMenu.style.display = "none";
+if (restoreFocus) exportTrigger.focus();
+return;
+}
+exportMenu.style.display = "flex";
+exportMenu.style.visibility = "hidden";
+const rootRect = root.getBoundingClientRect();
+const barRect = bar.getBoundingClientRect();
+const rootLeft = barRect.left - rootRect.left;
+const rootTop = barRect.top - rootRect.top;
+const below = bar.offsetHeight + 6;
+const above = -exportMenu.offsetHeight - 6;
+const preferredTop = barRect.bottom + 6 + exportMenu.offsetHeight <= rootRect.bottom
+? below
+: above;
+const maxLeft = root.clientWidth - rootLeft - exportMenu.offsetWidth;
+const maxTop = root.clientHeight - rootTop - exportMenu.offsetHeight;
+exportMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, exportTrigger.offsetLeft))}px`;
+exportMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
+exportMenu.style.visibility = "visible";
+};
 this._closeModebarMenu = () => {
 setZoomMenuOpen(false);
 setSelectMenuOpen(false);
+setExportMenuOpen(false);
 };
 this._listen(document, "pointerdown", (e) => {
 if (this._zoomMenuOpen && !bar.contains(e.target)) setZoomMenuOpen(false);
 if (this._selectMenuOpen && !bar.contains(e.target)) setSelectMenuOpen(false);
+if (this._exportMenuOpen && !bar.contains(e.target)) setExportMenuOpen(false);
 });
 this._listen(zoomTrigger, "keydown", (e) => {
 if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
@@ -6115,6 +6211,31 @@ next = (current - 1 + selectMenuItems.length) % selectMenuItems.length;
 selectMenuItems[next].focus();
 });
 }
+this._listen(exportTrigger, "keydown", (e) => {
+if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+e.preventDefault();
+e.stopPropagation();
+setExportMenuOpen(true);
+const index = e.key === "ArrowDown" ? 0 : exportMenuItems.length - 1;
+exportMenuItems[index].focus();
+});
+this._listen(exportMenu, "keydown", (e) => {
+if (e.key === "Escape") {
+e.preventDefault();
+e.stopPropagation();
+setExportMenuOpen(false, true);
+return;
+}
+if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(e.key)) return;
+e.preventDefault();
+const current = exportMenuItems.indexOf(document.activeElement);
+let next = e.key === "Home" ? 0 : e.key === "End" ? exportMenuItems.length - 1 : current;
+if (e.key === "ArrowDown") next = (current + 1) % exportMenuItems.length;
+if (e.key === "ArrowUp") {
+next = (current - 1 + exportMenuItems.length) % exportMenuItems.length;
+}
+exportMenuItems[next].focus();
+});
 root.appendChild(bar);
 this._fitModebar();
 setVisible(root.matches(":hover"));
@@ -6313,6 +6434,209 @@ const y0 = yReversed ? yhi : ylo;
 const y1 = yReversed ? ylo : yhi;
 this._setView({ x0, x1, y0, y1 }, { animate });
 },
+_updateColorModeItem() {
+if (!this._themeMenuItem) return;
+const dark = this._colorMode === "dark";
+const icon = this._themeMenuItem.querySelector("[data-fc-modebar-menu-icon]");
+const label = icon?.nextElementSibling;
+if (icon) icon.innerHTML = this._icon(dark ? "sun" : "moon");
+if (label) label.textContent = dark ? "Light Mode" : "Dark Mode";
+this._themeMenuItem.dataset.fcModebarExportItem = dark ? "light" : "dark";
+this._themeMenuItem.setAttribute("aria-checked", String(dark));
+},
+_setColorMode(mode) {
+const dark = mode === "dark";
+this._colorMode = dark ? "dark" : "light";
+this.root.dataset.fcColorMode = this._colorMode;
+const colors = dark ? {
+color: "#e5e7eb",
+background: "#0b1220",
+"--chart-bg": "#111827",
+"--chart-grid": "rgba(226,232,240,.14)",
+"--chart-axis": "#94a3b8",
+"--chart-text": "#e5e7eb",
+"--chart-legend-bg": "rgba(30,41,59,.84)",
+"--chart-modebar-bg": "rgba(15,23,42,.94)",
+"--chart-modebar-active": "rgba(148,163,184,.24)",
+"--chart-tooltip-bg": "rgba(2,6,23,.96)",
+"--chart-tooltip-text": "#f8fafc",
+"--chart-badge-bg": "rgba(30,41,59,.9)",
+"--chart-badge-text": "#e2e8f0",
+} : {
+color: "#1f2937",
+background: "#ffffff",
+"--chart-bg": "#ffffff",
+"--chart-grid": "rgba(15,23,42,.12)",
+"--chart-axis": "#64748b",
+"--chart-text": "#1f2937",
+"--chart-legend-bg": "rgba(241,245,249,.88)",
+"--chart-modebar-bg": "rgba(255,255,255,.94)",
+"--chart-modebar-active": "rgba(100,116,139,.18)",
+"--chart-tooltip-bg": "rgba(20,24,33,.94)",
+"--chart-tooltip-text": "#ffffff",
+"--chart-badge-bg": "rgba(255,255,255,.9)",
+"--chart-badge-text": "#0f172a",
+};
+for (const [name, value] of Object.entries(colors)) {
+if (name === "color" || name === "background") this.root.style[name] = value;
+else this.root.style.setProperty(name, value);
+}
+this._updateColorModeItem();
+this.refreshTheme();
+},
+_toggleColorMode() {
+this._setColorMode(this._colorMode === "dark" ? "light" : "dark");
+},
+_exportFilename(extension) {
+const title = String(this.spec.title || "xy-chart")
+.trim()
+.toLowerCase()
+.replace(/[^a-z0-9]+/g, "-")
+.replace(/^-+|-+$/g, "") || "xy-chart";
+return `${title}.${extension}`;
+},
+_downloadExport(blob, filename) {
+const url = URL.createObjectURL(blob);
+const link = document.createElement("a");
+link.href = url;
+link.download = filename;
+link.style.display = "none";
+document.body.appendChild(link);
+link.click();
+link.remove();
+setTimeout(() => URL.revokeObjectURL(url), 0);
+},
+_exportSvgMarkup() {
+this._drawNow?.();
+this.gl?.finish?.();
+const width = this.size.w;
+const height = this.size.h;
+const clone = this.root.cloneNode(true);
+clone.style.width = `${width}px`;
+clone.style.height = `${height}px`;
+clone.style.margin = "0";
+clone.setAttribute("xmlns", "http://www.w3.org/1999/xhtml");
+const sourceCanvases = [...this.root.querySelectorAll("canvas")];
+const clonedCanvases = [...clone.querySelectorAll("canvas")];
+for (let i = 0; i < clonedCanvases.length; i++) {
+const source = sourceCanvases[i];
+const target = clonedCanvases[i];
+if (!source || !target) continue;
+const image = document.createElement("img");
+image.setAttribute("src", source.toDataURL("image/png"));
+image.setAttribute("alt", "");
+image.setAttribute("style", target.getAttribute("style") || "");
+image.setAttribute("width", String(source.clientWidth || source.width));
+image.setAttribute("height", String(source.clientHeight || source.height));
+for (const attr of target.attributes) {
+if (attr.name.startsWith("data-")) image.setAttribute(attr.name, attr.value);
+}
+target.replaceWith(image);
+}
+clone.querySelectorAll(
+'[data-fc-slot="modebar"],[data-fc-slot="tooltip"],' +
+'[data-fc-slot="selection"],[data-fc-selection-lasso],' +
+'[data-fc-slot="crosshair_x"],[data-fc-slot="crosshair_y"]'
+).forEach((node) => node.remove());
+const stylesheet = document.createElement("style");
+stylesheet.textContent = FC_CHROME_CSS;
+clone.prepend(stylesheet);
+const content = new XMLSerializer().serializeToString(clone);
+return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" ` +
+`viewBox="0 0 ${width} ${height}"><foreignObject width="100%" height="100%">` +
+`${content}</foreignObject></svg>`;
+},
+_exportSvg() {
+const svg = this._exportSvgMarkup();
+this._downloadExport(
+new Blob([svg], { type: "image/svg+xml;charset=utf-8" }),
+this._exportFilename("svg")
+);
+},
+_exportPng() {
+const svg = this._exportSvgMarkup();
+const sourceUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+const image = new Image();
+return new Promise((resolve, reject) => {
+image.onload = () => {
+const scale = Math.max(1, window.devicePixelRatio || 1);
+const canvas = document.createElement("canvas");
+canvas.width = Math.round(this.size.w * scale);
+canvas.height = Math.round(this.size.h * scale);
+const ctx = canvas.getContext("2d");
+ctx.scale(scale, scale);
+ctx.drawImage(image, 0, 0, this.size.w, this.size.h);
+canvas.toBlob((blob) => {
+if (!blob) {
+reject(new Error("PNG encoding returned no data"));
+return;
+}
+this._downloadExport(blob, this._exportFilename("png"));
+resolve();
+}, "image/png");
+};
+image.onerror = () => {
+reject(new Error("chart SVG could not be rasterized"));
+};
+image.src = sourceUrl;
+});
+},
+_exportCsvText() {
+const columns = ["trace", "name", "kind", "index", "x", "y", "x0", "x1", "y0", "y1", "value"];
+const rows = [columns];
+const clean = (value) => Number.isFinite(value) ? value : "";
+for (const g of this.gpuTraces || []) {
+const trace = g.trace || {};
+const prefix = [trace.id ?? "", trace.name ?? "", trace.kind ?? ""];
+if (g._cpuRect) {
+const r = g._cpuRect;
+const n = Math.min(r.x0.length, r.x1.length, r.y0.length, r.y1.length);
+for (let i = 0; i < n; i++) {
+rows.push([...prefix, i, "", "",
+clean(this._decodeValue(r.x0, r.x0Meta, i)),
+clean(this._decodeValue(r.x1, r.x1Meta, i)),
+clean(this._decodeValue(r.y0, r.y0Meta, i)),
+clean(this._decodeValue(r.y1, r.y1Meta, i)), ""]);
+}
+continue;
+}
+if (g.heatmap && g._cpuHeatmap) {
+const h = g.heatmap;
+for (let i = 0; i < g._cpuHeatmap.grid.length; i++) {
+const row = Math.floor(i / h.w);
+const col = i % h.w;
+const x = h.xRange[0] + (col + 0.5) * ((h.xRange[1] - h.xRange[0]) / h.w);
+const y = h.yRange[0] + (row + 0.5) * ((h.yRange[1] - h.yRange[0]) / h.h);
+const value = this._denormalizeUnit(g._cpuHeatmap.grid[i], trace.color?.domain);
+rows.push([...prefix, i, clean(x), clean(y), "", "", "", "", clean(value)]);
+}
+continue;
+}
+const cpu = g._cpu;
+if (!cpu?.x || !cpu?.y) continue;
+const n = Math.min(cpu.x.length, cpu.y.length, g.n || Infinity);
+for (let i = 0; i < n; i++) {
+rows.push([...prefix, i,
+clean(this._decodeValue(cpu.x, cpu.xMeta || g.xMeta, i)),
+clean(this._decodeValue(cpu.y, cpu.yMeta || g.yMeta, i)),
+"", "", "", "", ""]);
+}
+}
+const quote = (value) => {
+const text = String(value ?? "");
+const escaped = text.split('"').join('""');
+return text.includes(",") || text.includes('"') || text.includes("\r") || text.includes("\n")
+? `"${escaped}"`
+: text;
+};
+return rows.map((row) => row.map(quote).join(",")).join("\r\n") + "\r\n";
+},
+_exportCsv() {
+this._downloadExport(
+new Blob([this._exportCsvText()], { type: "text/csv;charset=utf-8" }),
+this._exportFilename("csv")
+);
+},
 _icon(name) {
 const svg = (body) =>
 `<svg width="15" height="15" viewBox="0 0 20 20" fill="none" ` +
@@ -6350,6 +6674,25 @@ return svg('<rect x="5" y="3" width="10" height="14" rx="1" stroke-dasharray="2.
 '<path d="M10 6 V14 M10 6 L8 8 M10 6 L12 8 M10 14 L8 12 M10 14 L12 12"/>');
 case "chevrondown":
 return svg('<path d="M6 8 L10 12 L14 8"/>');
+case "more":
+return svg('<circle cx="5" cy="10" r="1" fill="currentColor" stroke="none"/>' +
+'<circle cx="10" cy="10" r="1" fill="currentColor" stroke="none"/>' +
+'<circle cx="15" cy="10" r="1" fill="currentColor" stroke="none"/>');
+case "moon":
+return svg('<path d="M14.8 13.8 A6.5 6.5 0 0 1 6.2 5.2 A6.5 6.5 0 1 0 14.8 13.8 Z"/>');
+case "sun":
+return svg('<circle cx="10" cy="10" r="3"/><path d="M10 2 V4 M10 16 V18 ' +
+'M2 10 H4 M16 10 H18 M4.3 4.3 L5.7 5.7 M14.3 14.3 L15.7 15.7 ' +
+'M15.7 4.3 L14.3 5.7 M5.7 14.3 L4.3 15.7"/>');
+case "png":
+return svg('<path d="M5 2.5 H12 L15.5 6 V17.5 H5 Z"/><path d="M12 2.5 V6 H15.5"/>' +
+'<path d="M7 13 L9 10.5 L11 12 L13.5 9 V15 H7 Z"/>');
+case "svg":
+return svg('<path d="M5 2.5 H12 L15.5 6 V17.5 H5 Z"/><path d="M12 2.5 V6 H15.5"/>' +
+'<path d="M7 13 L9 9 L11 14 L13.5 10"/>');
+case "csv":
+return svg('<path d="M5 2.5 H12 L15.5 6 V17.5 H5 Z"/><path d="M12 2.5 V6 H15.5"/>' +
+'<path d="M7 9 H13 M7 12 H13 M7 15 H13 M9 8 V16"/>');
 case "reset":
 return svg('<path d="M4 10 a6 6 0 1 1 1.8 4.3"/><path d="M4 6 V10 H8"/>');
 case "drag":

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -242,7 +242,10 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="badge_item"]){padding:3px 6px;border-radius:4px;color:var(--chart-badge-text,#0f172a);background:var(--chart-badge-bg,rgba(255,255,255,.82));box-shadow:0 1px 4px rgba(15,23,42,.14)}
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
 :where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
-:where(.xy [data-fc-modebar-drag-handle]){cursor:move}
+:where(.xy [data-fc-modebar-drag-handle]){position:relative;margin-right:3px;cursor:move}
+:where(.xy [data-fc-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-2px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
+:where(.xy [data-fc-slot="modebar"][data-fc-collapsed="true"]>[data-fc-modebar-drag-handle]){margin-right:0}
+:where(.xy [data-fc-slot="modebar"][data-fc-collapsed="true"]>[data-fc-modebar-drag-handle])::after{display:none}
 :where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:58px;gap:2px;padding:0 6px;font-size:11px;font-variant-numeric:tabular-nums}
 :where(.xy [data-fc-modebar-select-trigger]){width:auto;min-width:35px;gap:0;padding:0 4px}
 :where(.xy [data-fc-modebar-menu-indicator]){display:flex;transition:transform .15s}

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -244,10 +244,12 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-axis,currentColor);cursor:pointer}
 :where(.xy [data-fc-modebar-drag-handle]){cursor:move}
 :where(.xy [data-fc-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}
-:where(.xy [data-fc-modebar-menu-item]){width:100%;height:28px;justify-content:space-between;padding:0 9px;border-radius:4px;text-align:left;white-space:nowrap}
+:where(.xy [data-fc-modebar-menu-item]){width:100%;height:28px;justify-content:flex-start;padding:0 9px;border-radius:4px;text-align:left;white-space:nowrap}
 :where(.xy [data-fc-modebar-menu-item]:hover,.xy [data-fc-modebar-menu-item]:focus-visible){background:var(--chart-modebar-active,rgba(128,128,128,.18));outline:none}
 :where(.xy [data-fc-modebar-menu-item][data-fc-separator]){margin-top:3px;border-top:1px solid rgba(128,128,128,.2);border-radius:0 0 4px 4px}
-:where(.xy [data-fc-modebar-menu-shortcut]){margin-left:20px;color:var(--chart-axis,currentColor);font-size:10px;opacity:.72}
+:where(.xy [data-fc-modebar-menu-icon]){display:flex;width:16px;margin-right:7px}
+:where(.xy [data-fc-modebar-menu-icon] svg){width:14px;height:14px}
+:where(.xy [data-fc-modebar-menu-shortcut]){margin-left:auto;padding-left:20px;color:var(--chart-axis,currentColor);font-size:10px;opacity:.72}
 :where(.xy [data-fc-slot="modebar_button"].fc-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
 :where(.xy [data-fc-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-fc-slot="selection"][data-fc-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}
@@ -5762,6 +5764,10 @@ button.setAttribute("role", "menuitem");
 button.style.cssText =
 "display:flex;align-items:center;pointer-events:auto;";
 this._applySlot(button, "modebar_button");
+const icon = document.createElement("span");
+icon.dataset.fcModebarMenuIcon = "";
+icon.innerHTML = this._icon(name);
+button.appendChild(icon);
 const text = document.createElement("span");
 text.textContent = label;
 button.appendChild(text);

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -242,9 +242,9 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="badge_item"]){padding:3px 6px;border-radius:4px;color:var(--chart-badge-text,#0f172a);background:var(--chart-badge-bg,rgba(255,255,255,.82));box-shadow:0 1px 4px rgba(15,23,42,.14)}
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
 :where(.xy [data-fc-slot="modebar_button"]){width:24px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
-:where(.xy [data-fc-modebar-drag-handle]){position:relative;width:22px;margin-right:2px;cursor:move}
-:where(.xy [data-fc-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-1px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
-:where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:52px;gap:1px;padding:0 4px;font-size:11px;font-variant-numeric:tabular-nums}
+:where(.xy [data-fc-modebar-drag-handle]){position:relative;width:22px;margin-right:4px;cursor:move}
+:where(.xy [data-fc-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-3px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
+:where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:48px;gap:1px;padding:0 4px;font-size:11px;font-variant-numeric:tabular-nums}
 :where(.xy [data-fc-modebar-select-trigger]){width:auto;min-width:30px;gap:0;padding:0 2px}
 :where(.xy [data-fc-modebar-menu-indicator]){display:flex;transition:transform .15s}
 :where(.xy [data-fc-modebar-menu-indicator] svg){width:11px;height:11px}

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -6019,13 +6019,12 @@ exportMenu.style.cssText =
 "position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
 bar.appendChild(exportMenu);
 const exportMenuItems = [];
-const mkExportItem = (name, label, onClick, separator = false) => {
+const mkExportItem = (name, label, onClick) => {
 const button = document.createElement("button");
 button.type = "button";
 button.tabIndex = -1;
 button.dataset.fcModebarMenuItem = name;
 button.dataset.fcModebarExportItem = name;
-if (separator) button.dataset.fcSeparator = "";
 button.setAttribute("role", "menuitem");
 button.style.cssText = "display:flex;align-items:center;pointer-events:auto;";
 this._applySlot(button, "modebar_button");
@@ -6046,14 +6045,7 @@ exportMenu.appendChild(button);
 exportMenuItems.push(button);
 return button;
 };
-const themeItem = mkExportItem("moon", "Dark Mode", () => this._toggleColorMode());
-themeItem.dataset.fcModebarThemeToggle = "";
-themeItem.setAttribute("role", "menuitemcheckbox");
-themeItem.setAttribute("aria-checked", "false");
-this._themeMenuItem = themeItem;
-this._colorMode = "light";
-this._updateColorModeItem();
-mkExportItem("png", "Export PNG", () => this._exportPng(), true);
+mkExportItem("png", "Export PNG", () => this._exportPng());
 mkExportItem("svg", "Export SVG", () => this._exportSvg());
 mkExportItem("csv", "Export CSV", () => this._exportCsv());
 setZoomMenuOpen = (open, restoreFocus = false) => {
@@ -6434,59 +6426,6 @@ const y0 = yReversed ? yhi : ylo;
 const y1 = yReversed ? ylo : yhi;
 this._setView({ x0, x1, y0, y1 }, { animate });
 },
-_updateColorModeItem() {
-if (!this._themeMenuItem) return;
-const dark = this._colorMode === "dark";
-const icon = this._themeMenuItem.querySelector("[data-fc-modebar-menu-icon]");
-const label = icon?.nextElementSibling;
-if (icon) icon.innerHTML = this._icon(dark ? "sun" : "moon");
-if (label) label.textContent = dark ? "Light Mode" : "Dark Mode";
-this._themeMenuItem.dataset.fcModebarExportItem = dark ? "light" : "dark";
-this._themeMenuItem.setAttribute("aria-checked", String(dark));
-},
-_setColorMode(mode) {
-const dark = mode === "dark";
-this._colorMode = dark ? "dark" : "light";
-this.root.dataset.fcColorMode = this._colorMode;
-const colors = dark ? {
-color: "#e5e7eb",
-background: "#0b1220",
-"--chart-bg": "#111827",
-"--chart-grid": "rgba(226,232,240,.14)",
-"--chart-axis": "#94a3b8",
-"--chart-text": "#e5e7eb",
-"--chart-legend-bg": "rgba(30,41,59,.84)",
-"--chart-modebar-bg": "rgba(15,23,42,.94)",
-"--chart-modebar-active": "rgba(148,163,184,.24)",
-"--chart-tooltip-bg": "rgba(2,6,23,.96)",
-"--chart-tooltip-text": "#f8fafc",
-"--chart-badge-bg": "rgba(30,41,59,.9)",
-"--chart-badge-text": "#e2e8f0",
-} : {
-color: "#1f2937",
-background: "#ffffff",
-"--chart-bg": "#ffffff",
-"--chart-grid": "rgba(15,23,42,.12)",
-"--chart-axis": "#64748b",
-"--chart-text": "#1f2937",
-"--chart-legend-bg": "rgba(241,245,249,.88)",
-"--chart-modebar-bg": "rgba(255,255,255,.94)",
-"--chart-modebar-active": "rgba(100,116,139,.18)",
-"--chart-tooltip-bg": "rgba(20,24,33,.94)",
-"--chart-tooltip-text": "#ffffff",
-"--chart-badge-bg": "rgba(255,255,255,.9)",
-"--chart-badge-text": "#0f172a",
-};
-for (const [name, value] of Object.entries(colors)) {
-if (name === "color" || name === "background") this.root.style[name] = value;
-else this.root.style.setProperty(name, value);
-}
-this._updateColorModeItem();
-this.refreshTheme();
-},
-_toggleColorMode() {
-this._setColorMode(this._colorMode === "dark" ? "light" : "dark");
-},
 _exportFilename(extension) {
 const title = String(this.spec.title || "xy-chart")
 .trim()
@@ -6678,12 +6617,6 @@ case "more":
 return svg('<circle cx="5" cy="10" r="1" fill="currentColor" stroke="none"/>' +
 '<circle cx="10" cy="10" r="1" fill="currentColor" stroke="none"/>' +
 '<circle cx="15" cy="10" r="1" fill="currentColor" stroke="none"/>');
-case "moon":
-return svg('<path d="M14.8 13.8 A6.5 6.5 0 0 1 6.2 5.2 A6.5 6.5 0 1 0 14.8 13.8 Z"/>');
-case "sun":
-return svg('<circle cx="10" cy="10" r="3"/><path d="M10 2 V4 M10 16 V18 ' +
-'M2 10 H4 M16 10 H18 M4.3 4.3 L5.7 5.7 M14.3 14.3 L15.7 15.7 ' +
-'M15.7 4.3 L14.3 5.7 M5.7 14.3 L4.3 15.7"/>');
 case "png":
 return svg('<path d="M5 2.5 H12 L15.5 6 V17.5 H5 Z"/><path d="M12 2.5 V6 H15.5"/>' +
 '<path d="M7 13 L9 10.5 L11 12 L13.5 9 V15 H7 Z"/>');

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -5742,6 +5742,7 @@ bar.dataset.fcCollapsed = "false";
 let setZoomMenuOpen = () => {};
 let setSelectMenuOpen = () => {};
 let setExportMenuOpen = () => {};
+let updateCollapseItem = () => {};
 const setVisible = (visible) => {
 const show = visible || this._modebarDragging || bar.contains(document.activeElement);
 bar.style.opacity = show ? "1" : "0";
@@ -5760,10 +5761,13 @@ if (!root.matches(":hover")) setVisible(false);
 });
 const grip = document.createElement("button");
 grip.type = "button";
-grip.title = "Double-click to collapse; drag to move";
-grip.setAttribute("aria-label", "Collapse toolbar");
-grip.setAttribute("aria-expanded", "true");
+grip.title = "Click for toolbar options; drag to move; double-click to collapse";
+grip.setAttribute("aria-label", "Toolbar options");
+grip.setAttribute("aria-haspopup", "menu");
+grip.setAttribute("aria-expanded", "false");
 grip.dataset.fcModebarDragHandle = "";
+grip.dataset.fcModebarExport = "";
+grip.dataset.fcModebarExportTrigger = "";
 grip.innerHTML = this._icon("drag");
 grip.style.cssText =
 "display:flex;align-items:center;justify-content:center;pointer-events:auto;touch-action:none;";
@@ -5773,6 +5777,7 @@ const DOUBLE_CLICK_MS = 500;
 const DRAG_THRESHOLD_PX = 6;
 let modebarDrag = null;
 let lastGripDown = 0;
+let suppressGripClickUntil = 0;
 const setCollapsed = (collapsed) => {
 this._modebarCollapsed = collapsed;
 bar.dataset.fcCollapsed = String(collapsed);
@@ -5781,17 +5786,16 @@ setZoomMenuOpen(false);
 setSelectMenuOpen(false);
 setExportMenuOpen(false);
 }
-for (const button of bar.querySelectorAll("button")) {
+for (const button of bar.querySelectorAll(":scope > button")) {
 if (button !== grip) {
 button.hidden = collapsed;
 button.style.display = collapsed ? "none" : "flex";
 }
 }
 grip.title = collapsed
-? "Double-click to expand; drag to move"
-: "Double-click to collapse; drag to move";
-grip.setAttribute("aria-label", collapsed ? "Expand toolbar" : "Collapse toolbar");
-grip.setAttribute("aria-expanded", String(!collapsed));
+? "Click for toolbar options; drag to move; double-click to expand"
+: "Click for toolbar options; drag to move; double-click to collapse";
+updateCollapseItem();
 this._fitModebar();
 };
 const toggleModebar = () => setCollapsed(!this._modebarCollapsed);
@@ -5811,7 +5815,10 @@ dy: e.clientY - barRect.top,
 moved: false,
 };
 setVisible(true);
-if (doubleClick) toggleModebar();
+if (doubleClick) {
+suppressGripClickUntil = performance.now() + 100;
+toggleModebar();
+}
 });
 this._listen(grip, "pointermove", (e) => {
 if (!modebarDrag || e.pointerId !== modebarDrag.pointerId) return;
@@ -5843,20 +5850,22 @@ bar.style.transition = "opacity .15s";
 setVisible(root.matches(":hover"));
 if (moved || cancelled) {
 lastGripDown = 0;
+suppressGripClickUntil = performance.now() + 100;
 }
 };
 this._listen(grip, "pointerup", endModebarDrag);
 this._listen(grip, "pointercancel", endModebarDrag);
-this._listen(grip, "click", (e) => e.stopPropagation());
+this._listen(grip, "click", (e) => {
+e.stopPropagation();
+if (performance.now() <= suppressGripClickUntil) {
+suppressGripClickUntil = 0;
+return;
+}
+setExportMenuOpen(!this._exportMenuOpen);
+});
 this._listen(grip, "dblclick", (e) => {
 e.preventDefault();
 e.stopPropagation();
-});
-this._listen(grip, "keydown", (e) => {
-if (e.repeat || (e.key !== "Enter" && e.key !== " ")) return;
-e.preventDefault();
-e.stopPropagation();
-toggleModebar();
 });
 const mk = (name, title, onClick, toggles) => {
 const b = document.createElement("button");
@@ -5909,14 +5918,6 @@ selectIndicator.innerHTML = this._icon("chevrondown");
 selectTrigger.appendChild(selectIndicator);
 this._selectMenuButton = selectTrigger;
 }
-const exportTrigger = mk("more", "Export options", () => {
-setExportMenuOpen(!this._exportMenuOpen);
-});
-exportTrigger.dataset.fcModebarExport = "";
-exportTrigger.dataset.fcModebarExportTrigger = "";
-exportTrigger.setAttribute("aria-label", "Export options");
-exportTrigger.setAttribute("aria-haspopup", "menu");
-exportTrigger.setAttribute("aria-expanded", "false");
 const zoomMenu = document.createElement("div");
 zoomMenu.dataset.fcModebarMenu = "";
 zoomMenu.setAttribute("role", "menu");
@@ -6014,17 +6015,18 @@ const exportMenu = document.createElement("div");
 exportMenu.dataset.fcModebarMenu = "";
 exportMenu.dataset.fcModebarExportMenu = "";
 exportMenu.setAttribute("role", "menu");
-exportMenu.setAttribute("aria-label", "Export options");
+exportMenu.setAttribute("aria-label", "Toolbar options");
 exportMenu.style.cssText =
 "position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
 bar.appendChild(exportMenu);
 const exportMenuItems = [];
-const mkExportItem = (name, label, onClick) => {
+const mkExportItem = (name, label, onClick, separator = false) => {
 const button = document.createElement("button");
 button.type = "button";
 button.tabIndex = -1;
 button.dataset.fcModebarMenuItem = name;
 button.dataset.fcModebarExportItem = name;
+if (separator) button.dataset.fcSeparator = "";
 button.setAttribute("role", "menuitem");
 button.style.cssText = "display:flex;align-items:center;pointer-events:auto;";
 this._applySlot(button, "modebar_button");
@@ -6045,7 +6047,18 @@ exportMenu.appendChild(button);
 exportMenuItems.push(button);
 return button;
 };
-mkExportItem("png", "Export PNG", () => this._exportPng());
+const collapseItem = mkExportItem("collapse", "Collapse Toolbar", toggleModebar);
+collapseItem.dataset.fcModebarCollapseItem = "";
+updateCollapseItem = () => {
+const collapsed = this._modebarCollapsed;
+const icon = collapseItem.querySelector("[data-fc-modebar-menu-icon]");
+const label = icon?.nextElementSibling;
+if (icon) icon.innerHTML = this._icon(collapsed ? "expand" : "collapse");
+if (label) label.textContent = collapsed ? "Expand Toolbar" : "Collapse Toolbar";
+collapseItem.dataset.fcModebarExportItem = collapsed ? "expand" : "collapse";
+};
+updateCollapseItem();
+mkExportItem("png", "Export PNG", () => this._exportPng(), true);
 mkExportItem("svg", "Export SVG", () => this._exportSvg());
 mkExportItem("csv", "Export CSV", () => this._exportCsv());
 setZoomMenuOpen = (open, restoreFocus = false) => {
@@ -6114,16 +6127,16 @@ selectMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`
 selectMenu.style.visibility = "visible";
 };
 setExportMenuOpen = (open, restoreFocus = false) => {
-const show = Boolean(open) && !this._modebarCollapsed;
+const show = Boolean(open);
 if (show) {
 setZoomMenuOpen(false);
 setSelectMenuOpen(false);
 }
 this._exportMenuOpen = show;
-exportTrigger.setAttribute("aria-expanded", String(show));
+grip.setAttribute("aria-expanded", String(show));
 if (!show) {
 exportMenu.style.display = "none";
-if (restoreFocus) exportTrigger.focus();
+if (restoreFocus) grip.focus();
 return;
 }
 exportMenu.style.display = "flex";
@@ -6139,7 +6152,7 @@ const preferredTop = barRect.bottom + 6 + exportMenu.offsetHeight <= rootRect.bo
 : above;
 const maxLeft = root.clientWidth - rootLeft - exportMenu.offsetWidth;
 const maxTop = root.clientHeight - rootTop - exportMenu.offsetHeight;
-exportMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, exportTrigger.offsetLeft))}px`;
+exportMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, grip.offsetLeft))}px`;
 exportMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
 exportMenu.style.visibility = "visible";
 };
@@ -6203,7 +6216,7 @@ next = (current - 1 + selectMenuItems.length) % selectMenuItems.length;
 selectMenuItems[next].focus();
 });
 }
-this._listen(exportTrigger, "keydown", (e) => {
+this._listen(grip, "keydown", (e) => {
 if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
 e.preventDefault();
 e.stopPropagation();
@@ -6613,10 +6626,10 @@ return svg('<rect x="5" y="3" width="10" height="14" rx="1" stroke-dasharray="2.
 '<path d="M10 6 V14 M10 6 L8 8 M10 6 L12 8 M10 14 L8 12 M10 14 L12 12"/>');
 case "chevrondown":
 return svg('<path d="M6 8 L10 12 L14 8"/>');
-case "more":
-return svg('<circle cx="5" cy="10" r="1" fill="currentColor" stroke="none"/>' +
-'<circle cx="10" cy="10" r="1" fill="currentColor" stroke="none"/>' +
-'<circle cx="15" cy="10" r="1" fill="currentColor" stroke="none"/>');
+case "collapse":
+return svg('<path d="M4 5 H16 M4 15 H16 M7 8 L10 11 L13 8"/>');
+case "expand":
+return svg('<path d="M4 5 H16 M4 15 H16 M7 12 L10 9 L13 12"/>');
 case "png":
 return svg('<path d="M5 2.5 H12 L15.5 6 V17.5 H5 Z"/><path d="M12 2.5 V6 H15.5"/>' +
 '<path d="M7 13 L9 10.5 L11 12 L13.5 9 V15 H7 Z"/>');

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -242,7 +242,8 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="badge"]){gap:3px;font-size:11px;line-height:1.2}
 :where(.xy [data-fc-slot="badge_item"]){padding:3px 6px;border-radius:4px;color:var(--chart-badge-text,#0f172a);background:var(--chart-badge-bg,rgba(255,255,255,.82));box-shadow:0 1px 4px rgba(15,23,42,.14)}
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
-:where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
+:where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-axis,currentColor);cursor:pointer}
+:where(.xy [data-fc-modebar-drag-handle]){cursor:move}
 :where(.xy [data-fc-slot="modebar_button"].fc-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
 :where(.xy [data-fc-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-fc-slot="selection"][data-fc-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}
@@ -5119,29 +5120,12 @@ d.textContent = text;
 const dx = Number.isFinite(Number(ann.dx)) ? Number(ann.dx) : 0;
 const dy = Number.isFinite(Number(ann.dy)) ? Number(ann.dy) : 0;
 const anchor = ann.anchor === "middle" ? "-50%" : ann.anchor === "end" ? "-100%" : "0";
-const rot = Number.isFinite(Number(style.rotation))
-? ((Number(style.rotation) % 360) + 360) % 360
-: 0;
-const va = String(style.vertical_align || "");
+const va = style.vertical_align;
 const vAnchor =
 va === "center" || va === "middle" ? "-50%" : va === "bottom" ? "-100%" : "0";
-let transform = `translate(${anchor},${vAnchor})`;
-if (rot === 90 || rot === 270) {
-const cw = rot === 270;
-const along =
-va === "center" || va === "middle" ? "-50%"
-: va === "top" ? (cw ? "0" : "-100%")
-: va === "bottom" ? (cw ? "-100%" : "0")
-: cw ? "0" : "-100%";
-const cross =
-ann.anchor === "middle" ? "-50%" : ann.anchor === "end" ? (cw ? "0" : "-100%") : cw ? "-100%" : "0";
-transform = `rotate(${cw ? 90 : -90}deg) translate(${along},${cross})`;
-} else if (rot) {
-transform = `rotate(${-rot}deg) translate(${anchor},${vAnchor})`;
-}
 d.style.cssText =
 `position:absolute;left:${px + dx}px;top:${py + dy}px;` +
-`transform:${transform};transform-origin:0 0;pointer-events:none;` +
+`transform:translate(${anchor},${vAnchor});pointer-events:none;` +
 `white-space:pre-line;text-align:center;width:max-content;`;
 this._applySlot(d, "annotation_label");
 this._applyClass(d, ann.class_name);
@@ -5603,17 +5587,131 @@ if (this.comm) this.comm.send({ type: "select_clear" });
 this._dispatchChartEvent("select", { total: 0, view: this._eventView("select_clear") });
 }
 },
+_clampModebar(left, top) {
+const bar = this._modebar;
+if (!bar || !this.root) return;
+const currentLeft = left ?? (Number.parseFloat(bar.style.left) || 0);
+const currentTop = top ?? (Number.parseFloat(bar.style.top) || 0);
+const maxLeft = Math.max(0, this.root.clientWidth - bar.offsetWidth);
+const maxTop = Math.max(0, this.root.clientHeight - bar.offsetHeight);
+bar.style.left = `${Math.max(0, Math.min(maxLeft, currentLeft))}px`;
+bar.style.top = `${Math.max(0, Math.min(maxTop, currentTop))}px`;
+},
 _buildModebar(root) {
 if (this.spec.show_modebar === false) return;
 const bar = document.createElement("div");
 bar.style.cssText =
 `position:absolute;top:${this.plot.y + 4}px;left:${this.plot.x + 4}px;z-index:6;` +
-"display:flex;opacity:.72;transition:opacity .15s;";
+"display:flex;opacity:0;pointer-events:none;transition:opacity .15s;";
 this._applySlot(bar, "modebar");
-this._listen(root, "pointerenter", () => { bar.style.opacity = "1"; });
-this._listen(root, "pointerleave", () => { bar.style.opacity = ".72"; });
 this._modebar = bar;
 this._modeBtns = {};
+this._modebarCollapsed = false;
+this._modebarMoved = false;
+bar.dataset.fcCollapsed = "false";
+const setVisible = (visible) => {
+const show = visible || this._modebarDragging || bar.contains(document.activeElement);
+bar.style.opacity = show ? "1" : "0";
+bar.style.pointerEvents = show ? "auto" : "none";
+};
+this._listen(root, "pointerenter", () => setVisible(true));
+this._listen(root, "pointerleave", () => setVisible(false));
+this._listen(bar, "focusin", () => setVisible(true));
+this._listen(bar, "focusout", () => {
+if (!root.matches(":hover")) setVisible(false);
+});
+const grip = document.createElement("button");
+grip.type = "button";
+grip.title = "Double-click to collapse; drag to move";
+grip.setAttribute("aria-label", "Collapse toolbar");
+grip.setAttribute("aria-expanded", "true");
+grip.dataset.fcModebarDragHandle = "";
+grip.innerHTML = this._icon("drag");
+grip.style.cssText =
+"display:flex;align-items:center;justify-content:center;pointer-events:auto;touch-action:none;";
+this._applySlot(grip, "modebar_button");
+bar.appendChild(grip);
+const DOUBLE_CLICK_MS = 500;
+const DRAG_THRESHOLD_PX = 6;
+let modebarDrag = null;
+let lastGripDown = 0;
+const setCollapsed = (collapsed) => {
+this._modebarCollapsed = collapsed;
+bar.dataset.fcCollapsed = String(collapsed);
+for (const button of bar.querySelectorAll("button")) {
+if (button !== grip) {
+button.hidden = collapsed;
+button.style.display = collapsed ? "none" : "flex";
+}
+}
+grip.title = collapsed
+? "Double-click to expand; drag to move"
+: "Double-click to collapse; drag to move";
+grip.setAttribute("aria-label", collapsed ? "Expand toolbar" : "Collapse toolbar");
+grip.setAttribute("aria-expanded", String(!collapsed));
+this._fitModebar();
+};
+const toggleModebar = () => setCollapsed(!this._modebarCollapsed);
+this._listen(grip, "pointerdown", (e) => {
+if (e.pointerType === "mouse" && e.button !== 0) return;
+e.stopPropagation();
+const now = e.timeStamp || performance.now();
+const doubleClick = lastGripDown > 0 && now - lastGripDown <= DOUBLE_CLICK_MS;
+lastGripDown = doubleClick ? 0 : now;
+const barRect = bar.getBoundingClientRect();
+modebarDrag = {
+pointerId: e.pointerId,
+startX: e.clientX,
+startY: e.clientY,
+dx: e.clientX - barRect.left,
+dy: e.clientY - barRect.top,
+moved: false,
+};
+setVisible(true);
+if (doubleClick) toggleModebar();
+});
+this._listen(grip, "pointermove", (e) => {
+if (!modebarDrag || e.pointerId !== modebarDrag.pointerId) return;
+const distance = Math.hypot(e.clientX - modebarDrag.startX, e.clientY - modebarDrag.startY);
+if (!modebarDrag.moved) {
+if (distance < DRAG_THRESHOLD_PX) return;
+modebarDrag.moved = true;
+lastGripDown = 0;
+this._modebarDragging = true;
+this._modebarMoved = true;
+bar.style.transition = "none";
+try { grip.setPointerCapture(e.pointerId); } catch (_err) {   }
+}
+const rootRect = root.getBoundingClientRect();
+const left = e.clientX - rootRect.left - modebarDrag.dx;
+const top = e.clientY - rootRect.top - modebarDrag.dy;
+this._clampModebar(left, top);
+});
+const endModebarDrag = (e) => {
+if (!modebarDrag || e.pointerId !== modebarDrag.pointerId) return;
+const moved = modebarDrag.moved;
+const cancelled = e.type === "pointercancel";
+modebarDrag = null;
+this._modebarDragging = false;
+bar.style.transition = "opacity .15s";
+setVisible(root.matches(":hover"));
+if (moved || cancelled) {
+lastGripDown = 0;
+}
+};
+this._listen(grip, "pointerup", endModebarDrag);
+this._listen(grip, "pointercancel", endModebarDrag);
+this._listen(grip, "click", (e) => e.stopPropagation());
+this._listen(grip, "dblclick", (e) => {
+e.preventDefault();
+e.stopPropagation();
+});
+this._listen(grip, "keydown", (e) => {
+if (e.repeat || (e.key !== "Enter" && e.key !== " ")) return;
+e.preventDefault();
+e.stopPropagation();
+toggleModebar();
+});
 const mk = (name, title, onClick, toggles) => {
 const b = document.createElement("button");
 b.type = "button";
@@ -5638,17 +5736,24 @@ this._setView(this.view0, { animate: true });
 });
 root.appendChild(bar);
 this._fitModebar();
+setVisible(root.matches(":hover"));
 this._setDragMode(this.dragMode);
 },
 _fitModebar() {
 const bar = this._modebar;
 if (!bar) return;
+if (!this._modebarMoved) {
 bar.style.top = `${this.plot.y + 4}px`;
 bar.style.left = `${this.plot.x + 4}px`;
+}
 bar.style.display = "flex";
 const fits =
 bar.offsetWidth + 8 <= this.plot.w && bar.offsetHeight + 8 <= this.plot.h;
-if (!fits) bar.style.display = "none";
+if (!fits) {
+bar.style.display = "none";
+return;
+}
+this._clampModebar();
 },
 _setDragMode(mode) {
 this.dragMode = mode;
@@ -5822,6 +5927,13 @@ return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
 'stroke-dasharray="3 2"/>');
 case "reset":
 return svg('<path d="M4 10 a6 6 0 1 1 1.8 4.3"/><path d="M4 6 V10 H8"/>');
+case "drag":
+return svg('<circle cx="7" cy="5" r=".8" fill="currentColor" stroke="none"/>' +
+'<circle cx="13" cy="5" r=".8" fill="currentColor" stroke="none"/>' +
+'<circle cx="7" cy="10" r=".8" fill="currentColor" stroke="none"/>' +
+'<circle cx="13" cy="10" r=".8" fill="currentColor" stroke="none"/>' +
+'<circle cx="7" cy="15" r=".8" fill="currentColor" stroke="none"/>' +
+'<circle cx="13" cy="15" r=".8" fill="currentColor" stroke="none"/>');
 default:
 return svg("");
 }

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -242,9 +242,10 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="badge"]){gap:3px;font-size:11px;line-height:1.2}
 :where(.xy [data-fc-slot="badge_item"]){padding:3px 6px;border-radius:4px;color:var(--chart-badge-text,#0f172a);background:var(--chart-badge-bg,rgba(255,255,255,.82));box-shadow:0 1px 4px rgba(15,23,42,.14)}
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
-:where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-axis,currentColor);cursor:pointer}
+:where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
 :where(.xy [data-fc-modebar-drag-handle]){cursor:move}
 :where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:58px;gap:2px;padding:0 6px;font-size:11px;font-variant-numeric:tabular-nums}
+:where(.xy [data-fc-modebar-select-trigger]){width:auto;min-width:35px;gap:0;padding:0 4px}
 :where(.xy [data-fc-modebar-menu-indicator]){display:flex;transition:transform .15s}
 :where(.xy [data-fc-modebar-menu-indicator] svg){width:11px;height:11px}
 :where(.xy [data-fc-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}
@@ -257,6 +258,7 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar_button"].fc-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
 :where(.xy [data-fc-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-fc-slot="selection"][data-fc-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}
+:where(.xy [data-fc-selection-lasso]){fill:var(--chart-selection-fill,rgba(90,140,240,.15));stroke:var(--chart-selection,rgba(90,140,240,.9));stroke-width:1.5;stroke-linejoin:round}
 :where(.xy [data-fc-slot="crosshair_x"],.xy [data-fc-slot="crosshair_y"]){background:var(--chart-crosshair,rgba(15,23,42,.42))}
 :where(.xy [data-fc-slot="tick_label"]){color:var(--chart-text,inherit)}
 :where(.xy [data-fc-slot="axis_title"]){color:var(--chart-text,inherit);font-size:12px}
@@ -5131,12 +5133,29 @@ d.textContent = text;
 const dx = Number.isFinite(Number(ann.dx)) ? Number(ann.dx) : 0;
 const dy = Number.isFinite(Number(ann.dy)) ? Number(ann.dy) : 0;
 const anchor = ann.anchor === "middle" ? "-50%" : ann.anchor === "end" ? "-100%" : "0";
-const va = style.vertical_align;
+const rot = Number.isFinite(Number(style.rotation))
+? ((Number(style.rotation) % 360) + 360) % 360
+: 0;
+const va = String(style.vertical_align || "");
 const vAnchor =
 va === "center" || va === "middle" ? "-50%" : va === "bottom" ? "-100%" : "0";
+let transform = `translate(${anchor},${vAnchor})`;
+if (rot === 90 || rot === 270) {
+const cw = rot === 270;
+const along =
+va === "center" || va === "middle" ? "-50%"
+: va === "top" ? (cw ? "0" : "-100%")
+: va === "bottom" ? (cw ? "-100%" : "0")
+: cw ? "0" : "-100%";
+const cross =
+ann.anchor === "middle" ? "-50%" : ann.anchor === "end" ? (cw ? "0" : "-100%") : cw ? "-100%" : "0";
+transform = `rotate(${cw ? 90 : -90}deg) translate(${along},${cross})`;
+} else if (rot) {
+transform = `rotate(${-rot}deg) translate(${anchor},${vAnchor})`;
+}
 d.style.cssText =
 `position:absolute;left:${px + dx}px;top:${py + dy}px;` +
-`transform:translate(${anchor},${vAnchor});pointer-events:none;` +
+`transform:${transform};transform-origin:0 0;pointer-events:none;` +
 `white-space:pre-line;text-align:center;width:max-content;`;
 this._applySlot(d, "annotation_label");
 this._applyClass(d, ann.class_name);
@@ -5371,6 +5390,13 @@ this.selRect = document.createElement("div");
 this.selRect.style.cssText = "position:absolute;display:none;pointer-events:none;z-index:4;";
 this._applySlot(this.selRect, "selection");
 this.root.appendChild(this.selRect);
+this.selLasso = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+this.selLasso.style.cssText =
+"position:absolute;display:none;pointer-events:none;z-index:4;overflow:visible;";
+this.selLassoPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
+this.selLassoPath.dataset.fcSelectionLasso = "";
+this.selLasso.appendChild(this.selLassoPath);
+this.root.appendChild(this.selLasso);
 if (this._interactionFlag("crosshair")) {
 this.crosshairX = document.createElement("div");
 this.crosshairX.style.cssText =
@@ -5390,10 +5416,16 @@ return this._dataFromCanvas(clientX - r.left, clientY - r.top);
 this._listen(c, "pointerdown", (e) => {
 this._cancelViewAnimation();
 const canBrush = this._interactionFlag("brush", true) && this._interactionFlag("select", true);
-const mode = (e.shiftKey || this.dragMode === "select") && canBrush && this._pickable ? "select"
+const selectMode = this.dragMode.startsWith("select") ? this.dragMode : null;
+const mode = (e.shiftKey || selectMode) && canBrush && this._pickable
+? (e.shiftKey ? "select" : selectMode)
 : this.dragMode === "zoom" ? "zoom" : null;
 if (mode) {
-band = { mode, sx: e.clientX, sy: e.clientY, d0: dataAt(e.clientX, e.clientY) };
+const d0 = dataAt(e.clientX, e.clientY);
+band = {
+mode, sx: e.clientX, sy: e.clientY, d0,
+points: mode === "select-lasso" ? [{ x: e.clientX, y: e.clientY, data: d0 }] : null,
+};
 c.setPointerCapture(e.pointerId);
 this.tooltip.style.display = "none";
 return;
@@ -5430,11 +5462,24 @@ this._hover(e);
 const end = (e) => {
 if (band) {
 this.selRect.style.display = "none";
+this.selLasso.style.display = "none";
 const d1 = dataAt(e.clientX, e.clientY);
 const moved = Math.abs(e.clientX - band.sx) > 3 || Math.abs(e.clientY - band.sy) > 3;
 if (moved) {
 if (band.mode === "zoom") this._zoomToBox(band.d0, d1, true);
-else this._sendSelect(band.d0, d1);
+else if (band.mode === "select-lasso" && band.points.length >= 3) {
+this._sendSelectPolygon(band.points.map((point) => point.data));
+} else {
+let d0 = band.d0;
+if (band.mode === "select-x") {
+d0 = [band.d0[0], this.view.y0];
+d1[1] = this.view.y1;
+} else if (band.mode === "select-y") {
+d0 = [this.view.x0, band.d0[1]];
+d1[0] = this.view.x1;
+}
+this._sendSelect(d0, d1);
+}
 this._ignoreNextClick = true;
 }
 band = null;
@@ -5445,7 +5490,12 @@ if (drag && !drag.moved) this.tooltip.style.display = "none";
 drag = null;
 };
 this._listen(c, "pointerup", end);
-this._listen(c, "pointercancel", () => { this.selRect.style.display = "none"; band = null; drag = null; });
+this._listen(c, "pointercancel", () => {
+this.selRect.style.display = "none";
+this.selLasso.style.display = "none";
+band = null;
+drag = null;
+});
 this._listen(c, "pointerleave", () => {
 const hadHover = this._hoverId !== -1;
 this._hoverId = -1;
@@ -5528,19 +5578,43 @@ this.comm.send(msg);
 _updateBand(band, e) {
 const rect = this.canvas.getBoundingClientRect();
 const rootRect = this.root.getBoundingClientRect();
+if (band.mode === "select-lasso") {
+const previous = band.points[band.points.length - 1];
+if (band.points.length < 2048
+&& Math.hypot(e.clientX - previous.x, e.clientY - previous.y) >= 3) {
+band.points.push({ x: e.clientX, y: e.clientY, data: this._dataFromCanvas(
+e.clientX - rect.left, e.clientY - rect.top
+) });
+}
+const points = band.points.map((point) => [
+Math.max(this.plot.x, Math.min(this.plot.x + this.plot.w, point.x - rootRect.left)),
+Math.max(this.plot.y, Math.min(this.plot.y + this.plot.h, point.y - rootRect.top)),
+]);
+this.selLasso.style.display = "block";
+this.selLasso.style.inset = "0";
+this.selLasso.setAttribute("width", String(this.root.clientWidth));
+this.selLasso.setAttribute("height", String(this.root.clientHeight));
+this.selLassoPath.setAttribute(
+"d", points.map((point, i) => `${i ? "L" : "M"}${point[0]} ${point[1]}`).join(" ") + " Z"
+);
+return;
+}
 const x = Math.min(band.sx, e.clientX) - rootRect.left;
 const y = Math.min(band.sy, e.clientY) - rootRect.top;
 const w = Math.abs(e.clientX - band.sx);
 const h = Math.abs(e.clientY - band.sy);
 const px = this.plot.x, py = this.plot.y;
 const x2 = Math.min(x + w, px + this.plot.w), y2 = Math.min(y + h, py + this.plot.h);
-const cx = Math.max(x, px), cy = Math.max(y, py);
+let cx = Math.max(x, px), cy = Math.max(y, py);
+let bx2 = x2, by2 = y2;
+if (band.mode === "select-x") { cy = py; by2 = py + this.plot.h; }
+if (band.mode === "select-y") { cx = px; bx2 = px + this.plot.w; }
 this.selRect.dataset.fcBand = band.mode === "zoom" ? "zoom" : "select";
 this.selRect.style.display = "block";
 this.selRect.style.left = cx + "px";
 this.selRect.style.top = cy + "px";
-this.selRect.style.width = Math.max(0, x2 - cx) + "px";
-this.selRect.style.height = Math.max(0, y2 - cy) + "px";
+this.selRect.style.width = Math.max(0, bx2 - cx) + "px";
+this.selRect.style.height = Math.max(0, by2 - cy) + "px";
 void rect;
 },
 _sendSelect(d0, d1) {
@@ -5553,6 +5627,52 @@ this.comm.send({ type: "select", x0, x1, y0, y1 });
 } else {
 this._selectLocal(x0, x1, y0, y1);
 }
+},
+_sendSelectPolygon(points) {
+if (!Array.isArray(points) || points.length < 3) return;
+const polygon = points.map((point) => [point[0], point[1]]);
+this._dispatchChartEvent("brush", {
+polygon,
+view: this._eventView("brush"),
+});
+if (this.comm) {
+this.comm.send({ type: "select_polygon", points: polygon });
+} else {
+this._selectLocalPolygon(polygon);
+}
+},
+_selectLocalPolygon(points) {
+const inside = (x, y) => {
+let hit = false;
+for (let i = 0, j = points.length - 1; i < points.length; j = i++) {
+const [xi, yi] = points[i], [xj, yj] = points[j];
+if ((yi > y) !== (yj > y) && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) hit = !hit;
+}
+return hit;
+};
+let total = 0;
+for (const g of this.gpuTraces) {
+if (!g._cpu || g.tier === "density") continue;
+const cx = g._cpu.x, cy = g._cpu.y;
+const xMeta = g._cpu.xMeta || g.xMeta;
+const yMeta = g._cpu.yMeta || g.yMeta;
+const ox = xMeta.offset, sx = xMeta.scale || 1;
+const oy = yMeta.offset, sy = yMeta.scale || 1;
+const mask = new Float32Array(g.n);
+let count = 0;
+for (let i = 0; i < g.n; i++) {
+if (inside(cx[i] / sx + ox, cy[i] / sy + oy)) { mask[i] = 1; count++; }
+}
+this._applySelMask(g, mask);
+total += count;
+}
+this._selectionCount = total;
+this.draw();
+this._dispatchChartEvent("select", {
+total,
+polygon: points,
+view: this._eventView("select"),
+});
 },
 _selectLocal(x0, x1, y0, y1) {
 let total = 0;
@@ -5621,6 +5741,7 @@ this._modebarCollapsed = false;
 this._modebarMoved = false;
 bar.dataset.fcCollapsed = "false";
 let setZoomMenuOpen = () => {};
+let setSelectMenuOpen = () => {};
 const setVisible = (visible) => {
 const show = visible || this._modebarDragging || bar.contains(document.activeElement);
 bar.style.opacity = show ? "1" : "0";
@@ -5630,6 +5751,7 @@ this._listen(root, "pointerenter", () => setVisible(true));
 this._listen(root, "pointerleave", () => {
 setVisible(false);
 setZoomMenuOpen(false);
+setSelectMenuOpen(false);
 });
 this._listen(bar, "focusin", () => setVisible(true));
 this._listen(bar, "focusout", () => {
@@ -5653,7 +5775,10 @@ let lastGripDown = 0;
 const setCollapsed = (collapsed) => {
 this._modebarCollapsed = collapsed;
 bar.dataset.fcCollapsed = String(collapsed);
-if (collapsed) setZoomMenuOpen(false);
+if (collapsed) {
+setZoomMenuOpen(false);
+setSelectMenuOpen(false);
+}
 for (const button of bar.querySelectorAll("button")) {
 if (button !== grip) {
 button.hidden = collapsed;
@@ -5697,6 +5822,7 @@ this._modebarDragging = true;
 this._modebarMoved = true;
 bar.style.transition = "none";
 setZoomMenuOpen(false);
+setSelectMenuOpen(false);
 try { grip.setPointerCapture(e.pointerId); } catch (_err) {   }
 }
 const rootRect = root.getBoundingClientRect();
@@ -5764,11 +5890,21 @@ mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
 const canSelect = this._pickable
 && this._interactionFlag("brush", true)
 && this._interactionFlag("select", true);
+let selectTrigger = null;
+let selectIndicator = null;
 if (canSelect) {
-const selectButton = mk(
-"select", "Select points", () => this._setDragMode("select"), "select"
-);
-selectButton.dataset.fcModebarSelect = "";
+selectTrigger = mk("select", "Selection controls", () => {
+setSelectMenuOpen(!this._selectMenuOpen);
+});
+selectTrigger.dataset.fcModebarSelect = "";
+selectTrigger.dataset.fcModebarSelectTrigger = "";
+selectTrigger.setAttribute("aria-haspopup", "menu");
+selectTrigger.setAttribute("aria-expanded", "false");
+selectIndicator = document.createElement("span");
+selectIndicator.dataset.fcModebarMenuIndicator = "";
+selectIndicator.innerHTML = this._icon("chevrondown");
+selectTrigger.appendChild(selectIndicator);
+this._selectMenuButton = selectTrigger;
 }
 const zoomMenu = document.createElement("div");
 zoomMenu.dataset.fcModebarMenu = "";
@@ -5818,8 +5954,54 @@ mkZoomItem("zoomin", "Zoom In", "+", () => this._zoomBy(0.5, true));
 mkZoomItem("zoomout", "Zoom Out", "−", () => this._zoomBy(2, true));
 mkZoomItem("zoom", "Box Zoom", "B", () => this._setDragMode("zoom"), "zoom");
 mkZoomItem("reset", "Reset View", "0", resetView, null, true);
+const selectMenu = document.createElement("div");
+selectMenu.dataset.fcModebarMenu = "";
+selectMenu.dataset.fcModebarSelectMenu = "";
+selectMenu.setAttribute("role", "menu");
+selectMenu.setAttribute("aria-label", "Selection controls");
+selectMenu.style.cssText =
+"position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
+bar.appendChild(selectMenu);
+const selectMenuItems = [];
+const mkSelectItem = (name, label, shortcut, mode) => {
+const button = document.createElement("button");
+button.type = "button";
+button.tabIndex = -1;
+button.dataset.fcModebarMenuItem = name;
+button.dataset.fcModebarSelectItem = mode;
+button.setAttribute("role", "menuitem");
+button.style.cssText = "display:flex;align-items:center;pointer-events:auto;";
+this._applySlot(button, "modebar_button");
+const icon = document.createElement("span");
+icon.dataset.fcModebarMenuIcon = "";
+icon.innerHTML = this._icon(name);
+button.appendChild(icon);
+const text = document.createElement("span");
+text.textContent = label;
+button.appendChild(text);
+const hint = document.createElement("span");
+hint.dataset.fcModebarMenuShortcut = "";
+hint.textContent = shortcut;
+button.appendChild(hint);
+this._listen(button, "pointerdown", (e) => e.stopPropagation());
+this._listen(button, "click", (e) => {
+e.stopPropagation();
+setSelectMenuOpen(false, true);
+this._setDragMode(mode);
+});
+selectMenu.appendChild(button);
+selectMenuItems.push(button);
+this._modeBtns[mode] = button;
+};
+if (canSelect) {
+mkSelectItem("select", "Box Select", "B", "select");
+mkSelectItem("lasso", "Lasso Select", "L", "select-lasso");
+mkSelectItem("selectx", "X Range", "X", "select-x");
+mkSelectItem("selecty", "Y Range", "Y", "select-y");
+}
 setZoomMenuOpen = (open, restoreFocus = false) => {
 const show = Boolean(open) && !this._modebarCollapsed;
+if (show) setSelectMenuOpen(false);
 this._zoomMenuOpen = show;
 zoomTrigger.setAttribute("aria-expanded", String(show));
 if (!show) {
@@ -5846,9 +6028,43 @@ zoomMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, zoomTrigger.offse
 zoomMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
 zoomMenu.style.visibility = "visible";
 };
-this._closeModebarMenu = () => setZoomMenuOpen(false);
+setSelectMenuOpen = (open, restoreFocus = false) => {
+if (!selectTrigger) return;
+const show = Boolean(open) && !this._modebarCollapsed;
+if (show) setZoomMenuOpen(false);
+this._selectMenuOpen = show;
+selectTrigger.setAttribute("aria-expanded", String(show));
+if (!show) {
+selectMenu.style.display = "none";
+selectIndicator.style.transform = "none";
+if (restoreFocus) selectTrigger.focus();
+return;
+}
+selectMenu.style.display = "flex";
+selectMenu.style.visibility = "hidden";
+const rootRect = root.getBoundingClientRect();
+const barRect = bar.getBoundingClientRect();
+const rootLeft = barRect.left - rootRect.left;
+const rootTop = barRect.top - rootRect.top;
+const below = bar.offsetHeight + 6;
+const above = -selectMenu.offsetHeight - 6;
+const preferredTop = barRect.bottom + 6 + selectMenu.offsetHeight <= rootRect.bottom
+? below
+: above;
+selectIndicator.style.transform = preferredTop === above ? "rotate(180deg)" : "none";
+const maxLeft = root.clientWidth - rootLeft - selectMenu.offsetWidth;
+const maxTop = root.clientHeight - rootTop - selectMenu.offsetHeight;
+selectMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, selectTrigger.offsetLeft))}px`;
+selectMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
+selectMenu.style.visibility = "visible";
+};
+this._closeModebarMenu = () => {
+setZoomMenuOpen(false);
+setSelectMenuOpen(false);
+};
 this._listen(document, "pointerdown", (e) => {
 if (this._zoomMenuOpen && !bar.contains(e.target)) setZoomMenuOpen(false);
+if (this._selectMenuOpen && !bar.contains(e.target)) setSelectMenuOpen(false);
 });
 this._listen(zoomTrigger, "keydown", (e) => {
 if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
@@ -5873,6 +6089,33 @@ if (e.key === "ArrowDown") next = (current + 1) % zoomMenuItems.length;
 if (e.key === "ArrowUp") next = (current - 1 + zoomMenuItems.length) % zoomMenuItems.length;
 zoomMenuItems[next].focus();
 });
+if (selectTrigger) {
+this._listen(selectTrigger, "keydown", (e) => {
+if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+e.preventDefault();
+e.stopPropagation();
+setSelectMenuOpen(true);
+const index = e.key === "ArrowDown" ? 0 : selectMenuItems.length - 1;
+selectMenuItems[index].focus();
+});
+this._listen(selectMenu, "keydown", (e) => {
+if (e.key === "Escape") {
+e.preventDefault();
+e.stopPropagation();
+setSelectMenuOpen(false, true);
+return;
+}
+if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(e.key)) return;
+e.preventDefault();
+const current = selectMenuItems.indexOf(document.activeElement);
+let next = e.key === "Home" ? 0 : e.key === "End" ? selectMenuItems.length - 1 : current;
+if (e.key === "ArrowDown") next = (current + 1) % selectMenuItems.length;
+if (e.key === "ArrowUp") {
+next = (current - 1 + selectMenuItems.length) % selectMenuItems.length;
+}
+selectMenuItems[next].focus();
+});
+}
 root.appendChild(bar);
 this._fitModebar();
 setVisible(root.matches(":hover"));
@@ -5902,6 +6145,7 @@ for (const [name, btn] of Object.entries(this._modeBtns || {})) {
 btn.classList.toggle("fc-active", name === mode);
 }
 this._zoomMenuButton?.classList.toggle("fc-active", mode === "zoom");
+this._selectMenuButton?.classList.toggle("fc-active", mode.startsWith("select"));
 },
 _updateZoomMenuLabel() {
 if (!this._zoomMenuLabel || !this.view || !this.view0) return;
@@ -5918,10 +6162,13 @@ return Number.isFinite(span) && span > 0 && Number.isFinite(homeSpan) && homeSpa
 const percent = axisPercent("x", this.view.x0, this.view.x1, this.view0.x0, this.view0.x1)
 ?? axisPercent("y", this.view.y0, this.view.y1, this.view0.y0, this.view0.y1)
 ?? 100;
-const text = percent < 1 ? "<1%" : `${Math.round(percent)}%`;
-this._zoomMenuLabel.textContent = text;
-this._zoomMenuButton.title = `Zoom controls (${text})`;
-this._zoomMenuButton.setAttribute("aria-label", `Zoom controls, ${text}`);
+const rounded = Math.round(percent);
+const exactText = percent < 1 ? "<1%" : `${rounded}%`;
+const displayText = rounded > 999 ? `${String(rounded).slice(0, 3)}…%` : exactText;
+this._zoomMenuLabel.textContent = displayText;
+this._zoomMenuLabel.dataset.fcZoomExact = exactText;
+this._zoomMenuButton.title = `Zoom controls (${exactText})`;
+this._zoomMenuButton.setAttribute("aria-label", `Zoom controls, ${exactText}`);
 },
 _prefersReducedMotion() {
 return window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches === true;
@@ -6091,6 +6338,17 @@ return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
 'stroke-dasharray="2.5 2"/><circle cx="7" cy="7" r="1" fill="currentColor" ' +
 'stroke="none"/><circle cx="12.5" cy="9" r="1" fill="currentColor" stroke="none"/>' +
 '<circle cx="9.5" cy="13" r="1" fill="currentColor" stroke="none"/>');
+case "lasso":
+return svg('<path d="M4 6 C6 2 15 3 16 8 C17 13 11 17 6 14 C2 12 2 8 4 6 Z" ' +
+'stroke-dasharray="2.5 2"/><circle cx="6" cy="8" r="1" fill="currentColor" ' +
+'stroke="none"/><circle cx="12" cy="7" r="1" fill="currentColor" stroke="none"/>' +
+'<circle cx="10" cy="12" r="1" fill="currentColor" stroke="none"/>');
+case "selectx":
+return svg('<rect x="3" y="5" width="14" height="10" rx="1" stroke-dasharray="2.5 2"/>' +
+'<path d="M6 10 H14 M6 10 L8 8 M6 10 L8 12 M14 10 L12 8 M14 10 L12 12"/>');
+case "selecty":
+return svg('<rect x="5" y="3" width="10" height="14" rx="1" stroke-dasharray="2.5 2"/>' +
+'<path d="M10 6 V14 M10 6 L8 8 M10 6 L12 8 M10 14 L8 12 M10 14 L12 12"/>');
 case "chevrondown":
 return svg('<path d="M6 8 L10 12 L14 8"/>');
 case "reset":

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -244,6 +244,9 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
 :where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-axis,currentColor);cursor:pointer}
 :where(.xy [data-fc-modebar-drag-handle]){cursor:move}
+:where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:58px;gap:2px;padding:0 6px;font-size:11px;font-variant-numeric:tabular-nums}
+:where(.xy [data-fc-modebar-menu-indicator]){display:flex;transition:transform .15s}
+:where(.xy [data-fc-modebar-menu-indicator] svg){width:11px;height:11px}
 :where(.xy [data-fc-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}
 :where(.xy [data-fc-modebar-menu-item]){width:100%;height:28px;justify-content:flex-start;padding:0 9px;border-radius:4px;text-align:left;white-space:nowrap}
 :where(.xy [data-fc-modebar-menu-item]:hover,.xy [data-fc-modebar-menu-item]:focus-visible){background:var(--chart-modebar-active,rgba(128,128,128,.18));outline:none}
@@ -3373,6 +3376,7 @@ gl.uniform1i(u(`${prefix}mode`), this._axisMode(axisId));
 }
 draw(keepPick = false) {
 if (this._destroyed || this._glLost || !this.gl) return;
+this._updateZoomMenuLabel?.();
 if (this._raf) {
 this._rafKeepPick = this._rafKeepPick && keepPick;
 return;
@@ -5744,6 +5748,16 @@ setZoomMenuOpen(!this._zoomMenuOpen);
 });
 this._zoomMenuButton = zoomTrigger;
 zoomTrigger.dataset.fcModebarMenuTrigger = "";
+zoomTrigger.replaceChildren();
+const zoomPercent = document.createElement("span");
+zoomPercent.dataset.fcModebarZoomPercent = "";
+zoomPercent.textContent = "100%";
+zoomTrigger.appendChild(zoomPercent);
+const zoomIndicator = document.createElement("span");
+zoomIndicator.dataset.fcModebarMenuIndicator = "";
+zoomIndicator.innerHTML = this._icon("chevrondown");
+zoomTrigger.appendChild(zoomIndicator);
+this._zoomMenuLabel = zoomPercent;
 zoomTrigger.setAttribute("aria-haspopup", "menu");
 zoomTrigger.setAttribute("aria-expanded", "false");
 mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
@@ -5801,6 +5815,7 @@ this._zoomMenuOpen = show;
 zoomTrigger.setAttribute("aria-expanded", String(show));
 if (!show) {
 zoomMenu.style.display = "none";
+zoomIndicator.style.transform = "none";
 if (restoreFocus) zoomTrigger.focus();
 return;
 }
@@ -5815,6 +5830,7 @@ const above = -zoomMenu.offsetHeight - 6;
 const preferredTop = barRect.bottom + 6 + zoomMenu.offsetHeight <= rootRect.bottom
 ? below
 : above;
+zoomIndicator.style.transform = preferredTop === above ? "rotate(180deg)" : "none";
 const maxLeft = root.clientWidth - rootLeft - zoomMenu.offsetWidth;
 const maxTop = root.clientHeight - rootTop - zoomMenu.offsetHeight;
 zoomMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, zoomTrigger.offsetLeft))}px`;
@@ -5877,6 +5893,26 @@ for (const [name, btn] of Object.entries(this._modeBtns || {})) {
 btn.classList.toggle("fc-active", name === mode);
 }
 this._zoomMenuButton?.classList.toggle("fc-active", mode === "zoom");
+},
+_updateZoomMenuLabel() {
+if (!this._zoomMenuLabel || !this.view || !this.view0) return;
+const axisPercent = (axisId, lo, hi, homeLo, homeHi) => {
+const axis = this._axis(axisId);
+const span = Math.abs(this._axisCoord(axis, hi) - this._axisCoord(axis, lo));
+const homeSpan = Math.abs(
+this._axisCoord(axis, homeHi) - this._axisCoord(axis, homeLo)
+);
+return Number.isFinite(span) && span > 0 && Number.isFinite(homeSpan) && homeSpan > 0
+? (homeSpan / span) * 100
+: null;
+};
+const percent = axisPercent("x", this.view.x0, this.view.x1, this.view0.x0, this.view0.x1)
+?? axisPercent("y", this.view.y0, this.view.y1, this.view0.y0, this.view0.y1)
+?? 100;
+const text = percent < 1 ? "<1%" : `${Math.round(percent)}%`;
+this._zoomMenuLabel.textContent = text;
+this._zoomMenuButton.title = `Zoom controls (${text})`;
+this._zoomMenuButton.setAttribute("aria-label", `Zoom controls, ${text}`);
 },
 _prefersReducedMotion() {
 return window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches === true;
@@ -6041,9 +6077,8 @@ return svg('<path d="M10 3 V17 M3 10 H17"/><path d="M10 3 L8 5 M10 3 L12 5"/>' +
 case "zoom":
 return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
 'stroke-dasharray="3 2"/>');
-case "zoommenu":
-return svg('<circle cx="8" cy="8" r="4.5"/><path d="M11.5 11.5 L15 15"/>' +
-'<path d="M16 7 L18 9 L16 11"/>');
+case "chevrondown":
+return svg('<path d="M6 8 L10 12 L14 8"/>');
 case "reset":
 return svg('<path d="M4 10 a6 6 0 1 1 1.8 4.3"/><path d="M4 6 V10 H8"/>');
 case "drag":

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -5742,6 +5742,7 @@ this._modebarMoved = false;
 bar.dataset.fcCollapsed = "false";
 let setZoomMenuOpen = () => {};
 let setSelectMenuOpen = () => {};
+let setExportMenuOpen = () => {};
 const setVisible = (visible) => {
 const show = visible || this._modebarDragging || bar.contains(document.activeElement);
 bar.style.opacity = show ? "1" : "0";
@@ -5752,6 +5753,7 @@ this._listen(root, "pointerleave", () => {
 setVisible(false);
 setZoomMenuOpen(false);
 setSelectMenuOpen(false);
+setExportMenuOpen(false);
 });
 this._listen(bar, "focusin", () => setVisible(true));
 this._listen(bar, "focusout", () => {
@@ -5778,6 +5780,7 @@ bar.dataset.fcCollapsed = String(collapsed);
 if (collapsed) {
 setZoomMenuOpen(false);
 setSelectMenuOpen(false);
+setExportMenuOpen(false);
 }
 for (const button of bar.querySelectorAll("button")) {
 if (button !== grip) {
@@ -5823,6 +5826,7 @@ this._modebarMoved = true;
 bar.style.transition = "none";
 setZoomMenuOpen(false);
 setSelectMenuOpen(false);
+setExportMenuOpen(false);
 try { grip.setPointerCapture(e.pointerId); } catch (_err) {   }
 }
 const rootRect = root.getBoundingClientRect();
@@ -5906,6 +5910,14 @@ selectIndicator.innerHTML = this._icon("chevrondown");
 selectTrigger.appendChild(selectIndicator);
 this._selectMenuButton = selectTrigger;
 }
+const exportTrigger = mk("more", "Export options", () => {
+setExportMenuOpen(!this._exportMenuOpen);
+});
+exportTrigger.dataset.fcModebarExport = "";
+exportTrigger.dataset.fcModebarExportTrigger = "";
+exportTrigger.setAttribute("aria-label", "Export options");
+exportTrigger.setAttribute("aria-haspopup", "menu");
+exportTrigger.setAttribute("aria-expanded", "false");
 const zoomMenu = document.createElement("div");
 zoomMenu.dataset.fcModebarMenu = "";
 zoomMenu.setAttribute("role", "menu");
@@ -5999,9 +6011,58 @@ mkSelectItem("lasso", "Lasso Select", "L", "select-lasso");
 mkSelectItem("selectx", "X Range", "X", "select-x");
 mkSelectItem("selecty", "Y Range", "Y", "select-y");
 }
+const exportMenu = document.createElement("div");
+exportMenu.dataset.fcModebarMenu = "";
+exportMenu.dataset.fcModebarExportMenu = "";
+exportMenu.setAttribute("role", "menu");
+exportMenu.setAttribute("aria-label", "Export options");
+exportMenu.style.cssText =
+"position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
+bar.appendChild(exportMenu);
+const exportMenuItems = [];
+const mkExportItem = (name, label, onClick, separator = false) => {
+const button = document.createElement("button");
+button.type = "button";
+button.tabIndex = -1;
+button.dataset.fcModebarMenuItem = name;
+button.dataset.fcModebarExportItem = name;
+if (separator) button.dataset.fcSeparator = "";
+button.setAttribute("role", "menuitem");
+button.style.cssText = "display:flex;align-items:center;pointer-events:auto;";
+this._applySlot(button, "modebar_button");
+const icon = document.createElement("span");
+icon.dataset.fcModebarMenuIcon = "";
+icon.innerHTML = this._icon(name);
+button.appendChild(icon);
+const text = document.createElement("span");
+text.textContent = label;
+button.appendChild(text);
+this._listen(button, "pointerdown", (e) => e.stopPropagation());
+this._listen(button, "click", (e) => {
+e.stopPropagation();
+setExportMenuOpen(false, true);
+Promise.resolve(onClick()).catch((error) => console.error(`xy: ${label} failed`, error));
+});
+exportMenu.appendChild(button);
+exportMenuItems.push(button);
+return button;
+};
+const themeItem = mkExportItem("moon", "Dark Mode", () => this._toggleColorMode());
+themeItem.dataset.fcModebarThemeToggle = "";
+themeItem.setAttribute("role", "menuitemcheckbox");
+themeItem.setAttribute("aria-checked", "false");
+this._themeMenuItem = themeItem;
+this._colorMode = "light";
+this._updateColorModeItem();
+mkExportItem("png", "Export PNG", () => this._exportPng(), true);
+mkExportItem("svg", "Export SVG", () => this._exportSvg());
+mkExportItem("csv", "Export CSV", () => this._exportCsv());
 setZoomMenuOpen = (open, restoreFocus = false) => {
 const show = Boolean(open) && !this._modebarCollapsed;
-if (show) setSelectMenuOpen(false);
+if (show) {
+setSelectMenuOpen(false);
+setExportMenuOpen(false);
+}
 this._zoomMenuOpen = show;
 zoomTrigger.setAttribute("aria-expanded", String(show));
 if (!show) {
@@ -6031,7 +6092,10 @@ zoomMenu.style.visibility = "visible";
 setSelectMenuOpen = (open, restoreFocus = false) => {
 if (!selectTrigger) return;
 const show = Boolean(open) && !this._modebarCollapsed;
-if (show) setZoomMenuOpen(false);
+if (show) {
+setZoomMenuOpen(false);
+setExportMenuOpen(false);
+}
 this._selectMenuOpen = show;
 selectTrigger.setAttribute("aria-expanded", String(show));
 if (!show) {
@@ -6058,13 +6122,45 @@ selectMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, selectTrigger.o
 selectMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
 selectMenu.style.visibility = "visible";
 };
+setExportMenuOpen = (open, restoreFocus = false) => {
+const show = Boolean(open) && !this._modebarCollapsed;
+if (show) {
+setZoomMenuOpen(false);
+setSelectMenuOpen(false);
+}
+this._exportMenuOpen = show;
+exportTrigger.setAttribute("aria-expanded", String(show));
+if (!show) {
+exportMenu.style.display = "none";
+if (restoreFocus) exportTrigger.focus();
+return;
+}
+exportMenu.style.display = "flex";
+exportMenu.style.visibility = "hidden";
+const rootRect = root.getBoundingClientRect();
+const barRect = bar.getBoundingClientRect();
+const rootLeft = barRect.left - rootRect.left;
+const rootTop = barRect.top - rootRect.top;
+const below = bar.offsetHeight + 6;
+const above = -exportMenu.offsetHeight - 6;
+const preferredTop = barRect.bottom + 6 + exportMenu.offsetHeight <= rootRect.bottom
+? below
+: above;
+const maxLeft = root.clientWidth - rootLeft - exportMenu.offsetWidth;
+const maxTop = root.clientHeight - rootTop - exportMenu.offsetHeight;
+exportMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, exportTrigger.offsetLeft))}px`;
+exportMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
+exportMenu.style.visibility = "visible";
+};
 this._closeModebarMenu = () => {
 setZoomMenuOpen(false);
 setSelectMenuOpen(false);
+setExportMenuOpen(false);
 };
 this._listen(document, "pointerdown", (e) => {
 if (this._zoomMenuOpen && !bar.contains(e.target)) setZoomMenuOpen(false);
 if (this._selectMenuOpen && !bar.contains(e.target)) setSelectMenuOpen(false);
+if (this._exportMenuOpen && !bar.contains(e.target)) setExportMenuOpen(false);
 });
 this._listen(zoomTrigger, "keydown", (e) => {
 if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
@@ -6116,6 +6212,31 @@ next = (current - 1 + selectMenuItems.length) % selectMenuItems.length;
 selectMenuItems[next].focus();
 });
 }
+this._listen(exportTrigger, "keydown", (e) => {
+if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+e.preventDefault();
+e.stopPropagation();
+setExportMenuOpen(true);
+const index = e.key === "ArrowDown" ? 0 : exportMenuItems.length - 1;
+exportMenuItems[index].focus();
+});
+this._listen(exportMenu, "keydown", (e) => {
+if (e.key === "Escape") {
+e.preventDefault();
+e.stopPropagation();
+setExportMenuOpen(false, true);
+return;
+}
+if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(e.key)) return;
+e.preventDefault();
+const current = exportMenuItems.indexOf(document.activeElement);
+let next = e.key === "Home" ? 0 : e.key === "End" ? exportMenuItems.length - 1 : current;
+if (e.key === "ArrowDown") next = (current + 1) % exportMenuItems.length;
+if (e.key === "ArrowUp") {
+next = (current - 1 + exportMenuItems.length) % exportMenuItems.length;
+}
+exportMenuItems[next].focus();
+});
 root.appendChild(bar);
 this._fitModebar();
 setVisible(root.matches(":hover"));
@@ -6314,6 +6435,209 @@ const y0 = yReversed ? yhi : ylo;
 const y1 = yReversed ? ylo : yhi;
 this._setView({ x0, x1, y0, y1 }, { animate });
 },
+_updateColorModeItem() {
+if (!this._themeMenuItem) return;
+const dark = this._colorMode === "dark";
+const icon = this._themeMenuItem.querySelector("[data-fc-modebar-menu-icon]");
+const label = icon?.nextElementSibling;
+if (icon) icon.innerHTML = this._icon(dark ? "sun" : "moon");
+if (label) label.textContent = dark ? "Light Mode" : "Dark Mode";
+this._themeMenuItem.dataset.fcModebarExportItem = dark ? "light" : "dark";
+this._themeMenuItem.setAttribute("aria-checked", String(dark));
+},
+_setColorMode(mode) {
+const dark = mode === "dark";
+this._colorMode = dark ? "dark" : "light";
+this.root.dataset.fcColorMode = this._colorMode;
+const colors = dark ? {
+color: "#e5e7eb",
+background: "#0b1220",
+"--chart-bg": "#111827",
+"--chart-grid": "rgba(226,232,240,.14)",
+"--chart-axis": "#94a3b8",
+"--chart-text": "#e5e7eb",
+"--chart-legend-bg": "rgba(30,41,59,.84)",
+"--chart-modebar-bg": "rgba(15,23,42,.94)",
+"--chart-modebar-active": "rgba(148,163,184,.24)",
+"--chart-tooltip-bg": "rgba(2,6,23,.96)",
+"--chart-tooltip-text": "#f8fafc",
+"--chart-badge-bg": "rgba(30,41,59,.9)",
+"--chart-badge-text": "#e2e8f0",
+} : {
+color: "#1f2937",
+background: "#ffffff",
+"--chart-bg": "#ffffff",
+"--chart-grid": "rgba(15,23,42,.12)",
+"--chart-axis": "#64748b",
+"--chart-text": "#1f2937",
+"--chart-legend-bg": "rgba(241,245,249,.88)",
+"--chart-modebar-bg": "rgba(255,255,255,.94)",
+"--chart-modebar-active": "rgba(100,116,139,.18)",
+"--chart-tooltip-bg": "rgba(20,24,33,.94)",
+"--chart-tooltip-text": "#ffffff",
+"--chart-badge-bg": "rgba(255,255,255,.9)",
+"--chart-badge-text": "#0f172a",
+};
+for (const [name, value] of Object.entries(colors)) {
+if (name === "color" || name === "background") this.root.style[name] = value;
+else this.root.style.setProperty(name, value);
+}
+this._updateColorModeItem();
+this.refreshTheme();
+},
+_toggleColorMode() {
+this._setColorMode(this._colorMode === "dark" ? "light" : "dark");
+},
+_exportFilename(extension) {
+const title = String(this.spec.title || "xy-chart")
+.trim()
+.toLowerCase()
+.replace(/[^a-z0-9]+/g, "-")
+.replace(/^-+|-+$/g, "") || "xy-chart";
+return `${title}.${extension}`;
+},
+_downloadExport(blob, filename) {
+const url = URL.createObjectURL(blob);
+const link = document.createElement("a");
+link.href = url;
+link.download = filename;
+link.style.display = "none";
+document.body.appendChild(link);
+link.click();
+link.remove();
+setTimeout(() => URL.revokeObjectURL(url), 0);
+},
+_exportSvgMarkup() {
+this._drawNow?.();
+this.gl?.finish?.();
+const width = this.size.w;
+const height = this.size.h;
+const clone = this.root.cloneNode(true);
+clone.style.width = `${width}px`;
+clone.style.height = `${height}px`;
+clone.style.margin = "0";
+clone.setAttribute("xmlns", "http://www.w3.org/1999/xhtml");
+const sourceCanvases = [...this.root.querySelectorAll("canvas")];
+const clonedCanvases = [...clone.querySelectorAll("canvas")];
+for (let i = 0; i < clonedCanvases.length; i++) {
+const source = sourceCanvases[i];
+const target = clonedCanvases[i];
+if (!source || !target) continue;
+const image = document.createElement("img");
+image.setAttribute("src", source.toDataURL("image/png"));
+image.setAttribute("alt", "");
+image.setAttribute("style", target.getAttribute("style") || "");
+image.setAttribute("width", String(source.clientWidth || source.width));
+image.setAttribute("height", String(source.clientHeight || source.height));
+for (const attr of target.attributes) {
+if (attr.name.startsWith("data-")) image.setAttribute(attr.name, attr.value);
+}
+target.replaceWith(image);
+}
+clone.querySelectorAll(
+'[data-fc-slot="modebar"],[data-fc-slot="tooltip"],' +
+'[data-fc-slot="selection"],[data-fc-selection-lasso],' +
+'[data-fc-slot="crosshair_x"],[data-fc-slot="crosshair_y"]'
+).forEach((node) => node.remove());
+const stylesheet = document.createElement("style");
+stylesheet.textContent = FC_CHROME_CSS;
+clone.prepend(stylesheet);
+const content = new XMLSerializer().serializeToString(clone);
+return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" ` +
+`viewBox="0 0 ${width} ${height}"><foreignObject width="100%" height="100%">` +
+`${content}</foreignObject></svg>`;
+},
+_exportSvg() {
+const svg = this._exportSvgMarkup();
+this._downloadExport(
+new Blob([svg], { type: "image/svg+xml;charset=utf-8" }),
+this._exportFilename("svg")
+);
+},
+_exportPng() {
+const svg = this._exportSvgMarkup();
+const sourceUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+const image = new Image();
+return new Promise((resolve, reject) => {
+image.onload = () => {
+const scale = Math.max(1, window.devicePixelRatio || 1);
+const canvas = document.createElement("canvas");
+canvas.width = Math.round(this.size.w * scale);
+canvas.height = Math.round(this.size.h * scale);
+const ctx = canvas.getContext("2d");
+ctx.scale(scale, scale);
+ctx.drawImage(image, 0, 0, this.size.w, this.size.h);
+canvas.toBlob((blob) => {
+if (!blob) {
+reject(new Error("PNG encoding returned no data"));
+return;
+}
+this._downloadExport(blob, this._exportFilename("png"));
+resolve();
+}, "image/png");
+};
+image.onerror = () => {
+reject(new Error("chart SVG could not be rasterized"));
+};
+image.src = sourceUrl;
+});
+},
+_exportCsvText() {
+const columns = ["trace", "name", "kind", "index", "x", "y", "x0", "x1", "y0", "y1", "value"];
+const rows = [columns];
+const clean = (value) => Number.isFinite(value) ? value : "";
+for (const g of this.gpuTraces || []) {
+const trace = g.trace || {};
+const prefix = [trace.id ?? "", trace.name ?? "", trace.kind ?? ""];
+if (g._cpuRect) {
+const r = g._cpuRect;
+const n = Math.min(r.x0.length, r.x1.length, r.y0.length, r.y1.length);
+for (let i = 0; i < n; i++) {
+rows.push([...prefix, i, "", "",
+clean(this._decodeValue(r.x0, r.x0Meta, i)),
+clean(this._decodeValue(r.x1, r.x1Meta, i)),
+clean(this._decodeValue(r.y0, r.y0Meta, i)),
+clean(this._decodeValue(r.y1, r.y1Meta, i)), ""]);
+}
+continue;
+}
+if (g.heatmap && g._cpuHeatmap) {
+const h = g.heatmap;
+for (let i = 0; i < g._cpuHeatmap.grid.length; i++) {
+const row = Math.floor(i / h.w);
+const col = i % h.w;
+const x = h.xRange[0] + (col + 0.5) * ((h.xRange[1] - h.xRange[0]) / h.w);
+const y = h.yRange[0] + (row + 0.5) * ((h.yRange[1] - h.yRange[0]) / h.h);
+const value = this._denormalizeUnit(g._cpuHeatmap.grid[i], trace.color?.domain);
+rows.push([...prefix, i, clean(x), clean(y), "", "", "", "", clean(value)]);
+}
+continue;
+}
+const cpu = g._cpu;
+if (!cpu?.x || !cpu?.y) continue;
+const n = Math.min(cpu.x.length, cpu.y.length, g.n || Infinity);
+for (let i = 0; i < n; i++) {
+rows.push([...prefix, i,
+clean(this._decodeValue(cpu.x, cpu.xMeta || g.xMeta, i)),
+clean(this._decodeValue(cpu.y, cpu.yMeta || g.yMeta, i)),
+"", "", "", "", ""]);
+}
+}
+const quote = (value) => {
+const text = String(value ?? "");
+const escaped = text.split('"').join('""');
+return text.includes(",") || text.includes('"') || text.includes("\r") || text.includes("\n")
+? `"${escaped}"`
+: text;
+};
+return rows.map((row) => row.map(quote).join(",")).join("\r\n") + "\r\n";
+},
+_exportCsv() {
+this._downloadExport(
+new Blob([this._exportCsvText()], { type: "text/csv;charset=utf-8" }),
+this._exportFilename("csv")
+);
+},
 _icon(name) {
 const svg = (body) =>
 `<svg width="15" height="15" viewBox="0 0 20 20" fill="none" ` +
@@ -6351,6 +6675,25 @@ return svg('<rect x="5" y="3" width="10" height="14" rx="1" stroke-dasharray="2.
 '<path d="M10 6 V14 M10 6 L8 8 M10 6 L12 8 M10 14 L8 12 M10 14 L12 12"/>');
 case "chevrondown":
 return svg('<path d="M6 8 L10 12 L14 8"/>');
+case "more":
+return svg('<circle cx="5" cy="10" r="1" fill="currentColor" stroke="none"/>' +
+'<circle cx="10" cy="10" r="1" fill="currentColor" stroke="none"/>' +
+'<circle cx="15" cy="10" r="1" fill="currentColor" stroke="none"/>');
+case "moon":
+return svg('<path d="M14.8 13.8 A6.5 6.5 0 0 1 6.2 5.2 A6.5 6.5 0 1 0 14.8 13.8 Z"/>');
+case "sun":
+return svg('<circle cx="10" cy="10" r="3"/><path d="M10 2 V4 M10 16 V18 ' +
+'M2 10 H4 M16 10 H18 M4.3 4.3 L5.7 5.7 M14.3 14.3 L15.7 15.7 ' +
+'M15.7 4.3 L14.3 5.7 M5.7 14.3 L4.3 15.7"/>');
+case "png":
+return svg('<path d="M5 2.5 H12 L15.5 6 V17.5 H5 Z"/><path d="M12 2.5 V6 H15.5"/>' +
+'<path d="M7 13 L9 10.5 L11 12 L13.5 9 V15 H7 Z"/>');
+case "svg":
+return svg('<path d="M5 2.5 H12 L15.5 6 V17.5 H5 Z"/><path d="M12 2.5 V6 H15.5"/>' +
+'<path d="M7 13 L9 9 L11 14 L13.5 10"/>');
+case "csv":
+return svg('<path d="M5 2.5 H12 L15.5 6 V17.5 H5 Z"/><path d="M12 2.5 V6 H15.5"/>' +
+'<path d="M7 9 H13 M7 12 H13 M7 15 H13 M9 8 V16"/>');
 case "reset":
 return svg('<path d="M4 10 a6 6 0 1 1 1.8 4.3"/><path d="M4 6 V10 H8"/>');
 case "drag":

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -243,7 +243,10 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="badge_item"]){padding:3px 6px;border-radius:4px;color:var(--chart-badge-text,#0f172a);background:var(--chart-badge-bg,rgba(255,255,255,.82));box-shadow:0 1px 4px rgba(15,23,42,.14)}
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
 :where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
-:where(.xy [data-fc-modebar-drag-handle]){cursor:move}
+:where(.xy [data-fc-modebar-drag-handle]){position:relative;margin-right:3px;cursor:move}
+:where(.xy [data-fc-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-2px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
+:where(.xy [data-fc-slot="modebar"][data-fc-collapsed="true"]>[data-fc-modebar-drag-handle]){margin-right:0}
+:where(.xy [data-fc-slot="modebar"][data-fc-collapsed="true"]>[data-fc-modebar-drag-handle])::after{display:none}
 :where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:58px;gap:2px;padding:0 6px;font-size:11px;font-variant-numeric:tabular-nums}
 :where(.xy [data-fc-modebar-select-trigger]){width:auto;min-width:35px;gap:0;padding:0 4px}
 :where(.xy [data-fc-modebar-menu-indicator]){display:flex;transition:transform .15s}

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -5899,7 +5899,6 @@ zoomTrigger.appendChild(zoomIndicator);
 this._zoomMenuLabel = zoomPercent;
 zoomTrigger.setAttribute("aria-haspopup", "menu");
 zoomTrigger.setAttribute("aria-expanded", "false");
-mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
 const canSelect = this._pickable
 && this._interactionFlag("brush", true)
 && this._interactionFlag("select", true);
@@ -5919,6 +5918,7 @@ selectIndicator.innerHTML = this._icon("chevrondown");
 selectTrigger.appendChild(selectIndicator);
 this._selectMenuButton = selectTrigger;
 }
+mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
 const zoomMenu = document.createElement("div");
 zoomMenu.dataset.fcModebarMenu = "";
 zoomMenu.setAttribute("role", "menu");

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -244,6 +244,11 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
 :where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-axis,currentColor);cursor:pointer}
 :where(.xy [data-fc-modebar-drag-handle]){cursor:move}
+:where(.xy [data-fc-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}
+:where(.xy [data-fc-modebar-menu-item]){width:100%;height:28px;justify-content:space-between;padding:0 9px;border-radius:4px;text-align:left;white-space:nowrap}
+:where(.xy [data-fc-modebar-menu-item]:hover,.xy [data-fc-modebar-menu-item]:focus-visible){background:var(--chart-modebar-active,rgba(128,128,128,.18));outline:none}
+:where(.xy [data-fc-modebar-menu-item][data-fc-separator]){margin-top:3px;border-top:1px solid rgba(128,128,128,.2);border-radius:0 0 4px 4px}
+:where(.xy [data-fc-modebar-menu-shortcut]){margin-left:20px;color:var(--chart-axis,currentColor);font-size:10px;opacity:.72}
 :where(.xy [data-fc-slot="modebar_button"].fc-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
 :where(.xy [data-fc-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-fc-slot="selection"][data-fc-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}
@@ -5609,13 +5614,17 @@ this._modeBtns = {};
 this._modebarCollapsed = false;
 this._modebarMoved = false;
 bar.dataset.fcCollapsed = "false";
+let setZoomMenuOpen = () => {};
 const setVisible = (visible) => {
 const show = visible || this._modebarDragging || bar.contains(document.activeElement);
 bar.style.opacity = show ? "1" : "0";
 bar.style.pointerEvents = show ? "auto" : "none";
 };
 this._listen(root, "pointerenter", () => setVisible(true));
-this._listen(root, "pointerleave", () => setVisible(false));
+this._listen(root, "pointerleave", () => {
+setVisible(false);
+setZoomMenuOpen(false);
+});
 this._listen(bar, "focusin", () => setVisible(true));
 this._listen(bar, "focusout", () => {
 if (!root.matches(":hover")) setVisible(false);
@@ -5638,6 +5647,7 @@ let lastGripDown = 0;
 const setCollapsed = (collapsed) => {
 this._modebarCollapsed = collapsed;
 bar.dataset.fcCollapsed = String(collapsed);
+if (collapsed) setZoomMenuOpen(false);
 for (const button of bar.querySelectorAll("button")) {
 if (button !== grip) {
 button.hidden = collapsed;
@@ -5680,6 +5690,7 @@ lastGripDown = 0;
 this._modebarDragging = true;
 this._modebarMoved = true;
 bar.style.transition = "none";
+setZoomMenuOpen(false);
 try { grip.setPointerCapture(e.pointerId); } catch (_err) {   }
 }
 const rootRect = root.getBoundingClientRect();
@@ -5726,13 +5737,110 @@ bar.appendChild(b);
 if (toggles) this._modeBtns[toggles] = b;
 return b;
 };
-mk("zoomin", "Zoom in", () => this._zoomBy(0.5, true));
-mk("zoomout", "Zoom out", () => this._zoomBy(2, true));
+const zoomTrigger = mk("zoommenu", "Zoom controls", () => {
+setZoomMenuOpen(!this._zoomMenuOpen);
+});
+this._zoomMenuButton = zoomTrigger;
+zoomTrigger.dataset.fcModebarMenuTrigger = "";
+zoomTrigger.setAttribute("aria-haspopup", "menu");
+zoomTrigger.setAttribute("aria-expanded", "false");
 mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
-mk("zoom", "Box zoom", () => this._setDragMode("zoom"), "zoom");
-mk("reset", "Reset view", () => {
+const zoomMenu = document.createElement("div");
+zoomMenu.dataset.fcModebarMenu = "";
+zoomMenu.setAttribute("role", "menu");
+zoomMenu.setAttribute("aria-label", "Zoom controls");
+zoomMenu.style.cssText =
+"position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
+bar.appendChild(zoomMenu);
+const zoomMenuItems = [];
+const mkZoomItem = (name, label, shortcut, onClick, toggles, separator = false) => {
+const button = document.createElement("button");
+button.type = "button";
+button.tabIndex = -1;
+button.dataset.fcModebarMenuItem = name;
+if (separator) button.dataset.fcSeparator = "";
+button.setAttribute("role", "menuitem");
+button.style.cssText =
+"display:flex;align-items:center;pointer-events:auto;";
+this._applySlot(button, "modebar_button");
+const text = document.createElement("span");
+text.textContent = label;
+button.appendChild(text);
+const hint = document.createElement("span");
+hint.dataset.fcModebarMenuShortcut = "";
+hint.textContent = shortcut;
+button.appendChild(hint);
+this._listen(button, "pointerdown", (e) => e.stopPropagation());
+this._listen(button, "click", (e) => {
+e.stopPropagation();
+setZoomMenuOpen(false, true);
+onClick();
+});
+zoomMenu.appendChild(button);
+zoomMenuItems.push(button);
+if (toggles) this._modeBtns[toggles] = button;
+return button;
+};
+const resetView = () => {
 this._clearSelection();
 this._setView(this.view0, { animate: true });
+};
+mkZoomItem("zoomin", "Zoom In", "+", () => this._zoomBy(0.5, true));
+mkZoomItem("zoomout", "Zoom Out", "−", () => this._zoomBy(2, true));
+mkZoomItem("zoom", "Box Zoom", "B", () => this._setDragMode("zoom"), "zoom");
+mkZoomItem("reset", "Reset View", "0", resetView, null, true);
+setZoomMenuOpen = (open, restoreFocus = false) => {
+const show = Boolean(open) && !this._modebarCollapsed;
+this._zoomMenuOpen = show;
+zoomTrigger.setAttribute("aria-expanded", String(show));
+if (!show) {
+zoomMenu.style.display = "none";
+if (restoreFocus) zoomTrigger.focus();
+return;
+}
+zoomMenu.style.display = "flex";
+zoomMenu.style.visibility = "hidden";
+const rootRect = root.getBoundingClientRect();
+const barRect = bar.getBoundingClientRect();
+const rootLeft = barRect.left - rootRect.left;
+const rootTop = barRect.top - rootRect.top;
+const below = bar.offsetHeight + 6;
+const above = -zoomMenu.offsetHeight - 6;
+const preferredTop = barRect.bottom + 6 + zoomMenu.offsetHeight <= rootRect.bottom
+? below
+: above;
+const maxLeft = root.clientWidth - rootLeft - zoomMenu.offsetWidth;
+const maxTop = root.clientHeight - rootTop - zoomMenu.offsetHeight;
+zoomMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, zoomTrigger.offsetLeft))}px`;
+zoomMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
+zoomMenu.style.visibility = "visible";
+};
+this._closeModebarMenu = () => setZoomMenuOpen(false);
+this._listen(document, "pointerdown", (e) => {
+if (this._zoomMenuOpen && !bar.contains(e.target)) setZoomMenuOpen(false);
+});
+this._listen(zoomTrigger, "keydown", (e) => {
+if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+e.preventDefault();
+e.stopPropagation();
+setZoomMenuOpen(true);
+const index = e.key === "ArrowDown" ? 0 : zoomMenuItems.length - 1;
+zoomMenuItems[index].focus();
+});
+this._listen(zoomMenu, "keydown", (e) => {
+if (e.key === "Escape") {
+e.preventDefault();
+e.stopPropagation();
+setZoomMenuOpen(false, true);
+return;
+}
+if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(e.key)) return;
+e.preventDefault();
+const current = zoomMenuItems.indexOf(document.activeElement);
+let next = e.key === "Home" ? 0 : e.key === "End" ? zoomMenuItems.length - 1 : current;
+if (e.key === "ArrowDown") next = (current + 1) % zoomMenuItems.length;
+if (e.key === "ArrowUp") next = (current - 1 + zoomMenuItems.length) % zoomMenuItems.length;
+zoomMenuItems[next].focus();
 });
 root.appendChild(bar);
 this._fitModebar();
@@ -5742,6 +5850,7 @@ this._setDragMode(this.dragMode);
 _fitModebar() {
 const bar = this._modebar;
 if (!bar) return;
+this._closeModebarMenu?.();
 if (!this._modebarMoved) {
 bar.style.top = `${this.plot.y + 4}px`;
 bar.style.left = `${this.plot.x + 4}px`;
@@ -5761,6 +5870,7 @@ if (this.canvas) this.canvas.dataset.fcDragmode = mode;
 for (const [name, btn] of Object.entries(this._modeBtns || {})) {
 btn.classList.toggle("fc-active", name === mode);
 }
+this._zoomMenuButton?.classList.toggle("fc-active", mode === "zoom");
 },
 _prefersReducedMotion() {
 return window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches === true;
@@ -5925,6 +6035,9 @@ return svg('<path d="M10 3 V17 M3 10 H17"/><path d="M10 3 L8 5 M10 3 L12 5"/>' +
 case "zoom":
 return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
 'stroke-dasharray="3 2"/>');
+case "zoommenu":
+return svg('<circle cx="8" cy="8" r="4.5"/><path d="M11.5 11.5 L15 15"/>' +
+'<path d="M16 7 L18 9 L16 11"/>');
 case "reset":
 return svg('<path d="M4 10 a6 6 0 1 1 1.8 4.3"/><path d="M4 6 V10 H8"/>');
 case "drag":

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -5743,6 +5743,7 @@ bar.dataset.fcCollapsed = "false";
 let setZoomMenuOpen = () => {};
 let setSelectMenuOpen = () => {};
 let setExportMenuOpen = () => {};
+let updateCollapseItem = () => {};
 const setVisible = (visible) => {
 const show = visible || this._modebarDragging || bar.contains(document.activeElement);
 bar.style.opacity = show ? "1" : "0";
@@ -5761,10 +5762,13 @@ if (!root.matches(":hover")) setVisible(false);
 });
 const grip = document.createElement("button");
 grip.type = "button";
-grip.title = "Double-click to collapse; drag to move";
-grip.setAttribute("aria-label", "Collapse toolbar");
-grip.setAttribute("aria-expanded", "true");
+grip.title = "Click for toolbar options; drag to move; double-click to collapse";
+grip.setAttribute("aria-label", "Toolbar options");
+grip.setAttribute("aria-haspopup", "menu");
+grip.setAttribute("aria-expanded", "false");
 grip.dataset.fcModebarDragHandle = "";
+grip.dataset.fcModebarExport = "";
+grip.dataset.fcModebarExportTrigger = "";
 grip.innerHTML = this._icon("drag");
 grip.style.cssText =
 "display:flex;align-items:center;justify-content:center;pointer-events:auto;touch-action:none;";
@@ -5774,6 +5778,7 @@ const DOUBLE_CLICK_MS = 500;
 const DRAG_THRESHOLD_PX = 6;
 let modebarDrag = null;
 let lastGripDown = 0;
+let suppressGripClickUntil = 0;
 const setCollapsed = (collapsed) => {
 this._modebarCollapsed = collapsed;
 bar.dataset.fcCollapsed = String(collapsed);
@@ -5782,17 +5787,16 @@ setZoomMenuOpen(false);
 setSelectMenuOpen(false);
 setExportMenuOpen(false);
 }
-for (const button of bar.querySelectorAll("button")) {
+for (const button of bar.querySelectorAll(":scope > button")) {
 if (button !== grip) {
 button.hidden = collapsed;
 button.style.display = collapsed ? "none" : "flex";
 }
 }
 grip.title = collapsed
-? "Double-click to expand; drag to move"
-: "Double-click to collapse; drag to move";
-grip.setAttribute("aria-label", collapsed ? "Expand toolbar" : "Collapse toolbar");
-grip.setAttribute("aria-expanded", String(!collapsed));
+? "Click for toolbar options; drag to move; double-click to expand"
+: "Click for toolbar options; drag to move; double-click to collapse";
+updateCollapseItem();
 this._fitModebar();
 };
 const toggleModebar = () => setCollapsed(!this._modebarCollapsed);
@@ -5812,7 +5816,10 @@ dy: e.clientY - barRect.top,
 moved: false,
 };
 setVisible(true);
-if (doubleClick) toggleModebar();
+if (doubleClick) {
+suppressGripClickUntil = performance.now() + 100;
+toggleModebar();
+}
 });
 this._listen(grip, "pointermove", (e) => {
 if (!modebarDrag || e.pointerId !== modebarDrag.pointerId) return;
@@ -5844,20 +5851,22 @@ bar.style.transition = "opacity .15s";
 setVisible(root.matches(":hover"));
 if (moved || cancelled) {
 lastGripDown = 0;
+suppressGripClickUntil = performance.now() + 100;
 }
 };
 this._listen(grip, "pointerup", endModebarDrag);
 this._listen(grip, "pointercancel", endModebarDrag);
-this._listen(grip, "click", (e) => e.stopPropagation());
+this._listen(grip, "click", (e) => {
+e.stopPropagation();
+if (performance.now() <= suppressGripClickUntil) {
+suppressGripClickUntil = 0;
+return;
+}
+setExportMenuOpen(!this._exportMenuOpen);
+});
 this._listen(grip, "dblclick", (e) => {
 e.preventDefault();
 e.stopPropagation();
-});
-this._listen(grip, "keydown", (e) => {
-if (e.repeat || (e.key !== "Enter" && e.key !== " ")) return;
-e.preventDefault();
-e.stopPropagation();
-toggleModebar();
 });
 const mk = (name, title, onClick, toggles) => {
 const b = document.createElement("button");
@@ -5910,14 +5919,6 @@ selectIndicator.innerHTML = this._icon("chevrondown");
 selectTrigger.appendChild(selectIndicator);
 this._selectMenuButton = selectTrigger;
 }
-const exportTrigger = mk("more", "Export options", () => {
-setExportMenuOpen(!this._exportMenuOpen);
-});
-exportTrigger.dataset.fcModebarExport = "";
-exportTrigger.dataset.fcModebarExportTrigger = "";
-exportTrigger.setAttribute("aria-label", "Export options");
-exportTrigger.setAttribute("aria-haspopup", "menu");
-exportTrigger.setAttribute("aria-expanded", "false");
 const zoomMenu = document.createElement("div");
 zoomMenu.dataset.fcModebarMenu = "";
 zoomMenu.setAttribute("role", "menu");
@@ -6015,17 +6016,18 @@ const exportMenu = document.createElement("div");
 exportMenu.dataset.fcModebarMenu = "";
 exportMenu.dataset.fcModebarExportMenu = "";
 exportMenu.setAttribute("role", "menu");
-exportMenu.setAttribute("aria-label", "Export options");
+exportMenu.setAttribute("aria-label", "Toolbar options");
 exportMenu.style.cssText =
 "position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
 bar.appendChild(exportMenu);
 const exportMenuItems = [];
-const mkExportItem = (name, label, onClick) => {
+const mkExportItem = (name, label, onClick, separator = false) => {
 const button = document.createElement("button");
 button.type = "button";
 button.tabIndex = -1;
 button.dataset.fcModebarMenuItem = name;
 button.dataset.fcModebarExportItem = name;
+if (separator) button.dataset.fcSeparator = "";
 button.setAttribute("role", "menuitem");
 button.style.cssText = "display:flex;align-items:center;pointer-events:auto;";
 this._applySlot(button, "modebar_button");
@@ -6046,7 +6048,18 @@ exportMenu.appendChild(button);
 exportMenuItems.push(button);
 return button;
 };
-mkExportItem("png", "Export PNG", () => this._exportPng());
+const collapseItem = mkExportItem("collapse", "Collapse Toolbar", toggleModebar);
+collapseItem.dataset.fcModebarCollapseItem = "";
+updateCollapseItem = () => {
+const collapsed = this._modebarCollapsed;
+const icon = collapseItem.querySelector("[data-fc-modebar-menu-icon]");
+const label = icon?.nextElementSibling;
+if (icon) icon.innerHTML = this._icon(collapsed ? "expand" : "collapse");
+if (label) label.textContent = collapsed ? "Expand Toolbar" : "Collapse Toolbar";
+collapseItem.dataset.fcModebarExportItem = collapsed ? "expand" : "collapse";
+};
+updateCollapseItem();
+mkExportItem("png", "Export PNG", () => this._exportPng(), true);
 mkExportItem("svg", "Export SVG", () => this._exportSvg());
 mkExportItem("csv", "Export CSV", () => this._exportCsv());
 setZoomMenuOpen = (open, restoreFocus = false) => {
@@ -6115,16 +6128,16 @@ selectMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`
 selectMenu.style.visibility = "visible";
 };
 setExportMenuOpen = (open, restoreFocus = false) => {
-const show = Boolean(open) && !this._modebarCollapsed;
+const show = Boolean(open);
 if (show) {
 setZoomMenuOpen(false);
 setSelectMenuOpen(false);
 }
 this._exportMenuOpen = show;
-exportTrigger.setAttribute("aria-expanded", String(show));
+grip.setAttribute("aria-expanded", String(show));
 if (!show) {
 exportMenu.style.display = "none";
-if (restoreFocus) exportTrigger.focus();
+if (restoreFocus) grip.focus();
 return;
 }
 exportMenu.style.display = "flex";
@@ -6140,7 +6153,7 @@ const preferredTop = barRect.bottom + 6 + exportMenu.offsetHeight <= rootRect.bo
 : above;
 const maxLeft = root.clientWidth - rootLeft - exportMenu.offsetWidth;
 const maxTop = root.clientHeight - rootTop - exportMenu.offsetHeight;
-exportMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, exportTrigger.offsetLeft))}px`;
+exportMenu.style.left = `${Math.max(-rootLeft, Math.min(maxLeft, grip.offsetLeft))}px`;
 exportMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
 exportMenu.style.visibility = "visible";
 };
@@ -6204,7 +6217,7 @@ next = (current - 1 + selectMenuItems.length) % selectMenuItems.length;
 selectMenuItems[next].focus();
 });
 }
-this._listen(exportTrigger, "keydown", (e) => {
+this._listen(grip, "keydown", (e) => {
 if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
 e.preventDefault();
 e.stopPropagation();
@@ -6614,10 +6627,10 @@ return svg('<rect x="5" y="3" width="10" height="14" rx="1" stroke-dasharray="2.
 '<path d="M10 6 V14 M10 6 L8 8 M10 6 L12 8 M10 14 L8 12 M10 14 L12 12"/>');
 case "chevrondown":
 return svg('<path d="M6 8 L10 12 L14 8"/>');
-case "more":
-return svg('<circle cx="5" cy="10" r="1" fill="currentColor" stroke="none"/>' +
-'<circle cx="10" cy="10" r="1" fill="currentColor" stroke="none"/>' +
-'<circle cx="15" cy="10" r="1" fill="currentColor" stroke="none"/>');
+case "collapse":
+return svg('<path d="M4 5 H16 M4 15 H16 M7 8 L10 11 L13 8"/>');
+case "expand":
+return svg('<path d="M4 5 H16 M4 15 H16 M7 12 L10 9 L13 12"/>');
 case "png":
 return svg('<path d="M5 2.5 H12 L15.5 6 V17.5 H5 Z"/><path d="M12 2.5 V6 H15.5"/>' +
 '<path d="M7 13 L9 10.5 L11 12 L13.5 9 V15 H7 Z"/>');

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -242,13 +242,13 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="badge"]){gap:3px;font-size:11px;line-height:1.2}
 :where(.xy [data-fc-slot="badge_item"]){padding:3px 6px;border-radius:4px;color:var(--chart-badge-text,#0f172a);background:var(--chart-badge-bg,rgba(255,255,255,.82));box-shadow:0 1px 4px rgba(15,23,42,.14)}
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
-:where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
-:where(.xy [data-fc-modebar-drag-handle]){position:relative;margin-right:3px;cursor:move}
-:where(.xy [data-fc-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-2px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
+:where(.xy [data-fc-slot="modebar_button"]){width:24px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
+:where(.xy [data-fc-modebar-drag-handle]){position:relative;width:22px;margin-right:2px;cursor:move}
+:where(.xy [data-fc-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-1px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
 :where(.xy [data-fc-slot="modebar"][data-fc-collapsed="true"]>[data-fc-modebar-drag-handle]){margin-right:0}
 :where(.xy [data-fc-slot="modebar"][data-fc-collapsed="true"]>[data-fc-modebar-drag-handle])::after{display:none}
-:where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:58px;gap:2px;padding:0 6px;font-size:11px;font-variant-numeric:tabular-nums}
-:where(.xy [data-fc-modebar-select-trigger]){width:auto;min-width:35px;gap:0;padding:0 4px}
+:where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:52px;gap:1px;padding:0 4px;font-size:11px;font-variant-numeric:tabular-nums}
+:where(.xy [data-fc-modebar-select-trigger]){width:auto;min-width:30px;gap:0;padding:0 2px}
 :where(.xy [data-fc-modebar-menu-indicator]){display:flex;transition:transform .15s}
 :where(.xy [data-fc-modebar-menu-indicator] svg){width:11px;height:11px}
 :where(.xy [data-fc-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -245,8 +245,6 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar_button"]){width:24px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
 :where(.xy [data-fc-modebar-drag-handle]){position:relative;width:22px;margin-right:2px;cursor:move}
 :where(.xy [data-fc-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-1px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
-:where(.xy [data-fc-slot="modebar"][data-fc-collapsed="true"]>[data-fc-modebar-drag-handle]){margin-right:0}
-:where(.xy [data-fc-slot="modebar"][data-fc-collapsed="true"]>[data-fc-modebar-drag-handle])::after{display:none}
 :where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:52px;gap:1px;padding:0 4px;font-size:11px;font-variant-numeric:tabular-nums}
 :where(.xy [data-fc-modebar-select-trigger]){width:auto;min-width:30px;gap:0;padding:0 2px}
 :where(.xy [data-fc-modebar-menu-indicator]){display:flex;transition:transform .15s}
@@ -5740,13 +5738,10 @@ bar.style.cssText =
 this._applySlot(bar, "modebar");
 this._modebar = bar;
 this._modeBtns = {};
-this._modebarCollapsed = false;
 this._modebarMoved = false;
-bar.dataset.fcCollapsed = "false";
 let setZoomMenuOpen = () => {};
 let setSelectMenuOpen = () => {};
 let setExportMenuOpen = () => {};
-let updateCollapseItem = () => {};
 const setVisible = (visible) => {
 const show = visible || this._modebarDragging || bar.contains(document.activeElement);
 bar.style.opacity = show ? "1" : "0";
@@ -5765,7 +5760,7 @@ if (!root.matches(":hover")) setVisible(false);
 });
 const grip = document.createElement("button");
 grip.type = "button";
-grip.title = "Click for toolbar options; drag to move; double-click to collapse";
+grip.title = "Click for toolbar options; drag to move";
 grip.setAttribute("aria-label", "Toolbar options");
 grip.setAttribute("aria-haspopup", "menu");
 grip.setAttribute("aria-expanded", "false");
@@ -5777,38 +5772,12 @@ grip.style.cssText =
 "display:flex;align-items:center;justify-content:center;pointer-events:auto;touch-action:none;";
 this._applySlot(grip, "modebar_button");
 bar.appendChild(grip);
-const DOUBLE_CLICK_MS = 500;
 const DRAG_THRESHOLD_PX = 6;
 let modebarDrag = null;
-let lastGripDown = 0;
 let suppressGripClickUntil = 0;
-const setCollapsed = (collapsed) => {
-this._modebarCollapsed = collapsed;
-bar.dataset.fcCollapsed = String(collapsed);
-if (collapsed) {
-setZoomMenuOpen(false);
-setSelectMenuOpen(false);
-setExportMenuOpen(false);
-}
-for (const button of bar.querySelectorAll(":scope > button")) {
-if (button !== grip) {
-button.hidden = collapsed;
-button.style.display = collapsed ? "none" : "flex";
-}
-}
-grip.title = collapsed
-? "Click for toolbar options; drag to move; double-click to expand"
-: "Click for toolbar options; drag to move; double-click to collapse";
-updateCollapseItem();
-this._fitModebar();
-};
-const toggleModebar = () => setCollapsed(!this._modebarCollapsed);
 this._listen(grip, "pointerdown", (e) => {
 if (e.pointerType === "mouse" && e.button !== 0) return;
 e.stopPropagation();
-const now = e.timeStamp || performance.now();
-const doubleClick = lastGripDown > 0 && now - lastGripDown <= DOUBLE_CLICK_MS;
-lastGripDown = doubleClick ? 0 : now;
 const barRect = bar.getBoundingClientRect();
 modebarDrag = {
 pointerId: e.pointerId,
@@ -5819,10 +5788,6 @@ dy: e.clientY - barRect.top,
 moved: false,
 };
 setVisible(true);
-if (doubleClick) {
-suppressGripClickUntil = performance.now() + 100;
-toggleModebar();
-}
 });
 this._listen(grip, "pointermove", (e) => {
 if (!modebarDrag || e.pointerId !== modebarDrag.pointerId) return;
@@ -5830,7 +5795,6 @@ const distance = Math.hypot(e.clientX - modebarDrag.startX, e.clientY - modebarD
 if (!modebarDrag.moved) {
 if (distance < DRAG_THRESHOLD_PX) return;
 modebarDrag.moved = true;
-lastGripDown = 0;
 this._modebarDragging = true;
 this._modebarMoved = true;
 bar.style.transition = "none";
@@ -5853,7 +5817,6 @@ this._modebarDragging = false;
 bar.style.transition = "opacity .15s";
 setVisible(root.matches(":hover"));
 if (moved || cancelled) {
-lastGripDown = 0;
 suppressGripClickUntil = performance.now() + 100;
 }
 };
@@ -5866,10 +5829,6 @@ suppressGripClickUntil = 0;
 return;
 }
 setExportMenuOpen(!this._exportMenuOpen);
-});
-this._listen(grip, "dblclick", (e) => {
-e.preventDefault();
-e.stopPropagation();
 });
 const mk = (name, title, onClick, toggles) => {
 const b = document.createElement("button");
@@ -6051,22 +6010,11 @@ exportMenu.appendChild(button);
 exportMenuItems.push(button);
 return button;
 };
-const collapseItem = mkExportItem("collapse", "Collapse Toolbar", toggleModebar);
-collapseItem.dataset.fcModebarCollapseItem = "";
-updateCollapseItem = () => {
-const collapsed = this._modebarCollapsed;
-const icon = collapseItem.querySelector("[data-fc-modebar-menu-icon]");
-const label = icon?.nextElementSibling;
-if (icon) icon.innerHTML = this._icon(collapsed ? "expand" : "collapse");
-if (label) label.textContent = collapsed ? "Expand Toolbar" : "Collapse Toolbar";
-collapseItem.dataset.fcModebarExportItem = collapsed ? "expand" : "collapse";
-};
-updateCollapseItem();
-mkExportItem("png", "Export PNG", () => this._exportPng(), true);
+mkExportItem("png", "Export PNG", () => this._exportPng());
 mkExportItem("svg", "Export SVG", () => this._exportSvg());
 mkExportItem("csv", "Export CSV", () => this._exportCsv());
 setZoomMenuOpen = (open, restoreFocus = false) => {
-const show = Boolean(open) && !this._modebarCollapsed;
+const show = Boolean(open);
 if (show) {
 setSelectMenuOpen(false);
 setExportMenuOpen(false);
@@ -6099,7 +6047,7 @@ zoomMenu.style.visibility = "visible";
 };
 setSelectMenuOpen = (open, restoreFocus = false) => {
 if (!selectTrigger) return;
-const show = Boolean(open) && !this._modebarCollapsed;
+const show = Boolean(open);
 if (show) {
 setZoomMenuOpen(false);
 setExportMenuOpen(false);

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -259,7 +259,9 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar_button"].fc-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
 :where(.xy [data-fc-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-fc-slot="selection"][data-fc-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}
-:where(.xy [data-fc-selection-lasso]){fill:var(--chart-selection-fill,rgba(90,140,240,.15));stroke:var(--chart-selection,rgba(90,140,240,.9));stroke-width:1.5;stroke-linejoin:round}
+:where(.xy [data-fc-selection-lasso]){fill:var(--chart-selection-fill,rgba(90,140,240,.15));stroke:var(--chart-selection,rgba(90,140,240,.9));stroke-width:1.5;stroke-linejoin:round;pointer-events:none}
+:where(.xy [data-fc-selection-lasso-handle]){fill:var(--chart-bg,#fff);stroke:var(--chart-selection,rgba(90,140,240,.9));stroke-width:1.5;cursor:grab;pointer-events:all}
+:where(.xy [data-fc-selection-lasso-handle][data-fc-active]){cursor:grabbing;fill:var(--chart-selection,rgba(90,140,240,.9))}
 :where(.xy [data-fc-slot="crosshair_x"],.xy [data-fc-slot="crosshair_y"]){background:var(--chart-crosshair,rgba(15,23,42,.42))}
 :where(.xy [data-fc-slot="tick_label"]){color:var(--chart-text,inherit)}
 :where(.xy [data-fc-slot="axis_title"]){color:var(--chart-text,inherit);font-size:12px}
@@ -3412,6 +3414,7 @@ this._drawHoverState();
 if (!this._rafKeepPick) this._pickDirty = true;
 this._rafKeepPick = false;
 this._drawChrome();
+this._renderLassoSelection?.();
 }
 _now() {
 return performance.now();
@@ -5394,10 +5397,60 @@ this.root.appendChild(this.selRect);
 this.selLasso = document.createElementNS("http://www.w3.org/2000/svg", "svg");
 this.selLasso.style.cssText =
 "position:absolute;display:none;pointer-events:none;z-index:4;overflow:visible;";
+this.selLasso.dataset.fcSelectionLassoOverlay = "";
 this.selLassoPath = document.createElementNS("http://www.w3.org/2000/svg", "path");
 this.selLassoPath.dataset.fcSelectionLasso = "";
 this.selLasso.appendChild(this.selLassoPath);
+this.selLassoHandles = document.createElementNS("http://www.w3.org/2000/svg", "g");
+this.selLassoHandles.dataset.fcSelectionLassoHandles = "";
+this.selLasso.appendChild(this.selLassoHandles);
 this.root.appendChild(this.selLasso);
+this._lassoPolygon = null;
+let lassoHandleDrag = null;
+const moveLassoHandle = (e) => {
+if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId) return;
+const rect = c.getBoundingClientRect();
+const cssX = Math.max(0, Math.min(rect.width, e.clientX - rect.left));
+const cssY = Math.max(0, Math.min(rect.height, e.clientY - rect.top));
+this._lassoPolygon[lassoHandleDrag.index] = this._dataFromCanvas(cssX, cssY);
+this._renderLassoSelection();
+e.preventDefault();
+e.stopPropagation();
+};
+this._listen(this.selLasso, "pointerdown", (e) => {
+const handle = e.target.closest?.("[data-fc-selection-lasso-handle]");
+if (!handle || !this._lassoPolygon) return;
+const index = Number(handle.dataset.fcSelectionLassoHandle);
+if (!Number.isInteger(index) || !this._lassoPolygon[index]) return;
+lassoHandleDrag = {
+index,
+pointerId: e.pointerId,
+original: [...this._lassoPolygon[index]],
+handle,
+};
+handle.dataset.fcActive = "";
+this.tooltip.style.display = "none";
+try { this.selLasso.setPointerCapture(e.pointerId); } catch (_err) {   }
+e.preventDefault();
+e.stopPropagation();
+});
+this._listen(this.selLasso, "pointermove", moveLassoHandle);
+this._listen(this.selLasso, "pointerup", (e) => {
+if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId) return;
+moveLassoHandle(e);
+const handle = lassoHandleDrag.handle;
+lassoHandleDrag = null;
+delete handle.dataset.fcActive;
+this._sendSelectPolygon(this._lassoPolygon);
+});
+this._listen(this.selLasso, "pointercancel", (e) => {
+if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId) return;
+this._lassoPolygon[lassoHandleDrag.index] = lassoHandleDrag.original;
+delete lassoHandleDrag.handle.dataset.fcActive;
+lassoHandleDrag = null;
+this._renderLassoSelection();
+e.stopPropagation();
+});
 if (this._interactionFlag("crosshair")) {
 this.crosshairX = document.createElement("div");
 this.crosshairX.style.cssText =
@@ -5414,6 +5467,16 @@ const dataAt = (clientX, clientY) => {
 const r = c.getBoundingClientRect();
 return this._dataFromCanvas(clientX - r.left, clientY - r.top);
 };
+const lassoPointAt = (clientX, clientY) => {
+const r = c.getBoundingClientRect();
+const cssX = Math.max(0, Math.min(r.width, clientX - r.left));
+const cssY = Math.max(0, Math.min(r.height, clientY - r.top));
+return {
+x: r.left + cssX,
+y: r.top + cssY,
+data: this._dataFromCanvas(cssX, cssY),
+};
+};
 this._listen(c, "pointerdown", (e) => {
 this._cancelViewAnimation();
 const canBrush = this._interactionFlag("brush", true) && this._interactionFlag("select", true);
@@ -5422,10 +5485,16 @@ const mode = (e.shiftKey || selectMode) && canBrush && this._pickable
 ? (e.shiftKey ? "select" : selectMode)
 : this.dragMode === "zoom" ? "zoom" : null;
 if (mode) {
-const d0 = dataAt(e.clientX, e.clientY);
+const previousLasso = mode.startsWith("select") && this._lassoPolygon
+? this._lassoPolygon.map((point) => [...point])
+: null;
+if (mode.startsWith("select")) this._clearLassoOverlay();
+const firstLassoPoint = mode === "select-lasso" ? lassoPointAt(e.clientX, e.clientY) : null;
+const d0 = firstLassoPoint ? firstLassoPoint.data : dataAt(e.clientX, e.clientY);
 band = {
 mode, sx: e.clientX, sy: e.clientY, d0,
-points: mode === "select-lasso" ? [{ x: e.clientX, y: e.clientY, data: d0 }] : null,
+points: firstLassoPoint ? [firstLassoPoint] : null,
+previousLasso,
 };
 c.setPointerCapture(e.pointerId);
 this.tooltip.style.display = "none";
@@ -5469,7 +5538,8 @@ const moved = Math.abs(e.clientX - band.sx) > 3 || Math.abs(e.clientY - band.sy)
 if (moved) {
 if (band.mode === "zoom") this._zoomToBox(band.d0, d1, true);
 else if (band.mode === "select-lasso" && band.points.length >= 3) {
-this._sendSelectPolygon(band.points.map((point) => point.data));
+const editable = this._simplifyLassoPoints(band.points);
+this._sendSelectPolygon(editable.map((point) => point.data));
 } else {
 let d0 = band.d0;
 if (band.mode === "select-x") {
@@ -5482,6 +5552,9 @@ d1[0] = this.view.x1;
 this._sendSelect(d0, d1);
 }
 this._ignoreNextClick = true;
+} else if (band.previousLasso) {
+this._lassoPolygon = band.previousLasso;
+this._renderLassoSelection();
 }
 band = null;
 return;
@@ -5494,6 +5567,10 @@ this._listen(c, "pointerup", end);
 this._listen(c, "pointercancel", () => {
 this.selRect.style.display = "none";
 this.selLasso.style.display = "none";
+if (band?.previousLasso) {
+this._lassoPolygon = band.previousLasso;
+this._renderLassoSelection();
+}
 band = null;
 drag = null;
 });
@@ -5581,11 +5658,13 @@ const rect = this.canvas.getBoundingClientRect();
 const rootRect = this.root.getBoundingClientRect();
 if (band.mode === "select-lasso") {
 const previous = band.points[band.points.length - 1];
+const cssX = Math.max(0, Math.min(rect.width, e.clientX - rect.left));
+const cssY = Math.max(0, Math.min(rect.height, e.clientY - rect.top));
+const clientX = rect.left + cssX;
+const clientY = rect.top + cssY;
 if (band.points.length < 2048
-&& Math.hypot(e.clientX - previous.x, e.clientY - previous.y) >= 3) {
-band.points.push({ x: e.clientX, y: e.clientY, data: this._dataFromCanvas(
-e.clientX - rect.left, e.clientY - rect.top
-) });
+&& Math.hypot(clientX - previous.x, clientY - previous.y) >= 3) {
+band.points.push({ x: clientX, y: clientY, data: this._dataFromCanvas(cssX, cssY) });
 }
 const points = band.points.map((point) => [
 Math.max(this.plot.x, Math.min(this.plot.x + this.plot.w, point.x - rootRect.left)),
@@ -5618,7 +5697,108 @@ this.selRect.style.width = Math.max(0, bx2 - cx) + "px";
 this.selRect.style.height = Math.max(0, by2 - cy) + "px";
 void rect;
 },
+_simplifyLassoPoints(points, tolerance = 6, maxPoints = 16) {
+const source = points.filter((point) => point && Number.isFinite(point.x) && Number.isFinite(point.y));
+if (source.length > 3) {
+const first = source[0], last = source[source.length - 1];
+if (Math.hypot(first.x - last.x, first.y - last.y) <= tolerance) source.pop();
+}
+if (source.length <= 3) return source.slice();
+const distanceToSegmentSq = (point, start, end) => {
+const dx = end.x - start.x, dy = end.y - start.y;
+if (dx === 0 && dy === 0) {
+return (point.x - start.x) ** 2 + (point.y - start.y) ** 2;
+}
+const t = Math.max(0, Math.min(1,
+((point.x - start.x) * dx + (point.y - start.y) * dy) / (dx * dx + dy * dy)
+));
+const x = start.x + t * dx, y = start.y + t * dy;
+return (point.x - x) ** 2 + (point.y - y) ** 2;
+};
+const keep = new Uint8Array(source.length);
+keep[0] = 1;
+keep[source.length - 1] = 1;
+const stack = [[0, source.length - 1]];
+const toleranceSq = tolerance * tolerance;
+while (stack.length) {
+const [start, end] = stack.pop();
+let furthest = -1, furthestDistance = toleranceSq;
+for (let i = start + 1; i < end; i++) {
+const distance = distanceToSegmentSq(source[i], source[start], source[end]);
+if (distance > furthestDistance) {
+furthest = i;
+furthestDistance = distance;
+}
+}
+if (furthest >= 0) {
+keep[furthest] = 1;
+stack.push([start, furthest], [furthest, end]);
+}
+}
+let simplified = source.filter((_point, index) => keep[index]);
+if (simplified.length < 3) {
+simplified = [source[0], source[Math.floor(source.length / 2)], source[source.length - 1]];
+}
+if (simplified.length > maxPoints) {
+simplified = Array.from({ length: maxPoints }, (_value, index) => (
+simplified[Math.round(index * (simplified.length - 1) / (maxPoints - 1))]
+));
+}
+return simplified;
+},
+_clearLassoOverlay() {
+this._lassoPolygon = null;
+if (!this.selLasso) return;
+this.selLasso.style.display = "none";
+this.selLassoPath?.removeAttribute("d");
+this.selLassoHandles?.replaceChildren();
+},
+_renderLassoSelection() {
+const polygon = this._lassoPolygon;
+if (!this.selLasso || !this.selLassoPath || !this.selLassoHandles
+|| !Array.isArray(polygon) || polygon.length < 3) return;
+const [x0, x1] = this._axisRange("x");
+const [y0, y1] = this._axisRange("y");
+const xAxis = this._axis("x"), yAxis = this._axis("y");
+const cx0 = this._axisCoord(xAxis, x0), cx1 = this._axisCoord(xAxis, x1);
+const cy0 = this._axisCoord(yAxis, y0), cy1 = this._axisCoord(yAxis, y1);
+if (![cx0, cx1, cy0, cy1].every(Number.isFinite) || cx0 === cx1 || cy0 === cy1) return;
+const points = polygon.map((point) => {
+const cx = this._axisCoord(xAxis, point[0]);
+const cy = this._axisCoord(yAxis, point[1]);
+const x = this.plot.x + ((cx - cx0) / (cx1 - cx0)) * this.plot.w;
+const y = this.plot.y + ((cy1 - cy) / (cy1 - cy0)) * this.plot.h;
+return [
+Math.max(this.plot.x, Math.min(this.plot.x + this.plot.w, x)),
+Math.max(this.plot.y, Math.min(this.plot.y + this.plot.h, y)),
+];
+});
+if (!points.flat().every(Number.isFinite)) return;
+this.selLasso.style.display = "block";
+this.selLasso.style.inset = "0";
+this.selLasso.setAttribute("width", String(this.root.clientWidth));
+this.selLasso.setAttribute("height", String(this.root.clientHeight));
+this.selLassoPath.setAttribute(
+"d", points.map((point, index) => `${index ? "L" : "M"}${point[0]} ${point[1]}`).join(" ") + " Z"
+);
+while (this.selLassoHandles.childElementCount < points.length) {
+const handle = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+handle.dataset.fcSelectionLassoHandle = "";
+handle.setAttribute("r", "4");
+this.selLassoHandles.appendChild(handle);
+}
+while (this.selLassoHandles.childElementCount > points.length) {
+this.selLassoHandles.lastElementChild.remove();
+}
+[...this.selLassoHandles.children].forEach((handle, index) => {
+handle.dataset.fcSelectionLassoHandle = String(index);
+handle.setAttribute("cx", String(points[index][0]));
+handle.setAttribute("cy", String(points[index][1]));
+handle.setAttribute("aria-label", `Lasso point ${index + 1}`);
+});
+},
 _sendSelect(d0, d1) {
+this._clearLassoOverlay();
 const x0 = Math.min(d0[0], d1[0]), x1 = Math.max(d0[0], d1[0]);
 const y0 = Math.min(d0[1], d1[1]), y1 = Math.max(d0[1], d1[1]);
 const range = { x0, x1, y0, y1 };
@@ -5632,6 +5812,9 @@ this._selectLocal(x0, x1, y0, y1);
 _sendSelectPolygon(points) {
 if (!Array.isArray(points) || points.length < 3) return;
 const polygon = points.map((point) => [point[0], point[1]]);
+if (!polygon.every((point) => point.every(Number.isFinite))) return;
+this._lassoPolygon = polygon;
+this._renderLassoSelection();
 this._dispatchChartEvent("brush", {
 polygon,
 view: this._eventView("brush"),
@@ -5709,6 +5892,7 @@ gl.bufferData(gl.ARRAY_BUFFER, maskF32, gl.STATIC_DRAW);
 g.selActive = true;
 },
 _clearSelection() {
+this._clearLassoOverlay();
 for (const g of this.gpuTraces) {
 g.selActive = false;
 if (g.drill) g.drill.selActive = false;
@@ -6439,7 +6623,7 @@ target.replaceWith(image);
 }
 clone.querySelectorAll(
 '[data-fc-slot="modebar"],[data-fc-slot="tooltip"],' +
-'[data-fc-slot="selection"],[data-fc-selection-lasso],' +
+'[data-fc-slot="selection"],[data-fc-selection-lasso-overlay],' +
 '[data-fc-slot="crosshair_x"],[data-fc-slot="crosshair_y"]'
 ).forEach((node) => node.remove());
 const stylesheet = document.createElement("style");

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -5390,7 +5390,7 @@ return this._dataFromCanvas(clientX - r.left, clientY - r.top);
 this._listen(c, "pointerdown", (e) => {
 this._cancelViewAnimation();
 const canBrush = this._interactionFlag("brush", true) && this._interactionFlag("select", true);
-const mode = e.shiftKey && canBrush && this._pickable ? "select"
+const mode = (e.shiftKey || this.dragMode === "select") && canBrush && this._pickable ? "select"
 : this.dragMode === "zoom" ? "zoom" : null;
 if (mode) {
 band = { mode, sx: e.clientX, sy: e.clientY, d0: dataAt(e.clientX, e.clientY) };
@@ -5761,6 +5761,15 @@ this._zoomMenuLabel = zoomPercent;
 zoomTrigger.setAttribute("aria-haspopup", "menu");
 zoomTrigger.setAttribute("aria-expanded", "false");
 mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
+const canSelect = this._pickable
+&& this._interactionFlag("brush", true)
+&& this._interactionFlag("select", true);
+if (canSelect) {
+const selectButton = mk(
+"select", "Select points", () => this._setDragMode("select"), "select"
+);
+selectButton.dataset.fcModebarSelect = "";
+}
 const zoomMenu = document.createElement("div");
 zoomMenu.dataset.fcModebarMenu = "";
 zoomMenu.setAttribute("role", "menu");
@@ -6077,6 +6086,11 @@ return svg('<path d="M10 3 V17 M3 10 H17"/><path d="M10 3 L8 5 M10 3 L12 5"/>' +
 case "zoom":
 return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
 'stroke-dasharray="3 2"/>');
+case "select":
+return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
+'stroke-dasharray="2.5 2"/><circle cx="7" cy="7" r="1" fill="currentColor" ' +
+'stroke="none"/><circle cx="12.5" cy="9" r="1" fill="currentColor" stroke="none"/>' +
+'<circle cx="9.5" cy="13" r="1" fill="currentColor" stroke="none"/>');
 case "chevrondown":
 return svg('<path d="M6 8 L10 12 L14 8"/>');
 case "reset":

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -6020,13 +6020,12 @@ exportMenu.style.cssText =
 "position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
 bar.appendChild(exportMenu);
 const exportMenuItems = [];
-const mkExportItem = (name, label, onClick, separator = false) => {
+const mkExportItem = (name, label, onClick) => {
 const button = document.createElement("button");
 button.type = "button";
 button.tabIndex = -1;
 button.dataset.fcModebarMenuItem = name;
 button.dataset.fcModebarExportItem = name;
-if (separator) button.dataset.fcSeparator = "";
 button.setAttribute("role", "menuitem");
 button.style.cssText = "display:flex;align-items:center;pointer-events:auto;";
 this._applySlot(button, "modebar_button");
@@ -6047,14 +6046,7 @@ exportMenu.appendChild(button);
 exportMenuItems.push(button);
 return button;
 };
-const themeItem = mkExportItem("moon", "Dark Mode", () => this._toggleColorMode());
-themeItem.dataset.fcModebarThemeToggle = "";
-themeItem.setAttribute("role", "menuitemcheckbox");
-themeItem.setAttribute("aria-checked", "false");
-this._themeMenuItem = themeItem;
-this._colorMode = "light";
-this._updateColorModeItem();
-mkExportItem("png", "Export PNG", () => this._exportPng(), true);
+mkExportItem("png", "Export PNG", () => this._exportPng());
 mkExportItem("svg", "Export SVG", () => this._exportSvg());
 mkExportItem("csv", "Export CSV", () => this._exportCsv());
 setZoomMenuOpen = (open, restoreFocus = false) => {
@@ -6435,59 +6427,6 @@ const y0 = yReversed ? yhi : ylo;
 const y1 = yReversed ? ylo : yhi;
 this._setView({ x0, x1, y0, y1 }, { animate });
 },
-_updateColorModeItem() {
-if (!this._themeMenuItem) return;
-const dark = this._colorMode === "dark";
-const icon = this._themeMenuItem.querySelector("[data-fc-modebar-menu-icon]");
-const label = icon?.nextElementSibling;
-if (icon) icon.innerHTML = this._icon(dark ? "sun" : "moon");
-if (label) label.textContent = dark ? "Light Mode" : "Dark Mode";
-this._themeMenuItem.dataset.fcModebarExportItem = dark ? "light" : "dark";
-this._themeMenuItem.setAttribute("aria-checked", String(dark));
-},
-_setColorMode(mode) {
-const dark = mode === "dark";
-this._colorMode = dark ? "dark" : "light";
-this.root.dataset.fcColorMode = this._colorMode;
-const colors = dark ? {
-color: "#e5e7eb",
-background: "#0b1220",
-"--chart-bg": "#111827",
-"--chart-grid": "rgba(226,232,240,.14)",
-"--chart-axis": "#94a3b8",
-"--chart-text": "#e5e7eb",
-"--chart-legend-bg": "rgba(30,41,59,.84)",
-"--chart-modebar-bg": "rgba(15,23,42,.94)",
-"--chart-modebar-active": "rgba(148,163,184,.24)",
-"--chart-tooltip-bg": "rgba(2,6,23,.96)",
-"--chart-tooltip-text": "#f8fafc",
-"--chart-badge-bg": "rgba(30,41,59,.9)",
-"--chart-badge-text": "#e2e8f0",
-} : {
-color: "#1f2937",
-background: "#ffffff",
-"--chart-bg": "#ffffff",
-"--chart-grid": "rgba(15,23,42,.12)",
-"--chart-axis": "#64748b",
-"--chart-text": "#1f2937",
-"--chart-legend-bg": "rgba(241,245,249,.88)",
-"--chart-modebar-bg": "rgba(255,255,255,.94)",
-"--chart-modebar-active": "rgba(100,116,139,.18)",
-"--chart-tooltip-bg": "rgba(20,24,33,.94)",
-"--chart-tooltip-text": "#ffffff",
-"--chart-badge-bg": "rgba(255,255,255,.9)",
-"--chart-badge-text": "#0f172a",
-};
-for (const [name, value] of Object.entries(colors)) {
-if (name === "color" || name === "background") this.root.style[name] = value;
-else this.root.style.setProperty(name, value);
-}
-this._updateColorModeItem();
-this.refreshTheme();
-},
-_toggleColorMode() {
-this._setColorMode(this._colorMode === "dark" ? "light" : "dark");
-},
 _exportFilename(extension) {
 const title = String(this.spec.title || "xy-chart")
 .trim()
@@ -6679,12 +6618,6 @@ case "more":
 return svg('<circle cx="5" cy="10" r="1" fill="currentColor" stroke="none"/>' +
 '<circle cx="10" cy="10" r="1" fill="currentColor" stroke="none"/>' +
 '<circle cx="15" cy="10" r="1" fill="currentColor" stroke="none"/>');
-case "moon":
-return svg('<path d="M14.8 13.8 A6.5 6.5 0 0 1 6.2 5.2 A6.5 6.5 0 1 0 14.8 13.8 Z"/>');
-case "sun":
-return svg('<circle cx="10" cy="10" r="3"/><path d="M10 2 V4 M10 16 V18 ' +
-'M2 10 H4 M16 10 H18 M4.3 4.3 L5.7 5.7 M14.3 14.3 L15.7 15.7 ' +
-'M15.7 4.3 L14.3 5.7 M5.7 14.3 L4.3 15.7"/>');
 case "png":
 return svg('<path d="M5 2.5 H12 L15.5 6 V17.5 H5 Z"/><path d="M12 2.5 V6 H15.5"/>' +
 '<path d="M7 13 L9 10.5 L11 12 L13.5 9 V15 H7 Z"/>');

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -255,7 +255,6 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-modebar-menu-item][data-fc-separator]){margin-top:3px;border-top:1px solid rgba(128,128,128,.2);border-radius:0 0 4px 4px}
 :where(.xy [data-fc-modebar-menu-icon]){display:flex;width:16px;margin-right:7px}
 :where(.xy [data-fc-modebar-menu-icon] svg){width:14px;height:14px}
-:where(.xy [data-fc-modebar-menu-shortcut]){margin-left:auto;padding-left:20px;color:var(--chart-axis,currentColor);font-size:10px;opacity:.72}
 :where(.xy [data-fc-slot="modebar_button"].fc-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
 :where(.xy [data-fc-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-fc-slot="selection"][data-fc-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}
@@ -5408,7 +5407,8 @@ this.root.appendChild(this.selLasso);
 this._lassoPolygon = null;
 let lassoHandleDrag = null;
 const moveLassoHandle = (e) => {
-if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId) return;
+if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId
+|| !this._lassoPolygon) return;
 const rect = c.getBoundingClientRect();
 const cssX = Math.max(0, Math.min(rect.width, e.clientX - rect.left));
 const cssY = Math.max(0, Math.min(rect.height, e.clientY - rect.top));
@@ -5441,14 +5441,16 @@ moveLassoHandle(e);
 const handle = lassoHandleDrag.handle;
 lassoHandleDrag = null;
 delete handle.dataset.fcActive;
-this._sendSelectPolygon(this._lassoPolygon);
+if (this._lassoPolygon) this._sendSelectPolygon(this._lassoPolygon);
 });
 this._listen(this.selLasso, "pointercancel", (e) => {
 if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId) return;
+if (this._lassoPolygon) {
 this._lassoPolygon[lassoHandleDrag.index] = lassoHandleDrag.original;
+}
 delete lassoHandleDrag.handle.dataset.fcActive;
 lassoHandleDrag = null;
-this._renderLassoSelection();
+if (this._lassoPolygon) this._renderLassoSelection();
 e.stopPropagation();
 });
 if (this._interactionFlag("crosshair")) {
@@ -5537,9 +5539,14 @@ const d1 = dataAt(e.clientX, e.clientY);
 const moved = Math.abs(e.clientX - band.sx) > 3 || Math.abs(e.clientY - band.sy) > 3;
 if (moved) {
 if (band.mode === "zoom") this._zoomToBox(band.d0, d1, true);
-else if (band.mode === "select-lasso" && band.points.length >= 3) {
+else if (band.mode === "select-lasso") {
+if (band.points.length >= 3) {
 const editable = this._simplifyLassoPoints(band.points);
 this._sendSelectPolygon(editable.map((point) => point.data));
+} else if (band.previousLasso) {
+this._lassoPolygon = band.previousLasso;
+this._renderLassoSelection();
+}
 } else {
 let d0 = band.d0;
 if (band.mode === "select-x") {
@@ -5715,11 +5722,12 @@ const t = Math.max(0, Math.min(1,
 const x = start.x + t * dx, y = start.y + t * dy;
 return (point.x - x) ** 2 + (point.y - y) ** 2;
 };
+const simplifyAt = (currentTolerance) => {
 const keep = new Uint8Array(source.length);
 keep[0] = 1;
 keep[source.length - 1] = 1;
 const stack = [[0, source.length - 1]];
-const toleranceSq = tolerance * tolerance;
+const toleranceSq = currentTolerance * currentTolerance;
 while (stack.length) {
 const [start, end] = stack.pop();
 let furthest = -1, furthestDistance = toleranceSq;
@@ -5735,14 +5743,32 @@ keep[furthest] = 1;
 stack.push([start, furthest], [furthest, end]);
 }
 }
-let simplified = source.filter((_point, index) => keep[index]);
+return source.filter((_point, index) => keep[index]);
+};
+let simplified = simplifyAt(tolerance);
 if (simplified.length < 3) {
 simplified = [source[0], source[Math.floor(source.length / 2)], source[source.length - 1]];
 }
 if (simplified.length > maxPoints) {
-simplified = Array.from({ length: maxPoints }, (_value, index) => (
-simplified[Math.round(index * (simplified.length - 1) / (maxPoints - 1))]
-));
+let low = tolerance;
+let high = Math.max(tolerance, 1);
+for (let i = 0; i < 16 && simplified.length > maxPoints; i++) {
+low = high;
+high *= 2;
+simplified = simplifyAt(high);
+}
+for (let i = 0; i < 12; i++) {
+const middle = (low + high) / 2;
+const candidate = simplifyAt(middle);
+if (candidate.length > maxPoints) low = middle;
+else {
+high = middle;
+simplified = candidate;
+}
+}
+if (simplified.length < 3) {
+simplified = [source[0], source[Math.floor(source.length / 2)], source[source.length - 1]];
+}
 }
 return simplified;
 },
@@ -5826,6 +5852,10 @@ this._selectLocalPolygon(polygon);
 }
 },
 _selectLocalPolygon(points) {
+const xs = points.map((point) => point[0]);
+const ys = points.map((point) => point[1]);
+const minX = Math.min(...xs), maxX = Math.max(...xs);
+const minY = Math.min(...ys), maxY = Math.max(...ys);
 const inside = (x, y) => {
 let hit = false;
 for (let i = 0, j = points.length - 1; i < points.length; j = i++) {
@@ -5845,7 +5875,12 @@ const oy = yMeta.offset, sy = yMeta.scale || 1;
 const mask = new Float32Array(g.n);
 let count = 0;
 for (let i = 0; i < g.n; i++) {
-if (inside(cx[i] / sx + ox, cy[i] / sy + oy)) { mask[i] = 1; count++; }
+const x = cx[i] / sx + ox;
+const y = cy[i] / sy + oy;
+if (x >= minX && x <= maxX && y >= minY && y <= maxY && inside(x, y)) {
+mask[i] = 1;
+count++;
+}
 }
 this._applySelMask(g, mask);
 total += count;
@@ -5939,8 +5974,8 @@ setSelectMenuOpen(false);
 setExportMenuOpen(false);
 });
 this._listen(bar, "focusin", () => setVisible(true));
-this._listen(bar, "focusout", () => {
-if (!root.matches(":hover")) setVisible(false);
+this._listen(bar, "focusout", (e) => {
+if (!bar.contains(e.relatedTarget) && !root.matches(":hover")) setVisible(false);
 });
 const grip = document.createElement("button");
 grip.type = "button";
@@ -5971,6 +6006,7 @@ dx: e.clientX - barRect.left,
 dy: e.clientY - barRect.top,
 moved: false,
 };
+try { grip.setPointerCapture(e.pointerId); } catch (_err) {   }
 setVisible(true);
 });
 this._listen(grip, "pointermove", (e) => {
@@ -5985,7 +6021,6 @@ bar.style.transition = "none";
 setZoomMenuOpen(false);
 setSelectMenuOpen(false);
 setExportMenuOpen(false);
-try { grip.setPointerCapture(e.pointerId); } catch (_err) {   }
 }
 const rootRect = root.getBoundingClientRect();
 const left = e.clientX - rootRect.left - modebarDrag.dx;
@@ -6073,7 +6108,7 @@ zoomMenu.style.cssText =
 "position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
 bar.appendChild(zoomMenu);
 const zoomMenuItems = [];
-const mkZoomItem = (name, label, shortcut, onClick, toggles, separator = false) => {
+const mkZoomItem = (name, label, onClick, toggles, separator = false) => {
 const button = document.createElement("button");
 button.type = "button";
 button.tabIndex = -1;
@@ -6090,10 +6125,6 @@ button.appendChild(icon);
 const text = document.createElement("span");
 text.textContent = label;
 button.appendChild(text);
-const hint = document.createElement("span");
-hint.dataset.fcModebarMenuShortcut = "";
-hint.textContent = shortcut;
-button.appendChild(hint);
 this._listen(button, "pointerdown", (e) => e.stopPropagation());
 this._listen(button, "click", (e) => {
 e.stopPropagation();
@@ -6109,10 +6140,10 @@ const resetView = () => {
 this._clearSelection();
 this._setView(this.view0, { animate: true });
 };
-mkZoomItem("zoomin", "Zoom In", "+", () => this._zoomBy(0.5, true));
-mkZoomItem("zoomout", "Zoom Out", "−", () => this._zoomBy(2, true));
-mkZoomItem("zoom", "Box Zoom", "B", () => this._setDragMode("zoom"), "zoom");
-mkZoomItem("reset", "Reset View", "0", resetView, null, true);
+mkZoomItem("zoomin", "Zoom In", () => this._zoomBy(0.5, true));
+mkZoomItem("zoomout", "Zoom Out", () => this._zoomBy(2, true));
+mkZoomItem("zoom", "Box Zoom", () => this._setDragMode("zoom"), "zoom");
+mkZoomItem("reset", "Reset View", resetView, null, true);
 const selectMenu = document.createElement("div");
 selectMenu.dataset.fcModebarMenu = "";
 selectMenu.dataset.fcModebarSelectMenu = "";
@@ -6122,7 +6153,7 @@ selectMenu.style.cssText =
 "position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
 bar.appendChild(selectMenu);
 const selectMenuItems = [];
-const mkSelectItem = (name, label, shortcut, mode) => {
+const mkSelectItem = (name, label, mode) => {
 const button = document.createElement("button");
 button.type = "button";
 button.tabIndex = -1;
@@ -6138,10 +6169,6 @@ button.appendChild(icon);
 const text = document.createElement("span");
 text.textContent = label;
 button.appendChild(text);
-const hint = document.createElement("span");
-hint.dataset.fcModebarMenuShortcut = "";
-hint.textContent = shortcut;
-button.appendChild(hint);
 this._listen(button, "pointerdown", (e) => e.stopPropagation());
 this._listen(button, "click", (e) => {
 e.stopPropagation();
@@ -6153,10 +6180,10 @@ selectMenuItems.push(button);
 this._modeBtns[mode] = button;
 };
 if (canSelect) {
-mkSelectItem("select", "Box Select", "B", "select");
-mkSelectItem("lasso", "Lasso Select", "L", "select-lasso");
-mkSelectItem("selectx", "X Range", "X", "select-x");
-mkSelectItem("selecty", "Y Range", "Y", "select-y");
+mkSelectItem("select", "Box Select", "select");
+mkSelectItem("lasso", "Lasso Select", "select-lasso");
+mkSelectItem("selectx", "X Range", "select-x");
+mkSelectItem("selecty", "Y Range", "select-y");
 }
 const exportMenu = document.createElement("div");
 exportMenu.dataset.fcModebarMenu = "";
@@ -6426,6 +6453,8 @@ const percent = axisPercent("x", this.view.x0, this.view.x1, this.view0.x0, this
 const rounded = Math.round(percent);
 const exactText = percent < 1 ? "<1%" : `${rounded}%`;
 const displayText = rounded > 999 ? `${String(rounded).slice(0, 3)}…%` : exactText;
+if (this._zoomMenuLabel.dataset.fcZoomExact === exactText
+&& this._zoomMenuLabel.textContent === displayText) return;
 this._zoomMenuLabel.textContent = displayText;
 this._zoomMenuLabel.dataset.fcZoomExact = exactText;
 this._zoomMenuButton.title = `Zoom controls (${exactText})`;
@@ -6604,6 +6633,29 @@ clone.style.width = `${width}px`;
 clone.style.height = `${height}px`;
 clone.style.margin = "0";
 clone.setAttribute("xmlns", "http://www.w3.org/1999/xhtml");
+const computed = getComputedStyle(this.root);
+const inheritedProperties = [
+"color", "font-family", "font-size", "font-style", "font-weight",
+"letter-spacing", "line-height",
+];
+const chartTokens = [
+"--chart-bg", "--chart-text", "--chart-grid", "--chart-axis",
+"--chart-tooltip-bg", "--chart-tooltip-text", "--chart-legend-bg",
+"--chart-badge-bg", "--chart-badge-text", "--chart-modebar-bg",
+"--chart-modebar-active", "--chart-selection", "--chart-selection-fill",
+"--chart-zoom-selection", "--chart-zoom-selection-fill", "--chart-crosshair",
+"--chart-annotation-text", "--chart-cursor", "--chart-cursor-pan",
+];
+for (let i = 0; i < computed.length; i++) {
+const property = computed.item(i);
+if (!property.startsWith("--")) continue;
+const value = computed.getPropertyValue(property).trim();
+if (value) clone.style.setProperty(property, value);
+}
+for (const property of [...inheritedProperties, ...chartTokens]) {
+const value = computed.getPropertyValue(property).trim();
+if (value) clone.style.setProperty(property, value);
+}
 const sourceCanvases = [...this.root.querySelectorAll("canvas")];
 const clonedCanvases = [...clone.querySelectorAll("canvas")];
 for (let i = 0; i < clonedCanvases.length; i++) {

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -243,9 +243,9 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="badge_item"]){padding:3px 6px;border-radius:4px;color:var(--chart-badge-text,#0f172a);background:var(--chart-badge-bg,rgba(255,255,255,.82));box-shadow:0 1px 4px rgba(15,23,42,.14)}
 :where(.xy [data-fc-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
 :where(.xy [data-fc-slot="modebar_button"]){width:24px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
-:where(.xy [data-fc-modebar-drag-handle]){position:relative;width:22px;margin-right:2px;cursor:move}
-:where(.xy [data-fc-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-1px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
-:where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:52px;gap:1px;padding:0 4px;font-size:11px;font-variant-numeric:tabular-nums}
+:where(.xy [data-fc-modebar-drag-handle]){position:relative;width:22px;margin-right:4px;cursor:move}
+:where(.xy [data-fc-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-3px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
+:where(.xy [data-fc-modebar-menu-trigger]){width:auto;min-width:48px;gap:1px;padding:0 4px;font-size:11px;font-variant-numeric:tabular-nums}
 :where(.xy [data-fc-modebar-select-trigger]){width:auto;min-width:30px;gap:0;padding:0 2px}
 :where(.xy [data-fc-modebar-menu-indicator]){display:flex;transition:transform .15s}
 :where(.xy [data-fc-modebar-menu-indicator] svg){width:11px;height:11px}

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -245,10 +245,12 @@ const FC_CHROME_CSS = `
 :where(.xy [data-fc-slot="modebar_button"]){width:26px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-axis,currentColor);cursor:pointer}
 :where(.xy [data-fc-modebar-drag-handle]){cursor:move}
 :where(.xy [data-fc-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}
-:where(.xy [data-fc-modebar-menu-item]){width:100%;height:28px;justify-content:space-between;padding:0 9px;border-radius:4px;text-align:left;white-space:nowrap}
+:where(.xy [data-fc-modebar-menu-item]){width:100%;height:28px;justify-content:flex-start;padding:0 9px;border-radius:4px;text-align:left;white-space:nowrap}
 :where(.xy [data-fc-modebar-menu-item]:hover,.xy [data-fc-modebar-menu-item]:focus-visible){background:var(--chart-modebar-active,rgba(128,128,128,.18));outline:none}
 :where(.xy [data-fc-modebar-menu-item][data-fc-separator]){margin-top:3px;border-top:1px solid rgba(128,128,128,.2);border-radius:0 0 4px 4px}
-:where(.xy [data-fc-modebar-menu-shortcut]){margin-left:20px;color:var(--chart-axis,currentColor);font-size:10px;opacity:.72}
+:where(.xy [data-fc-modebar-menu-icon]){display:flex;width:16px;margin-right:7px}
+:where(.xy [data-fc-modebar-menu-icon] svg){width:14px;height:14px}
+:where(.xy [data-fc-modebar-menu-shortcut]){margin-left:auto;padding-left:20px;color:var(--chart-axis,currentColor);font-size:10px;opacity:.72}
 :where(.xy [data-fc-slot="modebar_button"].fc-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
 :where(.xy [data-fc-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-fc-slot="selection"][data-fc-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}
@@ -5763,6 +5765,10 @@ button.setAttribute("role", "menuitem");
 button.style.cssText =
 "display:flex;align-items:center;pointer-events:auto;";
 this._applySlot(button, "modebar_button");
+const icon = document.createElement("span");
+icon.dataset.fcModebarMenuIcon = "";
+icon.innerHTML = this._icon(name);
+button.appendChild(icon);
 const text = document.createElement("span");
 text.textContent = label;
 button.appendChild(text);

--- a/scripts/render_smoke_nonumpy.py
+++ b/scripts/render_smoke_nonumpy.py
@@ -344,17 +344,24 @@ try{{
       : [];
     const lassoPathBefore = v.selLassoPath.getAttribute("d");
     const lassoPointBefore = v._lassoPolygon ? [...v._lassoPolygon[0]] : null;
+    const pointer = (target, type, x, y, pointerId = 72) => target.dispatchEvent(new PointerEvent(type, {{
+      pointerId,pointerType:"mouse",button:0,buttons:type === "pointerup" ? 0 : 1,
+      clientX:x,clientY:y,bubbles:true,cancelable:true,
+    }}));
     if (lassoHandles[0]) {{
       const cr = v.canvas.getBoundingClientRect();
-      const pointer = (target, type, x, y) => target.dispatchEvent(new PointerEvent(type, {{
-        pointerId:72,pointerType:"mouse",button:0,buttons:type === "pointerup" ? 0 : 1,
-        clientX:x,clientY:y,bubbles:true,cancelable:true,
-      }}));
       const handleRect = lassoHandles[0].getBoundingClientRect();
       pointer(lassoHandles[0], "pointerdown", handleRect.left + 2, handleRect.top + 2);
       pointer(v.selLasso, "pointermove", cr.left + cr.width * 0.3, cr.top + cr.height * 0.25);
       pointer(v.selLasso, "pointerup", cr.left + cr.width * 0.3, cr.top + cr.height * 0.25);
     }}
+    const shortLassoBefore = JSON.stringify(v._lassoPolygon);
+    const lassoCanvasRect = v.canvas.getBoundingClientRect();
+    v._setDragMode("select-lasso");
+    pointer(v.canvas, "pointerdown", lassoCanvasRect.left + 30, lassoCanvasRect.top + 30, 73);
+    pointer(v.canvas, "pointermove", lassoCanvasRect.left + 34, lassoCanvasRect.top + 30, 73);
+    pointer(v.canvas, "pointerup", lassoCanvasRect.left + 34, lassoCanvasRect.top + 30, 73);
+    const shortLassoRestored = JSON.stringify(v._lassoPolygon) === shortLassoBefore;
     const manyLassoPoints = Array.from({{length:80}}, (_value, index) => ({{
       x:100+60*Math.cos(index/80*Math.PI*2),
       y:100+40*Math.sin(index/80*Math.PI*2),
@@ -366,7 +373,8 @@ try{{
         || v._lassoPolygon[0][1] !== lassoPointBefore[1])
       && v.selLassoPath.getAttribute("d") !== lassoPathBefore
       && v.selLassoHandles.childElementCount === 4
-      && simplifiedLasso.length >= 3 && simplifiedLasso.length <= 16 ? 1 : 0;
+      && simplifiedLasso.length >= 3 && simplifiedLasso.length <= 16
+      && shortLassoRestored ? 1 : 0;
     if (exportButton) exportButton.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
     const exportItems = exportMenu
       ? [...exportMenu.querySelectorAll("[data-fc-modebar-export-item]")]
@@ -376,10 +384,22 @@ try{{
       && exportButton.getAttribute("aria-expanded") === "true"
       && ["png", "svg", "csv"].every((format) => exportItems.includes(format));
     if (exportMenu) exportMenu.dispatchEvent(new KeyboardEvent("keydown", {{key:"Escape",bubbles:true}}));
+    const previousChartBg = v.root.style.getPropertyValue("--chart-bg");
+    const previousFontFamily = v.root.style.fontFamily;
+    v.root.style.setProperty("--chart-bg", "#123456");
+    v.root.style.fontFamily = "Smoke Export Sans, sans-serif";
+    const themedExport = v._exportSvgMarkup();
+    if (previousChartBg) v.root.style.setProperty("--chart-bg", previousChartBg);
+    else v.root.style.removeProperty("--chart-bg");
+    v.root.style.fontFamily = previousFontFamily;
+    const exportThemePreserved = themedExport.includes("#123456")
+      && themedExport.includes("Smoke Export Sans");
+    const shortcutHintsAbsent = !v.root.querySelector("[data-fc-modebar-menu-shortcut]");
     const modebarExport = exportOpened && typeof v._exportCsvText === "function"
       && typeof v._exportSvgMarkup === "function" && typeof v._exportPng === "function"
       && exportMenu.style.display === "none"
-      && exportButton.getAttribute("aria-expanded") === "false" ? 1 : 0;
+      && exportButton.getAttribute("aria-expanded") === "false"
+      && exportThemePreserved && shortcutHintsAbsent ? 1 : 0;
     v._setDragMode("pan");
     const spanX = () => v.view.x1 - v.view.x0;
     const s0 = spanX();

--- a/scripts/render_smoke_nonumpy.py
+++ b/scripts/render_smoke_nonumpy.py
@@ -314,6 +314,8 @@ try{{
     const zoomMenu = bar && bar.querySelector("[data-fc-modebar-menu]");
     const selectButton = bar && bar.querySelector("[data-fc-modebar-select]");
     const selectMenu = bar && bar.querySelector("[data-fc-modebar-select-menu]");
+    const exportButton = bar && bar.querySelector("[data-fc-modebar-export]");
+    const exportMenu = bar && bar.querySelector("[data-fc-modebar-export-menu]");
     const zoomPercent = zoomTrigger && zoomTrigger.querySelector("[data-fc-modebar-zoom-percent]");
     const zoomIndicator = zoomTrigger && zoomTrigger.querySelector("[data-fc-modebar-menu-indicator] svg");
     const zoomTriggerInitial = zoomPercent && zoomPercent.textContent === "100%" && zoomIndicator;
@@ -357,6 +359,27 @@ try{{
     const modebarSelect = selectMenuOpened && v.dragMode === "select-lasso"
       && selectButton.classList.contains("fc-active")
       && lassoItem.classList.contains("fc-active") && selectMenu.style.display === "none" ? 1 : 0;
+    if (exportButton) exportButton.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
+    const exportItems = exportMenu
+      ? [...exportMenu.querySelectorAll("[data-fc-modebar-export-item]")]
+        .map((item) => item.dataset.fcModebarExportItem)
+      : [];
+    const themeItem = exportMenu && exportMenu.querySelector("[data-fc-modebar-theme-toggle]");
+    const exportOpened = exportMenu && exportMenu.style.display === "flex"
+      && exportButton.getAttribute("aria-expanded") === "true"
+      && ["png", "svg", "csv"].every((format) => exportItems.includes(format));
+    if (themeItem) themeItem.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
+    const modebarTheme = v.root.dataset.fcColorMode === "dark"
+      && getComputedStyle(v.root).getPropertyValue("--chart-bg").trim() === "#111827"
+      && themeItem.textContent.includes("Light Mode")
+      && themeItem.getAttribute("aria-checked") === "true" ? 1 : 0;
+    v._toggleColorMode();
+    if (exportButton) exportButton.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
+    if (exportMenu) exportMenu.dispatchEvent(new KeyboardEvent("keydown", {{key:"Escape",bubbles:true}}));
+    const modebarExport = exportOpened && typeof v._exportCsvText === "function"
+      && typeof v._exportSvgMarkup === "function" && typeof v._exportPng === "function"
+      && exportMenu.style.display === "none"
+      && exportButton.getAttribute("aria-expanded") === "false" ? 1 : 0;
     v._setDragMode("pan");
     const spanX = () => v.view.x1 - v.view.x0;
     const s0 = spanX();
@@ -1000,7 +1023,7 @@ try{{
     const gLn=vSm.gpuTraces[0], gAr=vSm.gpuTraces[1];
     const msmooth=(gLn.n===65 && gLn._cpu.x.length===5 && gAr.n===65 && gAr._cpu.base.length===5)?1:0;
     vSm.destroy();holderSm.remove();
-    const base=`FC_OK lit=${{lit}} total=${{w*h}} labels=${{labels}} pick=${{hits}} row=${{hasXY}} selAll=${{selAll}} selSome=${{selSome}} active=${{active}} btns=${{btns}} modebarHidden=${{modebarHidden}} modebarHover=${{modebarHover}} modebarCollapse=${{modebarCollapse}} modebarMenu=${{modebarMenu}} modebarDrag=${{modebarDrag}} modebarSelect=${{modebarSelect}} zin=${{zin}} smooth=${{smooth}} labelThrottle=${{labelThrottle}} hoverSkip=${{hoverSkip}} zanch=${{zanch}} retarget=${{retarget}} nosnap=${{nosnap}} prefetch=${{prefetch}} maxwait=${{maxwait}} box=${{boxOk}} zmode=${{zmode}} densityLit=${{densityLit}} drill=${{drilled}} pending=${{pending}} dblend=${{dblend}} dseq=${{dseq}} hov=${{hov}} sstale=${{sstale}} sfresh=${{sfresh}} plut=${{plut}} reg=${{reg}} refresh=${{refresh}} dpick=${{dpick}} hold=${{hold}} zoomout=${{zoomout}} broad=${{broadfallback}} dying=${{dying}} dback=${{dback}} dnorm=${{dnorm}} dnormDone=${{dnormDone}} stale=${{stale}} thrash=${{thrash}} qwire=${{qwire}} stream=${{stream}} tj=${{Math.round(maxJump*100)}} td=${{Math.round(reviveDip*100)}} malformed=${{malformed}} pixdet=${{pixdet}} splitbuf=${{splitbuf}} barBase=${{barBase}} histBase=${{histBase}} edgepad=${{edgepad}} mgrad=${{mgrad}} axisontop=${{axisontop}} mtipbase=${{mtipbase}} mcorner=${{mcorner}} mstroke=${{mstroke}} bgrad=${{bgrad}} bcorner=${{bcorner}} msmooth=${{msmooth}} bgocc=${{bgocc}}`;
+    const base=`FC_OK lit=${{lit}} total=${{w*h}} labels=${{labels}} pick=${{hits}} row=${{hasXY}} selAll=${{selAll}} selSome=${{selSome}} active=${{active}} btns=${{btns}} modebarHidden=${{modebarHidden}} modebarHover=${{modebarHover}} modebarCollapse=${{modebarCollapse}} modebarMenu=${{modebarMenu}} modebarDrag=${{modebarDrag}} modebarSelect=${{modebarSelect}} modebarExport=${{modebarExport}} modebarTheme=${{modebarTheme}} zin=${{zin}} smooth=${{smooth}} labelThrottle=${{labelThrottle}} hoverSkip=${{hoverSkip}} zanch=${{zanch}} retarget=${{retarget}} nosnap=${{nosnap}} prefetch=${{prefetch}} maxwait=${{maxwait}} box=${{boxOk}} zmode=${{zmode}} densityLit=${{densityLit}} drill=${{drilled}} pending=${{pending}} dblend=${{dblend}} dseq=${{dseq}} hov=${{hov}} sstale=${{sstale}} sfresh=${{sfresh}} plut=${{plut}} reg=${{reg}} refresh=${{refresh}} dpick=${{dpick}} hold=${{hold}} zoomout=${{zoomout}} broad=${{broadfallback}} dying=${{dying}} dback=${{dback}} dnorm=${{dnorm}} dnormDone=${{dnormDone}} stale=${{stale}} thrash=${{thrash}} qwire=${{qwire}} stream=${{stream}} tj=${{Math.round(maxJump*100)}} td=${{Math.round(reviveDip*100)}} malformed=${{malformed}} pixdet=${{pixdet}} splitbuf=${{splitbuf}} barBase=${{barBase}} histBase=${{histBase}} edgepad=${{edgepad}} mgrad=${{mgrad}} axisontop=${{axisontop}} mtipbase=${{mtipbase}} mcorner=${{mcorner}} mstroke=${{mstroke}} bgrad=${{bgrad}} bcorner=${{bcorner}} msmooth=${{msmooth}} bgocc=${{bgocc}}`;
     // Responsive: 100%-by-100% chart in a 400x300 container tracks its parent;
     // growing the container must fire the ResizeObserver and re-render bigger.
     const spec2=JSON.parse(JSON.stringify(spec));
@@ -1175,6 +1198,8 @@ try{{
     modebar_menu = int(re.search(r"modebarMenu=(\d+)", title).group(1))
     modebar_drag = int(re.search(r"modebarDrag=(\d+)", title).group(1))
     modebar_select = int(re.search(r"modebarSelect=(\d+)", title).group(1))
+    modebar_export = int(re.search(r"modebarExport=(\d+)", title).group(1))
+    modebar_theme = int(re.search(r"modebarTheme=(\d+)", title).group(1))
     zin = int(re.search(r"zin=(\d+)", title).group(1))
     smooth = int(re.search(r"smooth=(\d+)", title).group(1))
     label_throttle = int(re.search(r"labelThrottle=(\d+)", title).group(1))
@@ -1238,9 +1263,9 @@ try{{
     print(
         f"lit fraction: {frac:.3%}, DOM chrome nodes: {labels}, pick hits: {pick}, "
         f"row-decoded: {rowok}, select all/sub: {sel_all}/{sel_some}, mask active: {active}, "
-        f"modebar btns: {btns}, hidden/hover/collapse/menu/drag/select: "
+        f"modebar btns: {btns}, hidden/hover/collapse/menu/drag/select/export/theme: "
         f"{modebar_hidden}/{modebar_hover}/{modebar_collapse}/{modebar_menu}/"
-        f"{modebar_drag}/{modebar_select}, "
+        f"{modebar_drag}/{modebar_select}/{modebar_export}/{modebar_theme}, "
         f"zoom-in: {zin}, box-zoom: {box}, zoom-mode: {zmode}, "
         f"fluid: {fluid}, resize grew: {grew}, pick realloc: {pick2}, "
         f"destroyed: {destroyed}, unsub: {unsub}"
@@ -1261,7 +1286,7 @@ try{{
         raise SystemExit(f"sub-range selection implausible: {sel_some} of {sel_all}")
     if active != 1:
         raise SystemExit("selection mask did not activate")
-    if btns < 12:
+    if btns < 17:
         raise SystemExit(f"modebar missing buttons: {btns}")
     if modebar_hidden != 1 or modebar_hover != 1:
         raise SystemExit("modebar did not hide at rest and show on chart hover")
@@ -1273,6 +1298,10 @@ try{{
         raise SystemExit("modebar drag handle did not move the toolbar")
     if modebar_select != 1:
         raise SystemExit("modebar select button did not activate selection mode")
+    if modebar_export != 1:
+        raise SystemExit("modebar export menu did not produce PNG/SVG/CSV actions")
+    if modebar_theme != 1:
+        raise SystemExit("modebar light/dark toggle did not refresh chart theme tokens")
     if zin != 1:
         raise SystemExit("modebar zoom-in did not shrink the view span")
     if smooth != 1:

--- a/scripts/render_smoke_nonumpy.py
+++ b/scripts/render_smoke_nonumpy.py
@@ -338,6 +338,35 @@ try{{
     const modebarSelect = selectMenuOpened && v.dragMode === "select-lasso"
       && selectButton.classList.contains("fc-active")
       && lassoItem.classList.contains("fc-active") && selectMenu.style.display === "none" ? 1 : 0;
+    v._sendSelectPolygon([[0,-0.4],[4,-0.4],[4,0.4],[0,0.4]]);
+    const lassoHandles = v.selLassoHandles
+      ? [...v.selLassoHandles.querySelectorAll("[data-fc-selection-lasso-handle]")]
+      : [];
+    const lassoPathBefore = v.selLassoPath.getAttribute("d");
+    const lassoPointBefore = v._lassoPolygon ? [...v._lassoPolygon[0]] : null;
+    if (lassoHandles[0]) {{
+      const cr = v.canvas.getBoundingClientRect();
+      const pointer = (target, type, x, y) => target.dispatchEvent(new PointerEvent(type, {{
+        pointerId:72,pointerType:"mouse",button:0,buttons:type === "pointerup" ? 0 : 1,
+        clientX:x,clientY:y,bubbles:true,cancelable:true,
+      }}));
+      const handleRect = lassoHandles[0].getBoundingClientRect();
+      pointer(lassoHandles[0], "pointerdown", handleRect.left + 2, handleRect.top + 2);
+      pointer(v.selLasso, "pointermove", cr.left + cr.width * 0.3, cr.top + cr.height * 0.25);
+      pointer(v.selLasso, "pointerup", cr.left + cr.width * 0.3, cr.top + cr.height * 0.25);
+    }}
+    const manyLassoPoints = Array.from({{length:80}}, (_value, index) => ({{
+      x:100+60*Math.cos(index/80*Math.PI*2),
+      y:100+40*Math.sin(index/80*Math.PI*2),
+      data:[index,index],
+    }}));
+    const simplifiedLasso = v._simplifyLassoPoints(manyLassoPoints);
+    const lassoEdit = lassoHandles.length === 4 && v.selLasso.style.display === "block"
+      && lassoPointBefore && (v._lassoPolygon[0][0] !== lassoPointBefore[0]
+        || v._lassoPolygon[0][1] !== lassoPointBefore[1])
+      && v.selLassoPath.getAttribute("d") !== lassoPathBefore
+      && v.selLassoHandles.childElementCount === 4
+      && simplifiedLasso.length >= 3 && simplifiedLasso.length <= 16 ? 1 : 0;
     if (exportButton) exportButton.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
     const exportItems = exportMenu
       ? [...exportMenu.querySelectorAll("[data-fc-modebar-export-item]")]
@@ -994,7 +1023,7 @@ try{{
     const gLn=vSm.gpuTraces[0], gAr=vSm.gpuTraces[1];
     const msmooth=(gLn.n===65 && gLn._cpu.x.length===5 && gAr.n===65 && gAr._cpu.base.length===5)?1:0;
     vSm.destroy();holderSm.remove();
-    const base=`FC_OK lit=${{lit}} total=${{w*h}} labels=${{labels}} pick=${{hits}} row=${{hasXY}} selAll=${{selAll}} selSome=${{selSome}} active=${{active}} btns=${{btns}} modebarHidden=${{modebarHidden}} modebarHover=${{modebarHover}} modebarNoCollapse=${{modebarNoCollapse}} modebarMenu=${{modebarMenu}} modebarDrag=${{modebarDrag}} modebarSelect=${{modebarSelect}} modebarExport=${{modebarExport}} zin=${{zin}} smooth=${{smooth}} labelThrottle=${{labelThrottle}} hoverSkip=${{hoverSkip}} zanch=${{zanch}} retarget=${{retarget}} nosnap=${{nosnap}} prefetch=${{prefetch}} maxwait=${{maxwait}} box=${{boxOk}} zmode=${{zmode}} densityLit=${{densityLit}} drill=${{drilled}} pending=${{pending}} dblend=${{dblend}} dseq=${{dseq}} hov=${{hov}} sstale=${{sstale}} sfresh=${{sfresh}} plut=${{plut}} reg=${{reg}} refresh=${{refresh}} dpick=${{dpick}} hold=${{hold}} zoomout=${{zoomout}} broad=${{broadfallback}} dying=${{dying}} dback=${{dback}} dnorm=${{dnorm}} dnormDone=${{dnormDone}} stale=${{stale}} thrash=${{thrash}} qwire=${{qwire}} stream=${{stream}} tj=${{Math.round(maxJump*100)}} td=${{Math.round(reviveDip*100)}} malformed=${{malformed}} pixdet=${{pixdet}} splitbuf=${{splitbuf}} barBase=${{barBase}} histBase=${{histBase}} edgepad=${{edgepad}} mgrad=${{mgrad}} axisontop=${{axisontop}} mtipbase=${{mtipbase}} mcorner=${{mcorner}} mstroke=${{mstroke}} bgrad=${{bgrad}} bcorner=${{bcorner}} msmooth=${{msmooth}} bgocc=${{bgocc}}`;
+    const base=`FC_OK lit=${{lit}} total=${{w*h}} labels=${{labels}} pick=${{hits}} row=${{hasXY}} selAll=${{selAll}} selSome=${{selSome}} active=${{active}} btns=${{btns}} modebarHidden=${{modebarHidden}} modebarHover=${{modebarHover}} modebarNoCollapse=${{modebarNoCollapse}} modebarMenu=${{modebarMenu}} modebarDrag=${{modebarDrag}} modebarSelect=${{modebarSelect}} lassoEdit=${{lassoEdit}} modebarExport=${{modebarExport}} zin=${{zin}} smooth=${{smooth}} labelThrottle=${{labelThrottle}} hoverSkip=${{hoverSkip}} zanch=${{zanch}} retarget=${{retarget}} nosnap=${{nosnap}} prefetch=${{prefetch}} maxwait=${{maxwait}} box=${{boxOk}} zmode=${{zmode}} densityLit=${{densityLit}} drill=${{drilled}} pending=${{pending}} dblend=${{dblend}} dseq=${{dseq}} hov=${{hov}} sstale=${{sstale}} sfresh=${{sfresh}} plut=${{plut}} reg=${{reg}} refresh=${{refresh}} dpick=${{dpick}} hold=${{hold}} zoomout=${{zoomout}} broad=${{broadfallback}} dying=${{dying}} dback=${{dback}} dnorm=${{dnorm}} dnormDone=${{dnormDone}} stale=${{stale}} thrash=${{thrash}} qwire=${{qwire}} stream=${{stream}} tj=${{Math.round(maxJump*100)}} td=${{Math.round(reviveDip*100)}} malformed=${{malformed}} pixdet=${{pixdet}} splitbuf=${{splitbuf}} barBase=${{barBase}} histBase=${{histBase}} edgepad=${{edgepad}} mgrad=${{mgrad}} axisontop=${{axisontop}} mtipbase=${{mtipbase}} mcorner=${{mcorner}} mstroke=${{mstroke}} bgrad=${{bgrad}} bcorner=${{bcorner}} msmooth=${{msmooth}} bgocc=${{bgocc}}`;
     // Responsive: 100%-by-100% chart in a 400x300 container tracks its parent;
     // growing the container must fire the ResizeObserver and re-render bigger.
     const spec2=JSON.parse(JSON.stringify(spec));
@@ -1169,6 +1198,7 @@ try{{
     modebar_menu = int(re.search(r"modebarMenu=(\d+)", title).group(1))
     modebar_drag = int(re.search(r"modebarDrag=(\d+)", title).group(1))
     modebar_select = int(re.search(r"modebarSelect=(\d+)", title).group(1))
+    lasso_edit = int(re.search(r"lassoEdit=(\d+)", title).group(1))
     modebar_export = int(re.search(r"modebarExport=(\d+)", title).group(1))
     zin = int(re.search(r"zin=(\d+)", title).group(1))
     smooth = int(re.search(r"smooth=(\d+)", title).group(1))
@@ -1233,9 +1263,9 @@ try{{
     print(
         f"lit fraction: {frac:.3%}, DOM chrome nodes: {labels}, pick hits: {pick}, "
         f"row-decoded: {rowok}, select all/sub: {sel_all}/{sel_some}, mask active: {active}, "
-        f"modebar btns: {btns}, hidden/hover/no-collapse/menu/drag/select/export: "
+        f"modebar btns: {btns}, hidden/hover/no-collapse/menu/drag/select/lasso-edit/export: "
         f"{modebar_hidden}/{modebar_hover}/{modebar_no_collapse}/{modebar_menu}/"
-        f"{modebar_drag}/{modebar_select}/{modebar_export}, "
+        f"{modebar_drag}/{modebar_select}/{lasso_edit}/{modebar_export}, "
         f"zoom-in: {zin}, box-zoom: {box}, zoom-mode: {zmode}, "
         f"fluid: {fluid}, resize grew: {grew}, pick realloc: {pick2}, "
         f"destroyed: {destroyed}, unsub: {unsub}"
@@ -1268,6 +1298,8 @@ try{{
         raise SystemExit("modebar drag handle did not move the toolbar")
     if modebar_select != 1:
         raise SystemExit("modebar select button did not activate selection mode")
+    if lasso_edit != 1:
+        raise SystemExit("completed lasso did not expose draggable editable points")
     if modebar_export != 1:
         raise SystemExit("modebar export menu did not produce PNG/SVG/CSV actions")
     if zin != 1:

--- a/scripts/render_smoke_nonumpy.py
+++ b/scripts/render_smoke_nonumpy.py
@@ -312,6 +312,7 @@ try{{
       && collapsedGrip && expandedButtons === 0 && keyboardCollapsed && keyboardExpanded ? 1 : 0;
     const zoomTrigger = bar && bar.querySelector("[data-fc-modebar-menu-trigger]");
     const zoomMenu = bar && bar.querySelector("[data-fc-modebar-menu]");
+    const selectButton = bar && bar.querySelector("[data-fc-modebar-select]");
     const zoomPercent = zoomTrigger && zoomTrigger.querySelector("[data-fc-modebar-zoom-percent]");
     const zoomIndicator = zoomTrigger && zoomTrigger.querySelector("[data-fc-modebar-menu-indicator] svg");
     const zoomTriggerInitial = zoomPercent && zoomPercent.textContent === "100%" && zoomIndicator;
@@ -334,6 +335,10 @@ try{{
     }}
     const modebarDrag = grip && parseFloat(bar.style.left) > barLeft0 + 20
       && bar.querySelectorAll("button[hidden]").length === 0 ? 1 : 0;
+    if (selectButton) selectButton.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
+    const modebarSelect = selectButton && v.dragMode === "select"
+      && selectButton.classList.contains("fc-active") ? 1 : 0;
+    v._setDragMode("pan");
     const spanX = () => v.view.x1 - v.view.x0;
     const s0 = spanX();
     v._zoomBy(0.5);                 // zoom in -> span shrinks
@@ -976,7 +981,7 @@ try{{
     const gLn=vSm.gpuTraces[0], gAr=vSm.gpuTraces[1];
     const msmooth=(gLn.n===65 && gLn._cpu.x.length===5 && gAr.n===65 && gAr._cpu.base.length===5)?1:0;
     vSm.destroy();holderSm.remove();
-    const base=`FC_OK lit=${{lit}} total=${{w*h}} labels=${{labels}} pick=${{hits}} row=${{hasXY}} selAll=${{selAll}} selSome=${{selSome}} active=${{active}} btns=${{btns}} modebarHidden=${{modebarHidden}} modebarHover=${{modebarHover}} modebarCollapse=${{modebarCollapse}} modebarMenu=${{modebarMenu}} modebarDrag=${{modebarDrag}} zin=${{zin}} smooth=${{smooth}} labelThrottle=${{labelThrottle}} hoverSkip=${{hoverSkip}} zanch=${{zanch}} retarget=${{retarget}} nosnap=${{nosnap}} prefetch=${{prefetch}} maxwait=${{maxwait}} box=${{boxOk}} zmode=${{zmode}} densityLit=${{densityLit}} drill=${{drilled}} pending=${{pending}} dblend=${{dblend}} dseq=${{dseq}} hov=${{hov}} sstale=${{sstale}} sfresh=${{sfresh}} plut=${{plut}} reg=${{reg}} refresh=${{refresh}} dpick=${{dpick}} hold=${{hold}} zoomout=${{zoomout}} broad=${{broadfallback}} dying=${{dying}} dback=${{dback}} dnorm=${{dnorm}} dnormDone=${{dnormDone}} stale=${{stale}} thrash=${{thrash}} qwire=${{qwire}} stream=${{stream}} tj=${{Math.round(maxJump*100)}} td=${{Math.round(reviveDip*100)}} malformed=${{malformed}} pixdet=${{pixdet}} splitbuf=${{splitbuf}} barBase=${{barBase}} histBase=${{histBase}} edgepad=${{edgepad}} mgrad=${{mgrad}} axisontop=${{axisontop}} mtipbase=${{mtipbase}} mcorner=${{mcorner}} mstroke=${{mstroke}} bgrad=${{bgrad}} bcorner=${{bcorner}} msmooth=${{msmooth}} bgocc=${{bgocc}}`;
+    const base=`FC_OK lit=${{lit}} total=${{w*h}} labels=${{labels}} pick=${{hits}} row=${{hasXY}} selAll=${{selAll}} selSome=${{selSome}} active=${{active}} btns=${{btns}} modebarHidden=${{modebarHidden}} modebarHover=${{modebarHover}} modebarCollapse=${{modebarCollapse}} modebarMenu=${{modebarMenu}} modebarDrag=${{modebarDrag}} modebarSelect=${{modebarSelect}} zin=${{zin}} smooth=${{smooth}} labelThrottle=${{labelThrottle}} hoverSkip=${{hoverSkip}} zanch=${{zanch}} retarget=${{retarget}} nosnap=${{nosnap}} prefetch=${{prefetch}} maxwait=${{maxwait}} box=${{boxOk}} zmode=${{zmode}} densityLit=${{densityLit}} drill=${{drilled}} pending=${{pending}} dblend=${{dblend}} dseq=${{dseq}} hov=${{hov}} sstale=${{sstale}} sfresh=${{sfresh}} plut=${{plut}} reg=${{reg}} refresh=${{refresh}} dpick=${{dpick}} hold=${{hold}} zoomout=${{zoomout}} broad=${{broadfallback}} dying=${{dying}} dback=${{dback}} dnorm=${{dnorm}} dnormDone=${{dnormDone}} stale=${{stale}} thrash=${{thrash}} qwire=${{qwire}} stream=${{stream}} tj=${{Math.round(maxJump*100)}} td=${{Math.round(reviveDip*100)}} malformed=${{malformed}} pixdet=${{pixdet}} splitbuf=${{splitbuf}} barBase=${{barBase}} histBase=${{histBase}} edgepad=${{edgepad}} mgrad=${{mgrad}} axisontop=${{axisontop}} mtipbase=${{mtipbase}} mcorner=${{mcorner}} mstroke=${{mstroke}} bgrad=${{bgrad}} bcorner=${{bcorner}} msmooth=${{msmooth}} bgocc=${{bgocc}}`;
     // Responsive: 100%-by-100% chart in a 400x300 container tracks its parent;
     // growing the container must fire the ResizeObserver and re-render bigger.
     const spec2=JSON.parse(JSON.stringify(spec));
@@ -1150,6 +1155,7 @@ try{{
     modebar_collapse = int(re.search(r"modebarCollapse=(\d+)", title).group(1))
     modebar_menu = int(re.search(r"modebarMenu=(\d+)", title).group(1))
     modebar_drag = int(re.search(r"modebarDrag=(\d+)", title).group(1))
+    modebar_select = int(re.search(r"modebarSelect=(\d+)", title).group(1))
     zin = int(re.search(r"zin=(\d+)", title).group(1))
     smooth = int(re.search(r"smooth=(\d+)", title).group(1))
     label_throttle = int(re.search(r"labelThrottle=(\d+)", title).group(1))
@@ -1213,8 +1219,9 @@ try{{
     print(
         f"lit fraction: {frac:.3%}, DOM chrome nodes: {labels}, pick hits: {pick}, "
         f"row-decoded: {rowok}, select all/sub: {sel_all}/{sel_some}, mask active: {active}, "
-        f"modebar btns: {btns}, hidden/hover/collapse/menu/drag: "
-        f"{modebar_hidden}/{modebar_hover}/{modebar_collapse}/{modebar_menu}/{modebar_drag}, "
+        f"modebar btns: {btns}, hidden/hover/collapse/menu/drag/select: "
+        f"{modebar_hidden}/{modebar_hover}/{modebar_collapse}/{modebar_menu}/"
+        f"{modebar_drag}/{modebar_select}, "
         f"zoom-in: {zin}, box-zoom: {box}, zoom-mode: {zmode}, "
         f"fluid: {fluid}, resize grew: {grew}, pick realloc: {pick2}, "
         f"destroyed: {destroyed}, unsub: {unsub}"
@@ -1235,7 +1242,7 @@ try{{
         raise SystemExit(f"sub-range selection implausible: {sel_some} of {sel_all}")
     if active != 1:
         raise SystemExit("selection mask did not activate")
-    if btns < 7:
+    if btns < 8:
         raise SystemExit(f"modebar missing buttons: {btns}")
     if modebar_hidden != 1 or modebar_hover != 1:
         raise SystemExit("modebar did not hide at rest and show on chart hover")
@@ -1245,6 +1252,8 @@ try{{
         raise SystemExit("modebar zoom dropdown did not open and close")
     if modebar_drag != 1:
         raise SystemExit("modebar drag handle did not move the toolbar")
+    if modebar_select != 1:
+        raise SystemExit("modebar select button did not activate selection mode")
     if zin != 1:
         raise SystemExit("modebar zoom-in did not shrink the view span")
     if smooth != 1:

--- a/scripts/render_smoke_nonumpy.py
+++ b/scripts/render_smoke_nonumpy.py
@@ -312,6 +312,9 @@ try{{
       && collapsedGrip && expandedButtons === 0 && keyboardCollapsed && keyboardExpanded ? 1 : 0;
     const zoomTrigger = bar && bar.querySelector("[data-fc-modebar-menu-trigger]");
     const zoomMenu = bar && bar.querySelector("[data-fc-modebar-menu]");
+    const zoomPercent = zoomTrigger && zoomTrigger.querySelector("[data-fc-modebar-zoom-percent]");
+    const zoomIndicator = zoomTrigger && zoomTrigger.querySelector("[data-fc-modebar-menu-indicator] svg");
+    const zoomTriggerInitial = zoomPercent && zoomPercent.textContent === "100%" && zoomIndicator;
     if (zoomTrigger) zoomTrigger.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
     const menuOpened = zoomMenu && zoomMenu.style.display === "flex"
       && zoomTrigger.getAttribute("aria-expanded") === "true"
@@ -334,7 +337,8 @@ try{{
     const spanX = () => v.view.x1 - v.view.x0;
     const s0 = spanX();
     v._zoomBy(0.5);                 // zoom in -> span shrinks
-    const zin = spanX() < s0 ? 1 : 0;
+    const zoomTriggerIn = zoomPercent && zoomPercent.textContent === "200%";
+    const zin = spanX() < s0 && zoomTriggerInitial && zoomTriggerIn ? 1 : 0;
     v._zoomBy(2);                   // back out
     v._zoomBy(0.8,true);            // modebar path animates
     const smooth=(v._viewAnim && v._animRaf)?1:0;

--- a/scripts/render_smoke_nonumpy.py
+++ b/scripts/render_smoke_nonumpy.py
@@ -280,6 +280,46 @@ try{{
     // Modebar: button row present, and its zoom controls actually move the view.
     const bar = v._modebar;
     const btns = bar ? bar.querySelectorAll("button").length : 0;
+    const modebarHidden = bar && bar.style.opacity === "0" && bar.style.pointerEvents === "none" ? 1 : 0;
+    v.root.dispatchEvent(new PointerEvent("pointerenter", {{bubbles:true}}));
+    const modebarHover = bar && bar.style.opacity === "1" && bar.style.pointerEvents === "auto" ? 1 : 0;
+    const grip = bar && bar.querySelector("[data-fc-modebar-drag-handle]");
+    const tapGrip = (pointerId) => {{
+      if (!grip) return;
+      const gr = grip.getBoundingClientRect();
+      const init = {{pointerId,pointerType:"mouse",button:0,
+        clientX:gr.left+gr.width/2,clientY:gr.top+gr.height/2,bubbles:true}};
+      grip.dispatchEvent(new PointerEvent("pointerdown", init));
+      grip.dispatchEvent(new PointerEvent("pointerup", init));
+    }};
+    tapGrip(65); tapGrip(66);
+    const collapsedButtons = bar ? bar.querySelectorAll("button[hidden]").length : 0;
+    const collapsedDisplays = bar
+      ? [...bar.querySelectorAll("button[hidden]")].filter((button) => button.style.display === "none").length
+      : 0;
+    const collapsedGrip = grip && !grip.hidden && grip.getAttribute("aria-expanded") === "false";
+    tapGrip(67); tapGrip(68);
+    const expandedButtons = bar ? bar.querySelectorAll("button[hidden]").length : -1;
+    if (grip) grip.dispatchEvent(new KeyboardEvent("keydown", {{key:"Enter",bubbles:true}}));
+    const keyboardCollapsed = grip && grip.getAttribute("aria-expanded") === "false"
+      && bar.querySelectorAll("button[hidden]").length === 5;
+    if (grip) grip.dispatchEvent(new KeyboardEvent("keydown", {{key:"Enter",bubbles:true}}));
+    const keyboardExpanded = grip && grip.getAttribute("aria-expanded") === "true"
+      && bar.querySelectorAll("button[hidden]").length === 0;
+    const modebarCollapse = collapsedButtons === 5 && collapsedDisplays === 5
+      && collapsedGrip && expandedButtons === 0 && keyboardCollapsed && keyboardExpanded ? 1 : 0;
+    const barLeft0 = bar ? parseFloat(bar.style.left) : 0;
+    if (grip) {{
+      const gr = grip.getBoundingClientRect();
+      grip.dispatchEvent(new PointerEvent("pointerdown", {{pointerId:71,pointerType:"mouse",button:0,
+        clientX:gr.left+gr.width/2,clientY:gr.top+gr.height/2,bubbles:true}}));
+      grip.dispatchEvent(new PointerEvent("pointermove", {{pointerId:71,pointerType:"mouse",button:0,
+        clientX:gr.left+gr.width/2+80,clientY:gr.top+gr.height/2+40,bubbles:true}}));
+      grip.dispatchEvent(new PointerEvent("pointerup", {{pointerId:71,pointerType:"mouse",button:0,
+        clientX:gr.left+gr.width/2+80,clientY:gr.top+gr.height/2+40,bubbles:true}}));
+    }}
+    const modebarDrag = grip && parseFloat(bar.style.left) > barLeft0 + 20
+      && bar.querySelectorAll("button[hidden]").length === 0 ? 1 : 0;
     const spanX = () => v.view.x1 - v.view.x0;
     const s0 = spanX();
     v._zoomBy(0.5);                 // zoom in -> span shrinks
@@ -921,7 +961,7 @@ try{{
     const gLn=vSm.gpuTraces[0], gAr=vSm.gpuTraces[1];
     const msmooth=(gLn.n===65 && gLn._cpu.x.length===5 && gAr.n===65 && gAr._cpu.base.length===5)?1:0;
     vSm.destroy();holderSm.remove();
-    const base=`FC_OK lit=${{lit}} total=${{w*h}} labels=${{labels}} pick=${{hits}} row=${{hasXY}} selAll=${{selAll}} selSome=${{selSome}} active=${{active}} btns=${{btns}} zin=${{zin}} smooth=${{smooth}} labelThrottle=${{labelThrottle}} hoverSkip=${{hoverSkip}} zanch=${{zanch}} retarget=${{retarget}} nosnap=${{nosnap}} prefetch=${{prefetch}} maxwait=${{maxwait}} box=${{boxOk}} zmode=${{zmode}} densityLit=${{densityLit}} drill=${{drilled}} pending=${{pending}} dblend=${{dblend}} dseq=${{dseq}} hov=${{hov}} sstale=${{sstale}} sfresh=${{sfresh}} plut=${{plut}} reg=${{reg}} refresh=${{refresh}} dpick=${{dpick}} hold=${{hold}} zoomout=${{zoomout}} broad=${{broadfallback}} dying=${{dying}} dback=${{dback}} dnorm=${{dnorm}} dnormDone=${{dnormDone}} stale=${{stale}} thrash=${{thrash}} qwire=${{qwire}} stream=${{stream}} tj=${{Math.round(maxJump*100)}} td=${{Math.round(reviveDip*100)}} malformed=${{malformed}} pixdet=${{pixdet}} splitbuf=${{splitbuf}} barBase=${{barBase}} histBase=${{histBase}} edgepad=${{edgepad}} mgrad=${{mgrad}} axisontop=${{axisontop}} mtipbase=${{mtipbase}} mcorner=${{mcorner}} mstroke=${{mstroke}} bgrad=${{bgrad}} bcorner=${{bcorner}} msmooth=${{msmooth}} bgocc=${{bgocc}}`;
+    const base=`FC_OK lit=${{lit}} total=${{w*h}} labels=${{labels}} pick=${{hits}} row=${{hasXY}} selAll=${{selAll}} selSome=${{selSome}} active=${{active}} btns=${{btns}} modebarHidden=${{modebarHidden}} modebarHover=${{modebarHover}} modebarCollapse=${{modebarCollapse}} modebarDrag=${{modebarDrag}} zin=${{zin}} smooth=${{smooth}} labelThrottle=${{labelThrottle}} hoverSkip=${{hoverSkip}} zanch=${{zanch}} retarget=${{retarget}} nosnap=${{nosnap}} prefetch=${{prefetch}} maxwait=${{maxwait}} box=${{boxOk}} zmode=${{zmode}} densityLit=${{densityLit}} drill=${{drilled}} pending=${{pending}} dblend=${{dblend}} dseq=${{dseq}} hov=${{hov}} sstale=${{sstale}} sfresh=${{sfresh}} plut=${{plut}} reg=${{reg}} refresh=${{refresh}} dpick=${{dpick}} hold=${{hold}} zoomout=${{zoomout}} broad=${{broadfallback}} dying=${{dying}} dback=${{dback}} dnorm=${{dnorm}} dnormDone=${{dnormDone}} stale=${{stale}} thrash=${{thrash}} qwire=${{qwire}} stream=${{stream}} tj=${{Math.round(maxJump*100)}} td=${{Math.round(reviveDip*100)}} malformed=${{malformed}} pixdet=${{pixdet}} splitbuf=${{splitbuf}} barBase=${{barBase}} histBase=${{histBase}} edgepad=${{edgepad}} mgrad=${{mgrad}} axisontop=${{axisontop}} mtipbase=${{mtipbase}} mcorner=${{mcorner}} mstroke=${{mstroke}} bgrad=${{bgrad}} bcorner=${{bcorner}} msmooth=${{msmooth}} bgocc=${{bgocc}}`;
     // Responsive: 100%-by-100% chart in a 400x300 container tracks its parent;
     // growing the container must fire the ResizeObserver and re-render bigger.
     const spec2=JSON.parse(JSON.stringify(spec));
@@ -1090,6 +1130,10 @@ try{{
     sel_some = int(re.search(r"selSome=(\d+)", title).group(1))
     active = int(re.search(r"active=(\d+)", title).group(1))
     btns = int(re.search(r"btns=(\d+)", title).group(1))
+    modebar_hidden = int(re.search(r"modebarHidden=(\d+)", title).group(1))
+    modebar_hover = int(re.search(r"modebarHover=(\d+)", title).group(1))
+    modebar_collapse = int(re.search(r"modebarCollapse=(\d+)", title).group(1))
+    modebar_drag = int(re.search(r"modebarDrag=(\d+)", title).group(1))
     zin = int(re.search(r"zin=(\d+)", title).group(1))
     smooth = int(re.search(r"smooth=(\d+)", title).group(1))
     label_throttle = int(re.search(r"labelThrottle=(\d+)", title).group(1))
@@ -1153,7 +1197,9 @@ try{{
     print(
         f"lit fraction: {frac:.3%}, DOM chrome nodes: {labels}, pick hits: {pick}, "
         f"row-decoded: {rowok}, select all/sub: {sel_all}/{sel_some}, mask active: {active}, "
-        f"modebar btns: {btns}, zoom-in: {zin}, box-zoom: {box}, zoom-mode: {zmode}, "
+        f"modebar btns: {btns}, hidden/hover/collapse/drag: "
+        f"{modebar_hidden}/{modebar_hover}/{modebar_collapse}/{modebar_drag}, "
+        f"zoom-in: {zin}, box-zoom: {box}, zoom-mode: {zmode}, "
         f"fluid: {fluid}, resize grew: {grew}, pick realloc: {pick2}, "
         f"destroyed: {destroyed}, unsub: {unsub}"
     )
@@ -1175,6 +1221,12 @@ try{{
         raise SystemExit("selection mask did not activate")
     if btns < 5:
         raise SystemExit(f"modebar missing buttons: {btns}")
+    if modebar_hidden != 1 or modebar_hover != 1:
+        raise SystemExit("modebar did not hide at rest and show on chart hover")
+    if modebar_collapse != 1:
+        raise SystemExit("modebar grip did not collapse and expand the toolbar")
+    if modebar_drag != 1:
+        raise SystemExit("modebar drag handle did not move the toolbar")
     if zin != 1:
         raise SystemExit("modebar zoom-in did not shrink the view span")
     if smooth != 1:

--- a/scripts/render_smoke_nonumpy.py
+++ b/scripts/render_smoke_nonumpy.py
@@ -284,35 +284,10 @@ try{{
     v.root.dispatchEvent(new PointerEvent("pointerenter", {{bubbles:true}}));
     const modebarHover = bar && bar.style.opacity === "1" && bar.style.pointerEvents === "auto" ? 1 : 0;
     const grip = bar && bar.querySelector("[data-fc-modebar-drag-handle]");
-    const tapGrip = (pointerId) => {{
-      if (!grip) return;
-      const gr = grip.getBoundingClientRect();
-      const init = {{pointerId,pointerType:"mouse",button:0,
-        clientX:gr.left+gr.width/2,clientY:gr.top+gr.height/2,bubbles:true}};
-      grip.dispatchEvent(new PointerEvent("pointerdown", init));
-      grip.dispatchEvent(new PointerEvent("pointerup", init));
-      grip.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
-    }};
-    tapGrip(65); tapGrip(66);
-    const expectedCollapsedButtons = Math.max(0, bar.querySelectorAll(":scope > button").length - 1);
-    const collapsedButtons = bar ? bar.querySelectorAll("button[hidden]").length : 0;
-    const collapsedDisplays = bar
-      ? [...bar.querySelectorAll("button[hidden]")].filter((button) => button.style.display === "none").length
-      : 0;
-    const collapsedGrip = grip && !grip.hidden && bar.dataset.fcCollapsed === "true"
-      && grip.getAttribute("aria-expanded") === "false";
-    tapGrip(67); tapGrip(68);
-    const expandedButtons = bar ? bar.querySelectorAll("button[hidden]").length : -1;
-    const collapseItem = bar && bar.querySelector("[data-fc-modebar-collapse-item]");
-    if (collapseItem) collapseItem.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
-    const menuCollapsed = grip && bar.dataset.fcCollapsed === "true"
-      && bar.querySelectorAll("button[hidden]").length === expectedCollapsedButtons;
-    if (collapseItem) collapseItem.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
-    const menuExpanded = grip && bar.dataset.fcCollapsed === "false"
-      && bar.querySelectorAll("button[hidden]").length === 0;
-    const modebarCollapse = collapsedButtons === expectedCollapsedButtons
-      && collapsedDisplays === expectedCollapsedButtons
-      && collapsedGrip && expandedButtons === 0 && menuCollapsed && menuExpanded ? 1 : 0;
+    const modebarNoCollapse = bar && !bar.hasAttribute("data-fc-collapsed")
+      && !bar.querySelector("[data-fc-modebar-collapse-item]")
+      && [...bar.querySelectorAll(":scope > button")]
+        .every((button) => !button.hidden && button.style.display !== "none") ? 1 : 0;
     const zoomTrigger = bar && bar.querySelector("[data-fc-modebar-menu-trigger]");
     const zoomMenu = bar && bar.querySelector("[data-fc-modebar-menu]");
     const selectButton = bar && bar.querySelector("[data-fc-modebar-select]");
@@ -1019,7 +994,7 @@ try{{
     const gLn=vSm.gpuTraces[0], gAr=vSm.gpuTraces[1];
     const msmooth=(gLn.n===65 && gLn._cpu.x.length===5 && gAr.n===65 && gAr._cpu.base.length===5)?1:0;
     vSm.destroy();holderSm.remove();
-    const base=`FC_OK lit=${{lit}} total=${{w*h}} labels=${{labels}} pick=${{hits}} row=${{hasXY}} selAll=${{selAll}} selSome=${{selSome}} active=${{active}} btns=${{btns}} modebarHidden=${{modebarHidden}} modebarHover=${{modebarHover}} modebarCollapse=${{modebarCollapse}} modebarMenu=${{modebarMenu}} modebarDrag=${{modebarDrag}} modebarSelect=${{modebarSelect}} modebarExport=${{modebarExport}} zin=${{zin}} smooth=${{smooth}} labelThrottle=${{labelThrottle}} hoverSkip=${{hoverSkip}} zanch=${{zanch}} retarget=${{retarget}} nosnap=${{nosnap}} prefetch=${{prefetch}} maxwait=${{maxwait}} box=${{boxOk}} zmode=${{zmode}} densityLit=${{densityLit}} drill=${{drilled}} pending=${{pending}} dblend=${{dblend}} dseq=${{dseq}} hov=${{hov}} sstale=${{sstale}} sfresh=${{sfresh}} plut=${{plut}} reg=${{reg}} refresh=${{refresh}} dpick=${{dpick}} hold=${{hold}} zoomout=${{zoomout}} broad=${{broadfallback}} dying=${{dying}} dback=${{dback}} dnorm=${{dnorm}} dnormDone=${{dnormDone}} stale=${{stale}} thrash=${{thrash}} qwire=${{qwire}} stream=${{stream}} tj=${{Math.round(maxJump*100)}} td=${{Math.round(reviveDip*100)}} malformed=${{malformed}} pixdet=${{pixdet}} splitbuf=${{splitbuf}} barBase=${{barBase}} histBase=${{histBase}} edgepad=${{edgepad}} mgrad=${{mgrad}} axisontop=${{axisontop}} mtipbase=${{mtipbase}} mcorner=${{mcorner}} mstroke=${{mstroke}} bgrad=${{bgrad}} bcorner=${{bcorner}} msmooth=${{msmooth}} bgocc=${{bgocc}}`;
+    const base=`FC_OK lit=${{lit}} total=${{w*h}} labels=${{labels}} pick=${{hits}} row=${{hasXY}} selAll=${{selAll}} selSome=${{selSome}} active=${{active}} btns=${{btns}} modebarHidden=${{modebarHidden}} modebarHover=${{modebarHover}} modebarNoCollapse=${{modebarNoCollapse}} modebarMenu=${{modebarMenu}} modebarDrag=${{modebarDrag}} modebarSelect=${{modebarSelect}} modebarExport=${{modebarExport}} zin=${{zin}} smooth=${{smooth}} labelThrottle=${{labelThrottle}} hoverSkip=${{hoverSkip}} zanch=${{zanch}} retarget=${{retarget}} nosnap=${{nosnap}} prefetch=${{prefetch}} maxwait=${{maxwait}} box=${{boxOk}} zmode=${{zmode}} densityLit=${{densityLit}} drill=${{drilled}} pending=${{pending}} dblend=${{dblend}} dseq=${{dseq}} hov=${{hov}} sstale=${{sstale}} sfresh=${{sfresh}} plut=${{plut}} reg=${{reg}} refresh=${{refresh}} dpick=${{dpick}} hold=${{hold}} zoomout=${{zoomout}} broad=${{broadfallback}} dying=${{dying}} dback=${{dback}} dnorm=${{dnorm}} dnormDone=${{dnormDone}} stale=${{stale}} thrash=${{thrash}} qwire=${{qwire}} stream=${{stream}} tj=${{Math.round(maxJump*100)}} td=${{Math.round(reviveDip*100)}} malformed=${{malformed}} pixdet=${{pixdet}} splitbuf=${{splitbuf}} barBase=${{barBase}} histBase=${{histBase}} edgepad=${{edgepad}} mgrad=${{mgrad}} axisontop=${{axisontop}} mtipbase=${{mtipbase}} mcorner=${{mcorner}} mstroke=${{mstroke}} bgrad=${{bgrad}} bcorner=${{bcorner}} msmooth=${{msmooth}} bgocc=${{bgocc}}`;
     // Responsive: 100%-by-100% chart in a 400x300 container tracks its parent;
     // growing the container must fire the ResizeObserver and re-render bigger.
     const spec2=JSON.parse(JSON.stringify(spec));
@@ -1190,7 +1165,7 @@ try{{
     btns = int(re.search(r"btns=(\d+)", title).group(1))
     modebar_hidden = int(re.search(r"modebarHidden=(\d+)", title).group(1))
     modebar_hover = int(re.search(r"modebarHover=(\d+)", title).group(1))
-    modebar_collapse = int(re.search(r"modebarCollapse=(\d+)", title).group(1))
+    modebar_no_collapse = int(re.search(r"modebarNoCollapse=(\d+)", title).group(1))
     modebar_menu = int(re.search(r"modebarMenu=(\d+)", title).group(1))
     modebar_drag = int(re.search(r"modebarDrag=(\d+)", title).group(1))
     modebar_select = int(re.search(r"modebarSelect=(\d+)", title).group(1))
@@ -1258,8 +1233,8 @@ try{{
     print(
         f"lit fraction: {frac:.3%}, DOM chrome nodes: {labels}, pick hits: {pick}, "
         f"row-decoded: {rowok}, select all/sub: {sel_all}/{sel_some}, mask active: {active}, "
-        f"modebar btns: {btns}, hidden/hover/collapse/menu/drag/select/export: "
-        f"{modebar_hidden}/{modebar_hover}/{modebar_collapse}/{modebar_menu}/"
+        f"modebar btns: {btns}, hidden/hover/no-collapse/menu/drag/select/export: "
+        f"{modebar_hidden}/{modebar_hover}/{modebar_no_collapse}/{modebar_menu}/"
         f"{modebar_drag}/{modebar_select}/{modebar_export}, "
         f"zoom-in: {zin}, box-zoom: {box}, zoom-mode: {zmode}, "
         f"fluid: {fluid}, resize grew: {grew}, pick realloc: {pick2}, "
@@ -1281,12 +1256,12 @@ try{{
         raise SystemExit(f"sub-range selection implausible: {sel_some} of {sel_all}")
     if active != 1:
         raise SystemExit("selection mask did not activate")
-    if btns < 16:
+    if btns < 15:
         raise SystemExit(f"modebar missing buttons: {btns}")
     if modebar_hidden != 1 or modebar_hover != 1:
         raise SystemExit("modebar did not hide at rest and show on chart hover")
-    if modebar_collapse != 1:
-        raise SystemExit("modebar grip did not collapse and expand the toolbar")
+    if modebar_no_collapse != 1:
+        raise SystemExit("modebar still exposes collapsible toolbar behavior")
     if modebar_menu != 1:
         raise SystemExit("modebar zoom dropdown did not open and close")
     if modebar_drag != 1:

--- a/scripts/render_smoke_nonumpy.py
+++ b/scripts/render_smoke_nonumpy.py
@@ -364,17 +364,9 @@ try{{
       ? [...exportMenu.querySelectorAll("[data-fc-modebar-export-item]")]
         .map((item) => item.dataset.fcModebarExportItem)
       : [];
-    const themeItem = exportMenu && exportMenu.querySelector("[data-fc-modebar-theme-toggle]");
     const exportOpened = exportMenu && exportMenu.style.display === "flex"
       && exportButton.getAttribute("aria-expanded") === "true"
       && ["png", "svg", "csv"].every((format) => exportItems.includes(format));
-    if (themeItem) themeItem.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
-    const modebarTheme = v.root.dataset.fcColorMode === "dark"
-      && getComputedStyle(v.root).getPropertyValue("--chart-bg").trim() === "#111827"
-      && themeItem.textContent.includes("Light Mode")
-      && themeItem.getAttribute("aria-checked") === "true" ? 1 : 0;
-    v._toggleColorMode();
-    if (exportButton) exportButton.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
     if (exportMenu) exportMenu.dispatchEvent(new KeyboardEvent("keydown", {{key:"Escape",bubbles:true}}));
     const modebarExport = exportOpened && typeof v._exportCsvText === "function"
       && typeof v._exportSvgMarkup === "function" && typeof v._exportPng === "function"
@@ -1023,7 +1015,7 @@ try{{
     const gLn=vSm.gpuTraces[0], gAr=vSm.gpuTraces[1];
     const msmooth=(gLn.n===65 && gLn._cpu.x.length===5 && gAr.n===65 && gAr._cpu.base.length===5)?1:0;
     vSm.destroy();holderSm.remove();
-    const base=`FC_OK lit=${{lit}} total=${{w*h}} labels=${{labels}} pick=${{hits}} row=${{hasXY}} selAll=${{selAll}} selSome=${{selSome}} active=${{active}} btns=${{btns}} modebarHidden=${{modebarHidden}} modebarHover=${{modebarHover}} modebarCollapse=${{modebarCollapse}} modebarMenu=${{modebarMenu}} modebarDrag=${{modebarDrag}} modebarSelect=${{modebarSelect}} modebarExport=${{modebarExport}} modebarTheme=${{modebarTheme}} zin=${{zin}} smooth=${{smooth}} labelThrottle=${{labelThrottle}} hoverSkip=${{hoverSkip}} zanch=${{zanch}} retarget=${{retarget}} nosnap=${{nosnap}} prefetch=${{prefetch}} maxwait=${{maxwait}} box=${{boxOk}} zmode=${{zmode}} densityLit=${{densityLit}} drill=${{drilled}} pending=${{pending}} dblend=${{dblend}} dseq=${{dseq}} hov=${{hov}} sstale=${{sstale}} sfresh=${{sfresh}} plut=${{plut}} reg=${{reg}} refresh=${{refresh}} dpick=${{dpick}} hold=${{hold}} zoomout=${{zoomout}} broad=${{broadfallback}} dying=${{dying}} dback=${{dback}} dnorm=${{dnorm}} dnormDone=${{dnormDone}} stale=${{stale}} thrash=${{thrash}} qwire=${{qwire}} stream=${{stream}} tj=${{Math.round(maxJump*100)}} td=${{Math.round(reviveDip*100)}} malformed=${{malformed}} pixdet=${{pixdet}} splitbuf=${{splitbuf}} barBase=${{barBase}} histBase=${{histBase}} edgepad=${{edgepad}} mgrad=${{mgrad}} axisontop=${{axisontop}} mtipbase=${{mtipbase}} mcorner=${{mcorner}} mstroke=${{mstroke}} bgrad=${{bgrad}} bcorner=${{bcorner}} msmooth=${{msmooth}} bgocc=${{bgocc}}`;
+    const base=`FC_OK lit=${{lit}} total=${{w*h}} labels=${{labels}} pick=${{hits}} row=${{hasXY}} selAll=${{selAll}} selSome=${{selSome}} active=${{active}} btns=${{btns}} modebarHidden=${{modebarHidden}} modebarHover=${{modebarHover}} modebarCollapse=${{modebarCollapse}} modebarMenu=${{modebarMenu}} modebarDrag=${{modebarDrag}} modebarSelect=${{modebarSelect}} modebarExport=${{modebarExport}} zin=${{zin}} smooth=${{smooth}} labelThrottle=${{labelThrottle}} hoverSkip=${{hoverSkip}} zanch=${{zanch}} retarget=${{retarget}} nosnap=${{nosnap}} prefetch=${{prefetch}} maxwait=${{maxwait}} box=${{boxOk}} zmode=${{zmode}} densityLit=${{densityLit}} drill=${{drilled}} pending=${{pending}} dblend=${{dblend}} dseq=${{dseq}} hov=${{hov}} sstale=${{sstale}} sfresh=${{sfresh}} plut=${{plut}} reg=${{reg}} refresh=${{refresh}} dpick=${{dpick}} hold=${{hold}} zoomout=${{zoomout}} broad=${{broadfallback}} dying=${{dying}} dback=${{dback}} dnorm=${{dnorm}} dnormDone=${{dnormDone}} stale=${{stale}} thrash=${{thrash}} qwire=${{qwire}} stream=${{stream}} tj=${{Math.round(maxJump*100)}} td=${{Math.round(reviveDip*100)}} malformed=${{malformed}} pixdet=${{pixdet}} splitbuf=${{splitbuf}} barBase=${{barBase}} histBase=${{histBase}} edgepad=${{edgepad}} mgrad=${{mgrad}} axisontop=${{axisontop}} mtipbase=${{mtipbase}} mcorner=${{mcorner}} mstroke=${{mstroke}} bgrad=${{bgrad}} bcorner=${{bcorner}} msmooth=${{msmooth}} bgocc=${{bgocc}}`;
     // Responsive: 100%-by-100% chart in a 400x300 container tracks its parent;
     // growing the container must fire the ResizeObserver and re-render bigger.
     const spec2=JSON.parse(JSON.stringify(spec));
@@ -1199,7 +1191,6 @@ try{{
     modebar_drag = int(re.search(r"modebarDrag=(\d+)", title).group(1))
     modebar_select = int(re.search(r"modebarSelect=(\d+)", title).group(1))
     modebar_export = int(re.search(r"modebarExport=(\d+)", title).group(1))
-    modebar_theme = int(re.search(r"modebarTheme=(\d+)", title).group(1))
     zin = int(re.search(r"zin=(\d+)", title).group(1))
     smooth = int(re.search(r"smooth=(\d+)", title).group(1))
     label_throttle = int(re.search(r"labelThrottle=(\d+)", title).group(1))
@@ -1263,9 +1254,9 @@ try{{
     print(
         f"lit fraction: {frac:.3%}, DOM chrome nodes: {labels}, pick hits: {pick}, "
         f"row-decoded: {rowok}, select all/sub: {sel_all}/{sel_some}, mask active: {active}, "
-        f"modebar btns: {btns}, hidden/hover/collapse/menu/drag/select/export/theme: "
+        f"modebar btns: {btns}, hidden/hover/collapse/menu/drag/select/export: "
         f"{modebar_hidden}/{modebar_hover}/{modebar_collapse}/{modebar_menu}/"
-        f"{modebar_drag}/{modebar_select}/{modebar_export}/{modebar_theme}, "
+        f"{modebar_drag}/{modebar_select}/{modebar_export}, "
         f"zoom-in: {zin}, box-zoom: {box}, zoom-mode: {zmode}, "
         f"fluid: {fluid}, resize grew: {grew}, pick realloc: {pick2}, "
         f"destroyed: {destroyed}, unsub: {unsub}"
@@ -1286,7 +1277,7 @@ try{{
         raise SystemExit(f"sub-range selection implausible: {sel_some} of {sel_all}")
     if active != 1:
         raise SystemExit("selection mask did not activate")
-    if btns < 17:
+    if btns < 16:
         raise SystemExit(f"modebar missing buttons: {btns}")
     if modebar_hidden != 1 or modebar_hover != 1:
         raise SystemExit("modebar did not hide at rest and show on chart hover")
@@ -1300,8 +1291,6 @@ try{{
         raise SystemExit("modebar select button did not activate selection mode")
     if modebar_export != 1:
         raise SystemExit("modebar export menu did not produce PNG/SVG/CSV actions")
-    if modebar_theme != 1:
-        raise SystemExit("modebar light/dark toggle did not refresh chart theme tokens")
     if zin != 1:
         raise SystemExit("modebar zoom-in did not shrink the view span")
     if smooth != 1:

--- a/scripts/render_smoke_nonumpy.py
+++ b/scripts/render_smoke_nonumpy.py
@@ -313,9 +313,17 @@ try{{
     const zoomTrigger = bar && bar.querySelector("[data-fc-modebar-menu-trigger]");
     const zoomMenu = bar && bar.querySelector("[data-fc-modebar-menu]");
     const selectButton = bar && bar.querySelector("[data-fc-modebar-select]");
+    const selectMenu = bar && bar.querySelector("[data-fc-modebar-select-menu]");
     const zoomPercent = zoomTrigger && zoomTrigger.querySelector("[data-fc-modebar-zoom-percent]");
     const zoomIndicator = zoomTrigger && zoomTrigger.querySelector("[data-fc-modebar-menu-indicator] svg");
     const zoomTriggerInitial = zoomPercent && zoomPercent.textContent === "100%" && zoomIndicator;
+    const zoomLabelView = {{...v.view}};
+    v.view = {{...v.view, x1:v.view.x0+(v.view.x1-v.view.x0)/4000}};
+    v._updateZoomMenuLabel();
+    const zoomCompact = zoomPercent && zoomPercent.textContent === "400…%"
+      && zoomPercent.dataset.fcZoomExact === "400000%";
+    v.view = zoomLabelView;
+    v._updateZoomMenuLabel();
     if (zoomTrigger) zoomTrigger.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
     const menuOpened = zoomMenu && zoomMenu.style.display === "flex"
       && zoomTrigger.getAttribute("aria-expanded") === "true"
@@ -336,14 +344,25 @@ try{{
     const modebarDrag = grip && parseFloat(bar.style.left) > barLeft0 + 20
       && bar.querySelectorAll("button[hidden]").length === 0 ? 1 : 0;
     if (selectButton) selectButton.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
-    const modebarSelect = selectButton && v.dragMode === "select"
-      && selectButton.classList.contains("fc-active") ? 1 : 0;
+    const selectItems = selectMenu
+      ? [...selectMenu.querySelectorAll("[data-fc-modebar-select-item]")]
+      : [];
+    const selectModes = selectItems.map((item) => item.dataset.fcModebarSelectItem);
+    const lassoItem = selectMenu
+      && selectMenu.querySelector('[data-fc-modebar-select-item="select-lasso"]');
+    const selectMenuOpened = selectMenu && selectMenu.style.display === "flex"
+      && selectButton.getAttribute("aria-expanded") === "true"
+      && ["select", "select-lasso", "select-x", "select-y"].every((mode) => selectModes.includes(mode));
+    if (lassoItem) lassoItem.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
+    const modebarSelect = selectMenuOpened && v.dragMode === "select-lasso"
+      && selectButton.classList.contains("fc-active")
+      && lassoItem.classList.contains("fc-active") && selectMenu.style.display === "none" ? 1 : 0;
     v._setDragMode("pan");
     const spanX = () => v.view.x1 - v.view.x0;
     const s0 = spanX();
     v._zoomBy(0.5);                 // zoom in -> span shrinks
     const zoomTriggerIn = zoomPercent && zoomPercent.textContent === "200%";
-    const zin = spanX() < s0 && zoomTriggerInitial && zoomTriggerIn ? 1 : 0;
+    const zin = spanX() < s0 && zoomTriggerInitial && zoomCompact && zoomTriggerIn ? 1 : 0;
     v._zoomBy(2);                   // back out
     v._zoomBy(0.8,true);            // modebar path animates
     const smooth=(v._viewAnim && v._animRaf)?1:0;
@@ -1242,7 +1261,7 @@ try{{
         raise SystemExit(f"sub-range selection implausible: {sel_some} of {sel_all}")
     if active != 1:
         raise SystemExit("selection mask did not activate")
-    if btns < 8:
+    if btns < 12:
         raise SystemExit(f"modebar missing buttons: {btns}")
     if modebar_hidden != 1 or modebar_hover != 1:
         raise SystemExit("modebar did not hide at rest and show on chart hover")

--- a/scripts/render_smoke_nonumpy.py
+++ b/scripts/render_smoke_nonumpy.py
@@ -293,6 +293,7 @@ try{{
       grip.dispatchEvent(new PointerEvent("pointerup", init));
     }};
     tapGrip(65); tapGrip(66);
+    const expectedCollapsedButtons = Math.max(0, btns - 1);
     const collapsedButtons = bar ? bar.querySelectorAll("button[hidden]").length : 0;
     const collapsedDisplays = bar
       ? [...bar.querySelectorAll("button[hidden]")].filter((button) => button.style.display === "none").length
@@ -302,12 +303,22 @@ try{{
     const expandedButtons = bar ? bar.querySelectorAll("button[hidden]").length : -1;
     if (grip) grip.dispatchEvent(new KeyboardEvent("keydown", {{key:"Enter",bubbles:true}}));
     const keyboardCollapsed = grip && grip.getAttribute("aria-expanded") === "false"
-      && bar.querySelectorAll("button[hidden]").length === 5;
+      && bar.querySelectorAll("button[hidden]").length === expectedCollapsedButtons;
     if (grip) grip.dispatchEvent(new KeyboardEvent("keydown", {{key:"Enter",bubbles:true}}));
     const keyboardExpanded = grip && grip.getAttribute("aria-expanded") === "true"
       && bar.querySelectorAll("button[hidden]").length === 0;
-    const modebarCollapse = collapsedButtons === 5 && collapsedDisplays === 5
+    const modebarCollapse = collapsedButtons === expectedCollapsedButtons
+      && collapsedDisplays === expectedCollapsedButtons
       && collapsedGrip && expandedButtons === 0 && keyboardCollapsed && keyboardExpanded ? 1 : 0;
+    const zoomTrigger = bar && bar.querySelector("[data-fc-modebar-menu-trigger]");
+    const zoomMenu = bar && bar.querySelector("[data-fc-modebar-menu]");
+    if (zoomTrigger) zoomTrigger.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
+    const menuOpened = zoomMenu && zoomMenu.style.display === "flex"
+      && zoomTrigger.getAttribute("aria-expanded") === "true"
+      && zoomMenu.querySelectorAll("[data-fc-modebar-menu-item]").length === 4;
+    if (zoomMenu) zoomMenu.dispatchEvent(new KeyboardEvent("keydown", {{key:"Escape",bubbles:true}}));
+    const modebarMenu = menuOpened && zoomMenu.style.display === "none"
+      && zoomTrigger.getAttribute("aria-expanded") === "false" ? 1 : 0;
     const barLeft0 = bar ? parseFloat(bar.style.left) : 0;
     if (grip) {{
       const gr = grip.getBoundingClientRect();
@@ -961,7 +972,7 @@ try{{
     const gLn=vSm.gpuTraces[0], gAr=vSm.gpuTraces[1];
     const msmooth=(gLn.n===65 && gLn._cpu.x.length===5 && gAr.n===65 && gAr._cpu.base.length===5)?1:0;
     vSm.destroy();holderSm.remove();
-    const base=`FC_OK lit=${{lit}} total=${{w*h}} labels=${{labels}} pick=${{hits}} row=${{hasXY}} selAll=${{selAll}} selSome=${{selSome}} active=${{active}} btns=${{btns}} modebarHidden=${{modebarHidden}} modebarHover=${{modebarHover}} modebarCollapse=${{modebarCollapse}} modebarDrag=${{modebarDrag}} zin=${{zin}} smooth=${{smooth}} labelThrottle=${{labelThrottle}} hoverSkip=${{hoverSkip}} zanch=${{zanch}} retarget=${{retarget}} nosnap=${{nosnap}} prefetch=${{prefetch}} maxwait=${{maxwait}} box=${{boxOk}} zmode=${{zmode}} densityLit=${{densityLit}} drill=${{drilled}} pending=${{pending}} dblend=${{dblend}} dseq=${{dseq}} hov=${{hov}} sstale=${{sstale}} sfresh=${{sfresh}} plut=${{plut}} reg=${{reg}} refresh=${{refresh}} dpick=${{dpick}} hold=${{hold}} zoomout=${{zoomout}} broad=${{broadfallback}} dying=${{dying}} dback=${{dback}} dnorm=${{dnorm}} dnormDone=${{dnormDone}} stale=${{stale}} thrash=${{thrash}} qwire=${{qwire}} stream=${{stream}} tj=${{Math.round(maxJump*100)}} td=${{Math.round(reviveDip*100)}} malformed=${{malformed}} pixdet=${{pixdet}} splitbuf=${{splitbuf}} barBase=${{barBase}} histBase=${{histBase}} edgepad=${{edgepad}} mgrad=${{mgrad}} axisontop=${{axisontop}} mtipbase=${{mtipbase}} mcorner=${{mcorner}} mstroke=${{mstroke}} bgrad=${{bgrad}} bcorner=${{bcorner}} msmooth=${{msmooth}} bgocc=${{bgocc}}`;
+    const base=`FC_OK lit=${{lit}} total=${{w*h}} labels=${{labels}} pick=${{hits}} row=${{hasXY}} selAll=${{selAll}} selSome=${{selSome}} active=${{active}} btns=${{btns}} modebarHidden=${{modebarHidden}} modebarHover=${{modebarHover}} modebarCollapse=${{modebarCollapse}} modebarMenu=${{modebarMenu}} modebarDrag=${{modebarDrag}} zin=${{zin}} smooth=${{smooth}} labelThrottle=${{labelThrottle}} hoverSkip=${{hoverSkip}} zanch=${{zanch}} retarget=${{retarget}} nosnap=${{nosnap}} prefetch=${{prefetch}} maxwait=${{maxwait}} box=${{boxOk}} zmode=${{zmode}} densityLit=${{densityLit}} drill=${{drilled}} pending=${{pending}} dblend=${{dblend}} dseq=${{dseq}} hov=${{hov}} sstale=${{sstale}} sfresh=${{sfresh}} plut=${{plut}} reg=${{reg}} refresh=${{refresh}} dpick=${{dpick}} hold=${{hold}} zoomout=${{zoomout}} broad=${{broadfallback}} dying=${{dying}} dback=${{dback}} dnorm=${{dnorm}} dnormDone=${{dnormDone}} stale=${{stale}} thrash=${{thrash}} qwire=${{qwire}} stream=${{stream}} tj=${{Math.round(maxJump*100)}} td=${{Math.round(reviveDip*100)}} malformed=${{malformed}} pixdet=${{pixdet}} splitbuf=${{splitbuf}} barBase=${{barBase}} histBase=${{histBase}} edgepad=${{edgepad}} mgrad=${{mgrad}} axisontop=${{axisontop}} mtipbase=${{mtipbase}} mcorner=${{mcorner}} mstroke=${{mstroke}} bgrad=${{bgrad}} bcorner=${{bcorner}} msmooth=${{msmooth}} bgocc=${{bgocc}}`;
     // Responsive: 100%-by-100% chart in a 400x300 container tracks its parent;
     // growing the container must fire the ResizeObserver and re-render bigger.
     const spec2=JSON.parse(JSON.stringify(spec));
@@ -1133,6 +1144,7 @@ try{{
     modebar_hidden = int(re.search(r"modebarHidden=(\d+)", title).group(1))
     modebar_hover = int(re.search(r"modebarHover=(\d+)", title).group(1))
     modebar_collapse = int(re.search(r"modebarCollapse=(\d+)", title).group(1))
+    modebar_menu = int(re.search(r"modebarMenu=(\d+)", title).group(1))
     modebar_drag = int(re.search(r"modebarDrag=(\d+)", title).group(1))
     zin = int(re.search(r"zin=(\d+)", title).group(1))
     smooth = int(re.search(r"smooth=(\d+)", title).group(1))
@@ -1197,8 +1209,8 @@ try{{
     print(
         f"lit fraction: {frac:.3%}, DOM chrome nodes: {labels}, pick hits: {pick}, "
         f"row-decoded: {rowok}, select all/sub: {sel_all}/{sel_some}, mask active: {active}, "
-        f"modebar btns: {btns}, hidden/hover/collapse/drag: "
-        f"{modebar_hidden}/{modebar_hover}/{modebar_collapse}/{modebar_drag}, "
+        f"modebar btns: {btns}, hidden/hover/collapse/menu/drag: "
+        f"{modebar_hidden}/{modebar_hover}/{modebar_collapse}/{modebar_menu}/{modebar_drag}, "
         f"zoom-in: {zin}, box-zoom: {box}, zoom-mode: {zmode}, "
         f"fluid: {fluid}, resize grew: {grew}, pick realloc: {pick2}, "
         f"destroyed: {destroyed}, unsub: {unsub}"
@@ -1219,12 +1231,14 @@ try{{
         raise SystemExit(f"sub-range selection implausible: {sel_some} of {sel_all}")
     if active != 1:
         raise SystemExit("selection mask did not activate")
-    if btns < 5:
+    if btns < 7:
         raise SystemExit(f"modebar missing buttons: {btns}")
     if modebar_hidden != 1 or modebar_hover != 1:
         raise SystemExit("modebar did not hide at rest and show on chart hover")
     if modebar_collapse != 1:
         raise SystemExit("modebar grip did not collapse and expand the toolbar")
+    if modebar_menu != 1:
+        raise SystemExit("modebar zoom dropdown did not open and close")
     if modebar_drag != 1:
         raise SystemExit("modebar drag handle did not move the toolbar")
     if zin != 1:

--- a/scripts/render_smoke_nonumpy.py
+++ b/scripts/render_smoke_nonumpy.py
@@ -291,25 +291,28 @@ try{{
         clientX:gr.left+gr.width/2,clientY:gr.top+gr.height/2,bubbles:true}};
       grip.dispatchEvent(new PointerEvent("pointerdown", init));
       grip.dispatchEvent(new PointerEvent("pointerup", init));
+      grip.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
     }};
     tapGrip(65); tapGrip(66);
-    const expectedCollapsedButtons = Math.max(0, btns - 1);
+    const expectedCollapsedButtons = Math.max(0, bar.querySelectorAll(":scope > button").length - 1);
     const collapsedButtons = bar ? bar.querySelectorAll("button[hidden]").length : 0;
     const collapsedDisplays = bar
       ? [...bar.querySelectorAll("button[hidden]")].filter((button) => button.style.display === "none").length
       : 0;
-    const collapsedGrip = grip && !grip.hidden && grip.getAttribute("aria-expanded") === "false";
+    const collapsedGrip = grip && !grip.hidden && bar.dataset.fcCollapsed === "true"
+      && grip.getAttribute("aria-expanded") === "false";
     tapGrip(67); tapGrip(68);
     const expandedButtons = bar ? bar.querySelectorAll("button[hidden]").length : -1;
-    if (grip) grip.dispatchEvent(new KeyboardEvent("keydown", {{key:"Enter",bubbles:true}}));
-    const keyboardCollapsed = grip && grip.getAttribute("aria-expanded") === "false"
+    const collapseItem = bar && bar.querySelector("[data-fc-modebar-collapse-item]");
+    if (collapseItem) collapseItem.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
+    const menuCollapsed = grip && bar.dataset.fcCollapsed === "true"
       && bar.querySelectorAll("button[hidden]").length === expectedCollapsedButtons;
-    if (grip) grip.dispatchEvent(new KeyboardEvent("keydown", {{key:"Enter",bubbles:true}}));
-    const keyboardExpanded = grip && grip.getAttribute("aria-expanded") === "true"
+    if (collapseItem) collapseItem.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
+    const menuExpanded = grip && bar.dataset.fcCollapsed === "false"
       && bar.querySelectorAll("button[hidden]").length === 0;
     const modebarCollapse = collapsedButtons === expectedCollapsedButtons
       && collapsedDisplays === expectedCollapsedButtons
-      && collapsedGrip && expandedButtons === 0 && keyboardCollapsed && keyboardExpanded ? 1 : 0;
+      && collapsedGrip && expandedButtons === 0 && menuCollapsed && menuExpanded ? 1 : 0;
     const zoomTrigger = bar && bar.querySelector("[data-fc-modebar-menu-trigger]");
     const zoomMenu = bar && bar.querySelector("[data-fc-modebar-menu]");
     const selectButton = bar && bar.querySelector("[data-fc-modebar-select]");
@@ -342,6 +345,7 @@ try{{
         clientX:gr.left+gr.width/2+80,clientY:gr.top+gr.height/2+40,bubbles:true}}));
       grip.dispatchEvent(new PointerEvent("pointerup", {{pointerId:71,pointerType:"mouse",button:0,
         clientX:gr.left+gr.width/2+80,clientY:gr.top+gr.height/2+40,bubbles:true}}));
+      grip.dispatchEvent(new MouseEvent("click", {{bubbles:true}}));
     }}
     const modebarDrag = grip && parseFloat(bar.style.left) > barLeft0 + 20
       && bar.querySelectorAll("button[hidden]").length === 0 ? 1 : 0;

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -174,6 +174,39 @@ def test_select_fires_brush_before_select_and_returns_selection_reply():
     assert buffers is not None and len(buffers) == len(msg["traces"])
 
 
+def test_lasso_select_returns_only_points_inside_polygon():
+    fig = Figure().scatter(
+        np.array([0.0, 1.0, 2.0, 1.0, 4.0]),
+        np.array([0.0, 0.5, 0.0, 2.0, 4.0]),
+    )
+    brush_calls = []
+    select_calls = []
+    polygon = [[-0.5, -0.5], [2.5, -0.5], [1.0, 1.5]]
+
+    reply = handle(
+        fig,
+        {"type": "select_polygon", "points": polygon},
+        on_brush=brush_calls.append,
+        on_select=select_calls.append,
+    )
+
+    assert brush_calls == [{"polygon": polygon}]
+    np.testing.assert_array_equal(select_calls[0].index, [0, 1, 2])
+    assert reply is not None
+    msg, buffers = reply
+    assert msg["type"] == "selection" and msg["total"] == 3
+    np.testing.assert_array_equal(np.frombuffer(buffers[0], dtype=np.uint32), [0, 1, 2])
+
+
+@pytest.mark.parametrize(
+    "points",
+    [None, [], [[0, 0], [1, 1]], [[0, 0], [1, 0], [float("nan"), 1]], [[0, 0, 2]]],
+)
+def test_malformed_lasso_selection_is_dropped(points):
+    fig = Figure().scatter(np.arange(3.0), np.arange(3.0))
+    assert handle(fig, {"type": "select_polygon", "points": points}) is None
+
+
 def test_select_wire_mask_is_shipped_space_selection_is_canonical():
     x = np.array([0.0, np.nan, 2.0, 3.0, 4.0])
     y = np.array([0.0, 1.0, 2.0, np.nan, 4.0])

--- a/tests/test_static_client_security.py
+++ b/tests/test_static_client_security.py
@@ -113,6 +113,8 @@ def test_client_user_text_surfaces_use_text_nodes_not_html() -> None:
             'grip.innerHTML = this._icon("drag");',
             "b.innerHTML = this._icon(name);",
             'zoomIndicator.innerHTML = this._icon("chevrondown");',
+            'selectIndicator.innerHTML = this._icon("chevrondown");',
+            "icon.innerHTML = this._icon(name);",
             "icon.innerHTML = this._icon(name);",
         ]
 

--- a/tests/test_static_client_security.py
+++ b/tests/test_static_client_security.py
@@ -107,7 +107,10 @@ def test_client_user_text_surfaces_use_text_nodes_not_html() -> None:
             assert sink not in text, f"{path} must not use HTML sink {sink}"
 
         inner_html_lines = [line.strip() for line in text.splitlines() if ".innerHTML" in line]
-        assert inner_html_lines == ["b.innerHTML = this._icon(name);"]
+        assert inner_html_lines == [
+            'grip.innerHTML = this._icon("drag");',
+            "b.innerHTML = this._icon(name);",
+        ]
 
 
 def test_client_respects_user_legend_max_height_style() -> None:

--- a/tests/test_static_client_security.py
+++ b/tests/test_static_client_security.py
@@ -112,6 +112,7 @@ def test_client_user_text_surfaces_use_text_nodes_not_html() -> None:
         assert inner_html_lines == [
             'grip.innerHTML = this._icon("drag");',
             "b.innerHTML = this._icon(name);",
+            'zoomIndicator.innerHTML = this._icon("chevrondown");',
             "icon.innerHTML = this._icon(name);",
         ]
 

--- a/tests/test_static_client_security.py
+++ b/tests/test_static_client_security.py
@@ -112,6 +112,7 @@ def test_client_user_text_surfaces_use_text_nodes_not_html() -> None:
         assert inner_html_lines == [
             'grip.innerHTML = this._icon("drag");',
             "b.innerHTML = this._icon(name);",
+            "icon.innerHTML = this._icon(name);",
         ]
 
 

--- a/tests/test_static_client_security.py
+++ b/tests/test_static_client_security.py
@@ -116,7 +116,26 @@ def test_client_user_text_surfaces_use_text_nodes_not_html() -> None:
             'selectIndicator.innerHTML = this._icon("chevrondown");',
             "icon.innerHTML = this._icon(name);",
             "icon.innerHTML = this._icon(name);",
+            "icon.innerHTML = this._icon(name);",
+            'if (icon) icon.innerHTML = this._icon(dark ? "sun" : "moon");',
         ]
+
+
+def test_modebar_exports_are_local_and_exclude_interaction_chrome() -> None:
+    """Browser exports stay self-contained and never serialize the toolbar itself."""
+    required = (
+        'exportMenu.dataset.fcModebarExportMenu = "";',
+        'new Blob([svg], { type: "image/svg+xml;charset=utf-8" })',
+        'new Blob([this._exportCsvText()], { type: "text/csv;charset=utf-8" })',
+        "link.download = filename;",
+        "const content = new XMLSerializer().serializeToString(clone);",
+        '[data-fc-slot="modebar"],[data-fc-slot="tooltip"]',
+        'const columns = ["trace", "name", "kind", "index", "x", "y"',
+        "this.root.dataset.fcColorMode = this._colorMode;",
+    )
+    for path, text in CLIENT_FILES:
+        for snippet in required:
+            assert snippet in text, f"{path} missing toolbar export contract {snippet!r}"
 
 
 def test_client_respects_user_legend_max_height_style() -> None:

--- a/tests/test_static_client_security.py
+++ b/tests/test_static_client_security.py
@@ -117,7 +117,6 @@ def test_client_user_text_surfaces_use_text_nodes_not_html() -> None:
             "icon.innerHTML = this._icon(name);",
             "icon.innerHTML = this._icon(name);",
             "icon.innerHTML = this._icon(name);",
-            'if (icon) icon.innerHTML = this._icon(collapsed ? "expand" : "collapse");',
         ]
 
 

--- a/tests/test_static_client_security.py
+++ b/tests/test_static_client_security.py
@@ -117,6 +117,7 @@ def test_client_user_text_surfaces_use_text_nodes_not_html() -> None:
             "icon.innerHTML = this._icon(name);",
             "icon.innerHTML = this._icon(name);",
             "icon.innerHTML = this._icon(name);",
+            'if (icon) icon.innerHTML = this._icon(collapsed ? "expand" : "collapse");',
         ]
 
 

--- a/tests/test_static_client_security.py
+++ b/tests/test_static_client_security.py
@@ -117,7 +117,6 @@ def test_client_user_text_surfaces_use_text_nodes_not_html() -> None:
             "icon.innerHTML = this._icon(name);",
             "icon.innerHTML = this._icon(name);",
             "icon.innerHTML = this._icon(name);",
-            'if (icon) icon.innerHTML = this._icon(dark ? "sun" : "moon");',
         ]
 
 
@@ -131,7 +130,6 @@ def test_modebar_exports_are_local_and_exclude_interaction_chrome() -> None:
         "const content = new XMLSerializer().serializeToString(clone);",
         '[data-fc-slot="modebar"],[data-fc-slot="tooltip"]',
         'const columns = ["trace", "name", "kind", "index", "x", "y"',
-        "this.root.dataset.fcColorMode = this._colorMode;",
     )
     for path, text in CLIENT_FILES:
         for snippet in required:

--- a/tests/test_static_client_security.py
+++ b/tests/test_static_client_security.py
@@ -44,6 +44,8 @@ def test_chrome_visual_defaults_are_a_defeatable_where_stylesheet() -> None:
         ':where(.xy [data-fc-slot="legend_swatch"]){',
         ':where(.xy [data-fc-slot="modebar"]){',
         ':where(.xy [data-fc-slot="modebar_button"]){',
+        ":where(.xy [data-fc-modebar-menu]){",
+        ":where(.xy [data-fc-modebar-menu-item]){",
         ':where(.xy [data-fc-slot="modebar_button"].fc-active){',
         ':where(.xy [data-fc-slot="selection"]){',
         ':where(.xy [data-fc-slot="badge_item"]){',


### PR DESCRIPTION
## Summary

- hide the chart toolbar until the chart is hovered or a toolbar control receives keyboard focus
- make the toolbar draggable and clamp its position inside the chart after responsive resizes
- combine the drag grip and toolbar-options trigger into one dotted control with PNG, SVG, and CSV exports
- show the live zoom percentage in a compact dropdown with Zoom In, Zoom Out, Box Zoom, and Reset View
- add a Select dropdown with Box, Lasso, X Range, and Y Range modes for selectable charts
- keep completed lasso polygons visible with up to 16 draggable vertex handles, then recalculate the selection when a handle is released
- preserve Shift-drag box selection and add kernel-backed polygon selection for lasso gestures
- support keyboard menu navigation, Escape and outside-click dismissal, and automatic above/below menu placement
- export complete visible chart chrome without interactive toolbar or selection overlays; CSV includes resident trace data
- rebuild the committed widget and standalone client bundles
- extend the Chromium render smoke to cover hover visibility, dragging, menus, selection modes, editable lasso handles, compact zoom labels, export, fit, and resize behavior

## Why

The always-visible modebar obscured chart content, could not be repositioned, and used separate zoom controls that consumed unnecessary width. The compact hover toolbar keeps the same capabilities while reducing visual obstruction.

Lasso selections previously disappeared as soon as the gesture ended, so refining a boundary required drawing it again. Persistent draggable vertices make the selected range adjustable without restarting the selection.

## Validation

- `uv run --with pre-commit pre-commit run --all-files`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest -q` (1748 passed, 65 skipped)
- `uv run python scripts/render_smoke_nonumpy.py` (passed; editable lasso, toolbar, zoom, selection, export, drag, fit, and resize verified)
- live browser verification with a 50,000-point scatter demo in light and dark host themes
