### PR TITLE
helm-pr: dev deploys target values-tenant-dev.yaml + bump chart version

### DIFF
--- a/.github/workflows/_helm-docs-pr.yml
+++ b/.github/workflows/_helm-docs-pr.yml
@@ -96,7 +96,12 @@ jobs:
           ENVIRONMENT: ${{ inputs.environment }}
           HELM_REPO: ${{ env.HELM_REPO }}
         run: |
-          FILE="${CHART_DIR}/values-${ENVIRONMENT}.yaml"
+          # The live dev env is tenant-dev on the main cluster; the dev
+          # cluster (values-dev.yaml) was retired 2026-07-01.
+          case "$ENVIRONMENT" in
+            dev)  FILE="${CHART_DIR}/values-tenant-dev.yaml" ;;
+            *)    FILE="${CHART_DIR}/values-${ENVIRONMENT}.yaml" ;;
+          esac
           if [[ ! -f "$FILE" ]]; then
             echo "::error::Values file $FILE not found in ${HELM_REPO}"
             exit 1
@@ -132,6 +137,11 @@ jobs:
           git checkout -b "$BRANCH"
           IMAGE_TAG="$IMAGE_TAG" yq -i '.apps.xy.frontend.image.tag = strenv(IMAGE_TAG)' "$VALUES_FILE"
           IMAGE_TAG="$IMAGE_TAG" yq -i '.apps.xy.backend.image.tag = strenv(IMAGE_TAG)' "$VALUES_FILE"
+          # ChartVersion reconcile strategy: Flux only repackages the chart
+          # when Chart.yaml's version changes, so bump patch every deploy.
+          CHART_FILE="$(dirname "$VALUES_FILE")/Chart.yaml"
+          NEW_VERSION=$(yq '.version' "$CHART_FILE" | awk -F. '{printf "%s.%s.%s", $1, $2, $3+1}')
+          NEW_VERSION="$NEW_VERSION" yq -i '.version = strenv(NEW_VERSION)' "$CHART_FILE"
 
       - name: Commit and push
         id: push
@@ -147,7 +157,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "$VALUES_FILE"
+          git add "$VALUES_FILE" "$(dirname "$VALUES_FILE")/Chart.yaml"
           if git diff --staged --quiet; then
             echo "pushed=false" >> "$GITHUB_OUTPUT"
             echo "::notice::${VALUES_FILE} already uses ${IMAGE_TAG}; skipping PR creation"


### PR DESCRIPTION
Fixes the merge→dev-site pipeline (found while debugging why /docs/xy never appeared):

1. **`environment: dev` now writes `values-tenant-dev.yaml`** — the dev cluster (`values-dev.yaml`) was retired 2026-07-01; the live dev site is the `internal` release on tenant-dev, which reads the tenant-dev file. The pipeline's first run updated a file nothing consumes.
2. **Auto-bump `charts/internal/Chart.yaml` patch version** in the same PR — tenant-dev's Flux HR uses `ChartVersion` reconcile strategy and only repackages when the version changes; a values-only merge deploys nothing (bit us live: helm-charts#1533 required a manual #1534 bump).

Pairs with helm-charts#1536 (tenant-dev pulls via the Harbor `ecr` proxy-cache, so ECR-only publishing — this repo's existing behavior — is sufficient). Known minor race: concurrent app pipelines bumping Chart.yaml can conflict; auto-merge just fails that PR and the next deploy supersedes.

The docs repo has the identical two bugs (its dev deploys have been silent no-ops since the dev cluster retired) — same fix going up in reflex-docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)