### PR TITLE
Align release version with v0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,7 +337,7 @@ in the README).
 - `XY_FORCE_FALLBACK` environment switch and the pure-NumPy kernel
   backend (`xy/_fallback.py`).
 
-## [0.1.0] — unreleased development line
+## [0.0.1] — 2026-07-16
 
 Initial development snapshot: line/scatter/area/histogram/bar/heatmap chart
 families, binary columnar transport, WebGL2 rendering, M4 decimation, density

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "xy"
-version = "0.1.0"
+version = "0.0.1"
 description = "Experimental Python charting engine with a native Rust core, binary columnar transport, and a GPU render client"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/xy/__init__.py
+++ b/python/xy/__init__.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.1.0"
+__version__ = "0.0.1"
 
 _EXPORTS = {
     "Annotation": ".components",

--- a/tests/test_verify_sdist.py
+++ b/tests/test_verify_sdist.py
@@ -126,7 +126,7 @@ RELEASE_YML = (
 DEFAULT_PKG_INFO = (
     "Metadata-Version: 2.4\n"
     "Name: xy\n"
-    "Version: 0.1.0\n"
+    "Version: 0.0.1\n"
     "Requires-Python: >=3.11\n"
     "Requires-Dist: anywidget>=0.9\n"
     "Requires-Dist: numpy>=1.24\n"
@@ -161,7 +161,7 @@ def _write_sdist(
     extra: Optional[dict[str, bytes]] = None,
     replacements: Optional[dict[str, Union[bytes, str]]] = None,
 ) -> None:
-    root = "xy-0.1.0"
+    root = "xy-0.0.1"
     omit = omit or set()
     extra = extra or {}
     replacements = replacements or {}
@@ -209,14 +209,14 @@ def _write_sdist(
 
 
 def test_verify_sdist_accepts_required_source_shape(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(sdist)
 
     verify_sdist.verify_sdist(str(sdist))
 
 
 def test_verify_sdist_accepts_normalized_metadata_spacing(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     pkg_info = DEFAULT_PKG_INFO.replace(
         "Requires-Dist: anywidget>=0.9", "Requires-Dist: anywidget >= 0.9"
     ).replace("Requires-Dist: numpy>=1.24", "Requires-Dist: numpy >= 1.24")
@@ -226,7 +226,7 @@ def test_verify_sdist_accepts_normalized_metadata_spacing(tmp_path: Path) -> Non
 
 
 def test_verify_sdist_rejects_missing_pkg_info(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(sdist, pkg_info=None)
 
     with pytest.raises(AssertionError, match="PKG-INFO"):
@@ -241,8 +241,8 @@ def test_verify_sdist_rejects_missing_pkg_info(tmp_path: Path) -> None:
             "Name: xy",
         ),
         (
-            DEFAULT_PKG_INFO.replace("Version: 0.1.0", "Version: 0.2.0"),
-            "Version: 0.1.0",
+            DEFAULT_PKG_INFO.replace("Version: 0.0.1", "Version: 0.2.0"),
+            "Version: 0.0.1",
         ),
         (
             DEFAULT_PKG_INFO.replace("Requires-Python: >=3.11", "Requires-Python: >=3.10"),
@@ -263,7 +263,7 @@ def test_verify_sdist_rejects_missing_pkg_info(tmp_path: Path) -> None:
     ],
 )
 def test_verify_sdist_rejects_invalid_pkg_info(tmp_path: Path, pkg_info: str, match: str) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(sdist, pkg_info=pkg_info)
 
     with pytest.raises(AssertionError, match=match):
@@ -271,7 +271,7 @@ def test_verify_sdist_rejects_invalid_pkg_info(tmp_path: Path, pkg_info: str, ma
 
 
 def test_verify_sdist_rejects_missing_static_bundle(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(sdist, omit={"python/xy/static/standalone.js"})
 
     with pytest.raises(AssertionError, match="missing required files"):
@@ -279,7 +279,7 @@ def test_verify_sdist_rejects_missing_static_bundle(tmp_path: Path) -> None:
 
 
 def test_verify_sdist_rejects_partial_type_marker(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(sdist, replacements={"python/xy/py.typed": "partial\n"})
 
     with pytest.raises(AssertionError, match="full-package PEP 561 marker"):
@@ -287,7 +287,7 @@ def test_verify_sdist_rejects_partial_type_marker(tmp_path: Path) -> None:
 
 
 def test_verify_sdist_rejects_missing_production_docs_or_tooling(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(
         sdist, omit={"docs/engineering/production-readiness.md", "scripts/verify_local.py"}
     )
@@ -297,7 +297,7 @@ def test_verify_sdist_rejects_missing_production_docs_or_tooling(tmp_path: Path)
 
 
 def test_verify_sdist_rejects_missing_benchmark_harness(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(sdist, omit={"benchmarks/bench_vs.py", "benchmarks/environment.py"})
 
     with pytest.raises(AssertionError, match="benchmarks/bench_vs"):
@@ -305,7 +305,7 @@ def test_verify_sdist_rejects_missing_benchmark_harness(tmp_path: Path) -> None:
 
 
 def test_verify_sdist_rejects_missing_workflow_benchmark(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(sdist, omit={"benchmarks/bench_workflows.py"})
 
     with pytest.raises(AssertionError, match="benchmarks/bench_workflows"):
@@ -313,7 +313,7 @@ def test_verify_sdist_rejects_missing_workflow_benchmark(tmp_path: Path) -> None
 
 
 def test_verify_sdist_rejects_missing_regression_gate_files(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(
         sdist,
         omit={
@@ -330,7 +330,7 @@ def test_verify_sdist_rejects_missing_regression_gate_files(tmp_path: Path) -> N
 
 
 def test_verify_sdist_rejects_corrupt_benchmark_baseline(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(sdist, replacements={"benchmarks/baseline.json": '{"metrics": {}}'})
 
     with pytest.raises(AssertionError, match="non-empty metrics object"):
@@ -338,7 +338,7 @@ def test_verify_sdist_rejects_corrupt_benchmark_baseline(tmp_path: Path) -> None
 
 
 def test_verify_sdist_rejects_missing_docs_example_guard(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(sdist, omit={"tests/test_docs_examples.py"})
 
     with pytest.raises(AssertionError, match="test_docs_examples"):
@@ -346,7 +346,7 @@ def test_verify_sdist_rejects_missing_docs_example_guard(tmp_path: Path) -> None
 
 
 def test_verify_sdist_rejects_missing_reflex_example_app_files(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(
         sdist,
         omit={
@@ -361,7 +361,7 @@ def test_verify_sdist_rejects_missing_reflex_example_app_files(tmp_path: Path) -
 
 
 def test_verify_sdist_rejects_stale_api_examples_doc(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(
         sdist,
         replacements={"docs/engineering/api-examples.md": "# API Examples\n" + ("padding\n" * 200)},
@@ -372,7 +372,7 @@ def test_verify_sdist_rejects_stale_api_examples_doc(tmp_path: Path) -> None:
 
 
 def test_verify_sdist_rejects_stale_benchmark_doc(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(
         sdist,
         replacements={"docs/engineering/benchmark.md": "# Benchmark\n" + ("padding\n" * 200)},
@@ -383,7 +383,7 @@ def test_verify_sdist_rejects_stale_benchmark_doc(tmp_path: Path) -> None:
 
 
 def test_verify_sdist_rejects_corrupt_public_docs(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(sdist, replacements={"README.md": "# xy\n" + ("padding\n" * 200)})
 
     with pytest.raises(AssertionError, match="README"):
@@ -391,7 +391,7 @@ def test_verify_sdist_rejects_corrupt_public_docs(tmp_path: Path) -> None:
 
 
 def test_verify_sdist_rejects_stale_production_readiness_doc(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(
         sdist,
         replacements={
@@ -405,7 +405,7 @@ def test_verify_sdist_rejects_stale_production_readiness_doc(tmp_path: Path) -> 
 
 
 def test_verify_sdist_rejects_stale_contributing_doc(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(
         sdist,
         replacements={"docs/engineering/contributing.md": "# Contributing\n" + ("padding\n" * 200)},
@@ -416,7 +416,7 @@ def test_verify_sdist_rejects_stale_contributing_doc(tmp_path: Path) -> None:
 
 
 def test_verify_sdist_rejects_stale_reflex_example_readme(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(
         sdist,
         replacements={"examples/reflex/README.md": "# Reflex\n" + ("padding\n" * 200)},
@@ -427,7 +427,7 @@ def test_verify_sdist_rejects_stale_reflex_example_readme(tmp_path: Path) -> Non
 
 
 def test_verify_sdist_rejects_stale_business_example_asset(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(
         sdist,
         replacements={
@@ -442,7 +442,7 @@ def test_verify_sdist_rejects_stale_business_example_asset(tmp_path: Path) -> No
 
 
 def test_verify_sdist_rejects_missing_release_workflow(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(sdist, omit={".github/workflows/release.yml"})
 
     with pytest.raises(AssertionError, match=r"release\.yml"):
@@ -450,7 +450,7 @@ def test_verify_sdist_rejects_missing_release_workflow(tmp_path: Path) -> None:
 
 
 def test_verify_sdist_rejects_missing_codspeed_workflow(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(sdist, omit={".github/workflows/codspeed.yml"})
 
     with pytest.raises(AssertionError, match=r"codspeed\.yml"):
@@ -458,7 +458,7 @@ def test_verify_sdist_rejects_missing_codspeed_workflow(tmp_path: Path) -> None:
 
 
 def test_verify_sdist_rejects_corrupt_codspeed_workflow(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(
         sdist,
         replacements={".github/workflows/codspeed.yml": "name: CodSpeed\n" + ("padding\n" * 200)},
@@ -469,7 +469,7 @@ def test_verify_sdist_rejects_corrupt_codspeed_workflow(tmp_path: Path) -> None:
 
 
 def test_verify_sdist_rejects_corrupt_release_workflow(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(
         sdist,
         replacements={".github/workflows/release.yml": "name: Release\n" + ("padding\n" * 200)},
@@ -480,7 +480,7 @@ def test_verify_sdist_rejects_corrupt_release_workflow(tmp_path: Path) -> None:
 
 
 def test_verify_sdist_rejects_corrupt_static_bundle(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(sdist, replacements={"python/xy/static/index.js": "not the client"})
 
     with pytest.raises(AssertionError, match=r"index\.js"):
@@ -488,7 +488,7 @@ def test_verify_sdist_rejects_corrupt_static_bundle(tmp_path: Path) -> None:
 
 
 def test_verify_sdist_rejects_corrupt_source_entry_bundle(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(sdist, replacements={"js/src/60_entries.js": "not the source client"})
 
     with pytest.raises(AssertionError, match=r"60_entries\.js"):
@@ -505,7 +505,7 @@ def test_verify_sdist_rejects_corrupt_source_entry_bundle(tmp_path: Path) -> Non
     ],
 )
 def test_verify_sdist_rejects_generated_artifacts(tmp_path: Path, artifact: str) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(sdist, extra={artifact: b"cache"})
 
     with pytest.raises(AssertionError, match="generated/native artifacts"):
@@ -513,7 +513,7 @@ def test_verify_sdist_rejects_generated_artifacts(tmp_path: Path, artifact: str)
 
 
 def test_verify_sdist_rejects_duplicate_file_member(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(sdist, extra={"README.md": b"duplicate"})
 
     with pytest.raises(AssertionError, match="duplicate file member"):
@@ -521,10 +521,10 @@ def test_verify_sdist_rejects_duplicate_file_member(tmp_path: Path) -> None:
 
 
 def test_verify_sdist_rejects_unsafe_member_paths(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.1.0.tar.gz"
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
     with tarfile.open(sdist, "w:gz") as tf:
-        _add_file(tf, "xy-0.1.0/PKG-INFO", b"Name: xy\n")
-        _add_file(tf, "xy-0.1.0/../evil.py", b"")
+        _add_file(tf, "xy-0.0.1/PKG-INFO", b"Name: xy\n")
+        _add_file(tf, "xy-0.0.1/../evil.py", b"")
 
     with pytest.raises(AssertionError, match="unsafe tar member path"):
         verify_sdist.verify_sdist(str(sdist))

--- a/tests/test_verify_wheel.py
+++ b/tests/test_verify_wheel.py
@@ -11,7 +11,7 @@ from typing import Optional, Union
 import pytest
 
 INIT_PY = """
-__version__ = "0.1.0"
+__version__ = "0.0.1"
 _EXPORTS = {"Selection": "._figure"}
 __all__ = ["Selection", "__version__"]
 def __getattr__(name):
@@ -72,7 +72,7 @@ DEFAULT_METADATA = "\n".join(
     [
         "Metadata-Version: 2.4",
         "Name: xy",
-        "Version: 0.1.0",
+        "Version: 0.0.1",
         "Requires-Python: >=3.11",
         "Requires-Dist: anywidget>=0.9",
         "Requires-Dist: numpy>=1.24",
@@ -166,15 +166,15 @@ def _write_wheel(
             write(zf, "xy/_native_lib/libxy_core.dylib", b"native")
         for name, data in extra.items():
             write(zf, name, data)
-        wheel_name = "xy-0.1.0.dist-info/WHEEL"
+        wheel_name = "xy-0.0.1.dist-info/WHEEL"
         write(
             zf,
             wheel_name,
             (f"Wheel-Version: 1.0\nRoot-Is-Purelib: {str(root_is_purelib).lower()}\nTag: {tag}\n"),
         )
         if metadata is not None:
-            write(zf, "xy-0.1.0.dist-info/METADATA", metadata)
-        record_name = "xy-0.1.0.dist-info/RECORD"
+            write(zf, "xy-0.0.1.dist-info/METADATA", metadata)
+        record_name = "xy-0.0.1.dist-info/RECORD"
         record_data = (
             record_override
             if record_override is not None
@@ -189,21 +189,21 @@ def _write_wheel(
 
 
 def test_verify_native_wheel_accepts_required_artifact_shape(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(whl)
 
     verify_wheel.verify_wheel(whl, expect_native=True)
 
 
 def test_verify_pure_wheel_accepts_required_artifact_shape(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-any.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-any.whl"
     _write_wheel(whl, tag="py3-none-any", root_is_purelib=True, native=False)
 
     verify_wheel.verify_wheel(whl, expect_native=False)
 
 
 def test_verify_wheel_accepts_normalized_metadata_spacing(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     metadata = DEFAULT_METADATA.replace(
         "Requires-Dist: anywidget>=0.9", "Requires-Dist: anywidget >= 0.9"
     ).replace("Requires-Dist: numpy>=1.24", "Requires-Dist: numpy >= 1.24")
@@ -213,7 +213,7 @@ def test_verify_wheel_accepts_normalized_metadata_spacing(tmp_path: Path) -> Non
 
 
 def test_verify_native_wheel_rejects_filename_tag_mismatch(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-any.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-any.whl"
     _write_wheel(whl, tag="py3-none-macosx_11_0_arm64")
 
     with pytest.raises(AssertionError, match="filename tag"):
@@ -221,7 +221,7 @@ def test_verify_native_wheel_rejects_filename_tag_mismatch(tmp_path: Path) -> No
 
 
 def test_verify_pure_wheel_rejects_filename_tag_mismatch(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(whl, tag="py3-none-any", root_is_purelib=True, native=False)
 
     with pytest.raises(AssertionError, match="filename tag"):
@@ -229,7 +229,7 @@ def test_verify_pure_wheel_rejects_filename_tag_mismatch(tmp_path: Path) -> None
 
 
 def test_verify_wheel_rejects_missing_metadata_file(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(whl, metadata=None)
 
     with pytest.raises(AssertionError, match="METADATA"):
@@ -244,8 +244,8 @@ def test_verify_wheel_rejects_missing_metadata_file(tmp_path: Path) -> None:
             "Name: xy",
         ),
         (
-            DEFAULT_METADATA.replace("Version: 0.1.0", "Version: 0.2.0"),
-            "Version: 0.1.0",
+            DEFAULT_METADATA.replace("Version: 0.0.1", "Version: 0.2.0"),
+            "Version: 0.0.1",
         ),
         (
             DEFAULT_METADATA.replace("Requires-Python: >=3.11", "Requires-Python: >=3.10"),
@@ -266,7 +266,7 @@ def test_verify_wheel_rejects_missing_metadata_file(tmp_path: Path) -> None:
     ],
 )
 def test_verify_wheel_rejects_invalid_metadata(tmp_path: Path, metadata: str, match: str) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(whl, metadata=metadata)
 
     with pytest.raises(AssertionError, match=match):
@@ -274,7 +274,7 @@ def test_verify_wheel_rejects_invalid_metadata(tmp_path: Path, metadata: str, ma
 
 
 def test_verify_wheel_rejects_missing_type_marker(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(whl, omit={"xy/py.typed"})
 
     with pytest.raises(AssertionError, match="py\\.typed"):
@@ -282,7 +282,7 @@ def test_verify_wheel_rejects_missing_type_marker(tmp_path: Path) -> None:
 
 
 def test_verify_wheel_rejects_partial_type_marker(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(whl, replacements={"xy/py.typed": "partial\n"})
 
     with pytest.raises(AssertionError, match="full-package PEP 561 marker"):
@@ -290,7 +290,7 @@ def test_verify_wheel_rejects_partial_type_marker(tmp_path: Path) -> None:
 
 
 def test_verify_wheel_rejects_corrupt_python_module(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(whl, replacements={"xy/__init__.py": ""})
 
     with pytest.raises(AssertionError, match=r"__init__\.py"):
@@ -298,7 +298,7 @@ def test_verify_wheel_rejects_corrupt_python_module(tmp_path: Path) -> None:
 
 
 def test_verify_wheel_rejects_stale_figure_export_surface(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(
         whl,
         replacements={
@@ -317,7 +317,7 @@ class Figure:
 
 
 def test_verify_wheel_rejects_stale_marks_export_surface(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(
         whl,
         replacements={
@@ -332,7 +332,7 @@ def line(self, x, y): ...
 
 
 def test_verify_wheel_rejects_stale_component_export_surface(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(
         whl,
         replacements={
@@ -350,7 +350,7 @@ class Chart:
 
 
 def test_verify_wheel_rejects_stale_html_export_safety_surface(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(
         whl,
         replacements={
@@ -368,7 +368,7 @@ def to_png(fig): ...
 
 
 def test_verify_wheel_rejects_missing_static_bundle(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(whl, omit={"xy/static/standalone.js"})
 
     with pytest.raises(AssertionError, match="required package files"):
@@ -376,7 +376,7 @@ def test_verify_wheel_rejects_missing_static_bundle(tmp_path: Path) -> None:
 
 
 def test_verify_wheel_rejects_corrupt_static_bundle(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(whl, replacements={"xy/static/standalone.js": "not the client"})
 
     with pytest.raises(AssertionError, match=r"standalone\.js"):
@@ -384,7 +384,7 @@ def test_verify_wheel_rejects_corrupt_static_bundle(tmp_path: Path) -> None:
 
 
 def test_verify_wheel_rejects_unexpected_native_artifact(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(whl, extra={"xy/bad_extension.so": b"native"})
 
     with pytest.raises(AssertionError, match="unexpected native artifacts"):
@@ -401,7 +401,7 @@ def test_verify_wheel_rejects_unexpected_native_artifact(tmp_path: Path) -> None
     ],
 )
 def test_verify_wheel_rejects_sdist_only_files(tmp_path: Path, extra_name: str) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(whl, extra={extra_name: b"sdist only"})
 
     with pytest.raises(AssertionError, match="sdist only"):
@@ -409,7 +409,7 @@ def test_verify_wheel_rejects_sdist_only_files(tmp_path: Path, extra_name: str) 
 
 
 def test_verify_pure_wheel_rejects_native_library(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-any.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-any.whl"
     _write_wheel(whl, tag="py3-none-any", root_is_purelib=True, native=True)
 
     with pytest.raises(AssertionError, match="must not contain native libs"):
@@ -417,7 +417,7 @@ def test_verify_pure_wheel_rejects_native_library(tmp_path: Path) -> None:
 
 
 def test_verify_wheel_rejects_missing_record(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(whl)
     with zipfile.ZipFile(whl) as zf:
         entries = [
@@ -434,7 +434,7 @@ def test_verify_wheel_rejects_missing_record(tmp_path: Path) -> None:
 
 
 def test_verify_wheel_rejects_empty_record(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(whl, record_override="")
 
     with pytest.raises(AssertionError, match="does not list archive files"):
@@ -442,7 +442,7 @@ def test_verify_wheel_rejects_empty_record(tmp_path: Path) -> None:
 
 
 def test_verify_wheel_rejects_incomplete_record(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(whl, record_omit={"xy/widget.py"})
 
     with pytest.raises(AssertionError, match="does not match archive files"):
@@ -450,7 +450,7 @@ def test_verify_wheel_rejects_incomplete_record(tmp_path: Path) -> None:
 
 
 def test_verify_wheel_rejects_record_hash_mismatch(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     _write_wheel(whl, record_overrides={"xy/widget.py": ("sha256=bad", "6559")})
 
     with pytest.raises(AssertionError, match="hash mismatch"):
@@ -458,7 +458,7 @@ def test_verify_wheel_rejects_record_hash_mismatch(tmp_path: Path) -> None:
 
 
 def test_verify_wheel_rejects_record_size_mismatch(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     init_hash = f"sha256={_record_hash(INIT_PY.encode('utf-8'))}"
     _write_wheel(whl, record_overrides={"xy/__init__.py": (init_hash, "1")})
 
@@ -467,7 +467,7 @@ def test_verify_wheel_rejects_record_size_mismatch(tmp_path: Path) -> None:
 
 
 def test_verify_wheel_rejects_duplicate_archive_entries(tmp_path: Path) -> None:
-    whl = tmp_path / "xy-0.1.0-py3-none-macosx_11_0_arm64.whl"
+    whl = tmp_path / "xy-0.0.1-py3-none-macosx_11_0_arm64.whl"
     with pytest.warns(UserWarning, match="Duplicate name"):
         _write_wheel(whl, extra={"xy/widget.py": b"duplicate"})
 


### PR DESCRIPTION
## What changed

- set the root Python package version to `0.0.1`
- keep `xy.__version__` aligned with the package metadata
- date the `0.0.1` changelog release section

## Why

The `v0.0.1` release tag failed the release-version gate because the project metadata still declared `0.1.0`, and the changelog had no dated `0.0.1` entry.

## Impact

The release tag, package metadata, public runtime version, and changelog now agree on `0.0.1`.

## Validation

- `python3 scripts/check_release_version.py --tag v0.0.1`
- `python3 -m pytest -q tests/test_check_release_version.py`
- targeted `validate_version_consistency` tests (4 passed)
