### PR TITLE
Add launch benchmark chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <h1 align="center">xy</h1>
 
 <p align="center">
-  <strong>Interactive Python charts whose cost follows the screen, not the dataset.</strong>
-</p>
-
-<p align="center">
   <a href="https://github.com/reflex-dev/xy/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/reflex-dev/xy/actions/workflows/ci.yml/badge.svg"></a>
   <a href="https://app.codspeed.io/reflex-dev/xy?utm_source=badge"><img alt="CodSpeed" src="https://img.shields.io/endpoint?url=https://codspeed.io/badge.json"></a>
   <a href="pyproject.toml"><img alt="Python 3.11+" src="https://img.shields.io/badge/python-3.11%2B-3776ab?logo=python&logoColor=white"></a>
+</p>
+
+<p align="center">
+  <img src="docs/assets/launch-benchmark-comparison.svg" alt="Grouped horizontal bar-chart comparison of xy, Matplotlib, and Plotly cold-render times at 10 million points; xy has the lowest measured time in all three output modes in this recorded run." width="1200">
 </p>
 
 xy is an experimental Python charting library for large, interactive datasets.
@@ -43,18 +43,18 @@ core. End users do not need Rust, Node, npm, or a CDN.
 Create a small business chart:
 
 ```python
-import xy as fc
+import xy
 
 months = [1, 2, 3, 4, 5, 6]
 revenue = [42, 45, 48, 51, 55, 59]
 pipeline = [35, 38, 42, 40, 46, 50]
 
-chart = fc.line_chart(
-    fc.line(months, revenue, name="revenue", color="#2563eb"),
-    fc.line(months, pipeline, name="pipeline", color="#16a34a"),
-    fc.x_axis(label="month"),
-    fc.y_axis(label="USD thousands"),
-    fc.legend(),
+chart = xy.line_chart(
+    xy.line(months, revenue, name="revenue", color="#2563eb"),
+    xy.line(months, pipeline, name="pipeline", color="#16a34a"),
+    xy.x_axis(label="month"),
+    xy.y_axis(label="USD thousands"),
+    xy.legend(),
     title="Revenue vs pipeline",
 )
 # chart.to_html("chart.html")
@@ -82,7 +82,7 @@ x = np.linspace(0, 10, 200)
 fig, ax = plt.subplots()
 ax.plot(x, np.sin(x), "r--", label="signal")
 ax.legend()
-fig
+plt.show()
 ```
 
 The shim intentionally covers common plotting workflows rather than every
@@ -105,11 +105,11 @@ an Apple M5 Pro with 64 GB RAM. Times are mean ± sample standard deviation.
 
 At 10M points, the same recorded run measured:
 
-| 900×420 output contract | xy | Plotly | Matplotlib |
+| 900×420 output contract | xy | Matplotlib | Plotly |
 |---|---:|---:|---:|
-| Static CPU PNG | 0.0232 s | 9.5834 s | 2.7842 s |
-| Interactive first render, default GPU | 0.1797 s | 3.6434 s | 3.0029 s |
-| Interactive first render, CPU fallback | 0.9920 s | 8.2152 s | 3.6735 s |
+| Static CPU PNG | 0.0232 s | 2.7842 s | 9.5834 s |
+| Interactive first render, default GPU | 0.1797 s | 3.0029 s | 3.6434 s |
+| Interactive first render, CPU fallback | 0.9920 s | 3.6735 s | 8.2152 s |
 
 At 1B points, xy produced a density PNG in 1.1452 seconds and an interactive
 density overview in 1.2530 seconds. The exact-point Plotly and Matplotlib paths

--- a/docs/assets/launch-benchmark-comparison.svg
+++ b/docs/assets/launch-benchmark-comparison.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="600" viewBox="0 0 1200 600" role="img" aria-labelledby="title desc">
+  <title id="title">10 million point cold-render benchmark comparison</title>
+  <desc id="desc">A grouped horizontal bar chart comparing xy, Matplotlib, and Plotly on a linear scale for a 900 by 420 pixel output. xy has the lowest measured time in static CPU PNG, interactive default GPU, and interactive CPU fallback. Lower times are better.</desc>
+  <defs>
+    <pattern id="grid-pattern" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M 48 0 L 0 0 0 48" fill="none" stroke="#E8E8EC" stroke-width="1"/>
+    </pattern>
+    <filter id="card-shadow" x="-8%" y="-8%" width="116%" height="116%">
+      <feDropShadow dx="0" dy="12" stdDeviation="16" flood-color="#1C2024" flood-opacity="0.06"/>
+    </filter>
+  </defs>
+
+  <rect width="1200" height="600" fill="#FCFCFD"/>
+  <rect width="1200" height="600" fill="url(#grid-pattern)" opacity="0.58"/>
+
+  <g filter="url(#card-shadow)">
+    <rect x="56" y="48" width="1088" height="504" rx="14" fill="#FFFFFF"/>
+    <rect x="56.5" y="48.5" width="1087" height="503" rx="13.5" fill="none" stroke="#E8E8EC"/>
+  </g>
+
+  <g font-family="Instrument Sans, Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif">
+    <text x="96" y="112" fill="#1C2024" font-size="32" font-weight="650">10M-point cold-render time</text>
+    <text x="96" y="138" fill="#60646C" font-size="16" font-weight="500">900×420 output · mean of three isolated runs · shared linear scale</text>
+
+    <g transform="translate(775 94)" font-size="14" font-weight="600" fill="#1C2024">
+      <rect x="-8" y="-5" width="16" height="10" rx="3" fill="#6E56CF"/>
+      <text x="14" y="5">xy</text>
+      <rect x="72" y="-5" width="16" height="10" rx="3" fill="#A8AAB3"/>
+      <text x="96" y="5">Matplotlib</text>
+      <rect x="184" y="-5" width="16" height="10" rx="3" fill="#C4C6CF"/>
+      <text x="208" y="5">Plotly</text>
+    </g>
+
+    <g transform="translate(350 190)">
+      <g stroke="#D9D9E0" stroke-width="1">
+        <path d="M0 0V326"/>
+        <path d="M144 0V326"/>
+        <path d="M288 0V326"/>
+        <path d="M432 0V326"/>
+        <path d="M576 0V326"/>
+        <path d="M720 0V326"/>
+      </g>
+      <g fill="#60646C" font-size="13" font-weight="500" text-anchor="middle">
+        <text x="0" y="-12">0 s</text>
+        <text x="144" y="-12">2 s</text>
+        <text x="288" y="-12">4 s</text>
+        <text x="432" y="-12">6 s</text>
+        <text x="576" y="-12">8 s</text>
+        <text x="720" y="-12">10 s</text>
+      </g>
+      <text x="360" y="-32" fill="#60646C" font-size="13" font-weight="600" text-anchor="middle">Render time (seconds) · Lower is better</text>
+    </g>
+
+    <g fill="#1C2024">
+      <text x="96" y="258" font-size="15" font-weight="650">Static CPU PNG</text>
+      <text x="96" y="378" font-size="15" font-weight="650">Interactive first render</text>
+      <text x="96" y="400" fill="#60646C" font-size="14" font-weight="500">default GPU</text>
+      <text x="96" y="498" font-size="15" font-weight="650">Interactive first render</text>
+      <text x="96" y="520" fill="#60646C" font-size="14" font-weight="500">CPU fallback</text>
+    </g>
+
+    <g fill="#6E56CF">
+      <rect x="350" y="225" width="3" height="18" rx="1.5"/>
+      <rect x="350" y="345" width="13" height="18" rx="4"/>
+      <rect x="350" y="465" width="71" height="18" rx="4"/>
+    </g>
+    <g fill="#C4C6CF">
+      <rect x="350" y="277" width="690" height="18" rx="4"/>
+      <rect x="350" y="397" width="262" height="18" rx="4"/>
+      <rect x="350" y="517" width="591" height="18" rx="4"/>
+    </g>
+    <g fill="#A8AAB3">
+      <rect x="350" y="251" width="200" height="18" rx="4"/>
+      <rect x="350" y="371" width="216" height="18" rx="4"/>
+      <rect x="350" y="491" width="265" height="18" rx="4"/>
+    </g>
+
+    <g fill="#1C2024" font-size="14" font-weight="650">
+      <text x="366" y="239">0.0232 s</text>
+      <text x="562" y="265">2.7842 s</text>
+      <text x="1052" y="291">9.5834 s</text>
+      <text x="377" y="359">0.1797 s</text>
+      <text x="578" y="385">3.0029 s</text>
+      <text x="624" y="411">3.6434 s</text>
+      <text x="433" y="479">0.9920 s</text>
+      <text x="627" y="505">3.6735 s</text>
+      <text x="953" y="531">8.2152 s</text>
+    </g>
+  </g>
+</svg>

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -115,10 +115,17 @@ def test_readme_python_example_runs(
 ) -> None:
     monkeypatch.chdir(tmp_path)
     namespace: dict[str, object] = {"__name__": f"xy_readme_example_{heading}"}
+    uses_pyplot_show = source.rstrip().endswith("plt.show()")
+    if uses_pyplot_show:
+        import xy.pyplot as pyplot
+
+        monkeypatch.setattr(pyplot, "show", lambda *_args, **_kwargs: None)
 
     exec(compile(_capture_final_expression(source), str(README), "exec"), namespace)
 
     result = namespace.get("__example_result__")
+    if uses_pyplot_show and result is None:
+        result = namespace.get("fig")
     assert result is not None, f"{heading} README example should end with an expression"
     if isinstance(result, str):
         assert "xy.renderStandalone" in result
@@ -316,8 +323,8 @@ def test_readme_getting_started_includes_small_business_chart() -> None:
         "Create a small business chart",
         "Revenue vs pipeline",
         "USD thousands",
-        "fc.line(months, revenue",
-        "fc.line(months, pipeline",
+        "xy.line(months, revenue",
+        "xy.line(months, pipeline",
     ]
     for marker in required:
         assert marker in text


### PR DESCRIPTION
## Summary

- add an accessible grouped bar chart for the recorded 10M-point launch benchmark near the top of the README
- use a linear 0–10 second scale, emphasize `xy` in purple, and keep Matplotlib and Plotly neutral
- remove the tagline, use the direct `xy` import in the getting-started example, and finish the pyplot example with `plt.show()`
- keep the benchmark table and documentation tests aligned with the revised presentation

## Why

The README previously led with an abstract tagline and made the recorded three-library comparison available only as a table. This makes the measured result legible at a glance and makes the introductory examples more conventional.

## Validation

- `uv run --with pre-commit pre-commit run --all-files`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/test_docs_examples.py tests/test_claim_guardrails.py -q` (60 passed)
- `python3 scripts/check_claim_guardrails.py README.md`
- `xmllint --noout docs/assets/launch-benchmark-comparison.svg`