### PR TITLE
Make the toolbar respect light and dark mode

### DIFF
--- a/docs/components/modebars-and-interaction-controls.md
+++ b/docs/components/modebars-and-interaction-controls.md
@@ -28,6 +28,12 @@ chart = xy.scatter_chart(
 the `modebar` and `modebar_button` chart slots. Use `show=False` to remove the
 toolbar. The last modebar component supplies the effective configuration.
 
+The toolbar's default surface follows your page's light or dark mode
+automatically: a `.dark` class on the chart root or any ancestor (as Reflex,
+Radix, and Tailwind set on the root `<html>`) switches it to a dark palette,
+while `--chart-modebar-*` tokens you supply still override it. See
+[Themes and tokens](/docs/xy/styling/themes-and-tokens/#automatic-dark-mode-for-the-toolbar).
+
 The CSV command exports data resident in the browser representation. On a
 decimated or density-tier chart that is not necessarily every canonical source
 row; export the source table from Python when a complete data extract is

--- a/docs/styling/themes-and-tokens.md
+++ b/docs/styling/themes-and-tokens.md
@@ -46,7 +46,7 @@ chart's own `style=` is the final root-level override.
 | `--chart-tooltip-bg` / `--chart-tooltip-text` | Tooltip | dark translucent / white |
 | `--chart-legend-bg` | Legend background | faint neutral fill |
 | `--chart-badge-bg` / `--chart-badge-text` | Reduction badges | light / dark |
-| `--chart-modebar-bg` / `--chart-modebar-active` | Toolbar and active button | light translucent / neutral |
+| `--chart-modebar-bg` / `--chart-modebar-active` | Toolbar and active button | light or dark translucent (follows a `.dark` root class) / neutral |
 | `--chart-selection` / `--chart-selection-fill` | Selection outline/fill | blue outline / translucent blue |
 | `--chart-zoom-selection` / `--chart-zoom-selection-fill` | Box-zoom outline/fill | neutral outline/fill |
 | `--chart-crosshair` | Crosshair lines | translucent dark |
@@ -81,6 +81,23 @@ chart = xy.line_chart(
 
 In Reflex, resolve reactive theme choices into ordinary classes, styles, or CSS
 variables. XY does not duplicate Reflex conditions or application state.
+
+## Automatic dark mode for the toolbar
+
+The interactive toolbar (modebar) has no colored default a page can show
+through, so it reads the light/dark state straight from your page: when a
+`.dark` class is present on the chart root or any ancestor — the convention
+Reflex (next-themes), Radix Themes, and Tailwind all set on the root `<html>`
+element — its background, border, and shadow switch to a dark palette. Icon
+color already follows the inherited text color, so the toolbar stays readable in
+both modes with no configuration. An explicit `.light` class (or no class at
+all) keeps the light palette.
+
+That is only the built-in default. A `--chart-modebar-bg` or
+`--chart-modebar-active` value you set — through `theme()`, chart `style=`, or a
+host stylesheet — still wins in either mode, so mapping the toolbar onto your
+own adaptive design tokens (for example Radix's `--secondary-2`) replaces the
+automatic palette entirely.
 
 ## Dark mode in a standalone export
 

--- a/js/src/20_theme.js
+++ b/js/src/20_theme.js
@@ -75,6 +75,16 @@ function cssColor([r, g, b, a]) {
 // *structural* inline styles (position/size/z-index/state), while background,
 // color, padding, border, font, box-shadow live here as overridable defaults.
 // All colors flow through --chart-* tokens so container theming still cascades.
+//
+// The modebar's own default surface (its background/border/shadow, which have
+// no public --chart-* token) is scheme-aware: it reads internal --xy-modebar-*
+// defaults that flip to a dark palette whenever a `.dark` class sits on the
+// chart root or any ancestor — the class-on-root convention every host we
+// target uses (Reflex/next-themes, Radix Themes, Tailwind). Icon color already
+// follows currentColor, so on a dark page the light default bar would have hit
+// light icons on white; the override keeps the toolbar readable in both modes.
+// These are still zero-specificity :where() rules, so a host --chart-modebar-*
+// token or utility class overrides them in either scheme.
 const XY_CHROME_CSS = `
 :where(.xy [data-xy-slot="title"]){text-align:center;font-size:14px;font-weight:600;color:var(--chart-text,inherit)}
 :where(.xy [data-xy-slot="tooltip"]){background:var(--chart-tooltip-bg,rgba(20,24,33,.92));color:var(--chart-tooltip-text,#fff);padding:5px 8px;border-radius:4px;font-size:11px;line-height:1.35;box-shadow:0 2px 8px rgba(0,0,0,.3)}
@@ -85,7 +95,9 @@ const XY_CHROME_CSS = `
 :where(.xy [data-xy-slot="colorbar_title"]){font-weight:500}
 :where(.xy [data-xy-slot="badge"]){gap:3px;font-size:11px;line-height:1.2}
 :where(.xy [data-xy-slot="badge_item"]){padding:3px 6px;border-radius:4px;color:var(--chart-badge-text,#0f172a);background:var(--chart-badge-bg,rgba(255,255,255,.82));box-shadow:0 1px 4px rgba(15,23,42,.14)}
-:where(.xy [data-xy-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
+:where(.xy){--xy-modebar-bg:rgba(255,255,255,.78);--xy-modebar-menu-bg:rgba(255,255,255,.94);--xy-modebar-border:rgba(128,128,128,.18);--xy-modebar-menu-border:rgba(128,128,128,.22);--xy-modebar-active:rgba(128,128,128,.2);--xy-modebar-shadow:0 1px 4px rgba(0,0,0,.08);--xy-modebar-menu-shadow:0 5px 18px rgba(15,23,42,.18)}
+:where(.dark .xy,.xy.dark){--xy-modebar-bg:rgba(37,42,52,.9);--xy-modebar-menu-bg:rgba(30,35,44,.97);--xy-modebar-border:rgba(255,255,255,.14);--xy-modebar-menu-border:rgba(255,255,255,.16);--xy-modebar-active:rgba(255,255,255,.16);--xy-modebar-shadow:0 1px 4px rgba(0,0,0,.5);--xy-modebar-menu-shadow:0 8px 24px rgba(0,0,0,.6)}
+:where(.xy [data-xy-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,var(--xy-modebar-bg));border:1px solid var(--xy-modebar-border);border-radius:4px;padding:1px;box-shadow:var(--xy-modebar-shadow)}
 :where(.xy [data-xy-slot="modebar_button"]){width:24px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
 :where(.xy [data-xy-modebar-drag-handle]){position:relative;width:22px;margin-right:4px;cursor:move}
 :where(.xy [data-xy-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-3px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
@@ -93,13 +105,13 @@ const XY_CHROME_CSS = `
 :where(.xy [data-xy-modebar-select-trigger]){width:auto;min-width:30px;gap:0;padding:0 2px}
 :where(.xy [data-xy-modebar-menu-indicator]){display:flex;transition:transform .15s}
 :where(.xy [data-xy-modebar-menu-indicator] svg){width:11px;height:11px}
-:where(.xy [data-xy-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}
+:where(.xy [data-xy-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,var(--xy-modebar-menu-bg));border:1px solid var(--xy-modebar-menu-border);border-radius:7px;box-shadow:var(--xy-modebar-menu-shadow);backdrop-filter:blur(8px)}
 :where(.xy [data-xy-modebar-menu-item]){width:100%;height:28px;justify-content:flex-start;padding:0 9px;border-radius:4px;text-align:left;white-space:nowrap}
-:where(.xy [data-xy-modebar-menu-item]:hover,.xy [data-xy-modebar-menu-item]:focus-visible){background:var(--chart-modebar-active,rgba(128,128,128,.18));outline:none}
+:where(.xy [data-xy-modebar-menu-item]:hover,.xy [data-xy-modebar-menu-item]:focus-visible){background:var(--chart-modebar-active,var(--xy-modebar-active));outline:none}
 :where(.xy [data-xy-modebar-menu-item][data-xy-separator]){margin-top:3px;border-top:1px solid rgba(128,128,128,.2);border-radius:0 0 4px 4px}
 :where(.xy [data-xy-modebar-menu-icon]){display:flex;width:16px;margin-right:7px}
 :where(.xy [data-xy-modebar-menu-icon] svg){width:14px;height:14px}
-:where(.xy [data-xy-slot="modebar_button"].xy-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
+:where(.xy [data-xy-slot="modebar_button"].xy-active){background:var(--chart-modebar-active,var(--xy-modebar-active))}
 :where(.xy [data-xy-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-xy-slot="selection"][data-xy-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}
 :where(.xy [data-xy-selection-lasso]){fill:var(--chart-selection-fill,rgba(90,140,240,.15));stroke:var(--chart-selection,rgba(90,140,240,.9));stroke-width:1.5;stroke-linejoin:round;pointer-events:none}

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -240,7 +240,9 @@ const XY_CHROME_CSS = `
 :where(.xy [data-xy-slot="colorbar_title"]){font-weight:500}
 :where(.xy [data-xy-slot="badge"]){gap:3px;font-size:11px;line-height:1.2}
 :where(.xy [data-xy-slot="badge_item"]){padding:3px 6px;border-radius:4px;color:var(--chart-badge-text,#0f172a);background:var(--chart-badge-bg,rgba(255,255,255,.82));box-shadow:0 1px 4px rgba(15,23,42,.14)}
-:where(.xy [data-xy-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
+:where(.xy){--xy-modebar-bg:rgba(255,255,255,.78);--xy-modebar-menu-bg:rgba(255,255,255,.94);--xy-modebar-border:rgba(128,128,128,.18);--xy-modebar-menu-border:rgba(128,128,128,.22);--xy-modebar-active:rgba(128,128,128,.2);--xy-modebar-shadow:0 1px 4px rgba(0,0,0,.08);--xy-modebar-menu-shadow:0 5px 18px rgba(15,23,42,.18)}
+:where(.dark .xy,.xy.dark){--xy-modebar-bg:rgba(37,42,52,.9);--xy-modebar-menu-bg:rgba(30,35,44,.97);--xy-modebar-border:rgba(255,255,255,.14);--xy-modebar-menu-border:rgba(255,255,255,.16);--xy-modebar-active:rgba(255,255,255,.16);--xy-modebar-shadow:0 1px 4px rgba(0,0,0,.5);--xy-modebar-menu-shadow:0 8px 24px rgba(0,0,0,.6)}
+:where(.xy [data-xy-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,var(--xy-modebar-bg));border:1px solid var(--xy-modebar-border);border-radius:4px;padding:1px;box-shadow:var(--xy-modebar-shadow)}
 :where(.xy [data-xy-slot="modebar_button"]){width:24px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
 :where(.xy [data-xy-modebar-drag-handle]){position:relative;width:22px;margin-right:4px;cursor:move}
 :where(.xy [data-xy-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-3px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
@@ -248,13 +250,13 @@ const XY_CHROME_CSS = `
 :where(.xy [data-xy-modebar-select-trigger]){width:auto;min-width:30px;gap:0;padding:0 2px}
 :where(.xy [data-xy-modebar-menu-indicator]){display:flex;transition:transform .15s}
 :where(.xy [data-xy-modebar-menu-indicator] svg){width:11px;height:11px}
-:where(.xy [data-xy-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}
+:where(.xy [data-xy-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,var(--xy-modebar-menu-bg));border:1px solid var(--xy-modebar-menu-border);border-radius:7px;box-shadow:var(--xy-modebar-menu-shadow);backdrop-filter:blur(8px)}
 :where(.xy [data-xy-modebar-menu-item]){width:100%;height:28px;justify-content:flex-start;padding:0 9px;border-radius:4px;text-align:left;white-space:nowrap}
-:where(.xy [data-xy-modebar-menu-item]:hover,.xy [data-xy-modebar-menu-item]:focus-visible){background:var(--chart-modebar-active,rgba(128,128,128,.18));outline:none}
+:where(.xy [data-xy-modebar-menu-item]:hover,.xy [data-xy-modebar-menu-item]:focus-visible){background:var(--chart-modebar-active,var(--xy-modebar-active));outline:none}
 :where(.xy [data-xy-modebar-menu-item][data-xy-separator]){margin-top:3px;border-top:1px solid rgba(128,128,128,.2);border-radius:0 0 4px 4px}
 :where(.xy [data-xy-modebar-menu-icon]){display:flex;width:16px;margin-right:7px}
 :where(.xy [data-xy-modebar-menu-icon] svg){width:14px;height:14px}
-:where(.xy [data-xy-slot="modebar_button"].xy-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
+:where(.xy [data-xy-slot="modebar_button"].xy-active){background:var(--chart-modebar-active,var(--xy-modebar-active))}
 :where(.xy [data-xy-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-xy-slot="selection"][data-xy-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}
 :where(.xy [data-xy-selection-lasso]){fill:var(--chart-selection-fill,rgba(90,140,240,.15));stroke:var(--chart-selection,rgba(90,140,240,.9));stroke-width:1.5;stroke-linejoin:round;pointer-events:none}

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -241,7 +241,9 @@ const XY_CHROME_CSS = `
 :where(.xy [data-xy-slot="colorbar_title"]){font-weight:500}
 :where(.xy [data-xy-slot="badge"]){gap:3px;font-size:11px;line-height:1.2}
 :where(.xy [data-xy-slot="badge_item"]){padding:3px 6px;border-radius:4px;color:var(--chart-badge-text,#0f172a);background:var(--chart-badge-bg,rgba(255,255,255,.82));box-shadow:0 1px 4px rgba(15,23,42,.14)}
-:where(.xy [data-xy-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,rgba(255,255,255,.78));border:1px solid rgba(128,128,128,.18);border-radius:4px;padding:1px;box-shadow:0 1px 4px rgba(0,0,0,.08)}
+:where(.xy){--xy-modebar-bg:rgba(255,255,255,.78);--xy-modebar-menu-bg:rgba(255,255,255,.94);--xy-modebar-border:rgba(128,128,128,.18);--xy-modebar-menu-border:rgba(128,128,128,.22);--xy-modebar-active:rgba(128,128,128,.2);--xy-modebar-shadow:0 1px 4px rgba(0,0,0,.08);--xy-modebar-menu-shadow:0 5px 18px rgba(15,23,42,.18)}
+:where(.dark .xy,.xy.dark){--xy-modebar-bg:rgba(37,42,52,.9);--xy-modebar-menu-bg:rgba(30,35,44,.97);--xy-modebar-border:rgba(255,255,255,.14);--xy-modebar-menu-border:rgba(255,255,255,.16);--xy-modebar-active:rgba(255,255,255,.16);--xy-modebar-shadow:0 1px 4px rgba(0,0,0,.5);--xy-modebar-menu-shadow:0 8px 24px rgba(0,0,0,.6)}
+:where(.xy [data-xy-slot="modebar"]){gap:1px;background:var(--chart-modebar-bg,var(--xy-modebar-bg));border:1px solid var(--xy-modebar-border);border-radius:4px;padding:1px;box-shadow:var(--xy-modebar-shadow)}
 :where(.xy [data-xy-slot="modebar_button"]){width:24px;height:24px;padding:0;border:none;background:transparent;border-radius:3px;color:var(--chart-text,currentColor);cursor:pointer}
 :where(.xy [data-xy-modebar-drag-handle]){position:relative;width:22px;margin-right:4px;cursor:move}
 :where(.xy [data-xy-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-3px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
@@ -249,13 +251,13 @@ const XY_CHROME_CSS = `
 :where(.xy [data-xy-modebar-select-trigger]){width:auto;min-width:30px;gap:0;padding:0 2px}
 :where(.xy [data-xy-modebar-menu-indicator]){display:flex;transition:transform .15s}
 :where(.xy [data-xy-modebar-menu-indicator] svg){width:11px;height:11px}
-:where(.xy [data-xy-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}
+:where(.xy [data-xy-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,var(--xy-modebar-menu-bg));border:1px solid var(--xy-modebar-menu-border);border-radius:7px;box-shadow:var(--xy-modebar-menu-shadow);backdrop-filter:blur(8px)}
 :where(.xy [data-xy-modebar-menu-item]){width:100%;height:28px;justify-content:flex-start;padding:0 9px;border-radius:4px;text-align:left;white-space:nowrap}
-:where(.xy [data-xy-modebar-menu-item]:hover,.xy [data-xy-modebar-menu-item]:focus-visible){background:var(--chart-modebar-active,rgba(128,128,128,.18));outline:none}
+:where(.xy [data-xy-modebar-menu-item]:hover,.xy [data-xy-modebar-menu-item]:focus-visible){background:var(--chart-modebar-active,var(--xy-modebar-active));outline:none}
 :where(.xy [data-xy-modebar-menu-item][data-xy-separator]){margin-top:3px;border-top:1px solid rgba(128,128,128,.2);border-radius:0 0 4px 4px}
 :where(.xy [data-xy-modebar-menu-icon]){display:flex;width:16px;margin-right:7px}
 :where(.xy [data-xy-modebar-menu-icon] svg){width:14px;height:14px}
-:where(.xy [data-xy-slot="modebar_button"].xy-active){background:var(--chart-modebar-active,rgba(128,128,128,.22))}
+:where(.xy [data-xy-slot="modebar_button"].xy-active){background:var(--chart-modebar-active,var(--xy-modebar-active))}
 :where(.xy [data-xy-slot="selection"]){border:1px solid var(--chart-selection,rgba(90,140,240,.9));background:var(--chart-selection-fill,rgba(90,140,240,.15))}
 :where(.xy [data-xy-slot="selection"][data-xy-band="zoom"]){border-color:var(--chart-zoom-selection,rgba(120,120,120,.9));background:var(--chart-zoom-selection-fill,rgba(120,120,120,.12))}
 :where(.xy [data-xy-selection-lasso]){fill:var(--chart-selection-fill,rgba(90,140,240,.15));stroke:var(--chart-selection,rgba(90,140,240,.9));stroke-width:1.5;stroke-linejoin:round;pointer-events:none}


### PR DESCRIPTION
The modebar baked light-only colors into its CSS var() fallbacks, so on a
dark page the icons (which follow currentColor) rendered light on a white
bar. Route the toolbar's default surface — background, menu, border, shadow,
and active/hover tint — through internal --xy-modebar-* variables that flip
to a dark palette whenever a `.dark` class sits on the chart root or any
ancestor, the class-on-root convention Reflex (next-themes), Radix Themes,
and Tailwind all use on the root <html>.

Every rule stays a zero-specificity :where() default, so a host
--chart-modebar-* token or utility class still overrides it in either scheme,
and an explicit `.light` class (or none) keeps today's light appearance.

Rebuild the committed static bundles and document the behavior.