### PR TITLE
docs deploy: CalVer tags (2026.WW.N), disjoint from library v* releases

### DIFF
--- a/.github/workflows/deploy-docs-stg.yml
+++ b/.github/workflows/deploy-docs-stg.yml
@@ -7,12 +7,15 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Existing XY version tag (for example v0.1.0)"
+        description: "Existing XY docs deploy tag (CalVer, for example 2026.26.1)"
         required: true
         type: string
   push:
+    # CalVer deploy tags (2026.WW.N) — matches the flexgen/helm-charts release
+    # scheme and stays disjoint from the library's semver v* tags, which
+    # trigger release.yml (PyPI/Cargo) and must NOT deploy the docs site.
     tags:
-      - "v[0-9]*"
+      - "20[0-9][0-9].[0-9]*"
 
 permissions:
   contents: read
@@ -39,8 +42,8 @@ jobs:
           EVENT_SHA: ${{ github.sha }}
           REPO: ${{ github.repository }}
         run: |
-          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$ ]]; then
-            echo "::error::version must be semver like v0.1.0"
+          if [[ ! "$VERSION" =~ ^20[0-9]{2}\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::version must be CalVer like 2026.26.1"
             exit 1
           fi
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then


### PR DESCRIPTION
Aligns the docs-site deploy pipeline with the org's CalVer scheme (flexgen `2026.WW.N`, helm-charts releases `v2026.WW.N`, docs/blog/marketing image tags):

- `deploy-docs-stg.yml` now triggers on **`2026.WW.N`-style tags** (validated `^20\d\d\.\d+\.\d+$`), not `v*`.
- **Fixes an unintended coupling**: `v*` previously fired BOTH `release.yml` (library → PyPI/Cargo) and the docs stg/prod deploy — a library release would have pushed the docs site toward production. Now `v*` = library release only; CalVer tag = docs deploy only.
- Image tags follow the deploy tag, so stg/prod values get `2026.WW.N` tags consistent with the sibling apps (also: ECR's 7-day lifecycle only expires `sha-*`, so CalVer deploy images persist like the other apps' release tags).

Deploy flow for xy docs after this: cut CalVer tag → images built + `[stg]` values PR auto-merges → (helm-charts release + stg pin bump) → prod approval → same for prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)