### PR TITLE
Refine XY gallery previews

### DIFF
--- a/docs/app/tests/test_docs_site.py
+++ b/docs/app/tests/test_docs_site.py
@@ -48,6 +48,7 @@ from xy_docs.breadcrumb import xy_docs_breadcrumb
 from xy_docs.config import DOCS_CONFIG, DOCS_NAVIGATION, DOCS_SECTIONS
 from xy_docs.footer import xy_docs_footer
 from xy_docs.gallery import (
+    _gallery_chart,
     _iter_gallery_items,
     _responsive_gallery_svg,
     chart_gallery_grid,
@@ -448,8 +449,8 @@ def test_chart_gallery_grid_renders_every_type_with_bounded_live_previews(
     )
     assert len(chart_section) == 9
     assert rendered.count("XYChart") == 9
-    assert rendered.count(" chart guide") == 30
-    assert rendered.count("dangerouslySetInnerHTML") == 21
+    assert rendered.count(" chart guide") == 28
+    assert rendered.count("dangerouslySetInnerHTML") == 19
     assert rendered.count('id:"xy-chart-gallery"') == 1
     assert rendered.count("main:has(#xy-chart-gallery) > div:has(#toc-navigation)") == 1
     assert (
@@ -461,7 +462,7 @@ def test_chart_gallery_grid_renders_every_type_with_bounded_live_previews(
     assert rendered.count("display: none") == 1
     assert rendered.count("max-width: 88rem") == 1
     assert rendered.count("2xl:grid-cols-3") == 9
-    assert rendered.count("h-[220px]") == 51
+    assert rendered.count("h-[220px]") == 47
     assert rendered.count('["height"] : "220px"') == 9
     for chart_type in (
         "Line",
@@ -508,6 +509,40 @@ def test_chart_gallery_grid_renders_every_type_with_bounded_live_previews(
     } == app_payloads_before
 
 
+def test_chart_gallery_combines_only_the_requested_related_tiles() -> None:
+    """Merge Step/Stairs and Bar/Column without collapsing other chart types."""
+    titles = {
+        title
+        for title, _description, _route, _chart_factory, _live in _iter_gallery_items()
+    }
+
+    assert len(titles) == 28
+    assert {"Step + Stairs", "Bar + Column"} <= titles
+    assert {"Step", "Stairs", "Bar", "Column"}.isdisjoint(titles)
+    assert {
+        "Box",
+        "Violin",
+        "Hexbin",
+        "Heatmap",
+        "Contour",
+        "Error Band",
+        "Error Bar",
+        "Facet Chart",
+        "Layered Marks",
+    } <= titles
+
+
+def test_chart_gallery_hides_the_modebar_from_every_preview() -> None:
+    """Keep compact gallery tiles focused on the chart itself."""
+    for _title, _description, _route, chart_factory, _live in _iter_gallery_items():
+        chart = _gallery_chart(chart_factory)
+        modebars = [
+            child for child in chart.children if type(child).__name__ == "Modebar"
+        ]
+        assert len(modebars) == 1
+        assert modebars[0].show is False
+
+
 def test_chart_gallery_uses_only_purple_and_gray() -> None:
     """Keep every rendered gallery preview inside one restrained palette."""
     svg_paint = re.compile(
@@ -546,6 +581,45 @@ def test_chart_gallery_uses_only_purple_and_gray() -> None:
     }
 
     assert not {title: paints for title, paints in violations.items() if paints}
+
+
+def test_density_grid_heatmap_uses_only_purple_truecolor() -> None:
+    """Keep the live density preview on one cohesive purple ramp."""
+    heatmap_factory = next(
+        chart_factory
+        for title, _description, _route, chart_factory, _live in _iter_gallery_items()
+        if title == "Heatmap"
+    )
+    heatmap = heatmap_factory()
+    mark = next(child for child in heatmap.children if child.kind == "heatmap")
+    colors = {tuple(color) for row in mark.props["z"] for color in row}
+
+    assert (255, 255, 255) not in colors
+    assert colors == {
+        (237, 233, 254),
+        (196, 181, 253),
+        (167, 139, 250),
+        (110, 86, 207),
+        (101, 80, 185),
+    }
+    assert all(blue > red and blue > green for red, green, blue in colors)
+
+
+def test_density_grid_hexbin_replaces_white_bins_with_light_purple() -> None:
+    """Keep every occupied Hexbin visible as a shade of purple."""
+    hexbin_factory = next(
+        chart_factory
+        for title, _description, _route, chart_factory, _live in _iter_gallery_items()
+        if title == "Hexbin"
+    )
+    hexbin = hexbin_factory()
+    raw_svg = hexbin.to_svg()
+    responsive_svg = _responsive_gallery_svg(hexbin)
+
+    assert "rgb(252,251,253)" in raw_svg
+    assert "rgb(252,251,253)" not in responsive_svg
+    assert "var(--primary-7)" in responsive_svg
+    assert "rgb(63,0,125)" in responsive_svg
 
 
 def test_chart_gallery_previews_follow_the_site_color_mode() -> None:

--- a/docs/app/xy_docs/gallery.py
+++ b/docs/app/xy_docs/gallery.py
@@ -40,25 +40,6 @@ main:has(#xy-chart-gallery) > div:has(#toc-navigation) {
 main:has(#xy-chart-gallery) > div:has(article #xy-chart-gallery) {
   max-width: 88rem;
 }
-#xy-chart-gallery [data-xy-slot="modebar"],
-#xy-chart-gallery [data-xy-modebar-menu] {
-  border-color: var(--secondary-a6);
-  border-radius: 8px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
-}
-#xy-chart-gallery [data-xy-slot="modebar"] {
-  padding: 2px;
-}
-#xy-chart-gallery [data-xy-slot="modebar_button"] {
-  border-radius: 6px;
-  transition: background-color 150ms ease, color 150ms ease;
-}
-#xy-chart-gallery [data-xy-slot="modebar_button"]:hover {
-  background: var(--chart-modebar-active);
-}
-#xy-chart-gallery [data-xy-slot="modebar_button"].xy-active {
-  color: var(--primary-11);
-}
 """
 
 
@@ -304,15 +285,19 @@ def _hexbin() -> xy.Chart:
 
 
 def _heatmap() -> xy.Chart:
+    purple_pale = tuple(bytes.fromhex("EDE9FE"))
+    purple_light = tuple(bytes.fromhex(_PURPLE_LIGHT[1:]))
+    purple_mid = tuple(bytes.fromhex("A78BFA"))
+    purple = tuple(bytes.fromhex(_PURPLE[1:]))
+    purple_dark = tuple(bytes.fromhex(_PURPLE_DARK[1:]))
     return xy.heatmap_chart(
         xy.heatmap(
             [
-                [0.1, 0.3, 0.5, 0.2],
-                [0.2, 0.7, 1.0, 0.4],
-                [0.1, 0.4, 0.6, 0.3],
+                [purple_pale, purple_light, purple_mid, purple_light],
+                [purple_light, purple, purple_dark, purple],
+                [purple_pale, purple_light, purple_mid, purple_light],
             ],
-            colormap="purples",
-            domain=(-0.2, 1.0),
+            opacity=1.0,
         ),
         _gallery_theme(),
         width=_WIDTH,
@@ -571,8 +556,12 @@ _GALLERY_GROUPS: tuple[GalleryGroup, ...] = (
         (
             ("Line", "Continuous trends and ordered series.", _line, True),
             ("Area", "Magnitude over an ordered domain.", _area, False),
-            ("Step", "Values that change at each observation.", _step, False),
-            ("Stairs", "Binned values defined by explicit edges.", _stairs, False),
+            (
+                "Step + Stairs",
+                "Piecewise-constant values at observations or explicit bin edges.",
+                _step,
+                False,
+            ),
         ),
     ),
     (
@@ -584,8 +573,12 @@ _GALLERY_GROUPS: tuple[GalleryGroup, ...] = (
         "Bar and Column",
         "/charts/bar-and-column/",
         (
-            ("Bar", "Horizontal category comparisons.", _bar, False),
-            ("Column", "Vertical category comparisons.", _column, True),
+            (
+                "Bar + Column",
+                "Horizontal and vertical category comparisons.",
+                _column,
+                True,
+            ),
         ),
     ),
     (
@@ -679,13 +672,24 @@ def _iter_gallery_items() -> Iterator[tuple[str, str, str, ChartFactory, bool]]:
 def _responsive_gallery_svg(chart: ChartSource) -> str:
     """Replace static-renderer fallback paints with site color-mode tokens."""
     svg = chart.to_svg()
+    if any(getattr(child, "kind", None) == "hexbin" for child in chart.children):
+        # The first ``purples`` stop is nearly white. Keep low-count hexagons
+        # visible by promoting that Hexbin-only stop to the light site purple.
+        svg = svg.replace("rgb(252,251,253)", _PURPLE_LIGHT)
     for paint, token in _STATIC_SVG_PAINT_TOKENS.items():
         svg = svg.replace(paint, token)
     return svg
 
 
-def _gallery_preview(chart_factory: ChartFactory, *, live: bool) -> rx.Component:
+def _gallery_chart(chart_factory: ChartFactory) -> ChartSource:
+    """Build a preview chart without the full-page interaction toolbar."""
     chart = chart_factory()
+    chart.children = (*chart.children, xy.modebar(show=False))
+    return chart
+
+
+def _gallery_preview(chart_factory: ChartFactory, *, live: bool) -> rx.Component:
+    chart = _gallery_chart(chart_factory)
     if live:
         return reflex_xy.chart(chart, width="100%", height="220px")
 

--- a/docs/overview/gallery.md
+++ b/docs/overview/gallery.md
@@ -5,10 +5,10 @@ description: Browse every chart type and visual pattern available in XY.
 
 # Gallery
 
-Start with the visual result you need. Every public chart type has a tile below,
-grouped to match the Chart Gallery navigation. Each tile opens a focused family
-page with guidance on when to use the chart, a live example, its expected data
-shape, common variants, and the options that matter most.
+Start with the visual result you need. Every public chart type is represented
+below, grouped to match the Chart Gallery navigation. Each tile opens a focused
+family page with guidance on when to use the chart, a live example, its expected
+data shape, common variants, and the options that matter most.
 
 ~~~python exec
 from xy_docs.gallery import chart_gallery_grid
@@ -19,8 +19,9 @@ chart_gallery_grid()
 ~~~
 
 The representative tile in each family is interactive; the remaining previews
-are SVGs rendered by XY itself so this index stays quick and avoids creating 30
-WebGL contexts at once. Every linked family page includes a full-size live demo.
+are SVGs rendered by XY itself so this index stays quick and avoids creating a
+WebGL context for every tile at once. Every linked family page includes a
+full-size live demo.
 
 All chart families use the same [composition model](/docs/xy/core-concepts/),
 [data binding](/docs/xy/core-concepts/data/), styling surface, and display/export


### PR DESCRIPTION
## Summary

- hide the Plotly modebar from every chart in the Gallery preview
- combine only the Step + Stairs and Bar + Column gallery cards
- update Hexbin and Heatmap previews to use visible purple-only palettes
- update the gallery documentation and add regression coverage

## Why

Gallery cards are compact previews, so chart toolbars add visual noise and can overlap the examples. Step/Stairs and Bar/Column are closely related variants that can share destinations, while the remaining examples should stay separate. The previous density palettes also introduced white and gray cells that looked inconsistent with the purple gallery theme.

## User impact

The Gallery is cleaner and easier to scan: previews have no toolbars, related variants are grouped without collapsing unrelated examples, and density/grid charts consistently use purple shades.

## Validation

- 31 documentation tests passed
- all pre-commit hooks passed
- Reflex dry compile passed
- sitemap link test and validator passed
- Markdown asset validator passed
- HTML route validator passed
- visually verified `/docs/xy/overview/gallery/` in the browser