### PR TITLE
Fix Pyodide runtime wheel loading

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,29 +121,36 @@ jobs:
           name: dist-${{ matrix.plat }}
           path: dist/*.whl
 
-  # Best-effort Pyodide / Emscripten WASM wheel for in-browser CPython. The core
-  # cross-compiles to wasm32-unknown-emscripten; loading a side-module cdylib via
-  # ctypes under Pyodide is the remaining risk, so this job is non-blocking and
-  # the wheel is treated as experimental (see docs/production-readiness.md).
+  # Pyodide / Emscripten WASM wheel for in-browser CPython. Pyodide's platform
+  # ABI is compiler-sensitive, so keep Rust, Emscripten, the wheel tag, and the
+  # runtime probe pinned as one tested set (see docs/production-readiness.md).
   wasm:
-    name: Wheel pyodide (experimental)
+    name: Wheel Pyodide (runtime verified)
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
+          toolchain: 1.97.0
           targets: wasm32-unknown-emscripten
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
       - uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
+        with:
+          # Pyodide 0.29.x / pyodide_2025_0 ABI compiler version.
+          version: "4.0.9"
       - name: Verify committed JS bundles are fresh
         run: node js/build.mjs --check
       - name: Build JS client
         run: node js/build.mjs
       - name: Cross-compile the native core (emscripten)
+        env:
+          # Unwinding imports a __cpp_exception WebAssembly tag that Pyodide's
+          # main module does not provide. Abort keeps the C ABI side module
+          # exception-free and was runtime-verified against Pyodide 0.29.4.
+          RUSTFLAGS: "-C panic=abort"
         run: cargo build --release --target wasm32-unknown-emscripten
       - name: Build the Pyodide wheel
         shell: bash
@@ -151,21 +158,18 @@ jobs:
           XY_REQUIRE_CARGO: "1"
           XY_SKIP_CARGO: "1"
           XY_CARGO_TARGET: wasm32-unknown-emscripten
-          XY_WHEEL_PLATFORM: pyodide_2024_0_wasm32
+          XY_WHEEL_PLATFORM: pyodide_2025_0_wasm32
         run: uv build --wheel
       - name: Verify wheel contents
         shell: bash
         run: |
           whl=$(ls dist/*.whl)
           python scripts/verify_wheel.py "$whl" --expect-native
-      # Runtime load probe: "builds" is not "loads". This installs the wheel in
-      # a real Pyodide (node) and calls a native kernel. It currently FAILS
-      # (Rust panic=unwind emits a __cpp_exception import Pyodide can't satisfy)
-      # — kept non-gating via the job's continue-on-error so the experimental
-      # wheel never blocks a release, but the status stays visible until fixed.
-      - name: Pyodide runtime load probe (informational)
+      # "Builds" is not "loads": install the exact wheel in a real Pyodide
+      # runtime and call both the C ABI version function and a native kernel.
+      - name: Pyodide runtime load probe
         run: |
-          npm i --no-save pyodide@0.26.4
+          npm i --no-save pyodide@0.29.4
           whl=$(ls dist/*.whl)
           python scripts/pyodide_load_smoke.py "$whl"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/README.md
+++ b/README.md
@@ -160,10 +160,10 @@ npm, no CDN** at install time. Wheels are published per platform by the release
 workflow — Linux glibc **and** musl/Alpine (x86-64, aarch64, armv7), macOS
 (x86-64, Apple Silicon), and Windows (x86, x64, arm64). Because the core is a
 plain C ABI with no CPython ABI, one wheel per platform serves every supported
-Python version. An experimental Pyodide/Emscripten WASM wheel is also built,
-but does **not** yet load in-browser — the Rust core's `panic=unwind` emits a
-`__cpp_exception` import Pyodide's runtime can't satisfy — so it is not part of
-the supported set (see [`docs/production-readiness.md`](docs/production-readiness.md)).
+Python version. The release workflow also builds a Pyodide/Emscripten wheel for
+the `pyodide_2025_0` ABI and gates it by installing the artifact in Pyodide
+0.29.4 and calling a native Rust kernel (see
+[`docs/production-readiness.md`](docs/production-readiness.md)).
 
 ### From source
 
@@ -202,9 +202,9 @@ loudly on import, keeping the no-wheel behavior a defined, actionable error.
 
 Published wheels cover Linux glibc and musl/Alpine (x86-64, aarch64, armv7),
 macOS (x86-64, Apple Silicon), and Windows (x86, x64, arm64); the C-ABI core
-means one wheel per platform serves every supported Python version. An
-experimental Pyodide/Emscripten WASM wheel is built but does not yet load
-in-browser (see [`docs/production-readiness.md`](docs/production-readiness.md)).
+means one wheel per platform serves every supported Python version. Release
+artifacts also include a runtime-verified `pyodide_2025_0` WASM wheel (see
+[`docs/production-readiness.md`](docs/production-readiness.md)).
 
 ### Check the active backend
 

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -301,19 +301,15 @@ Before tagging a release:
 - Confirm CI built and verified native wheels for Linux glibc and musl/Alpine
   (x86-64, aarch64, armv7), macOS (x86-64, Apple Silicon), and Windows (x86, x64,
   arm64).
-- The Pyodide/Emscripten WASM wheel is **built but not functional at runtime**
-  and is excluded from the supported set. Verified 2026-07-08 by loading the
-  wheel in Pyodide 0.26.4 (node): it is a structurally valid side-module (wasm
-  magic, `dylink` section, all `fc_*` symbols exported), and micropip installs
-  it, but `WebAssembly.instantiate` fails with `LinkError: Import "env"
-  "__cpp_exception": tag import requires a WebAssembly.Tag`. Root cause: the
-  Rust core builds with the default `panic=unwind`, which emits a C++
-  exception-handling tag import Pyodide's runtime does not provide. Fix
-  direction: build the `wasm32-unknown-emscripten` target with `panic=abort`
-  (likely `-Z build-std=std,panic_abort`) or force emscripten's legacy JS
-  exception handling, then re-verify with a Pyodide load. The wasm job stays
-  `continue-on-error` and the wheel is not advertised as working until a
-  Pyodide runtime load passes in CI.
+- Confirm the Pyodide/Emscripten wheel passes its runtime load gate, not only
+  its structural wheel check. The tested toolchain is Rust 1.97.0 with
+  `panic=abort`, Emscripten 4.0.9, the `pyodide_2025_0` wheel ABI, and Pyodide
+  0.29.4. The abort strategy is required: the previous unwind build imported a
+  `__cpp_exception` WebAssembly tag that Pyodide's main module did not provide.
+  `scripts/pyodide_load_smoke.py` installs the built artifact with micropip,
+  loads the C ABI through `ctypes`, verifies `fc_abi_version`, and calls the
+  native `min_max` kernel. The wasm job is release-blocking so an ABI or
+  toolchain drift cannot silently ship a build-only, unloadable artifact.
 - Confirm the no-Rust install job passed (it must build, install, and then
   raise a clear ImportError on first compute — never a silent fallback).
 - Confirm the sdist verifier passed and the source archive contains the expected

--- a/scripts/pyodide_load_smoke.py
+++ b/scripts/pyodide_load_smoke.py
@@ -2,15 +2,10 @@
 """Load the built Pyodide wheel in a real Pyodide runtime (node) and call a
 native kernel through the ctypes seam.
 
-The wasm job builds a structurally valid Emscripten side-module, but "builds"
-is not "loads": Pyodide's dynamic linker must instantiate the module and the
-`fc_*` C-ABI symbols must be callable. As of 2026-07-08 this FAILS — the Rust
-core's default `panic=unwind` emits a `__cpp_exception` tag import Pyodide's
-runtime does not provide (LinkError at WebAssembly.instantiate). This smoke is
-the regression probe for that: it prints a clear PASS/FAIL and exits non-zero
-on failure, but the wasm CI job runs it non-gating (continue-on-error) so the
-experimental wheel never blocks a release — it just keeps the status honest and
-visible until the exception-handling build is fixed.
+"Builds" is not "loads": Pyodide's dynamic linker must instantiate the module
+and the `fc_*` C-ABI symbols must be callable. This is the regression probe for
+the release wheel's exception-free Rust build: it installs the exact artifact,
+checks the ABI version, calls a native kernel, and exits non-zero on failure.
 
 Usage: python scripts/pyodide_load_smoke.py path/to/xy-...-pyodide_....whl
 Requires: node with the `pyodide` npm package resolvable from CWD.

--- a/scripts/verify_ci_workflow.py
+++ b/scripts/verify_ci_workflow.py
@@ -448,13 +448,21 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
         jobs,
         "wasm",
         "release",
-        "best-effort Pyodide/Emscripten WASM wheel",
-        "continue-on-error: true",
+        "runtime-verified Pyodide/Emscripten WASM wheel",
+        "toolchain: 1.97.0",
         "wasm32-unknown-emscripten",
         "setup-emsdk",
+        'version: "4.0.9"',
+        'RUSTFLAGS: "-C panic=abort"',
+        "pyodide_2025_0_wasm32",
+        "pyodide@0.29.4",
+        "scripts/pyodide_load_smoke.py",
         "scripts/verify_wheel.py",
         "--expect-native",
     )
+    wasm_job = jobs.get("wasm", "")
+    if "continue-on-error:" in wasm_job:
+        errors.append("release wasm job must block publishing when the Pyodide runtime probe fails")
     _require_job_contains(
         errors,
         jobs,

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -392,6 +392,43 @@ def test_release_workflow_rejects_missing_native_wheel_verifier(tmp_path: Path) 
     assert any("release wheels job" in error and "verify_wheel" in error for error in errors)
 
 
+def test_release_workflow_rejects_unpinned_pyodide_runtime_contract(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace('          RUSTFLAGS: "-C panic=abort"\n', "")
+        .replace('          version: "4.0.9"\n', "")
+        .replace("          npm i --no-save pyodide@0.29.4\n", ""),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any(
+        "release wasm job" in error and "panic=abort" in error and "pyodide@0.29.4" in error
+        for error in errors
+    )
+
+
+def test_release_workflow_rejects_nonblocking_pyodide_probe(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(
+            "    runs-on: ubuntu-latest\n",
+            "    runs-on: ubuntu-latest\n    continue-on-error: true\n",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("wasm job must block publishing" in error for error in errors)
+
+
 def test_release_workflow_rejects_missing_sdist_norust_smoke(tmp_path: Path) -> None:
     workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
     path = tmp_path / "release.yml"


### PR DESCRIPTION
## Summary

- pin the Pyodide wheel build to Rust 1.97.0, Emscripten 4.0.9, and the `pyodide_2025_0` ABI
- compile the Emscripten side module with `panic=abort` so it no longer imports the unsupported `__cpp_exception` WebAssembly tag
- upgrade the runtime probe to Pyodide 0.29.4 and make a failed native-kernel call block releases
- lock the toolchain/runtime contract into the workflow verifier and update release documentation

## Root cause

The previous Rust `panic=unwind` build emitted an `env.__cpp_exception` tag import that the Pyodide main module did not provide. The job also mixed an unpinned Emscripten compiler with the older `pyodide_2024_0` ABI and treated the known runtime failure as non-blocking.

## Impact

Release artifacts now include a Pyodide wheel that is tested by installation into the matching runtime, C-ABI loading through `ctypes`, ABI version lookup, and a real native `min_max` kernel call. Compiler or ABI drift fails the release instead of shipping a build-only artifact.

## Validation

- `python3 scripts/verify_ci_workflow.py`
- `.venv/bin/pytest -q tests/test_verify_ci_workflow.py` (33 passed)
- `make PYTHON=.venv/bin/python check-docs` (74 tests passed; both gates passed)
- `python3 scripts/verify_wheel.py ... --expect-native`
- `python3 scripts/pyodide_load_smoke.py ...` → `PASS: pyodide loaded xy, backend=native abi=34 min_max=(1,3)`
