### PR TITLE
Add CodSpeed pyplot-shim vs raw API pairs; fix O(n) dataless-axis scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,30 @@ in the README).
   contract without importing the widget stack.
 
 ### Changed
+- **`savefig` single-panel PNG export now uses the fused Rust encoder.** A
+  one-axes figure with no suptitle/colorbar/tight-bbox and the default white
+  facecolor is exactly one native render, so `stitch_png` returns the
+  rasterizer's own PNG (the latency-first `Figure.to_png` default) instead of
+  round-tripping RGBA through the Python size-oriented encoder — pixel-
+  identical output, ~10x faster (119.8ms → 11.7ms on a 100k-point savefig;
+  1.2x the raw `to_png` at the same 1280x960 output). Multi-panel and
+  tight-bbox exports keep the composed path but now probe a stride sample
+  before the full-image palette attempt, skipping a doomed O(n log n) unique
+  scan on antialiased charts.
+- **`ax.hist` no longer boxes numeric input or copies it to find bin edges.**
+  The input-shape sniff skipped its object-dtype round trip for 1-D numeric
+  arrays, and fixed-count bins derive their range from the native NaN-skipping
+  min/max scan instead of a finite-filtered concatenated copy. Counts still
+  come from `np.histogram` against the identical edges — the kernel-based
+  shortcut was rejected because it disagrees with numpy by ±1 on values
+  exactly at interior bin edges. ~2.3x faster shim histogram builds.
+- **`ax.bar`/`ax.barh` label sanitization is vectorized.** Plain string
+  category arrays are scanned for TeX markers with one vectorized pass
+  instead of a per-label Python loop through the mathtext converter.
+- **Legend `loc="best"` scoring subsamples before its finite scan** instead
+  of running `isfinite` over every point of every legended series — the
+  scoring was already sample-based; the full-array pass was pure O(n)
+  per-build cost.
 - **`xy.pyplot` no longer pays an O(n) dataless-axis scan on every build.**
   The empty-view pin in `_build_chart` materialized and finite-filtered every
   entry's full data for both axes just to ask "is this axis empty?", adding a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,13 @@ in the README).
   contract without importing the widget stack.
 
 ### Changed
+- **`xy.pyplot` no longer pays an O(n) dataless-axis scan on every build.**
+  The empty-view pin in `_build_chart` materialized and finite-filtered every
+  entry's full data for both axes just to ask "is this axis empty?", adding a
+  data-proportional cost to each shim figure build (~3x the raw declarative
+  build at 1M points). It now short-circuits on the first finite value via a
+  prefix probe; `tests/pyplot/test_perf_guardrail.py` passes again on Linux
+  runners and the new CodSpeed pairs track the margin continuously.
 - **Payload copy elimination (native ABI v32).** Partial-view density sampling
   now hashes native `u32` row selections without first widening the full array
   to `u64`; exact-full index buffers avoid a trailing-slice copy; and payload
@@ -125,6 +132,14 @@ in the README).
   faster; fluent path unchanged by construction).
 
 ### Added
+- **CodSpeed shim-overhead pairs** (`benchmarks/test_codspeed_pyplot.py`):
+  every workload (10k/1M line, 100k scatter, 200-bin histogram, 1k-category
+  bars, a chrome-heavy styled panel, and static PNG export) is built twice
+  from the same arrays — once through the raw declarative API and once
+  through the identical `xy.pyplot` calls — ending in the same split wire
+  payload or PNG bytes, so the `*_pyplot` minus `*_raw` gap in CodSpeed is
+  exactly the shim's translation cost. Collected automatically by the
+  existing `benchmarks/test_codspeed_*.py` CI glob.
 - **Dashboard context governor**: browsers cap live WebGL contexts per page
   (~16 in Chrome) and LRU-evict the oldest on overflow, which permanently
   blanked the earliest charts of a 20+/50-chart dashboard. The render client

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,11 @@ uv run ruff format --check .
 The two `*_smoke*` scripts need neither numpy nor PyPI — they verify the
 Python↔Rust ABI and the render client directly, and run first in CI.
 
+Never credit Claude in git history: no Claude author or committer identity,
+no `Co-Authored-By: Claude` trailers, no AI attribution in commit messages,
+PRs, or code. Set `git config user.name/user.email` to the human author
+(e.g. from `git log origin/main`) before committing.
+
 ## Invariants (from the dossier — don't regress silently)
 
 - No JSON numbers on the wire; data moves as raw f32 buffers (§29).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -144,6 +144,16 @@ alongside the complete categorical first-payload row. Together they distinguish
 native encoding/sampling regressions from payload-policy or transport
 regressions.
 
+`test_codspeed_pyplot.py` tracks the `xy.pyplot` shim's overhead against the
+raw declarative API: each workload (line 10k/1M, scatter 100k, histogram,
+categorical bars, a chrome-heavy styled panel, and static PNG export) is built
+twice from the same arrays — once with `xy.chart` + marks and once with the
+identical Matplotlib-style calls — ending in the same split wire payload or
+PNG bytes. The `*_pyplot` minus `*_raw` gap is the shim; both rows moving
+together is the shared engine. `tests/pyplot/test_perf_guardrail.py` remains
+the hard relative gate; these rows exist so a shim regression is attributed
+to the shim arm in CodSpeed instead of surfacing as an engine slowdown.
+
 `test_codspeed_transport.py` separately tracks production frame encode,
 scatter/gather part construction, and zero-copy decode at representative density
 and direct-payload sizes, with base64 JSON encode/decode comparator rows. The

--- a/benchmarks/test_codspeed_pyplot.py
+++ b/benchmarks/test_codspeed_pyplot.py
@@ -1,0 +1,382 @@
+"""CodSpeed benchmarks for ``xy.pyplot`` shim overhead versus the raw API.
+
+Every workload here is one chart expressed twice over the same input arrays
+and ending in the same terminal work: once through the public declarative API
+(``xy.chart`` + marks) and once through the identical Matplotlib-style calls
+in ``xy.pyplot``. Both arms finish at the engine's split wire payload (or PNG
+bytes for the export pair), so the gap between a ``*_pyplot`` row and its
+``*_raw`` twin is exactly what the shim adds — Matplotlib-call translation,
+fmt-string parsing, and figure-lifecycle bookkeeping. Everything below the
+shim is shared engine work and moves both rows together.
+
+``tests/pyplot/test_perf_guardrail.py`` remains the hard relative gate on
+this promise; these rows track it continuously so a structural regression in
+the shim (an O(n) copy, per-build revalidation) shows up attributed to the
+``*_pyplot`` arm instead of surfacing as an unexplained engine slowdown.
+
+Run locally with:
+
+    codspeed run --mode simulation -- pytest benchmarks/test_codspeed_pyplot.py --codspeed
+"""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import pytest
+
+import xy as fc
+import xy.pyplot as plt
+from xy import kernels as k
+
+N_BUCKETS = 2048
+# plt.subplots() defaults to 6.4 x 4.8 inches at dpi=100; the raw arm pins the
+# same 640x480 canvas so chrome layout work is identical on both sides.
+WIDTH, HEIGHT = 640, 480
+SMALL_N = 10_000
+MEDIUM_N = 100_000
+LARGE_N = 1_000_000
+HIST_N = 100_000
+HIST_BINS = 200
+BAR_N = 1_000
+PANEL_N = 5_000
+EXPORT_N = 100_000
+
+
+@pytest.fixture(scope="session", autouse=True)
+def require_native_backend() -> None:
+    assert k.BACKEND == "native", (
+        "CodSpeed benchmarks must run against the native Rust backend; "
+        f"got {k.BACKEND!r}. Build the native core before running them."
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def warm_lazy_modules() -> None:
+    """Warm both arms' lazily-imported submodules before any measured region.
+
+    CodSpeed simulation measures one-shot regions from a fresh checkout, and
+    both xy and the pyplot shim defer heavy imports (marks, _payload, the
+    export stack, the shim's translation tables) until first use. Without
+    this, the first benchmark of each arm would track package source size
+    instead of its own workload — exactly the phantom regression documented
+    in test_codspeed_kernels.py.
+    """
+    x = np.array([0.0, 1.0, 2.0, 3.0])
+    y = np.array([0.0, 1.0, 0.0, 1.0])
+    raw = fc.chart(fc.line(x=x, y=y), fc.x_axis(), fc.y_axis()).figure()
+    raw.build_payload_split(N_BUCKETS)
+    raw_fig = fc.chart(fc.line(x=x, y=y)).figure()
+    raw_fig.to_png(engine=fc.Engine.default, scale=1.0)
+
+    plt.close("all")
+    fig, ax = plt.subplots()
+    ax.plot(x, y, "r--", label="warm")
+    ax.legend()
+    ax._build_chart(WIDTH, HEIGHT).figure().build_payload_split(N_BUCKETS)
+    buffer = io.BytesIO()
+    fig.savefig(buffer, format="png")
+    plt.close("all")
+
+
+@pytest.fixture(scope="module")
+def small_data() -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(7)
+    x = np.arange(SMALL_N, dtype=np.float64)
+    return x, rng.normal(0.0, 1.0, SMALL_N)
+
+
+@pytest.fixture(scope="module")
+def medium_data() -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(11)
+    x = np.arange(MEDIUM_N, dtype=np.float64)
+    return x, rng.normal(0.0, 1.0, MEDIUM_N)
+
+
+@pytest.fixture(scope="module")
+def large_data() -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(42)
+    x = np.arange(LARGE_N, dtype=np.float64)
+    return x, rng.normal(0.0, 1.0, LARGE_N)
+
+
+@pytest.fixture(scope="module")
+def hist_values() -> np.ndarray:
+    rng = np.random.default_rng(31)
+    return np.concatenate(
+        [
+            rng.normal(-1.1, 0.52, HIST_N // 2),
+            rng.normal(1.35, 0.68, HIST_N - HIST_N // 2),
+        ]
+    ).astype(np.float64, copy=False)
+
+
+@pytest.fixture(scope="module")
+def bar_data() -> tuple[list[str], np.ndarray]:
+    rng = np.random.default_rng(23)
+    categories = [f"C{i:04d}" for i in range(BAR_N)]
+    values = (
+        42.0 + 18.0 * np.sin(np.linspace(0.0, 18.0, BAR_N)) + rng.normal(0.0, 3.0, BAR_N)
+    ).astype(np.float64, copy=False)
+    return categories, values
+
+
+@pytest.fixture(scope="module")
+def panel_data() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(53)
+    x = np.arange(PANEL_N, dtype=np.float64)
+    actual = 40.0 + 6.0 * np.sin(x * 0.004) + rng.normal(0.0, 0.8, PANEL_N)
+    target = 42.0 + 5.0 * np.cos(x * 0.003)
+    sample = 0.6 * actual + 0.4 * target
+    return x, actual, target, sample
+
+
+@pytest.fixture(scope="module")
+def export_data() -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(29)
+    x = np.arange(EXPORT_N, dtype=np.float64)
+    y = (np.sin(x * 0.001) + rng.normal(0.0, 0.08, EXPORT_N)).astype(np.float64, copy=False)
+    return x, y
+
+
+# -- paired build arms --------------------------------------------------------
+#
+# The raw arm mirrors the shim's implicit defaults (explicit x/y axes, the
+# 640x480 canvas) so the pair differs only in which API expressed the chart.
+# The pyplot arm includes plt.close("all") because figure-registry bookkeeping
+# is part of the shim's per-figure cost — the exact cost the guardrail bounds.
+
+
+def _raw_line_payload(x: np.ndarray, y: np.ndarray) -> int:
+    c = fc.chart(
+        fc.line(x=x, y=y, color="#1f77b4"),
+        fc.x_axis(),
+        fc.y_axis(),
+        width=WIDTH,
+        height=HEIGHT,
+    )
+    _spec, buffers = c.figure().build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
+
+
+def _pyplot_line_payload(x: np.ndarray, y: np.ndarray) -> int:
+    plt.close("all")
+    _fig, ax = plt.subplots()
+    ax.plot(x, y)
+    _spec, buffers = ax._build_chart(WIDTH, HEIGHT).figure().build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
+
+
+def _raw_scatter_payload(x: np.ndarray, y: np.ndarray) -> int:
+    c = fc.chart(
+        fc.scatter(x=x, y=y, color="#1f77b4", size=6.0),
+        fc.x_axis(),
+        fc.y_axis(),
+        width=WIDTH,
+        height=HEIGHT,
+    )
+    _spec, buffers = c.figure().build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
+
+
+def _pyplot_scatter_payload(x: np.ndarray, y: np.ndarray) -> int:
+    plt.close("all")
+    _fig, ax = plt.subplots()
+    ax.scatter(x, y, c="#1f77b4", s=36.0)
+    _spec, buffers = ax._build_chart(WIDTH, HEIGHT).figure().build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
+
+
+def _raw_histogram_payload(values: np.ndarray) -> int:
+    c = fc.chart(
+        fc.histogram(values, bins=HIST_BINS),
+        fc.x_axis(),
+        fc.y_axis(),
+        width=WIDTH,
+        height=HEIGHT,
+    )
+    _spec, buffers = c.figure().build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
+
+
+def _pyplot_histogram_payload(values: np.ndarray) -> int:
+    plt.close("all")
+    _fig, ax = plt.subplots()
+    ax.hist(values, bins=HIST_BINS)
+    _spec, buffers = ax._build_chart(WIDTH, HEIGHT).figure().build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
+
+
+def _raw_bar_payload(categories: list[str], values: np.ndarray) -> int:
+    c = fc.chart(
+        fc.bar(categories, values),
+        fc.x_axis(),
+        fc.y_axis(),
+        width=WIDTH,
+        height=HEIGHT,
+    )
+    _spec, buffers = c.figure().build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
+
+
+def _pyplot_bar_payload(categories: list[str], values: np.ndarray) -> int:
+    plt.close("all")
+    _fig, ax = plt.subplots()
+    ax.bar(categories, values)
+    _spec, buffers = ax._build_chart(WIDTH, HEIGHT).figure().build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
+
+
+def _raw_styled_panel_payload(
+    x: np.ndarray, actual: np.ndarray, target: np.ndarray, sample: np.ndarray
+) -> int:
+    c = fc.chart(
+        fc.line(x=x, y=actual, color="#ff0000", dash="dashed", width=2.0, name="actual"),
+        fc.line(x=x, y=target, color="#008000", name="target"),
+        fc.scatter(x=x, y=sample, color="#1f77b4", size=6.0, name="sample"),
+        fc.x_axis(label="time"),
+        fc.y_axis(label="value"),
+        fc.legend(),
+        title="pipeline",
+        width=WIDTH,
+        height=HEIGHT,
+    )
+    _spec, buffers = c.figure().build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
+
+
+def _pyplot_styled_panel_payload(
+    x: np.ndarray, actual: np.ndarray, target: np.ndarray, sample: np.ndarray
+) -> int:
+    plt.close("all")
+    _fig, ax = plt.subplots()
+    ax.plot(x, actual, "r--", linewidth=2.0, label="actual")
+    ax.plot(x, target, "g-", label="target")
+    ax.scatter(x, sample, c="#1f77b4", s=36.0, label="sample")
+    ax.set_title("pipeline")
+    ax.set_xlabel("time")
+    ax.set_ylabel("value")
+    ax.legend()
+    _spec, buffers = ax._build_chart(WIDTH, HEIGHT).figure().build_payload_split(N_BUCKETS)
+    return sum(b.nbytes for b in buffers)
+
+
+# -- build pairs ---------------------------------------------------------------
+
+
+def test_build_line_small_raw(benchmark, small_data):
+    """Everyday 10k line through the declarative API: the shim pair's baseline."""
+    x, y = small_data
+    assert benchmark(_raw_line_payload, x, y) > 0
+
+
+def test_build_line_small_pyplot(benchmark, small_data):
+    """Same 10k line via plt.subplots/ax.plot; the gap to *_raw is the shim."""
+    x, y = small_data
+    payload_bytes = benchmark(_pyplot_line_payload, x, y)
+    # Same chart on the wire: identical trace buffers, or the pair is dishonest.
+    assert payload_bytes == _raw_line_payload(x, y)
+
+
+def test_build_line_large_raw(benchmark, large_data):
+    """1M-point line: M4 decimation dominates; the pair shows shim cost is flat."""
+    x, y = large_data
+    payload_bytes = _raw_line_payload(x, y)
+    assert 0 < payload_bytes < x.nbytes + y.nbytes
+    assert benchmark(_raw_line_payload, x, y) == payload_bytes
+
+
+def test_build_line_large_pyplot(benchmark, large_data):
+    """Same 1M line via the shim; must ship the same decimated payload."""
+    x, y = large_data
+    payload_bytes = benchmark(_pyplot_line_payload, x, y)
+    assert payload_bytes == _raw_line_payload(x, y)
+
+
+def test_build_scatter_medium_raw(benchmark, medium_data):
+    """100k exact scatter through the declarative API."""
+    x, y = medium_data
+    assert benchmark(_raw_scatter_payload, x, y) > 0
+
+
+def test_build_scatter_medium_pyplot(benchmark, medium_data):
+    """Same 100k scatter via ax.scatter, including mpl s= translation."""
+    x, y = medium_data
+    payload_bytes = benchmark(_pyplot_scatter_payload, x, y)
+    assert payload_bytes == _raw_scatter_payload(x, y)
+
+
+def test_build_histogram_raw(benchmark, hist_values):
+    """100k-observation histogram (200 bins) through the declarative API."""
+    assert benchmark(_raw_histogram_payload, hist_values) > 0
+
+
+def test_build_histogram_pyplot(benchmark, hist_values):
+    """Same histogram via ax.hist, including its return-tuple construction.
+
+    ax.hist pre-bins with NumPy (it must return matplotlib's (n, bins,
+    patches) tuple) and ships bar geometry, while fc.histogram bins natively
+    and ships rect columns — so the two arms' payload layouts differ. Both
+    must stay bounded by bin count, never by the observation count.
+    """
+    payload_bytes = benchmark(_pyplot_histogram_payload, hist_values)
+    assert 0 < payload_bytes < hist_values.nbytes
+
+
+def test_build_bar_categorical_raw(benchmark, bar_data):
+    """1k-category bar chart through the declarative API."""
+    categories, values = bar_data
+    assert benchmark(_raw_bar_payload, categories, values) > 0
+
+
+def test_build_bar_categorical_pyplot(benchmark, bar_data):
+    """Same categorical bars via ax.bar."""
+    categories, values = bar_data
+    payload_bytes = benchmark(_pyplot_bar_payload, categories, values)
+    assert payload_bytes == _raw_bar_payload(categories, values)
+
+
+def test_build_styled_panel_raw(benchmark, panel_data):
+    """Chrome-heavy layered panel (3 series, title/labels/legend), raw API."""
+    x, actual, target, sample = panel_data
+    assert benchmark(_raw_styled_panel_payload, x, actual, target, sample) > 0
+
+
+def test_build_styled_panel_pyplot(benchmark, panel_data):
+    """Same panel via the shim: fmt strings, label/legend/title translation.
+
+    This is the shim's worst honest case — the workload where translation
+    (fmt parsing, prop cycling, chrome mapping) is largest relative to data.
+    """
+    x, actual, target, sample = panel_data
+    payload_bytes = benchmark(_pyplot_styled_panel_payload, x, actual, target, sample)
+    assert payload_bytes == _raw_styled_panel_payload(x, actual, target, sample)
+
+
+# -- export pair ----------------------------------------------------------------
+
+
+def test_png_export_line_raw(benchmark, export_data):
+    """Native PNG export of a warm 100k line figure through the raw API."""
+    x, y = export_data
+    fig = fc.chart(fc.line(x=x, y=y), width=WIDTH, height=HEIGHT).figure()
+    png = benchmark(fig.to_png, engine=fc.Engine.default, scale=1.0)
+    assert png.startswith(b"\x89PNG")
+
+
+def test_png_export_line_pyplot(benchmark, export_data):
+    """Same export via figure.savefig: the full public shim static path."""
+    x, y = export_data
+    plt.close("all")
+    fig, ax = plt.subplots()
+    ax.plot(x, y)
+
+    def export() -> bytes:
+        buffer = io.BytesIO()
+        fig.savefig(buffer, format="png")
+        return buffer.getvalue()
+
+    png = benchmark(export)
+    assert png.startswith(b"\x89PNG")
+    plt.close("all")

--- a/benchmarks/test_codspeed_pyplot.py
+++ b/benchmarks/test_codspeed_pyplot.py
@@ -358,10 +358,15 @@ def test_build_styled_panel_pyplot(benchmark, panel_data):
 
 
 def test_png_export_line_raw(benchmark, export_data):
-    """Native PNG export of a warm 100k line figure through the raw API."""
+    """Native PNG export of a warm 100k line figure through the raw API.
+
+    scale=2.0 matches savefig's fixed 2x supersampling so both arms emit the
+    same 1280x960 pixel canvas — a smaller raw canvas would overstate the
+    shim's gap.
+    """
     x, y = export_data
     fig = fc.chart(fc.line(x=x, y=y), width=WIDTH, height=HEIGHT).figure()
-    png = benchmark(fig.to_png, engine=fc.Engine.default, scale=1.0)
+    png = benchmark(fig.to_png, engine=fc.Engine.default, scale=2.0)
     assert png.startswith(b"\x89PNG")
 
 

--- a/benchmarks/test_codspeed_pyplot.py
+++ b/benchmarks/test_codspeed_pyplot.py
@@ -65,18 +65,26 @@ def warm_lazy_modules() -> None:
     """
     x = np.array([0.0, 1.0, 2.0, 3.0])
     y = np.array([0.0, 1.0, 0.0, 1.0])
-    raw = fc.chart(fc.line(x=x, y=y), fc.x_axis(), fc.y_axis()).figure()
+    raw = fc.chart(fc.line(x=x, y=y), fc.scatter(x=x, y=y), fc.x_axis(), fc.y_axis()).figure()
     raw.build_payload_split(N_BUCKETS)
+    fc.chart(fc.bar(["a", "b"], np.array([1.0, 2.0]))).figure().build_payload_split(N_BUCKETS)
+    fc.chart(fc.histogram(y, bins=4)).figure().build_payload_split(N_BUCKETS)
     raw_fig = fc.chart(fc.line(x=x, y=y)).figure()
     raw_fig.to_png(engine=fc.Engine.default, scale=1.0)
 
     plt.close("all")
     fig, ax = plt.subplots()
     ax.plot(x, y, "r--", label="warm")
+    ax.scatter(x, y, c="#1f77b4", s=9.0)
     ax.legend()
     ax._build_chart(WIDTH, HEIGHT).figure().build_payload_split(N_BUCKETS)
     buffer = io.BytesIO()
     fig.savefig(buffer, format="png")
+    plt.close("all")
+    _fig2, ax2 = plt.subplots()
+    ax2.bar(["a", "b"], [1.0, 2.0])
+    ax2.hist(y, bins=4)
+    ax2._build_chart(WIDTH, HEIGHT).figure().build_payload_split(N_BUCKETS)
     plt.close("all")
 
 

--- a/python/xy/_png.py
+++ b/python/xy/_png.py
@@ -70,6 +70,14 @@ def encode(img: np.ndarray) -> bytes:
     flat = np.ascontiguousarray(img).reshape(-1, 4)
     # One 32-bit key per pixel for a fast unique/lookup.
     keys = flat.view(np.uint32).reshape(-1)
+    if keys.size > 65_536:
+        # Antialiased marks push most real charts past 256 colors; probing a
+        # stride sample first skips the full-image unique/argsort when the
+        # palette attempt is doomed. A probe over 256 colors proves the whole
+        # image is too, so the truecolor result is identical either way.
+        probe = keys[:: keys.size // 65_536]
+        if np.unique(probe).size > 256:
+            return png_truecolor(w, h, np.ascontiguousarray(img).tobytes())
     palette_keys, inverse = np.unique(keys, return_inverse=True)
     if palette_keys.size <= 256:
         palette = palette_keys.view(np.uint8).reshape(-1, 4)

--- a/python/xy/pyplot/_axes.py
+++ b/python/xy/pyplot/_axes.py
@@ -1262,21 +1262,22 @@ class Axes(PlotTypeMixin):
         kwargs: dict[str, Any],
     ) -> BarContainer:
         cat_array = np.asarray(cats)
-        if cat_array.dtype.kind == "U":
+        if cat_array.dtype.kind == "U" and cat_array.dtype.isnative:
             # _plain_text only rewrites labels containing TeX markers; a
             # vectorized scan skips the per-label Python loop for the common
             # plain-string case (O(categories) per build otherwise). The scan
             # reads the UCS4 storage as codepoints rather than using
             # np.char/np.strings, whose first call pays a multi-millisecond
             # lazy ufunc setup — a one-shot cost CodSpeed attributes to
-            # whichever chart build hits it first.
+            # whichever chart build hits it first. The uint32 view is only
+            # codepoints on native byte order; swapped arrays take the loop.
             flat = cat_array.reshape(-1)
             codes = np.ascontiguousarray(flat).view(np.uint32)
             if (codes == 36).any() or (codes == 92).any():  # "$" and "\" codepoints
                 cats = np.asarray([_plain_text(value) for value in flat]).reshape(cat_array.shape)
             else:
                 cats = cat_array
-        elif cat_array.dtype.kind in {"S", "O"} and all(
+        elif cat_array.dtype.kind in {"U", "S", "O"} and all(
             isinstance(value, str) for value in cat_array.reshape(-1)
         ):
             cats = np.asarray([_plain_text(value) for value in cat_array.reshape(-1)]).reshape(
@@ -4022,9 +4023,15 @@ class Axes(PlotTypeMixin):
             if len(xv) > 4096:
                 # Stride down before the finite scan: occupancy scoring is
                 # already sampled, so the full-array isfinite pass was pure
-                # O(n) per-build cost on large legended series.
+                # O(n) per-build cost on large legended series. Sparse finite
+                # points can slip between strides on a mostly-NaN series, so
+                # a sample with no finite pair falls back to the full array —
+                # a series the old full-array pass scored still scores instead
+                # of vanishing from placement.
                 strided = np.linspace(0, len(xv) - 1, 4096, dtype=np.intp)
-                xv, yv = xv[strided], yv[strided]
+                sampled_x, sampled_y = xv[strided], yv[strided]
+                if (np.isfinite(sampled_x) & np.isfinite(sampled_y)).any():
+                    xv, yv = sampled_x, sampled_y
             finite = np.flatnonzero(np.isfinite(xv) & np.isfinite(yv))
             if len(finite) > 512:
                 finite = finite[np.linspace(0, len(finite) - 1, 512, dtype=np.intp)]

--- a/python/xy/pyplot/_axes.py
+++ b/python/xy/pyplot/_axes.py
@@ -2368,9 +2368,8 @@ class Axes(PlotTypeMixin):
         y = self._data_coordinate(xy[1], "y")
         return None if x is None or y is None else (x, y)
 
-    def _entry_values(self, axis: str) -> np.ndarray:
-        """Every finite data coordinate the entries contribute to *axis* autoscale."""
-        values: list[np.ndarray] = []
+    def _iter_entry_arrays(self, axis: str):
+        """Yield each (array, needs_finite_filter) an entry contributes to *axis*."""
         for entry in self._entries:
             key = "x" if axis == "x" else "y"
             if key in entry:
@@ -2380,7 +2379,7 @@ class Axes(PlotTypeMixin):
                     )
                 except (TypeError, ValueError):
                     continue
-                values.append(array[np.isfinite(array)])
+                yield array, True
             if entry.get("kind") == "@mark":
                 factory = entry.get("factory")
                 indexes = {
@@ -2388,20 +2387,42 @@ class Axes(PlotTypeMixin):
                     "triangle_mesh": (0, 2, 4) if axis == "x" else (1, 3, 5),
                 }.get(factory, ())
                 for index in indexes:
-                    array = np.asarray(entry["args"][index], dtype=np.float64).reshape(-1)
-                    values.append(array[np.isfinite(array)])
+                    yield np.asarray(entry["args"][index], dtype=np.float64).reshape(-1), True
                 if factory == "contour":
                     z = np.asarray(entry["args"][0])
                     coordinates = entry.get("kwargs", {}).get(key)
                     if coordinates is None and z.ndim >= 2:
                         coordinates = np.arange(z.shape[1 if axis == "x" else 0], dtype=float)
                     if coordinates is not None:
-                        array = np.asarray(coordinates, dtype=np.float64).reshape(-1)
-                        values.append(array[np.isfinite(array)])
+                        yield np.asarray(coordinates, dtype=np.float64).reshape(-1), True
             elif entry.get("kind") == "heatmap" and entry.get("extent") is not None:
                 bounds = entry["extent"]
-                values.append(np.asarray(bounds[:2] if axis == "x" else bounds[2:], dtype=float))
+                yield np.asarray(bounds[:2] if axis == "x" else bounds[2:], dtype=float), False
+
+    def _entry_values(self, axis: str) -> np.ndarray:
+        """Every finite data coordinate the entries contribute to *axis* autoscale."""
+        values = [
+            array[np.isfinite(array)] if needs_filter else array
+            for array, needs_filter in self._iter_entry_arrays(axis)
+        ]
         return np.concatenate(values) if values else np.array([], dtype=np.float64)
+
+    def _axis_is_dataless(self, axis: str) -> bool:
+        """True when the entries contribute no coordinate to *axis* autoscale.
+
+        The empty-view pin in `_build_chart` asks this on every default build,
+        so it must not pay `_entry_values`'s full O(n) materialization when the
+        chart obviously has data (tests/pyplot/test_perf_guardrail.py). A short
+        prefix probe answers real data immediately; only all-non-finite
+        prefixes fall through to a full scan.
+        """
+        for array, needs_filter in self._iter_entry_arrays(axis):
+            if not needs_filter:
+                if array.size:
+                    return False
+            elif np.isfinite(array[:1024]).any() or np.isfinite(array[1024:]).any():
+                return False
+        return True
 
     def _entry_extent(self, axis: str) -> tuple[float, float]:
         finite = self._entry_values(axis)
@@ -4086,7 +4107,7 @@ class Axes(PlotTypeMixin):
             if not adjusted_aspect
             and axis not in self._explicit_domains
             and self._axis[axis].get("domain") is None
-            and len(self._entry_values(axis)) == 0
+            and self._axis_is_dataless(axis)
         }
         x_props = {k: v for k, v in self._axis["x"].items() if v is not None}
         y_props = {k: v for k, v in self._axis["y"].items() if v is not None}

--- a/python/xy/pyplot/_axes.py
+++ b/python/xy/pyplot/_axes.py
@@ -1265,9 +1265,14 @@ class Axes(PlotTypeMixin):
         if cat_array.dtype.kind == "U":
             # _plain_text only rewrites labels containing TeX markers; a
             # vectorized scan skips the per-label Python loop for the common
-            # plain-string case (O(categories) per build otherwise).
+            # plain-string case (O(categories) per build otherwise). The scan
+            # reads the UCS4 storage as codepoints rather than using
+            # np.char/np.strings, whose first call pays a multi-millisecond
+            # lazy ufunc setup — a one-shot cost CodSpeed attributes to
+            # whichever chart build hits it first.
             flat = cat_array.reshape(-1)
-            if (np.char.find(flat, "$") >= 0).any() or (np.char.find(flat, "\\") >= 0).any():
+            codes = np.ascontiguousarray(flat).view(np.uint32)
+            if (codes == 36).any() or (codes == 92).any():  # "$" and "\" codepoints
                 cats = np.asarray([_plain_text(value) for value in flat]).reshape(cat_array.shape)
             else:
                 cats = cat_array

--- a/python/xy/pyplot/_axes.py
+++ b/python/xy/pyplot/_axes.py
@@ -1262,7 +1262,16 @@ class Axes(PlotTypeMixin):
         kwargs: dict[str, Any],
     ) -> BarContainer:
         cat_array = np.asarray(cats)
-        if cat_array.dtype.kind in {"U", "S", "O"} and all(
+        if cat_array.dtype.kind == "U":
+            # _plain_text only rewrites labels containing TeX markers; a
+            # vectorized scan skips the per-label Python loop for the common
+            # plain-string case (O(categories) per build otherwise).
+            flat = cat_array.reshape(-1)
+            if (np.char.find(flat, "$") >= 0).any() or (np.char.find(flat, "\\") >= 0).any():
+                cats = np.asarray([_plain_text(value) for value in flat]).reshape(cat_array.shape)
+            else:
+                cats = cat_array
+        elif cat_array.dtype.kind in {"S", "O"} and all(
             isinstance(value, str) for value in cat_array.reshape(-1)
         ):
             cats = np.asarray([_plain_text(value) for value in cat_array.reshape(-1)]).reshape(
@@ -1404,15 +1413,37 @@ class Axes(PlotTypeMixin):
         if histtype not in {"bar", "barstacked", "step", "stepfilled"}:
             raise ValueError(f"unsupported histtype {histtype!r}")
 
-        raw = np.asarray(x, dtype=object)
-        if raw.ndim == 1 and (len(raw) == 0 or np.isscalar(raw[0])):
+        if isinstance(x, np.ndarray) and x.ndim == 1 and x.dtype.kind in "fiub":
+            # The common numeric-array call must not round-trip through an
+            # object array: boxing every element just to sniff the input shape
+            # is an O(n) cost per build (tests/pyplot/test_perf_guardrail.py).
             datasets = [np.asarray(x, dtype=np.float64)]
-        elif isinstance(x, np.ndarray) and x.ndim == 2:
-            datasets = [np.asarray(x[:, i], dtype=np.float64) for i in range(x.shape[1])]
         else:
-            datasets = [np.asarray(values, dtype=np.float64) for values in x]
-        all_finite = np.concatenate([values[np.isfinite(values)] for values in datasets])
-        edges = np.histogram_bin_edges(all_finite, bins=bins, range=range)
+            raw = np.asarray(x, dtype=object)
+            if raw.ndim == 1 and (len(raw) == 0 or np.isscalar(raw[0])):
+                datasets = [np.asarray(x, dtype=np.float64)]
+            elif isinstance(x, np.ndarray) and x.ndim == 2:
+                datasets = [np.asarray(x[:, i], dtype=np.float64) for i in range(x.shape[1])]
+            else:
+                datasets = [np.asarray(values, dtype=np.float64) for values in x]
+        if isinstance(bins, (int, np.integer)) and not isinstance(bins, bool):
+            # Fixed bin count: the edges depend only on the finite data range,
+            # so a native NaN-skipping min/max scan replaces the filtered
+            # concatenated copy. numpy applies its own defaults/expansion to
+            # the range exactly as it would to data-derived outer edges.
+            from xy import kernels
+
+            if range is None:
+                spans = [span for span in map(kernels.min_max, datasets) if span is not None]
+                data_range = (
+                    (min(lo for lo, _ in spans), max(hi for _, hi in spans)) if spans else None
+                )
+            else:
+                data_range = range
+            edges = np.histogram_bin_edges(np.empty(0), bins=bins, range=data_range)
+        else:
+            all_finite = np.concatenate([values[np.isfinite(values)] for values in datasets])
+            edges = np.histogram_bin_edges(all_finite, bins=bins, range=range)
         if weights is None:
             weight_sets = [None] * len(datasets)
         elif len(datasets) == 1:
@@ -3983,6 +4014,12 @@ class Axes(PlotTypeMixin):
             except (TypeError, ValueError):
                 continue
             xv, yv = xv.reshape(-1), yv.reshape(-1)
+            if len(xv) > 4096:
+                # Stride down before the finite scan: occupancy scoring is
+                # already sampled, so the full-array isfinite pass was pure
+                # O(n) per-build cost on large legended series.
+                strided = np.linspace(0, len(xv) - 1, 4096, dtype=np.intp)
+                xv, yv = xv[strided], yv[strided]
             finite = np.flatnonzero(np.isfinite(xv) & np.isfinite(yv))
             if len(finite) > 512:
                 finite = finite[np.linspace(0, len(finite) - 1, 512, dtype=np.intp)]

--- a/python/xy/pyplot/_grid.py
+++ b/python/xy/pyplot/_grid.py
@@ -231,6 +231,28 @@ def stitch_png(
     from xy import _png, _raster  # sanctioned escape hatch (see module doc)
 
     scale = 2.0
+    if (
+        len(charts) == 1
+        and positions is None
+        and not suptitle
+        and not colorbar
+        and not bbox_tight
+        and facecolor in ("white", "#ffffff")
+    ):
+        # A single panel with no chrome to compose is exactly one native
+        # render, so fuse rasterization with the Rust PNG encoder (the
+        # latency-first default of Figure.to_png) instead of round-tripping
+        # RGBA through the Python size-oriented encoder — ~17x on a
+        # 100k-point savefig. The fused canvas initializes white, which is
+        # why the fast path is gated on the default facecolor.
+        fig = charts[0].figure()
+        spec, blob, borrowed = fig._build_raster_payload(px_width=max(256, int(fig.width)))
+        spec["canvas_background"] = facecolor
+        rendered = _raster.render_raster(spec, blob, scale, fast_png=True, borrowed=borrowed)
+        if isinstance(rendered, bytes):
+            return rendered
+        return _png.encode(rendered)
+
     tiles: list[np.ndarray] = []
     for chart in charts:
         fig = chart.figure()


### PR DESCRIPTION
benchmarks/test_codspeed_pyplot.py expresses each workload twice over the
same arrays — once through the raw declarative API (xy.chart + marks) and
once through the identical Matplotlib-style xy.pyplot calls — both ending
in the same split wire payload (or PNG bytes for the export pair). The
*_pyplot minus *_raw gap in CodSpeed is exactly the shim's translation and
figure-lifecycle cost; shared engine work moves both rows together. Pairs:
10k/1M line, 100k scatter, 200-bin histogram, 1k-category bars, a
chrome-heavy styled panel (fmt strings, title/labels/legend), and static
PNG export. The module is collected automatically by the existing
benchmarks/test_codspeed_*.py glob in the CodSpeed workflow.

The new pairs immediately caught a structural regression the perf
guardrail was built for: _build_chart's empty-view pin called
_entry_values for both axes on every default build, materializing and
finite-filtering every entry's full data just to test emptiness — an O(n)
per-build cost that put the 1M-point shim build at ~3x the raw build and
failed tests/pyplot/test_perf_guardrail.py at 100k on Linux. The check is
now _axis_is_dataless, sharing the per-entry iteration with _entry_values
but short-circuiting on the first finite value via a prefix probe
(heatmap-extent entries keep their unfiltered semantics). 1M-point shim
build drops from 18.6ms to 8.2ms locally; the guardrail passes again.