### PR TITLE
Docs styles fixes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,8 +53,8 @@ jobs:
         run: uv run --project docs/app --no-sync pytest docs/app/tests -v
       - name: Run docs quality hooks
         run: |
-          uv run --project docs/app --no-sync pre-commit run docs-app-ruff-format --all-files
-          uv run --project docs/app --no-sync pre-commit run docs-app-ruff-check --all-files
+          uv run --project docs/app --no-sync pre-commit run ruff-format --all-files
+          uv run --project docs/app --no-sync pre-commit run ruff-check --all-files
           uv run --project docs/app --no-sync pre-commit run docs-app-codespell --all-files
 
   production:
@@ -134,9 +134,11 @@ jobs:
           fi
       - name: Validate Markdown links against the generated sitemap
         working-directory: docs/app
-        run: >-
-          uv run --no-sync pytest --runxfail
-          tests/test_docs_site.py::test_xy_markdown_docs_links_match_exported_sitemap -v
+        run: |
+          uv run --no-sync pytest --runxfail \
+            tests/test_docs_site.py::test_xy_markdown_docs_links_match_exported_sitemap \
+            tests/test_docs_site.py::test_static_xy_tailwind_manifest_reaches_compiled_css \
+            -v
       - name: Validate generated sitemap
         working-directory: docs/app
         run: uv run --no-sync python scripts/check_sitemap.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,31 +5,15 @@ repos:
     rev: v0.15.8
     hooks:
       - id: ruff-check
-        args: ["."]
+        args: ["--config=pyproject.toml", "."]
         pass_filenames: false
         stages: [pre-commit]
       - id: ruff-format
-        args: [--check, .]
+        args: [--config=pyproject.toml, --check, .]
         pass_filenames: false
         stages: [pre-commit]
   - repo: local
     hooks:
-      - id: docs-app-ruff-format
-        name: docs app ruff format
-        entry: uv run --project docs/app --no-sync ruff format --config docs/app/pyproject.toml
-        language: system
-        types_or: [python, markdown]
-        files: ^docs/
-        exclude: ^docs/engineering/
-        require_serial: true
-      - id: docs-app-ruff-check
-        name: docs app ruff check
-        entry: uv run --project docs/app --no-sync ruff check --config docs/app/pyproject.toml
-        args: [--fix, --exit-non-zero-on-fix]
-        language: system
-        types_or: [python, pyi]
-        files: ^docs/app/
-        require_serial: true
       - id: docs-app-codespell
         name: docs app codespell
         entry: uv run --project docs/app --no-sync codespell --toml docs/app/pyproject.toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,11 @@ repos:
     rev: v0.15.8
     hooks:
       - id: ruff-check
-        args: ["--config=pyproject.toml", "."]
+        args: ["--config=pyproject.toml", "--fix", "--exit-non-zero-on-fix", "."]
         pass_filenames: false
         stages: [pre-commit]
       - id: ruff-format
-        args: [--config=pyproject.toml, --check, .]
+        args: [--config=pyproject.toml, .]
         pass_filenames: false
         stages: [pre-commit]
   - repo: local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,19 @@ in the README).
   to the internal engine object.
 
 ### Added
+- **Declarative continuous colorbars.** `xy.colorbar()` derives the domain,
+  colormap, and default title from the last compatible heatmap, continuous
+  scatter, hexbin, contour, segment, or triangle-mesh mark, with explicit
+  `title`, `orientation`, and `ticks`. Constant/categorical colors, truecolor
+  grids, and density scatter whose source color channel was dropped do not
+  advertise a misleading scale.
+- **Complete styling atlas and Reflex/Tailwind bridge.** New styling guides and
+  live stress examples cover every rendered mark family, all 17 scatter
+  symbols, grouped/normalized bars, axes and annotations, both colorbar
+  orientations, responsive chrome, custom host components, facets, badges,
+  interactions, and export boundaries. Fixed charts passed directly to
+  `reflex_xy.chart()` now mirror their embedded class tokens into generated JSX
+  so Reflex's Tailwind plugin can discover them at compile time.
 - **Compact chart toolbar and editable lasso selection.** The client toolbar
   appears on chart hover or keyboard focus, can be dragged within the chart,
   groups zoom and selection modes into accessible menus, and exports PNG, SVG,
@@ -106,6 +119,23 @@ in the README).
   contract without importing the widget stack.
 
 ### Changed
+- **Responsive, author-defeatable browser chrome.** XY's visual defaults now
+  live in a low-priority cascade layer, so Tailwind utilities, ordinary author
+  CSS, and slot styles override them without `!important`. Long legends remain
+  bounded and correctly anchored after compact-layout resizes; edge tooltips
+  wrap, clamp, and flip within the chart; canvas offsets refresh with the plot.
+- **Named-axis and static-export parity.** Browser, SVG, and native PNG output
+  now render and independently scale named x and y axes, including their
+  baseline, ticks, labels, titles, style, reverse ranges, collision strategy,
+  and label placement. Static legends are bounded and long labels ellipsize
+  instead of escaping small plots.
+- Rich tooltips retain resident color/size fields after WebGL context recovery
+  and rehydrate shared fields after exact kernel picks instead of collapsing to
+  positional x/y values.
+- Annotation geometry opacity no longer fades browser DOM labels. Rules,
+  bands, markers, arrows, and callouts can stay visually subtle while their
+  text remains readable; annotation-style `label_opacity` explicitly controls
+  label alpha when desired.
 - **`savefig` single-panel PNG export now uses the fused Rust encoder.** A
   one-axes figure with no suptitle/colorbar/tight-bbox and the default white
   facecolor is exactly one native render, so `stitch_png` returns the

--- a/docs/api-reference/events-and-callbacks.md
+++ b/docs/api-reference/events-and-callbacks.md
@@ -74,6 +74,8 @@ The separate `reflex-xy` adapter intentionally uses semantic component props:
 `on_point_hover`, `on_point_click`, `on_select_end`, and `on_view_change`.
 Those are adapter props, not aliases accepted by core `Chart`. See the
 [Reflex integration](/docs/xy/integrations/reflex/) for state-backed payloads.
+`on_select_end` includes `total`, `cleared`, and either box bounds or the
+data-space `polygon` used by a lasso selection.
 
 Linked charts broadcast viewport ranges only. They do not automatically link
 selection state or cross-filter data.

--- a/docs/api-reference/limitations-and-alpha-status.md
+++ b/docs/api-reference/limitations-and-alpha-status.md
@@ -60,8 +60,9 @@ and [Benchmarks](/docs/xy/overview/benchmarks/) for scoped evidence.
   structural layout rule, mark renderer, annotation shape, or native export.
 - Native PNG cannot apply author `custom_css`. Use renderable chart/mark styles
   or `Engine.chromium` for browser CSS fidelity.
-- Declarative `colorbar()` is a visibility/style/replacement hook; it does not
-  yet build a complete colorbar from a continuous mark channel.
+- Declarative `colorbar()` derives built-in chrome from supported continuous
+  marks. It intentionally omits constant/categorical color, truecolor grids,
+  and density scatter after that tier drops per-row color values.
 - Self-contained HTML blocks network access but requires inline script/style
   and a `blob:` worker under its emitted CSP. A nonce/hash-only host must serve
   the bundle and data through its own wrapper.

--- a/docs/api-reference/marks-and-components.md
+++ b/docs/api-reference/marks-and-components.md
@@ -39,9 +39,10 @@ axes_and_annotations_api()
 
 ## Chrome and Behavior
 
-Chrome components configure legends, tooltips, colorbar hooks, the modebar,
-theme tokens, and interaction behavior. The public colorbar component is
-minimal; it does not independently author ticks, title, orientation, or domain.
+Chrome components configure legends, tooltips, inferred colorbars, the modebar,
+theme tokens, and interaction behavior. `colorbar()` derives its domain and
+colormap from the last supported continuous mark, while `title`, `ticks`, and
+`orientation` control its presentation.
 
 ~~~python exec
 from xy_docs.api_reference import chrome_and_behavior_api

--- a/docs/api-reference/public-types.md
+++ b/docs/api-reference/public-types.md
@@ -18,7 +18,7 @@ construct lowercase factory results and only name these types in annotations.
 | `Axis` | X or y scale and tick specification |
 | `Legend` | Legend chrome or opaque framework replacement |
 | `Tooltip` | Tooltip chrome or opaque framework replacement |
-| `Colorbar` | Minimal colorbar chrome or replacement hook |
+| `Colorbar` | Inferred continuous-scale chrome or opaque framework replacement |
 | `Modebar` | Toolbar visibility and DOM styling |
 | `Theme` | Validated chart theme tokens |
 | `Interaction` | Browser interaction and linked-viewport configuration |

--- a/docs/app/pyproject.toml
+++ b/docs/app/pyproject.toml
@@ -6,21 +6,16 @@ requires-python = ">=3.11"
 dependencies = [
     "numpy",
     "pillow",
-    "reflex @ git+https://github.com/reflex-dev/reflex@carlos/reusable-docs-components",
-    "reflex-components-internal @ git+https://github.com/reflex-dev/reflex@carlos/reusable-docs-components#subdirectory=packages/reflex-components-internal",
-    "reflex-docgen @ git+https://github.com/reflex-dev/reflex@carlos/reusable-docs-components#subdirectory=packages/reflex-docgen",
+    "reflex @ git+https://github.com/reflex-dev/reflex@main",
+    "reflex-components-internal @ git+https://github.com/reflex-dev/reflex@main#subdirectory=packages/reflex-components-internal",
+    "reflex-docgen @ git+https://github.com/reflex-dev/reflex@main#subdirectory=packages/reflex-docgen",
     "reflex-xy",
-    "reflex-site-shared @ git+https://github.com/reflex-dev/reflex@carlos/reusable-docs-components#subdirectory=packages/reflex-site-shared",
+    "reflex-site-shared @ git+https://github.com/reflex-dev/reflex@main#subdirectory=packages/reflex-site-shared",
     "xy",
 ]
 
 [dependency-groups]
-dev = [
-    "codespell",
-    "pre-commit",
-    "pytest",
-    "ruff",
-]
+dev = ["codespell", "pre-commit", "pytest", "ruff"]
 
 [tool.uv.sources]
 reflex-xy = { path = "../../python/reflex-xy", editable = true }
@@ -37,42 +32,7 @@ allow-direct-references = true
 packages = ["xy_docs"]
 
 [tool.ruff]
-target-version = "py311"
-output-format = "concise"
-
-[tool.ruff.lint]
-select = [
-    "B",
-    "C4",
-    "D",
-    "E",
-    "F",
-    "FURB",
-    "I",
-    "N",
-    "PERF",
-    "PGH",
-    "RUF",
-    "SIM",
-    "T",
-    "TRY",
-    "W",
-]
-ignore = [
-    "D100",
-    "D104",
-    "E501",
-]
-allowed-confusables = ["’"]
-
-[tool.ruff.lint.isort]
-split-on-trailing-comma = false
-
-[tool.ruff.lint.pydocstyle]
-convention = "google"
-
-[tool.ruff.format]
-preview = true
+extend = "../../pyproject.toml"
 
 [tool.codespell]
 skip = "*/.venv/*,*/.web/*,*/assets/external/*,*/assets/xy/*,*/reflex.lock/*,*/uv.lock"

--- a/docs/app/scripts/check_html_routes.py
+++ b/docs/app/scripts/check_html_routes.py
@@ -44,11 +44,7 @@ def route_module_path(route: str) -> Path:
         Generated route module path.
     """
     parts = route.strip("/").split("/") if route.strip("/") else []
-    filename = (
-        ".".join(f"[{part}]" for part in parts) + "._index.jsx"
-        if parts
-        else "_index.jsx"
-    )
+    filename = ".".join(f"[{part}]" for part in parts) + "._index.jsx" if parts else "_index.jsx"
     return ROUTES_ROOT / filename
 
 

--- a/docs/app/scripts/check_markdown_assets.py
+++ b/docs/app/scripts/check_markdown_assets.py
@@ -20,9 +20,7 @@ def markdown_paths(route: str, *, is_index: bool) -> tuple[Path, Path]:
         Paths relative to the documentation build root.
     """
     route_path = Path(route.strip("/"))
-    direct_path = (
-        route_path / "index.md" if is_index else Path(f"{route.strip('/')}.md")
-    )
+    direct_path = route_path / "index.md" if is_index else Path(f"{route.strip('/')}.md")
     trailing_path = route_path / ".md" if route_path.parts else Path(".md")
     return direct_path, trailing_path
 

--- a/docs/app/tests/test_docs_site.py
+++ b/docs/app/tests/test_docs_site.py
@@ -11,7 +11,6 @@ from urllib.parse import urlparse
 
 import pytest
 import reflex_xy
-import xy
 from reflex_base.components.memo import MemoComponent
 from reflex_docgen.markdown import (
     Block,
@@ -53,6 +52,7 @@ from xy_docs.gallery import (
     _responsive_gallery_svg,
     chart_gallery_grid,
 )
+from xy_docs.markdown import render_xy_markdown_page
 from xy_docs.navbar import xy_docs_navbar
 from xy_docs.sidebar import (
     SIDEBAR_SECTION_GROUPS,
@@ -60,10 +60,15 @@ from xy_docs.sidebar import (
     xy_docs_sidebar_comp,
 )
 
+import xy
+from xy._validate import _POINT_SYMBOLS
+from xy.components import _MARK_APPLIERS
+
 SITEMAP_NAMESPACE = {"sitemap": "https://www.sitemaps.org/schemas/sitemap/0.9"}
 DOCS_APP_ROOT = Path(__file__).resolve().parent.parent
 DOCS_ROOT = DOCS_APP_ROOT.parent
 EXPORTED_SITEMAP = DOCS_APP_ROOT / ".web" / "public" / "sitemap.xml"
+EXPORTED_CLIENT_ASSETS = DOCS_APP_ROOT / ".web" / "build" / "client" / "docs" / "xy" / "assets"
 CHECK_HTML_ROUTES_PATH = DOCS_APP_ROOT / "scripts" / "check_html_routes.py"
 CHECK_HTML_ROUTES_SPEC = importlib.util.spec_from_file_location(
     "xy_docs_check_html_routes",
@@ -211,11 +216,7 @@ def test_public_markdown_routes_match_the_docs_navigation() -> None:
     )
     assert section_routes == DOCS_NAVIGATION
     assert (
-        max(
-            len(tuple(part for part in route.split("/") if part))
-            for route in section_routes
-        )
-        <= 2
+        max(len(tuple(part for part in route.split("/") if part)) for route in section_routes) <= 2
     )
 
     pages = discover_docs(DOCS_CONFIG)
@@ -230,12 +231,237 @@ def test_docs_app_configures_the_reflex_xy_adapter() -> None:
     assert any(isinstance(plugin, reflex_xy.XYPlugin) for plugin in config.plugins)
 
 
+def test_tailwind_styling_docs_match_the_reflex_plugin_contract() -> None:
+    """Keep the Reflex scan-path guidance aligned with the configured plugin."""
+    content = (DOCS_ROOT / "styling/chrome-slots.md").read_text(encoding="utf-8")
+
+    assert any(plugin.__class__.__name__ == "TailwindV4Plugin" for plugin in config.plugins)
+    assert "the adapter mirrors its chart, slot, mark, and annotation class strings" in content
+    assert "without adding the original Python or\nMarkdown file" in content
+    assert "Live token/Var charts are different" in content
+    assert "normal Reflex component (or safelist it" in content
+
+
+@pytest.mark.xfail(
+    not EXPORTED_CLIENT_ASSETS.is_dir(),
+    reason="Build the XY docs frontend before validating compiled Tailwind CSS.",
+    run=False,
+)
+def test_static_xy_tailwind_manifest_reaches_compiled_css() -> None:
+    """Prove an XYBF-only class survives the complete Tailwind build.
+
+    The sentinel is assembled from fragments in ``xy_docs.gallery``, so
+    Tailwind cannot find its complete arbitrary-property token in Python
+    source. The compiled route must receive it through ``tailwindClassTokens``
+    and the final stylesheet must contain the corresponding declaration.
+    """
+    javascript = "\n".join(
+        path.read_text(encoding="utf-8") for path in EXPORTED_CLIENT_ASSETS.glob("*.js")
+    )
+    stylesheets = "\n".join(
+        path.read_text(encoding="utf-8") for path in EXPORTED_CLIENT_ASSETS.glob("*.css")
+    )
+
+    sentinel = "[--xy-tailwind-bridge:compiled]"
+    assert "tailwindClassTokens" in javascript
+    assert sentinel in javascript
+    assert "--xy-tailwind-bridge:compiled" in stylesheets
+
+
+def test_styling_troubleshooting_covers_common_host_and_export_failures() -> None:
+    """Keep the public styling entry point useful when visual CSS fails."""
+    content = (DOCS_ROOT / "styling/index.md").read_text(encoding="utf-8")
+
+    for requirement in (
+        "## Styling troubleshooting",
+        "Tailwind classes are present but have no effect",
+        "A custom font silently falls back",
+        "Marks are WebGL/canvas geometry",
+        "to_html(custom_css=...)",
+        "engine=Engine.chromium",
+        "overflow-hidden",
+        'height="100%"',
+        "normal cascade",
+    ):
+        assert requirement in content
+
+
+def test_component_styling_matrix_covers_public_chrome_boundaries() -> None:
+    """Keep the styling guide explicit about built-in and custom components."""
+    content = (DOCS_ROOT / "styling/component-variations.md").read_text(encoding="utf-8")
+    expected = {
+        "legend_item",
+        "legend_swatch",
+        "tooltip(fields=..., title=..., format=...)",
+        "x_axis(...)",
+        "y_axis(...)",
+        "vline(x)",
+        "hline(y)",
+        "crosshair_x",
+        "crosshair_y",
+        "selection",
+        "legend(render=...)",
+        "tooltip(render=...)",
+        "colorbar(render=...)",
+    }
+
+    missing = {value for value in expected if value not in content}
+    assert not missing
+    assert 'id="x2"' in content
+    assert 'side="top"' in content
+    assert "button_class_name=" in content
+    assert "button_style=" in content
+    assert "does not render components passed through" in content
+    assert "Standalone exports cannot include framework-owned components either." in content
+
+
+def test_styling_docs_cover_every_public_dom_slot() -> None:
+    """Make a new stable browser slot fail docs CI until it is documented."""
+    chrome = (DOCS_ROOT / "styling/chrome-slots.md").read_text(encoding="utf-8")
+    variations = (DOCS_ROOT / "styling/component-variations.md").read_text(encoding="utf-8")
+
+    assert all(f"`{slot}`" in chrome for slot in xy.CHART_DOM_SLOTS)
+    for slot in ("root", "title", "chrome", "canvas", "labels", "badge", "badge_item"):
+        assert f"`{slot}`" in variations
+
+
+def test_styling_docs_cover_every_rendered_mark_family() -> None:
+    """Tie the mark-style matrix to the actual declarative mark registry."""
+    content = (DOCS_ROOT / "styling/mark-styles.md").read_text(encoding="utf-8").lower()
+
+    missing = {
+        kind
+        for kind in _MARK_APPLIERS
+        if kind not in content and kind.replace("_", " ") not in content
+    }
+    assert not missing
+
+
+def test_styling_gallery_exercises_every_rendered_mark_family() -> None:
+    """Keep the visual styling atlas complete as XY gains mark families."""
+    content = (DOCS_ROOT / "styling/gallery.md").read_text(encoding="utf-8").lower()
+
+    missing = {
+        kind
+        for kind in _MARK_APPLIERS
+        if f"`{kind}`" not in content and f"`{kind.replace('_', ' ')}`" not in content
+    }
+    assert not missing
+
+    required_surfaces = {
+        "responsive",
+        "prefers-color-scheme",
+        "custom legend",
+        "custom tooltip",
+        "reduction badge",
+        "facet_chart",
+        "categorical",
+        "time axis",
+        "to_html(custom_css=",
+        "xy.interaction_config(",
+        "hover=true",
+        "click=true",
+        "select=true",
+        "brush=true",
+        "crosshair=true",
+        "view_change=true",
+        'loc="upper center"',
+        "critical-payments-reconciliation-with-extra-long-label",
+    }
+    assert all(surface in content for surface in required_surfaces)
+    assert len(_POINT_SYMBOLS) == 17
+    assert all(f'"{symbol}"' in content for symbol in _POINT_SYMBOLS)
+    assert 'mode="grouped"' in content
+    assert 'mode="normalized"' in content
+    assert 'mode="stacked"' in content
+    assert 'orientation="vertical"' in content
+    assert 'orientation="horizontal"' in content
+    assert "colorbar_bar" in content
+    assert "colorbar_tick" in content
+    assert "colorbar_title" in content
+
+
+def test_markdown_heading_links_are_route_local_after_client_navigation() -> None:
+    """Do not let a previously visited docs route leak into heading self-links."""
+    pages = {page.route: page for page in discover_docs(DOCS_CONFIG)}
+
+    for route in ("/overview/gallery/", "/styling/gallery/"):
+        rendered = str(render_xy_markdown_page(pages[route]))
+        assert 'to:"#' in rendered
+        assert "router_rx_state_" not in rendered
+
+
+def test_colorbar_docs_match_the_declarative_and_custom_boundaries() -> None:
+    """Keep inferred built-ins distinct from opaque framework replacements."""
+    content = (DOCS_ROOT / "components/colorbars.md").read_text(encoding="utf-8")
+
+    for option in (
+        "title=",
+        "orientation=",
+        "ticks=",
+        "colorbar(show=False)",
+    ):
+        assert option in content
+    for slot in ("colorbar", "colorbar_bar", "colorbar_tick", "colorbar_title"):
+        assert f"`{slot}`" in content
+    assert "The last compatible continuous mark wins" in content
+    assert "does not currently mount custom chrome" in content
+
+
+def test_custom_font_docs_cover_browser_and_static_export_boundaries() -> None:
+    """Keep font loading advice honest across browser and native outputs."""
+    content = (DOCS_ROOT / "styling/themes-and-tokens.md").read_text(encoding="utf-8")
+
+    for requirement in (
+        "## Custom fonts and export limitations",
+        "@font-face",
+        'style={"font_family":',
+        "Engine.chromium",
+        "Toolbar PNG",
+        "Toolbar SVG",
+        "Native PNG",
+        "Python `to_svg()`",
+        "baked bitmap font",
+    ):
+        assert requirement in content
+
+
+def test_generated_mark_api_does_not_claim_canvas_marks_are_dom_nodes() -> None:
+    """Keep generated class_name descriptions aligned with canvas rendering."""
+    for factory in MARKS:
+        if "class_name" not in inspect.signature(factory).parameters:
+            continue
+        docstring = inspect.getdoc(factory) or ""
+        assert "DOM class name applied to the mark" not in docstring
+        assert "Adapter-only trace metadata" in docstring
+
+
+def test_styling_docs_cover_every_annotation_factory_and_alias() -> None:
+    """Keep every public annotation primitive visible in the styling guide."""
+    content = (DOCS_ROOT / "styling/component-variations.md").read_text(encoding="utf-8")
+    factories = (
+        "vline",
+        "hline",
+        "x_band",
+        "y_band",
+        "text",
+        "label",
+        "marker",
+        "arrow",
+        "threshold",
+        "threshold_zone",
+        "callout",
+    )
+
+    assert all(f"`{factory}" in content for factory in factories)
+
+
 def test_what_is_xy_shows_density_hero_without_inline_code() -> None:
     """Keep the signature example visible without exposing its long source."""
     content = (DOCS_ROOT / "index.md").read_text(encoding="utf-8")
-    demo_source = (
-        DOCS_APP_ROOT / "xy_docs/demos/instrument_sans_density.py"
-    ).read_text(encoding="utf-8")
+    demo_source = (DOCS_APP_ROOT / "xy_docs/demos/instrument_sans_density.py").read_text(
+        encoding="utf-8"
+    )
     font = DOCS_APP_ROOT / "xy_docs/assets/InstrumentSans-wdth-wght.ttf"
     license_file = DOCS_APP_ROOT / "xy_docs/assets/OFL.txt"
 
@@ -246,9 +472,7 @@ def test_what_is_xy_shows_density_hero_without_inline_code() -> None:
 
     assert introduction < styling < hero < early_alpha
     assert "demo exec toggle" not in content
-    assert (
-        "from xy_docs.demos.instrument_sans_density import xy_density_hero" in content
-    )
+    assert "from xy_docs.demos.instrument_sans_density import xy_density_hero" in content
     assert "View the complete Python source" in content
     assert "N_POINTS = 40_000" in demo_source
     assert "N_INLIERS = round(N_POINTS * 0.97)" in demo_source
@@ -258,9 +482,7 @@ def test_what_is_xy_shows_density_hero_without_inline_code() -> None:
     assert hashlib.sha256(font.read_bytes()).hexdigest() == (
         "b24f1812584816958afcf22e22d08e44318c5e51651e25d2438efdde389b33b1"
     )
-    assert "SIL OPEN FONT LICENSE Version 1.1" in license_file.read_text(
-        encoding="utf-8"
-    )
+    assert "SIL OPEN FONT LICENSE Version 1.1" in license_file.read_text(encoding="utf-8")
 
 
 def test_density_hero_toolbar_follows_reflex_color_mode() -> None:
@@ -312,16 +534,12 @@ def test_live_preview_markdown_builds_real_xy_components(
 ) -> None:
     """Compile every live preview through docgen and the static XY adapter."""
     app_payload_dir = DOCS_APP_ROOT / "assets" / "xy"
-    app_payloads_before = {
-        path: path.read_bytes() for path in app_payload_dir.glob("*.xyf")
-    }
+    app_payloads_before = {path: path.read_bytes() for path in app_payload_dir.glob("*.xyf")}
     monkeypatch.chdir(tmp_path)
     pages = [
         page
         for page in discover_docs(DOCS_CONFIG)
-        if any(
-            marker in page.content for marker in check_html_routes.LIVE_PREVIEW_MARKERS
-        )
+        if any(marker in page.content for marker in check_html_routes.LIVE_PREVIEW_MARKERS)
     ]
 
     assert pages
@@ -336,19 +554,51 @@ def test_live_preview_markdown_builds_real_xy_components(
         )
         assert "XYChart" in rendered, page.relative_path
         assert "Interactive preview coming soon" not in page.content
-        page_payloads = set(
-            re.findall(r'src:"(?:/docs/xy)?/xy/([^"]+\.xyf)"', rendered)
-        )
+        page_payloads = set(re.findall(r'src:"(?:/docs/xy)?/xy/([^"]+\.xyf)"', rendered))
         assert page_payloads, page.relative_path
         referenced_payloads.update(page_payloads)
 
-    generated_payloads = {
-        path.name for path in (tmp_path / "assets" / "xy").glob("*.xyf")
-    }
+    generated_payloads = {path.name for path in (tmp_path / "assets" / "xy").glob("*.xyf")}
     assert generated_payloads == referenced_payloads
     assert {
         path: path.read_bytes() for path in app_payload_dir.glob("*.xyf")
     } == app_payloads_before
+
+
+def test_complete_styling_examples_render_live_previews() -> None:
+    """Do not show component-producing styling examples as source code only."""
+    violations: list[str] = []
+    for path in sorted((DOCS_ROOT / "styling").glob("*.md")):
+        content = path.read_text(encoding="utf-8")
+        for fence, body in re.findall(r"~~~(python[^\n]*)\n(.*?)\n~~~", content, re.DOTALL):
+            if re.search(r"^def\s+\w+\(", body, re.MULTILINE) and "demo exec" not in fence:
+                violations.append(f"{path.relative_to(DOCS_ROOT)}: {fence}")
+
+    assert not violations, "\n".join(violations)
+
+
+def test_styling_demos_pair_light_surfaces_with_readable_text() -> None:
+    """Prevent light demo panels from inheriting low-contrast dark-mode text."""
+    violations: list[str] = []
+    for path in sorted((DOCS_ROOT / "styling").glob("*.md")):
+        content = path.read_text(encoding="utf-8")
+        for _fence, body in re.findall(
+            r"~~~(python demo exec[^\n]*)\n(.*?)\n~~~",
+            content,
+            re.DOTALL,
+        ):
+            if "bg-white" in body and "dark:bg" not in body:
+                violations.append(f"{path.relative_to(DOCS_ROOT)}: unpaired bg-white")
+            if re.search(r'(?:plot_background|"background")\s*[:=]\s*"#f', body):
+                violations.append(f"{path.relative_to(DOCS_ROOT)}: fixed light background")
+            if '"background": "rgb(255 255 255' in body and '"color":' not in body:
+                violations.append(f"{path.relative_to(DOCS_ROOT)}: light component without color")
+
+    assert not violations, "\n".join(violations)
+
+    gallery = (DOCS_ROOT / "styling/gallery.md").read_text(encoding="utf-8")
+    assert '"background": "var(--chart-bg)"' in gallery
+    assert '"colorbar_tick": {"color": "var(--chart-text)"}' in gallery
 
 
 @pytest.mark.parametrize(
@@ -436,16 +686,12 @@ def test_chart_gallery_grid_renders_every_type_with_bounded_live_previews(
 ) -> None:
     """Show every chart type without exceeding the live WebGL context budget."""
     app_payload_dir = DOCS_APP_ROOT / "assets" / "xy"
-    app_payloads_before = {
-        path: path.read_bytes() for path in app_payload_dir.glob("*.xyf")
-    }
+    app_payloads_before = {path: path.read_bytes() for path in app_payload_dir.glob("*.xyf")}
     monkeypatch.chdir(tmp_path)
 
     rendered = str(chart_gallery_grid())
     chart_section = next(
-        leaves
-        for title, _landing_route, _icon, leaves in DOCS_SECTIONS
-        if title == "Chart Gallery"
+        leaves for title, _landing_route, _icon, leaves in DOCS_SECTIONS if title == "Chart Gallery"
     )
     assert len(chart_section) == 9
     assert rendered.count("XYChart") == 9
@@ -453,12 +699,7 @@ def test_chart_gallery_grid_renders_every_type_with_bounded_live_previews(
     assert rendered.count("dangerouslySetInnerHTML") == 19
     assert rendered.count('id:"xy-chart-gallery"') == 1
     assert rendered.count("main:has(#xy-chart-gallery) > div:has(#toc-navigation)") == 1
-    assert (
-        rendered.count(
-            "main:has(#xy-chart-gallery) > div:has(article #xy-chart-gallery)"
-        )
-        == 1
-    )
+    assert rendered.count("main:has(#xy-chart-gallery) > div:has(article #xy-chart-gallery)") == 1
     assert rendered.count("display: none") == 1
     assert rendered.count("max-width: 88rem") == 1
     assert rendered.count("2xl:grid-cols-3") == 9
@@ -511,10 +752,7 @@ def test_chart_gallery_grid_renders_every_type_with_bounded_live_previews(
 
 def test_chart_gallery_combines_only_the_requested_related_tiles() -> None:
     """Merge Step/Stairs and Bar/Column without collapsing other chart types."""
-    titles = {
-        title
-        for title, _description, _route, _chart_factory, _live in _iter_gallery_items()
-    }
+    titles = {title for title, _description, _route, _chart_factory, _live in _iter_gallery_items()}
 
     assert len(titles) == 28
     assert {"Step + Stairs", "Bar + Column"} <= titles
@@ -536,18 +774,14 @@ def test_chart_gallery_hides_the_modebar_from_every_preview() -> None:
     """Keep compact gallery tiles focused on the chart itself."""
     for _title, _description, _route, chart_factory, _live in _iter_gallery_items():
         chart = _gallery_chart(chart_factory)
-        modebars = [
-            child for child in chart.children if type(child).__name__ == "Modebar"
-        ]
+        modebars = [child for child in chart.children if type(child).__name__ == "Modebar"]
         assert len(modebars) == 1
         assert modebars[0].show is False
 
 
 def test_chart_gallery_uses_only_purple_and_gray() -> None:
     """Keep every rendered gallery preview inside one restrained palette."""
-    svg_paint = re.compile(
-        r"#[0-9a-fA-F]{6}|rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+(?:\s*,[^)]*)?\)"
-    )
+    svg_paint = re.compile(r"#[0-9a-fA-F]{6}|rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+(?:\s*,[^)]*)?\)")
 
     def _paint_rgb(paint: str) -> tuple[int, int, int]:
         if paint.startswith("#"):
@@ -642,9 +876,7 @@ def test_chart_gallery_previews_follow_the_site_color_mode() -> None:
     }
 
     for chart in charts:
-        theme = next(
-            child for child in chart.children if type(child).__name__ == "Theme"
-        )
+        theme = next(child for child in chart.children if type(child).__name__ == "Theme")
         assert theme.style == expected_theme
 
         svg = _responsive_gallery_svg(chart)
@@ -754,9 +986,7 @@ def test_xy_sitemap_path_normalization_requires_the_exact_frontend_path() -> Non
     """Normalize canonical locations without accepting sibling docs sites."""
     assert _normalize_xy_docs_path("https://reflex.dev/docs/xy/") == "/"
     assert (
-        _normalize_xy_docs_path(
-            "https://reflex.dev/docs/xy/charts/scatter/?source=test#example"
-        )
+        _normalize_xy_docs_path("https://reflex.dev/docs/xy/charts/scatter/?source=test#example")
         == "/charts/scatter"
     )
     assert _normalize_xy_docs_path("https://reflex.dev/docs/charts/") is None
@@ -770,9 +1000,7 @@ def test_xy_link_walker_resolves_references_and_ignores_code_fences() -> None:
         "```markdown\n[not a link](/docs/xy/missing/)\n```\n"
     )
 
-    assert [link.target for link in _walk_blocks(document.blocks)] == [
-        "/docs/xy/charts/"
-    ]
+    assert [link.target for link in _walk_blocks(document.blocks)] == ["/docs/xy/charts/"]
 
 
 def test_xy_sidebar_reuses_memoized_official_navigation_rows() -> None:
@@ -844,9 +1072,7 @@ def test_xy_mobile_navbar_uses_the_official_drawer_button() -> None:
 
 def test_xy_breadcrumb_opens_the_official_docs_sidebar_drawer() -> None:
     """Reuse the complete memoized sidebar in the mobile page-header drawer."""
-    page = next(
-        page for page in discover_docs(DOCS_CONFIG) if page.route == "/charts/scatter/"
-    )
+    page = next(page for page in discover_docs(DOCS_CONFIG) if page.route == "/charts/scatter/")
 
     rendered = str(xy_docs_breadcrumb(page, xy_docs_sidebar(page.route)))
 
@@ -857,6 +1083,20 @@ def test_xy_breadcrumb_opens_the_official_docs_sidebar_drawer() -> None:
     assert "/charts/" in rendered
     assert "/charts/scatter/" in rendered
     assert "ArrowDown01Icon" in rendered
+
+
+def test_xy_breadcrumb_shortens_the_modebar_page_label() -> None:
+    """Keep the longest component route from overflowing the mobile header."""
+    page = next(
+        page
+        for page in discover_docs(DOCS_CONFIG)
+        if page.route == "/components/modebars-and-interaction-controls/"
+    )
+
+    rendered = str(xy_docs_breadcrumb(page, xy_docs_sidebar(page.route)))
+
+    assert "Modebars & Controls" in rendered
+    assert "Modebars And Interaction Controls" not in rendered
 
 
 def test_xy_footer_reuses_official_footer_with_source_aware_links() -> None:

--- a/docs/app/tests/test_docs_site.py
+++ b/docs/app/tests/test_docs_site.py
@@ -52,7 +52,7 @@ from xy_docs.gallery import (
     _responsive_gallery_svg,
     chart_gallery_grid,
 )
-from xy_docs.markdown import render_xy_markdown_page
+from xy_docs.markdown import XyDocsMarkdownTransformer, render_xy_markdown_page
 from xy_docs.navbar import xy_docs_navbar
 from xy_docs.sidebar import (
     SIDEBAR_SECTION_GROUPS,
@@ -426,6 +426,39 @@ def test_custom_font_docs_cover_browser_and_static_export_boundaries() -> None:
         assert requirement in content
 
 
+def test_theme_component_demo_uses_site_color_mode_tokens() -> None:
+    """Keep the introductory theme demo neutral and responsive to site mode."""
+    content = (DOCS_ROOT / "styling/themes-and-tokens.md").read_text(encoding="utf-8")
+    demo = content.split("~~~python demo exec", 1)[1].split("~~~", 1)[0]
+
+    for token in (
+        "var(--secondary-2)",
+        "var(--secondary-a5)",
+        "var(--secondary-a8)",
+        "var(--secondary-11)",
+        "var(--primary-9)",
+    ):
+        assert token in demo
+    assert "--demo-bg" not in demo
+
+
+def test_accessible_monochrome_recipe_uses_neutral_site_tokens() -> None:
+    """Keep the monochrome recipe neutral in both site color modes."""
+    content = (DOCS_ROOT / "styling/recipes.md").read_text(encoding="utf-8")
+    section = content.split("## Accessible monochrome comparison", 1)[1].split("## ", 1)[0]
+
+    for token in (
+        "var(--secondary-2)",
+        "var(--secondary-a5)",
+        "var(--secondary-a8)",
+        "var(--secondary-10)",
+        "var(--secondary-11)",
+        "var(--secondary-12)",
+    ):
+        assert token in section
+    assert "--mono-bg" not in section
+
+
 def test_generated_mark_api_does_not_claim_canvas_marks_are_dom_nodes() -> None:
     """Keep generated class_name descriptions aligned with canvas rendering."""
     for factory in MARKS:
@@ -575,6 +608,44 @@ def test_complete_styling_examples_render_live_previews() -> None:
                 violations.append(f"{path.relative_to(DOCS_ROOT)}: {fence}")
 
     assert not violations, "\n".join(violations)
+
+
+def test_single_chart_styling_demos_keep_only_the_parent_preview_card() -> None:
+    """Keep Live Demo chrome while avoiding a second chart-owned surface."""
+    gallery = (DOCS_ROOT / "styling/gallery.md").read_text(encoding="utf-8")
+    blocks = re.findall(r"~~~(python[^\n]*)\n(.*?)\n~~~", gallery, re.DOTALL)
+    long_legend = next(
+        body for _fence, body in blocks if "long_legend_edge_tooltip_preview" in body
+    )
+    facets = next(body for _fence, body in blocks if "styled_facet_preview" in body)
+
+    chrome_slots = (DOCS_ROOT / "styling/chrome-slots.md").read_text(encoding="utf-8")
+    chrome_blocks = re.findall(r"~~~(python[^\n]*)\n(.*?)\n~~~", chrome_slots, re.DOTALL)
+    tailwind_chrome = next(
+        body for _fence, body in chrome_blocks if "tailwind_chrome_preview" in body
+    )
+
+    assert "rounded-2xl border border-slate-200 bg-white" not in long_legend
+    assert "overflow-hidden rounded-xl border border-slate-200" not in facets
+    assert "rounded-xl border border-slate-200 bg-white" not in tailwind_chrome
+
+    content = """~~~python demo exec
+import reflex as rx
+
+def one_chart_preview():
+    return rx.box("chart", width="100%")
+~~~"""
+    rendered = str(
+        XyDocsMarkdownTransformer(
+            virtual_filepath="docs/styling/test.md",
+            filename="docs/styling/test.md",
+        ).transform(parse_document(content))
+    )
+    parent_card = (
+        'className:"flex flex-col p-6 rounded-xl overflow-x-auto border '
+        'border-secondary-4 bg-secondary-2 items-center justify-center w-full"'
+    )
+    assert rendered.count(parent_card) == 1
 
 
 def test_styling_demos_pair_light_surfaces_with_readable_text() -> None:

--- a/docs/app/tests/test_framework_integration_examples.py
+++ b/docs/app/tests/test_framework_integration_examples.py
@@ -6,9 +6,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-FRAMEWORK_INTEGRATION_DOC = (
-    Path(__file__).resolve().parents[2] / "integrations" / "reflex.md"
-)
+FRAMEWORK_INTEGRATION_DOC = Path(__file__).resolve().parents[2] / "integrations" / "reflex.md"
 
 
 def _python_examples() -> dict[str, str]:

--- a/docs/app/uv.lock
+++ b/docs/app/uv.lock
@@ -177,11 +177,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.30.1"
+version = "3.30.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/b7/e82e2bf111ba6ea135062e556f2ed7f4ff1c17a6c385e95ffddd99885535/filelock-3.30.1.tar.gz", hash = "sha256:6ad1b1ec6a5e2c91e02979b7d1096e5e964d83ad8a55679bacd1d96f917fda6e", size = 176008, upload-time = "2026-07-16T16:59:22.201Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/f7/2165ef325da22d854b8f81ca4799395f2eb6afa55cdb52c7710f028b5336/filelock-3.30.2.tar.gz", hash = "sha256:1ea7c857465c897a4a6e64c1aace28ff6b83f5bc66c1c06ea148efa65bc2ec5d", size = 176823, upload-time = "2026-07-16T19:50:42.724Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/5e/6060a5791d3d5b54aae21c510eb2f76a51e1b28c2122cc1e39b12237e2e7/filelock-3.30.1-py3-none-any.whl", hash = "sha256:69b98bab51bed4c86b141ef338f85ca07937573e8a7798f7fe6a31ccd94b9338", size = 93698, upload-time = "2026-07-16T16:59:20.727Z" },
+    { url = "https://files.pythonhosted.org/packages/02/df/05118016cad66cd0d7c9417b2d4fc245be35decc4c36810f3c8dbf729d88/filelock-3.30.2-py3-none-any.whl", hash = "sha256:a64b58f75048ec39589983e97f5117163f822261dcb6ba843e098f05aac9663f", size = 94092, upload-time = "2026-07-16T19:50:41.189Z" },
 ]
 
 [[package]]
@@ -1094,8 +1094,8 @@ wheels = [
 
 [[package]]
 name = "reflex"
-version = "0.9.7.post9.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "0.9.7.post4.dev0+2edaf128"
+source = { git = "https://github.com/reflex-dev/reflex?rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 dependencies = [
     { name = "click" },
     { name = "granian", extra = ["reload"] },
@@ -1127,8 +1127,8 @@ dependencies = [
 
 [[package]]
 name = "reflex-base"
-version = "0.9.7.post9.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-base&rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "0.9.7.post4.dev0+2edaf128"
+source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-base&rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 dependencies = [
     { name = "packaging" },
     { name = "platformdirs" },
@@ -1139,8 +1139,8 @@ dependencies = [
 
 [[package]]
 name = "reflex-components-code"
-version = "0.9.2.post205.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-code&rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "0.9.2.post200.dev0+2edaf128"
+source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-code&rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 dependencies = [
     { name = "reflex-base" },
     { name = "reflex-components-core" },
@@ -1150,8 +1150,8 @@ dependencies = [
 
 [[package]]
 name = "reflex-components-core"
-version = "0.9.7.post8.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-core&rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "0.9.7.post3.dev0+2edaf128"
+source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-core&rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 dependencies = [
     { name = "python-multipart" },
     { name = "reflex-base" },
@@ -1163,8 +1163,8 @@ dependencies = [
 
 [[package]]
 name = "reflex-components-dataeditor"
-version = "0.9.1.post245.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-dataeditor&rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "0.9.1.post240.dev0+2edaf128"
+source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-dataeditor&rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 dependencies = [
     { name = "reflex-base" },
     { name = "reflex-components-core" },
@@ -1172,32 +1172,32 @@ dependencies = [
 
 [[package]]
 name = "reflex-components-gridjs"
-version = "0.9.1.post245.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-gridjs&rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "0.9.1.post240.dev0+2edaf128"
+source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-gridjs&rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 dependencies = [
     { name = "reflex-base" },
 ]
 
 [[package]]
 name = "reflex-components-internal"
-version = "0.0.23.post43.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-internal&rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "0.0.23.post38.dev0+2edaf128"
+source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-internal&rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 dependencies = [
     { name = "reflex" },
 ]
 
 [[package]]
 name = "reflex-components-lucide"
-version = "1.0.2.post88.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-lucide&rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "1.0.2.post83.dev0+2edaf128"
+source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-lucide&rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 dependencies = [
     { name = "reflex-base" },
 ]
 
 [[package]]
 name = "reflex-components-markdown"
-version = "0.9.3.post113.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-markdown&rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "0.9.3.post108.dev0+2edaf128"
+source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-markdown&rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 dependencies = [
     { name = "reflex-base" },
     { name = "reflex-components-code" },
@@ -1207,16 +1207,16 @@ dependencies = [
 
 [[package]]
 name = "reflex-components-moment"
-version = "0.9.2.post54.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-moment&rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "0.9.2.post49.dev0+2edaf128"
+source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-moment&rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 dependencies = [
     { name = "reflex-base" },
 ]
 
 [[package]]
 name = "reflex-components-plotly"
-version = "0.9.3.post54.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-plotly&rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "0.9.3.post49.dev0+2edaf128"
+source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-plotly&rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 dependencies = [
     { name = "reflex-base" },
     { name = "reflex-components-core" },
@@ -1224,8 +1224,8 @@ dependencies = [
 
 [[package]]
 name = "reflex-components-radix"
-version = "0.9.6.post8.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-radix&rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "0.9.6.post3.dev0+2edaf128"
+source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-radix&rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 dependencies = [
     { name = "reflex-base" },
     { name = "reflex-components-core" },
@@ -1234,8 +1234,8 @@ dependencies = [
 
 [[package]]
 name = "reflex-components-react-player"
-version = "0.9.1.post245.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-react-player&rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "0.9.1.post240.dev0+2edaf128"
+source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-react-player&rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 dependencies = [
     { name = "reflex-base" },
     { name = "reflex-components-core" },
@@ -1243,16 +1243,16 @@ dependencies = [
 
 [[package]]
 name = "reflex-components-recharts"
-version = "0.9.1.post245.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-recharts&rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "0.9.1.post240.dev0+2edaf128"
+source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-recharts&rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 dependencies = [
     { name = "reflex-base" },
 ]
 
 [[package]]
 name = "reflex-components-sonner"
-version = "0.9.1.post245.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-sonner&rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "0.9.1.post240.dev0+2edaf128"
+source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-sonner&rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 dependencies = [
     { name = "reflex-base" },
     { name = "reflex-components-lucide" },
@@ -1260,8 +1260,8 @@ dependencies = [
 
 [[package]]
 name = "reflex-docgen"
-version = "0.9.3.post8.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-docgen&rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "0.9.3.post3.dev0+2edaf128"
+source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-docgen&rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 dependencies = [
     { name = "griffelib" },
     { name = "mistletoe" },
@@ -1272,8 +1272,8 @@ dependencies = [
 
 [[package]]
 name = "reflex-hosting-cli"
-version = "0.1.67.post72.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-hosting-cli&rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "0.1.67.post67.dev0+2edaf128"
+source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-hosting-cli&rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 dependencies = [
     { name = "click" },
     { name = "httpx" },
@@ -1284,13 +1284,13 @@ dependencies = [
 
 [[package]]
 name = "reflex-integrations-docs"
-version = "0.0.0.post3251.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Fintegrations-docs&rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "0.0.0.post3246.dev0+2edaf128"
+source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Fintegrations-docs&rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 
 [[package]]
 name = "reflex-site-shared"
-version = "0.0.36.post42.dev0+4f818610"
-source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-site-shared&rev=carlos%2Freusable-docs-components#4f818610e125eeed022cd60fcdb1f9f1f983aff1" }
+version = "0.0.37"
+source = { git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-site-shared&rev=main#2edaf12869894e146b92f32e5de2d1816a2f3512" }
 dependencies = [
     { name = "email-validator" },
     { name = "httpx" },
@@ -1690,7 +1690,7 @@ wheels = [
 
 [[package]]
 name = "xy"
-version = "0.1.0"
+version = "0.0.1"
 source = { editable = "../../" }
 dependencies = [
     { name = "anywidget" },
@@ -1740,10 +1740,10 @@ dev = [
 requires-dist = [
     { name = "numpy" },
     { name = "pillow" },
-    { name = "reflex", git = "https://github.com/reflex-dev/reflex?rev=carlos%2Freusable-docs-components" },
-    { name = "reflex-components-internal", git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-internal&rev=carlos%2Freusable-docs-components" },
-    { name = "reflex-docgen", git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-docgen&rev=carlos%2Freusable-docs-components" },
-    { name = "reflex-site-shared", git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-site-shared&rev=carlos%2Freusable-docs-components" },
+    { name = "reflex", git = "https://github.com/reflex-dev/reflex?rev=main" },
+    { name = "reflex-components-internal", git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-components-internal&rev=main" },
+    { name = "reflex-docgen", git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-docgen&rev=main" },
+    { name = "reflex-site-shared", git = "https://github.com/reflex-dev/reflex?subdirectory=packages%2Freflex-site-shared&rev=main" },
     { name = "reflex-xy", editable = "../../python/reflex-xy" },
     { name = "xy", editable = "../../" },
 ]

--- a/docs/app/xy_docs/api_reference.py
+++ b/docs/app/xy_docs/api_reference.py
@@ -1,11 +1,12 @@
 """Generated API-reference sections for XY's public component factories."""
 
 import reflex as rx
-import xy
 from reflex_site_shared.components.docs_api import (
     callable_api_group,
     callable_api_reference,
 )
+
+import xy
 
 CHART_FACTORY_GROUPS = (
     (

--- a/docs/app/xy_docs/breadcrumb.py
+++ b/docs/app/xy_docs/breadcrumb.py
@@ -5,6 +5,10 @@ import reflex_components_internal as ui
 from reflex_site_shared.docs.models import DocsPage
 from reflex_site_shared.views.sidebar import docs_sidebar_drawer
 
+_BREADCRUMB_LABELS = {
+    "modebars-and-interaction-controls": "Modebars & Controls",
+}
+
 
 def _breadcrumb_label(segment: str) -> str:
     """Convert one URL segment to its visible breadcrumb label.
@@ -15,7 +19,7 @@ def _breadcrumb_label(segment: str) -> str:
     Returns:
         Title-cased breadcrumb label.
     """
-    return segment.replace("-", " ").title()
+    return _BREADCRUMB_LABELS.get(segment, segment.replace("-", " ").title())
 
 
 def xy_docs_breadcrumb(page: DocsPage, sidebar: rx.Component) -> rx.Component:
@@ -51,16 +55,18 @@ def xy_docs_breadcrumb(page: DocsPage, sidebar: rx.Component) -> rx.Component:
             )
         )
         if index < len(segments) - 1:
-            breadcrumbs.extend((
-                ui.icon(
-                    "ArrowRight01Icon",
-                    class_name="hidden size-4 text-secondary-11 lg:flex",
-                ),
-                rx.text(
-                    "/",
-                    class_name="flex font-sm text-secondary-11 lg:hidden",
-                ),
-            ))
+            breadcrumbs.extend(
+                (
+                    ui.icon(
+                        "ArrowRight01Icon",
+                        class_name="hidden size-4 text-secondary-11 lg:flex",
+                    ),
+                    rx.text(
+                        "/",
+                        class_name="flex font-sm text-secondary-11 lg:hidden",
+                    ),
+                )
+            )
 
     if not breadcrumbs:
         breadcrumbs.append(

--- a/docs/app/xy_docs/config.py
+++ b/docs/app/xy_docs/config.py
@@ -43,7 +43,9 @@ DOCS_SECTIONS = (
         "palette",
         (
             ("Overview", "/styling/"),
+            ("Styling Gallery", "/styling/gallery/"),
             ("Chrome Slots", "/styling/chrome-slots/"),
+            ("Component Variations", "/styling/component-variations/"),
             ("Mark Styles", "/styling/mark-styles/"),
             ("Themes and Tokens", "/styling/themes-and-tokens/"),
             ("Recipes", "/styling/recipes/"),
@@ -76,7 +78,7 @@ DOCS_SECTIONS = (
             ("Tooltips", "/components/tooltips/"),
             ("Colorbars", "/components/colorbars/"),
             (
-                "Modebars and Interaction Controls",
+                "Modebars & Controls",
                 "/components/modebars-and-interaction-controls/",
             ),
             ("Annotations", "/components/annotations/"),

--- a/docs/app/xy_docs/demos/instrument_sans_density.py
+++ b/docs/app/xy_docs/demos/instrument_sans_density.py
@@ -4,8 +4,9 @@ from importlib.resources import files
 
 import numpy as np
 import reflex_xy
-import xy
 from PIL import Image, ImageDraw, ImageFont
+
+import xy
 
 N_POINTS = 40_000
 N_INLIERS = round(N_POINTS * 0.97)
@@ -55,12 +56,14 @@ def _inside(mask, points):
 
 def _sample_glyph(mask, box, count, correlation):
     x0, y0, x1, y1 = box
-    bounds = np.array([
-        (x0 - _left) / _pixels_per_unit,
-        (_bottom - y1) / _pixels_per_unit,
-        (x1 - _left) / _pixels_per_unit,
-        (_bottom - y0) / _pixels_per_unit,
-    ])
+    bounds = np.array(
+        [
+            (x0 - _left) / _pixels_per_unit,
+            (_bottom - y1) / _pixels_per_unit,
+            (x1 - _left) / _pixels_per_unit,
+            (_bottom - y0) / _pixels_per_unit,
+        ]
+    )
     center = bounds.reshape(2, 2).mean(axis=0)
     width, height = bounds[2:] - bounds[:2]
     sx, sy = width * 0.42, height * 0.44
@@ -81,10 +84,12 @@ def _sample_glyph(mask, box, count, correlation):
 
 
 _n_x = round(N_INLIERS * 0.48)
-_inliers = np.vstack((
-    _sample_glyph(_x_mask, _x_box, _n_x, 0.08),
-    _sample_glyph(_y_mask, _y_box, N_INLIERS - _n_x, -0.10),
-))
+_inliers = np.vstack(
+    (
+        _sample_glyph(_x_mask, _x_box, _n_x, 0.08),
+        _sample_glyph(_y_mask, _y_box, N_INLIERS - _n_x, -0.10),
+    )
+)
 _xlim = (-3.5, (_right - _left) / _pixels_per_unit + 3.5)
 _ylim = (-3.5, (_bottom - _top) / _pixels_per_unit + 3.5)
 
@@ -95,10 +100,12 @@ while _outlier_count < N_POINTS - N_INLIERS:
     _source = _RNG.integers(0, N_INLIERS, _batch)
     _spread = _RNG.choice([0.65, 1.45, 2.75], _batch, p=[0.55, 0.32, 0.13])
     _spread *= np.sqrt(0.60)
-    _candidates = np.column_stack((
-        _inliers[_source, 0] + _RNG.normal(0, _spread),
-        _inliers[_source, 1] + _RNG.normal(0, _spread),
-    ))
+    _candidates = np.column_stack(
+        (
+            _inliers[_source, 0] + _RNG.normal(0, _spread),
+            _inliers[_source, 1] + _RNG.normal(0, _spread),
+        )
+    )
     _keep = ~_inside(_glyph_mask_xy, _candidates)
     _keep &= np.all(
         (_candidates >= [_xlim[0], _ylim[0]]) & (_candidates <= [_xlim[1], _ylim[1]]),
@@ -119,15 +126,17 @@ _density = np.histogram2d(
 )[0].T
 _density = np.where(_density >= 8, _density, np.nan)
 
-_stops = np.array([
-    [0.06, 0.055, 0.07],
-    [0.10, 0.075, 0.13],
-    [0.17, 0.12, 0.27],
-    [0.26, 0.18, 0.43],
-    [0.34, 0.25, 0.62],
-    [0.431, 0.337, 0.812],
-    [0.61, 0.53, 0.91],
-])
+_stops = np.array(
+    [
+        [0.06, 0.055, 0.07],
+        [0.10, 0.075, 0.13],
+        [0.17, 0.12, 0.27],
+        [0.26, 0.18, 0.43],
+        [0.34, 0.25, 0.62],
+        [0.431, 0.337, 0.812],
+        [0.61, 0.53, 0.91],
+    ]
+)
 _finite = np.isfinite(_density)
 _lo, _hi = np.nanmin(_density), np.nanpercentile(_density, 98)
 _scaled = np.clip((_density - _lo) / (_hi - _lo), 0, 1) ** 1.25

--- a/docs/app/xy_docs/gallery.py
+++ b/docs/app/xy_docs/gallery.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Iterator
 
 import reflex as rx
 import reflex_xy
+
 import xy
 
 ChartSource = xy.Chart | xy.FacetChart
@@ -22,6 +23,9 @@ _PURPLE_LIGHT = "#C4B5FD"
 _GRAY_DARK = "#1C2024"
 _GRAY_MID = "#8B8D98"
 _GRAY_LIGHT = "#CDCED6"
+# Constructed in two pieces so Tailwind cannot discover the complete arbitrary
+# property from Python source. It must arrive through XYChart's scan manifest.
+_TAILWIND_BRIDGE_SENTINEL = "[--xy-tailwind-" + "bridge:compiled]"
 _STATIC_SVG_PAINT_TOKENS = {
     "rgba(32,32,32,0.14)": "var(--secondary-a5)",
     "rgba(32,32,32,0.55)": "var(--secondary-a8)",
@@ -73,6 +77,7 @@ def _line() -> xy.Chart:
         width=_WIDTH,
         height=_HEIGHT,
         padding=_PADDING,
+        class_name=_TAILWIND_BRIDGE_SENTINEL,
     )
 
 
@@ -505,9 +510,7 @@ def _text() -> xy.Chart:
 
 
 def _threshold_zone() -> xy.Chart:
-    return _annotation_base(
-        xy.threshold_zone(6, 9, text="healthy", color=_PURPLE, opacity=0.13)
-    )
+    return _annotation_base(xy.threshold_zone(6, 9, text="healthy", color=_PURPLE, opacity=0.13))
 
 
 def _facet_chart() -> xy.FacetChart:
@@ -726,9 +729,7 @@ def _gallery_card(
                     rx.icon(
                         "arrow-up-right",
                         size=15,
-                        class_name=(
-                            "text-secondary-8 transition group-hover:text-primary-10"
-                        ),
+                        class_name=("text-secondary-8 transition group-hover:text-primary-10"),
                     ),
                     class_name="flex items-center justify-between gap-3",
                 ),
@@ -780,10 +781,7 @@ def chart_gallery_grid() -> rx.Component:
                             )
                             for title, description, chart_factory, live in items
                         ),
-                        class_name=(
-                            "grid w-full grid-cols-1 gap-6 md:grid-cols-2 "
-                            "2xl:grid-cols-3"
-                        ),
+                        class_name=("grid w-full grid-cols-1 gap-6 md:grid-cols-2 2xl:grid-cols-3"),
                     ),
                     class_name="flex w-full flex-col gap-4",
                 )

--- a/docs/app/xy_docs/markdown.py
+++ b/docs/app/xy_docs/markdown.py
@@ -1,0 +1,81 @@
+"""XY-specific Markdown rendering behavior."""
+
+from __future__ import annotations
+
+import json
+
+import reflex as rx
+from reflex_docgen.markdown import HeadingBlock, parse_document
+from reflex_site_shared.docs.markdown import ReflexDocTransformer, _spans_to_plaintext
+from reflex_site_shared.docs.models import DocsPage
+from reflex_site_shared.views.hosting_banner import HostingBannerState
+
+_HEADING_PRESENTATION = {
+    1: ("h1", "4", "lg:text-4xl text-3xl font-semibold"),
+    2: ("h2", "8", "lg:text-2xl text-xl font-semibold"),
+    3: ("h3", "4", "lg:text-xl text-lg font-semibold"),
+    4: ("h4", "2", "lg:text-base text-base font-semibold"),
+}
+
+
+def _heading_link(text: str, level: int) -> rx.Component:
+    """Render a heading whose self-link stays on the current browser route."""
+    normalized_level = min(max(level, 1), 4)
+    tag, margin_top, class_name = _HEADING_PRESENTATION[normalized_level]
+    slug = text.lower().replace(" ", "-")
+    fragment = f"#{slug}"
+    scroll_margin = rx.cond(
+        HostingBannerState.is_banner_visible,
+        "scroll-mt-[113px]",
+        "scroll-mt-[77px]",
+    )
+    copy_href = (
+        f"navigator.clipboard.writeText(new URL({json.dumps(fragment)}, window.location.href).href)"
+    )
+
+    return rx.link(
+        rx.heading(
+            text,
+            id=slug,
+            as_=tag,
+            class_name=f"{class_name} " + scroll_margin + f" mt-{margin_top}",
+        ),
+        rx.icon(
+            tag="link",
+            size=18,
+            class_name=(
+                "!text-primary-11 invisible "
+                "transition-[visibility_0.075s_ease-out] "
+                f"group-hover:visible mt-{margin_top}"
+            ),
+        ),
+        underline="none",
+        href=fragment,
+        on_click=rx.call_script(copy_href),
+        class_name=(
+            "flex flex-row items-center gap-2 hover:!text-primary-11 "
+            "cursor-pointer mb-3 transition-colors group text-secondary-12"
+        ),
+    )
+
+
+class XyDocsMarkdownTransformer(ReflexDocTransformer):
+    """Render XY docs while keeping heading links independent of router state."""
+
+    def heading(self, block: HeadingBlock) -> rx.Component:
+        """Render one route-local Markdown heading."""
+        return _heading_link(_spans_to_plaintext(block.children), block.level)
+
+
+def render_xy_markdown_page(page: DocsPage) -> rx.Component:
+    """Render one discovered XY documentation page."""
+    source_path = page.source_path.resolve()
+    document = parse_document(page.content)
+    transformer = XyDocsMarkdownTransformer(
+        virtual_filepath=str(source_path),
+        filename=str(source_path),
+    )
+    return transformer.transform(document)
+
+
+__all__ = ["XyDocsMarkdownTransformer", "render_xy_markdown_page"]

--- a/docs/app/xy_docs/xy_docs.py
+++ b/docs/app/xy_docs/xy_docs.py
@@ -8,6 +8,7 @@ from reflex_site_shared.telemetry import get_pixel_website_trackers
 from xy_docs.breadcrumb import xy_docs_breadcrumb
 from xy_docs.config import DOCS_CONFIG
 from xy_docs.footer import xy_docs_footer
+from xy_docs.markdown import render_xy_markdown_page
 from xy_docs.navbar import xy_docs_navbar
 from xy_docs.sidebar import xy_docs_sidebar
 
@@ -38,6 +39,7 @@ app = rx.App(
 register_docs(
     app,
     DOCS_CONFIG,
+    renderer=render_xy_markdown_page,
     layout_config=DocsLayoutConfig(
         site_title="XY",
         github_url="https://github.com/reflex-dev/xy",

--- a/docs/app/xy_docs/xy_docs.py
+++ b/docs/app/xy_docs/xy_docs.py
@@ -4,6 +4,8 @@ import reflex as rx
 from reflex_site_shared import styles
 from reflex_site_shared.docs import DocsLayoutConfig, register_docs
 from reflex_site_shared.telemetry import get_pixel_website_trackers
+from reflex_site_shared.templates.docs import docs_layout
+from reflex_site_shared.utils.docpage import right_sidebar_item_highlight
 
 from xy_docs.breadcrumb import xy_docs_breadcrumb
 from xy_docs.config import DOCS_CONFIG
@@ -35,18 +37,29 @@ app = rx.App(
     head_components=get_pixel_website_trackers(),
 )
 
+_LAYOUT_CONFIG = DocsLayoutConfig(
+    site_title="XY",
+    github_url="https://github.com/reflex-dev/xy",
+    show_github_navbar=False,
+    navbar=xy_docs_navbar,
+    sidebar=xy_docs_sidebar,
+    breadcrumb=xy_docs_breadcrumb,
+    page_footer=xy_docs_footer,
+)
+
+
+def xy_docs_layout(page, content, navigation) -> rx.Component:
+    """Render the shared docs layout with Reflex's TOC scroll highlighter."""
+    return rx.box(
+        docs_layout(page, content, navigation, config=_LAYOUT_CONFIG),
+        display="contents",
+        on_mount=rx.call_script(right_sidebar_item_highlight()),
+    )
+
 
 register_docs(
     app,
     DOCS_CONFIG,
     renderer=render_xy_markdown_page,
-    layout_config=DocsLayoutConfig(
-        site_title="XY",
-        github_url="https://github.com/reflex-dev/xy",
-        show_github_navbar=False,
-        navbar=xy_docs_navbar,
-        sidebar=xy_docs_sidebar,
-        breadcrumb=xy_docs_breadcrumb,
-        page_footer=xy_docs_footer,
-    ),
+    layout=xy_docs_layout,
 )

--- a/docs/charts/density-and-grids.md
+++ b/docs/charts/density-and-grids.md
@@ -68,11 +68,11 @@ Heatmaps use `colormap`, `domain`, and `opacity`. Hexbin uses `gridsize`,
 `bins`, `mincnt`, `C`, and `reduce_C_function`. Contours use `levels`,
 `filled`, `colormap`, `width`, `opacity`, and `dash_negative`.
 
-The colormap is encoded directly into these marks. Declarative
-[`xy.colorbar()`](/docs/xy/components/colorbars/) only configures or replaces
-colorbar chrome; it does not generate colorbar metadata from a mark's colormap
-and domain. Without adapter-supplied metadata it adds no visible scale, so the
-examples omit it.
+The colormap is encoded directly into these marks. Add declarative
+[`xy.colorbar()`](/docs/xy/components/colorbars/) to derive visible scale
+chrome from the last compatible heatmap, hexbin, or contour domain and
+colormap. Use its `title`, `orientation`, and `ticks` options to override the
+inferred presentation.
 
 `hexbin` bins source points in the native engine and ships occupied cell
 centers plus values, so its rendered geometry is bounded by `gridsize`; the

--- a/docs/charts/scatter.md
+++ b/docs/charts/scatter.md
@@ -52,8 +52,10 @@ source row.
 uses `colormap` and optional `color_domain`; categorical color creates a stable
 palette. `size_range` maps numeric size values into pixel diameters.
 
-Markers support `circle`, `square`, `diamond`, `triangle`, and `cross` symbols,
-plus `stroke` and `stroke_width` for crisp borders.
+Markers support 17 renderer-backed symbols, from `circle`, `square`, and
+directional triangles through `star`, `hexagon`, pixel/point, and line-only
+glyphs, plus `stroke` and `stroke_width` for crisp borders. The complete list
+is in [Mark styles](/docs/xy/styling/mark-styles/#mark-specific-appearance).
 
 ## Expected Data Shape
 

--- a/docs/components/annotations.md
+++ b/docs/components/annotations.md
@@ -56,8 +56,10 @@ CSS subset.
 
 Annotation labels are browser DOM elements. Their `class_name` and `style`
 values can customize the label, and chart-level styling can target the stable
-`annotation_label` slot. Keep geometry in the component props when output must
-agree across HTML, SVG, and native PNG.
+`annotation_label` slot. Geometry `opacity` is independent from label text;
+use annotation-style `label_opacity` only when the label should also fade.
+Keep geometry in the component props when output must agree across HTML, SVG,
+and native PNG.
 
 If more than one annotation occupies the same coordinate, declaration order
 controls their paint order. For a chart-family view of annotation patterns, see

--- a/docs/components/colorbars.md
+++ b/docs/components/colorbars.md
@@ -1,14 +1,84 @@
 ---
 title: Colorbars
-description: Understand continuous-scale colorbar chrome and its current declarative boundary.
+description: Author, orient, and style built-in continuous-scale colorbars or replace them in a custom adapter.
 ---
 
 # Colorbars
 
-A colorbar explains a continuous color scale. XY's public `colorbar()`
-component currently has a deliberately small role: it holds an opaque
-replacement for a framework adapter and carries visibility or DOM styling for
-colorbar metadata supplied by an advanced integration.
+A colorbar explains a continuous color scale. Add `xy.colorbar()` after a
+compatible continuous-color mark and XY derives the validated domain,
+colormap, and a useful title from that mark. The built-in colorbar renders in
+the browser, SVG, native PNG, and Chromium PNG.
+
+## Built-in declarative colorbars
+
+The two orientations share the same title and explicit-tick API. Browser DOM
+chrome additionally exposes the class and slot styling shown here:
+
+~~~python demo exec
+import reflex as rx
+import reflex_xy
+import xy
+
+vertical_scale = xy.heatmap_chart(
+    xy.heatmap(
+        [[-2.0, 0.0], [2.0, 4.0]],
+        name="temperature",
+        colormap="coolwarm",
+        domain=(-3, 5),
+    ),
+    xy.colorbar(
+        title="Temperature (°C)",
+        ticks=[-3, 0, 5],
+        class_name="rounded-lg bg-white/90",
+    ),
+    styles={
+        "colorbar_bar": {"border_radius": 5},
+        "colorbar_tick": {"color": "#475569"},
+        "colorbar_title": {"font_weight": 700},
+    },
+    title="Vertical scale",
+)
+
+horizontal_scale = xy.scatter_chart(
+    xy.scatter(
+        [0, 1, 2, 3],
+        [2, 5, 3, 8],
+        color=[0.1, 0.4, 0.7, 1.0],
+        colormap="viridis",
+        size=12,
+    ),
+    xy.colorbar(
+        title="Confidence",
+        orientation="horizontal",
+        ticks=[0.1, 0.5, 1.0],
+    ),
+    title="Horizontal scale",
+)
+
+
+def colorbar_orientation_preview():
+    return rx.el.div(
+        reflex_xy.chart(vertical_scale, height="330px"),
+        reflex_xy.chart(horizontal_scale, height="330px"),
+        class_name="grid w-full grid-cols-1 gap-5 xl:grid-cols-2",
+    )
+~~~
+
+The last compatible continuous mark wins when a chart layers several scales. XY
+derives colorbars for heatmaps, continuous scatter, hexbin, contour,
+continuous segments, and triangle meshes. A field or mark name supplies the
+default title; `title=` overrides it, `ticks=` supplies finite tick positions,
+and `orientation=` accepts `"vertical"` or `"horizontal"`.
+
+XY deliberately emits no built-in colorbar for constant or categorical color,
+RGB(A) heatmaps, or density-tier scatter whose per-row color channel is not
+resident in the browser. `colorbar(show=False)` removes an inferred scale.
+`xy.pyplot` has its own Matplotlib-shaped colorbar-authoring API.
+
+## Framework-owned replacement
+
+`render=` (or one positional child) remains an opaque integration hook:
 
 ~~~python
 import reflex as rx
@@ -35,25 +105,12 @@ replacement = chart.chrome_components()["colorbar"]
 assert replacement is my_color_scale
 ~~~
 
-This is a complete example of storing a Reflex component as opaque replacement
-content. Core XY does not mount the component, and the shipped
+Core XY stores that object but does not mount it, and the shipped
 `reflex_xy.chart` adapter does not currently mount custom chrome either. A
 custom adapter must read `chrome_components()` and place the returned component
-itself; standalone HTML, SVG, and PNG ignore it.
+itself; standalone HTML, SVG, and PNG ignore the opaque replacement.
 
-## Current Declarative Boundary
-
-The core declarative mark factories keep the colormap and numerical domain on
-the mark. They do not currently synthesize a complete colorbar specification
-from those channels. Consequently, adding `colorbar()` is not itself a request
-to create ticks, a title, an orientation, or a domain.
-
-If an advanced integration supplies built-in colorbar metadata, `show=False`
-removes it and the style hooks apply to its DOM. The public component does not
-expose independent tick, label, or orientation options yet. `xy.pyplot` has its
-own colorbar-authoring API; it is not configured by this declarative component.
-
-## Style or Replace It
+## Styling slots
 
 The chart slots `colorbar`, `colorbar_bar`, `colorbar_tick`, and
 `colorbar_title` target built-in browser chrome:
@@ -61,14 +118,16 @@ The chart slots `colorbar`, `colorbar_bar`, `colorbar_tick`, and
 ~~~python
 chart = xy.scatter_chart(
     xy.scatter([1, 2, 3], [3, 5, 4], color=[0.2, 0.8, 1.4]),
+    xy.colorbar(title="Intensity"),
     class_names={"colorbar_title": "font-semibold"},
-    styles={"colorbar_bar": {"border-radius": "4px"}},
+    styles={
+        "colorbar_bar": {"border_radius": 4},
+        "colorbar_tick": {"font_size": 10},
+    },
 )
 ~~~
 
-For a framework-owned replacement, pass one positional child or `render=` as
-in the first example. Core XY keeps that object out of standalone
-serialization. See the
+See the
 [Reflex integration](/docs/xy/integrations/reflex/) for the shipped chart
 adapter and [Marks and components reference](/docs/xy/api-reference/marks-and-components/)
-for the current minimal signature.
+for the complete signature.

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -31,7 +31,7 @@ the last declaration as their effective configuration.
 | [Axes](/docs/xy/components/axes/) | Scales, domains, ticks, labels, and named axes |
 | [Legends](/docs/xy/components/legends/) | Named-series keys and framework replacements |
 | [Tooltips](/docs/xy/components/tooltips/) | Hover fields, titles, formatting, and replacements |
-| [Colorbars](/docs/xy/components/colorbars/) | Continuous-scale chrome and its current declarative boundary |
+| [Colorbars](/docs/xy/components/colorbars/) | Inferred continuous scales, orientation, ticks, slots, and custom replacements |
 | [Modebars and interaction controls](/docs/xy/components/modebars-and-interaction-controls/) | Pan, zoom, selection, export controls, and linked viewports |
 | [Annotations](/docs/xy/components/annotations/) | Rules, bands, text, markers, arrows, thresholds, and callouts |
 

--- a/docs/components/marks.md
+++ b/docs/components/marks.md
@@ -73,9 +73,9 @@ family-specific choices.
 
 Canvas and WebGL marks are not DOM elements. CSS selectors and Tailwind classes
 cannot paint their geometry; use `style=` or the mark's paint props. In
-particular, `class_name=` should not be treated as a portable mark-painting
-hook. See [Mark styles](/docs/xy/styling/mark-styles/) for the compiled CSS
-subset.
+particular, `class_name=` is adapter-only trace metadata, not a mark-painting
+hook in the shipped browser, Reflex, SVG, or native renderers. See
+[Mark styles](/docs/xy/styling/mark-styles/) for the compiled CSS subset.
 
 ## Representation Does Not Change the Mark
 

--- a/docs/components/modebars-and-interaction-controls.md
+++ b/docs/components/modebars-and-interaction-controls.md
@@ -1,9 +1,9 @@
 ---
-title: Modebars and Interaction Controls
+title: Modebars & Controls
 description: Configure XY's toolbar, gestures, selection, exports, and linked viewports.
 ---
 
-# Modebars and Interaction Controls
+# Modebars & Controls
 
 Interactive charts include a compact modebar by default. It exposes pan, zoom
 in/out, box zoom, reset, selection modes when selection is enabled, and local

--- a/docs/components/tooltips.md
+++ b/docs/components/tooltips.md
@@ -59,7 +59,11 @@ The last tooltip component supplies the effective configuration.
 
 Like legends, a positional child or `render=` object is kept opaque for an
 adapter and can be retrieved through `chart.chrome_components()`. It is not
-embedded into standalone HTML.
+embedded into standalone HTML, and the shipped `reflex_xy.chart` adapter does
+not mount it. With that adapter, disable the built-in tooltip, handle
+`on_point_hover` in Reflex state, and render the framework-owned tooltip beside
+or over the chart. See [Component Variations](/docs/xy/styling/component-variations/#custom-component-replacements)
+for the complete integration boundary.
 
 See [Events and callbacks](/docs/xy/api-reference/events-and-callbacks/) for
 hover payloads and [Marks and components reference](/docs/xy/api-reference/marks-and-components/)

--- a/docs/engineering/chart-roadmap.md
+++ b/docs/engineering/chart-roadmap.md
@@ -298,8 +298,8 @@ The marks themselves speak CSS. `fill=` accepts a real CSS
 `linear-gradient(...)` (mark-space or plot-space); bars/rects take
 `corner_radius` (scalar or independent `(tip, base)`), `stroke`, and
 `stroke_width`; lines and area outlines take `dash` (presets or an on/off
-pattern); line/area take `curve="smooth"` (monotone-cubic); scatter takes
-`symbol` (circle/square/diamond/triangle/cross) plus point strokes. Mark colors
+pattern); line/area take `curve="smooth"` (monotone-cubic); scatter takes 17
+renderer-backed `symbol` glyphs plus point strokes. Mark colors
 flow through the same `--chart-*` tokens as the chrome, so a theme change
 re-resolves marks and chrome together. The full matrix and per-mark support
 table live in [`docs/engineering/styling.md`](styling.md). Static SVG export reproduces all
@@ -318,19 +318,23 @@ variables on the container, and can style the wrapper freely.
 
 **Status: shipped.** Every DOM chrome element now carries a `data-xy-slot`
 attribute and takes per-slot `class_names` / `chrome_styles`, and its *visual*
-defaults live in a single zero-specificity `:where([data-xy-slot="…"])`
-stylesheet injected once per document. Because `:where(...)` contributes zero
-specificity, a `class_names` utility class (or an inline `chrome_styles` value)
-always wins over the built-in look **without `!important`** — verified in a real
-browser (a `.bg-*` class on the tooltip changes its computed background). The
+defaults live in a single low-priority `base` cascade layer with
+zero-specificity `:where([data-xy-slot="…"])` selectors, injected once per
+document. Tailwind's later utility layer, unlayered author CSS, and inline
+`chrome_styles` therefore win over the built-in look **without `!important`** —
+verified in a real browser (a `.bg-*` class on the tooltip changes its computed
+background). The
 elements keep only *structural* inline styles (position/size/z-index/state), so
 nothing themeable competes with a user class. The full slot list (including
 `legend_swatch`, `tick_label`, `axis_title`, and the class-driven modebar
 active state via `--chart-modebar-active`) is `xy.CHART_DOM_SLOTS`.
 
-For the standalone `to_html(...)` export — which has no host page to inherit
-Tailwind from — pass `custom_css="…"` to inject the stylesheet defining those
-utility classes; the widget path inherits the host page's Tailwind directly.
+For a fixed chart, the Reflex adapter also mirrors embedded class strings into
+generated JSX for Tailwind's compile-time scan. Runtime token/Var charts must
+put their complete names in ordinary host source or a safelist. For the
+standalone `to_html(...)` export — which has no host page to inherit Tailwind
+from — pass `custom_css="…"` to inject the stylesheet defining those utility
+classes.
 
 Explicitly **out of scope** (browser limit, not a backlog item): the plotted
 marks are WebGL2 canvas pixels — no CSS, Tailwind or otherwise, can style them.

--- a/docs/engineering/design/reflex-shaped-api.md
+++ b/docs/engineering/design/reflex-shaped-api.md
@@ -302,8 +302,9 @@ DOM chrome slots:
 Each rendered slot also receives `data-xy-slot="<slot>"`, so plain CSS,
 attribute selectors, and Tailwind arbitrary variants can target the same stable
 surface even when the caller does not add a class. The client ships one
-zero-specificity `:where([data-xy-slot="…"])` default stylesheet, so a
-`class_names` utility class (or an inline `chrome_styles` value) always wins
+low-priority `base`-layer stylesheet whose selectors use
+zero-specificity `:where([data-xy-slot="…"])`. Tailwind utilities in their
+later layer, unlayered author CSS, and inline `chrome_styles` therefore win
 over the built-in look without needing `!important`. In the standalone
 `to_html(...)` export — which has no host page to inherit Tailwind from — pass
 `custom_css="…"` to inject the stylesheet that defines those utility classes.
@@ -355,6 +356,11 @@ xy.scatter(x="x", y="y", data=df, color="var(--chart-accent)")
 ```
 
 This keeps Tailwind useful without pretending CSS can reach GPU buffers.
+
+The Reflex adapter mirrors class strings from a fixed `xy.Chart`/`xy.Figure`
+into generated JSX so Tailwind can discover them at compile time. A live token
+or Var figure does not exist until runtime; its complete utility names must
+also appear literally in ordinary application source or in the host safelist.
 
 ## 5. Tooltip Customization
 
@@ -686,7 +692,8 @@ Now part of the core alpha contract:
 
 - Neutral `xy.chart(...)`.
 - `xy.tooltip(...)`, `xy.modebar(...)`, `xy.theme(...)`.
-- `xy.colorbar(...)` with the same CSS-slot and opaque adapter-render contract.
+- `xy.colorbar(...)` with inferred built-in continuous-scale chrome, the same
+  CSS slots, and an opaque adapter-render replacement contract.
 - `class_name`, `class_names`, and `style` props.
 
 Can add:

--- a/docs/engineering/styling.md
+++ b/docs/engineering/styling.md
@@ -4,8 +4,11 @@ Every rendered chrome element is a stable, CSS-addressable surface. You can
 restyle the whole chart with plain CSS, attribute selectors, Tailwind, or
 per-slot inline styles — and your styles always win, without `!important`.
 
-This guide is the single reference for the styling contract. For the API shapes
-see [reflex-shaped-api.md](design/reflex-shaped-api.md); for the render internals
+This engineering guide explains the implementation contract. The public,
+task-oriented references are [Styling](../styling/index.md),
+[Component Variations](../styling/component-variations.md), and
+[Mark Styles](../styling/mark-styles.md). For the API shapes see
+[reflex-shaped-api.md](design/reflex-shaped-api.md); for the render internals
 see [renderer-architecture.md](design/renderer-architecture.md).
 
 ## The five ways to style
@@ -15,7 +18,7 @@ see [renderer-architecture.md](design/renderer-architecture.md).
 | `class_names={slot: "..."}` | Add classes to a chrome slot (great for Tailwind) | `xy.chart(...)` |
 | `styles={slot: {...}}` | Inline CSS on a chrome slot | `xy.chart(...)` |
 | `style={...}` | Cross-renderer CSS appearance subset for a rendered mark | `xy.line(...)`, `xy.scatter(...)`, … |
-| `class_name=` / `style=` | A single annotation (per-call) | `.vline(...)`, `.text(...)`, … |
+| `class_name=` / `style=` | One annotation label; geometry still uses typed props | `.vline(...)`, `.text(...)`, … |
 | `custom_css="..."` | A raw author stylesheet in the exported document | `to_html(fig, custom_css=...)` |
 
 ```python
@@ -40,6 +43,12 @@ chart = xy.chart(
 style APIs: a bare number on a length property becomes `px` (`{"font_size": 18}`
 → `font-size:18px`), custom properties (`--x`) and unitless properties pass
 through untouched.
+
+In Reflex, Tailwind utilities require `rx.plugins.TailwindV4Plugin()`. Complete
+literal classes emitted into Reflex's generated JSX work with the plugin's
+normal scan paths; the original Python or Markdown path does not need to be
+added. See the public [Chrome Slots](../styling/chrome-slots.md) guide for the
+standalone-export and dynamic-class boundaries.
 
 ## Rendered marks: standard CSS vocabulary
 
@@ -89,6 +98,10 @@ Within `style`, use the standard paint property for the geometry: `stroke` for
 line-like marks and `fill` for filled marks. `color` is not a paint alias there;
 this avoids ambiguous combinations such as `color` plus `stroke` and keeps the
 same declarations meaningful in SVG, WebGL, and native PNG output.
+
+A mark's `class_name` is adapter-only trace metadata. It does not create a DOM
+node and is not interpreted as a paint selector by the shipped browser,
+Reflex, SVG, or native renderers.
 
 ### Reflex integration boundary
 
@@ -158,7 +171,7 @@ raises before it reaches the client.
 | `tooltip` | Hover tooltip |
 | `modebar` | Mode/tool bar container |
 | `modebar_button` | One mode/tool button (`.xy-active` when engaged) |
-| `selection` | Box/lasso selection rectangle |
+| `selection` | Active box-select or box-zoom rectangle |
 | `crosshair_x` | Vertical crosshair line |
 | `crosshair_y` | Horizontal crosshair line |
 | `badge` | Reduction/density badge container |
@@ -182,11 +195,11 @@ raises before it reaches the client.
 ## Why your styles always win
 
 The client injects one stylesheet of *visual* defaults (background, color,
-padding, border, font, box-shadow, cursor). Every rule is wrapped in
-[`:where(...)`](https://developer.mozilla.org/en-US/docs/Web/CSS/:where), which
-has **zero specificity**. A Tailwind utility class (specificity `0,1,0`) or an
-inline `styles[slot]` (inline, highest) therefore beats the default with no
-`!important` and regardless of stylesheet source order.
+padding, border, font, box-shadow, cursor). It lives in the low-priority `base`
+cascade layer, and every selector uses
+[`:where(...)`](https://developer.mozilla.org/en-US/docs/Web/CSS/:where) for
+**zero specificity**. Tailwind's later utility layer, unlayered author CSS, and
+inline `styles[slot]` therefore beat the defaults without `!important`.
 
 The rendered elements carry only **structural** inline styles — position, size,
 z-index, and interaction state (`data-xy-dragmode`, the `.xy-active` class).
@@ -334,12 +347,13 @@ fill with an opaque outline, keep whole-mark opacity at `1` and set
 
 ### Scatter markers — `symbol`, `stroke`, `stroke_width`
 
-`scatter` markers take a `symbol` — `circle` (default), `square`, `diamond`,
-`triangle`, or `cross` — plus a `stroke` color and `stroke_width` (px) for a
-border, e.g. `scatter(x, y, symbol="triangle", stroke="#fff", stroke_width=2)`.
-Each is an antialiased SDF in the point shader, so shapes stay crisp at any size
-and the border is a true ring (a stroke width with no color borders in the mark
-color). Symbols compose with the color/size channels.
+`scatter` markers take any of the 17 renderer-backed symbols listed in the
+public [Mark styles](../styling/mark-styles.md#mark-specific-appearance) guide,
+plus a `stroke` color and `stroke_width` (px) for a border, e.g.
+`scatter(x, y, symbol="triangle", stroke="#fff", stroke_width=2)`. Each is an
+antialiased SDF in the point shader, so shapes stay crisp at any size and the
+border is a true ring (a stroke width with no color borders in the mark color).
+Symbols compose with the color/size channels.
 
 Interaction state belongs to the host framework. In Reflex, use Reflex state,
 event handlers, conditions, and ordinary CSS classes/styles; XY only emits the
@@ -354,7 +368,11 @@ Hover and tooltips keep reporting the real data points, not interpolated ones.
 Densification caps at ~32k vertices — past that the polyline is sub-pixel
 dense and smoothing is invisible by construction.
 
-### The full mark-styling matrix
+### Common typed appearance combinations
+
+This table compares the most feature-rich typed appearance props. The public
+[Mark Styles](../styling/mark-styles.md) matrix is exhaustive across every
+rendered mark family and its accepted `style=` properties.
 
 | Mark | Color/opacity | Gradient fill | Corner radius | Stroke | Curve | Dash | Size/width |
 | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -362,7 +380,7 @@ dense and smoothing is invisible by construction.
 | `histogram` | ✅ | ✅ | ✅ all or `(tip, base)` | ✅ | — | — | bin-driven |
 | `area` | ✅ (+ `line_width`/`line_opacity`) | ✅ | — | line is the stroke | ✅ | ✅ outline | ✅ |
 | `line` | ✅ | — (stroke gradients: roadmap) | — | is a stroke | ✅ | ✅ | ✅ `width` |
-| `scatter` | ✅ + color/size channels | — | `symbol` (circle/square/diamond/triangle/cross) | ✅ `stroke`/`stroke_width` | — | — | ✅ + size channel |
+| `scatter` | ✅ + color/size channels | — | 17 `symbol` glyphs | ✅ `stroke`/`stroke_width` | — | — | ✅ + size channel |
 | `heatmap` | colormap + `domain` | colormap is the gradient | — | — | — | — | cell-driven |
 
 On the roadmap, in likely order: per-mark drop

--- a/docs/integrations/reflex.md
+++ b/docs/integrations/reflex.md
@@ -132,7 +132,7 @@ component props:
 | `on_hover` | `on_point_hover` | Resolved row dictionary |
 | `on_click` | `on_point_click` | Resolved row dictionary |
 | `on_brush` | No dedicated prop | — |
-| `on_select` | `on_select_end` | JSON-safe summary with `total`, optional bounds, and `cleared` |
+| `on_select` | `on_select_end` | JSON-safe summary with `total`, optional bounds or `polygon`, and `cleared` |
 | `on_view_change` | `on_view_change` | View dictionary |
 
 In particular, notebook `on_select` receives an `xy.Selection` with canonical

--- a/docs/styling/chrome-slots.md
+++ b/docs/styling/chrome-slots.md
@@ -28,7 +28,7 @@ and a plain CSS attribute selector.
 | `tooltip` | Hover tooltip |
 | `modebar` | Mode/tool bar container |
 | `modebar_button` | One mode/tool button; `.xy-active` when active |
-| `selection` | Box/lasso selection rectangle |
+| `selection` | Active box-select or box-zoom rectangle |
 | `crosshair_x` | Vertical crosshair line |
 | `crosshair_y` | Horizontal crosshair line |
 | `badge` | Reduction/density badge container |
@@ -40,29 +40,130 @@ and a plain CSS attribute selector.
 Unknown slot names raise while the chart is built, before a typo can become a
 silently unstyled client element.
 
-## Classes and Tailwind
+## Classes and Tailwind in Reflex
+
+In a Reflex app, enable its Tailwind plugin once in `rxconfig.py`:
 
 ~~~python
+import reflex as rx
+
+config = rx.Config(
+    app_name="dashboard",
+    plugins=[rx.plugins.TailwindV4Plugin()],
+)
+~~~
+
+For a fixed `xy.Chart` or `xy.Figure` passed directly to `reflex_xy.chart(...)`,
+the adapter mirrors its chart, slot, mark, and annotation class strings into
+generated JSX. That JSX is already in the plugin's default scan paths, so the
+complete utility names below work without adding the original Python or
+Markdown file to Tailwind's source configuration.
+
+~~~python demo exec
+import reflex_xy
 import xy
 
 chart = xy.line_chart(
     xy.line([0, 1, 2, 3], [2, 5, 3, 8], name="Signal"),
     xy.legend(),
-    class_name="rounded-xl border border-slate-200 bg-white shadow-sm",
+    class_name=(
+        "rounded-xl border border-slate-200 bg-white text-slate-900 shadow-sm "
+        "dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+    ),
     class_names={
-        "title": "text-base font-semibold text-slate-900",
-        "legend": "bg-transparent text-xs text-slate-600",
+        "title": "text-base font-semibold",
+        "legend": "bg-transparent text-xs text-slate-600 dark:text-slate-300",
         "tooltip": "rounded-lg bg-slate-950/90 px-3 py-2 text-white shadow-xl",
-        "modebar_button": "hover:bg-slate-100 focus:ring-2",
+        "modebar_button": "hover:bg-slate-100 focus:ring-2 dark:hover:bg-slate-800",
     },
     title="Tailwind chrome",
 )
+
+
+def tailwind_chrome_preview():
+    return reflex_xy.chart(chart, height="320px")
 ~~~
 
-Tailwind must see these literal class strings during its normal source scan.
-An XY standalone HTML export carries class names but does not bundle the
-Tailwind framework automatically; inject the compiled rules with `custom_css`
-or use ordinary CSS for a portable file.
+Keep each utility name complete and literal, such as `bg-slate-950/90`. Tailwind
+cannot discover a name assembled at runtime from fragments such as
+`f"bg-{tone}-950"`; map dynamic state to complete class strings instead.
+
+Live token/Var charts are different: their figure is produced at runtime, after
+Tailwind has compiled the app, so the adapter cannot mirror those class names
+ahead of time. Put every complete utility name used by a live chart literally
+in a normal Reflex component (or safelist it in the host app). The same rule
+applies when application logic chooses classes that were not present on the
+fixed figure at compile time.
+
+Without `TailwindV4Plugin`, XY still places the names in the DOM but no Tailwind
+utilities are generated, so the chart renders without those styles. An XY
+standalone HTML export likewise carries the names but does not bundle Tailwind;
+inject already-compiled rules with `custom_css` or use ordinary CSS for a
+portable file.
+
+## One tooltip, three styling approaches
+
+All three examples target the same `tooltip` slot. Choose based on where the
+style originates; do not combine them unless you intentionally want normal CSS
+cascade precedence.
+
+Use `class_names` when the host already provides utilities or reusable classes:
+
+~~~python
+chart = xy.scatter_chart(
+    xy.scatter([1, 2, 3], [3, 5, 4]),
+    class_names={
+        "tooltip": (
+            "rounded-lg border border-slate-700 bg-slate-950 "
+            "px-3 py-2 text-white shadow-xl"
+        )
+    },
+)
+~~~
+
+Use `styles` for values computed in Python or when no stylesheet is involved:
+
+~~~python
+chart = xy.scatter_chart(
+    xy.scatter([1, 2, 3], [3, 5, 4]),
+    styles={
+        "tooltip": {
+            "background": "#020617",
+            "color": "#ffffff",
+            "border": "1px solid #334155",
+            "border_radius": 8,
+            "padding": "8px 12px",
+            "box_shadow": "0 12px 30px rgb(15 23 42 / 35%)",
+        }
+    },
+)
+~~~
+
+Use a `data-xy-slot` selector when one host rule should style many charts or an
+export needs raw author CSS:
+
+~~~python
+tooltip_css = """
+.analytics [data-xy-slot="tooltip"] {
+  background: #020617;
+  color: #fff;
+  border: 1px solid #334155;
+  border-radius: 8px;
+  padding: 8px 12px;
+  box-shadow: 0 12px 30px rgb(15 23 42 / 35%);
+}
+"""
+
+chart = xy.scatter_chart(
+    xy.scatter([1, 2, 3], [3, 5, 4]),
+    class_name="analytics",
+)
+chart.to_html("analytics.html", custom_css=tooltip_css)
+~~~
+
+An inline `styles["tooltip"]` declaration normally wins over a class or plain
+author rule targeting the same property. Prefer one primary approach per slot
+instead of escalating to `!important`.
 
 ## Inline slot styles
 
@@ -114,10 +215,18 @@ works for Chromium PNG capture; native PNG has no browser cascade and rejects
 
 ## Cascade and structural layout
 
-Built-in visual rules use zero-specificity `:where(...)`, so classes and author
-selectors beat them without `!important`. XY retains structural inline styles
+Built-in visual rules live in the low-priority `base` cascade layer and use
+zero-specificity `:where(...)`, so Tailwind's utility layer and ordinary
+unlayered author selectors beat them without `!important`. XY retains structural inline styles
 for positioning, dimensions, z-index, and interaction state. Avoid overriding
 those unless you intentionally take responsibility for chart layout.
+
+Responsive legend bounds, anchors, and tooltip wrapping use the same layered,
+zero-specificity defaults. Long legends become scrollable and edge tooltips
+wrap or flip inside the chart, while a class or `styles` entry can still
+replace those defaults. Completed lasso polygons are canvas chrome and use the
+`--chart-selection` / `--chart-selection-fill` tokens rather than the
+`selection` DOM slot.
 
 Annotation **labels** use `annotation_label`; canvas-painted arrow shafts,
 markers, rules, and zones do not. Style those through their annotation props as

--- a/docs/styling/chrome-slots.md
+++ b/docs/styling/chrome-slots.md
@@ -66,15 +66,12 @@ import xy
 chart = xy.line_chart(
     xy.line([0, 1, 2, 3], [2, 5, 3, 8], name="Signal"),
     xy.legend(),
-    class_name=(
-        "rounded-xl border border-slate-200 bg-white text-slate-900 shadow-sm "
-        "dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
-    ),
+    class_name="text-slate-900 dark:text-zinc-100",
     class_names={
         "title": "text-base font-semibold",
         "legend": "bg-transparent text-xs text-slate-600 dark:text-slate-300",
-        "tooltip": "rounded-lg bg-slate-950/90 px-3 py-2 text-white shadow-xl",
-        "modebar_button": "hover:bg-slate-100 focus:ring-2 dark:hover:bg-slate-800",
+        "tooltip": "rounded-lg bg-zinc-950/90 px-3 py-2 text-white shadow-xl",
+        "modebar_button": "hover:bg-zinc-100 focus:ring-2 dark:hover:bg-zinc-800",
     },
     title="Tailwind chrome",
 )
@@ -84,7 +81,7 @@ def tailwind_chrome_preview():
     return reflex_xy.chart(chart, height="320px")
 ~~~
 
-Keep each utility name complete and literal, such as `bg-slate-950/90`. Tailwind
+Keep each utility name complete and literal, such as `bg-zinc-950/90`. Tailwind
 cannot discover a name assembled at runtime from fragments such as
 `f"bg-{tone}-950"`; map dynamic state to complete class strings instead.
 
@@ -114,7 +111,7 @@ chart = xy.scatter_chart(
     xy.scatter([1, 2, 3], [3, 5, 4]),
     class_names={
         "tooltip": (
-            "rounded-lg border border-slate-700 bg-slate-950 "
+            "rounded-lg border border-zinc-700 bg-zinc-950 "
             "px-3 py-2 text-white shadow-xl"
         )
     },
@@ -128,7 +125,7 @@ chart = xy.scatter_chart(
     xy.scatter([1, 2, 3], [3, 5, 4]),
     styles={
         "tooltip": {
-            "background": "#020617",
+            "background": "#09090b",
             "color": "#ffffff",
             "border": "1px solid #334155",
             "border_radius": 8,
@@ -145,7 +142,7 @@ export needs raw author CSS:
 ~~~python
 tooltip_css = """
 .analytics [data-xy-slot="tooltip"] {
-  background: #020617;
+  background: #09090b;
   color: #fff;
   border: 1px solid #334155;
   border-radius: 8px;
@@ -176,7 +173,7 @@ chart = xy.scatter_chart(
     styles={
         "title": {"font_size": 18, "letter_spacing": "0.02em"},
         "tooltip": {
-            "background_color": "rgba(15, 23, 42, 0.94)",
+            "background_color": "rgba(24, 24, 27, 0.94)",
             "border_radius": 10,
         },
     },

--- a/docs/styling/component-variations.md
+++ b/docs/styling/component-variations.md
@@ -105,7 +105,7 @@ legend_tooltip_chart = xy.line_chart(
         title="Month {month}",
         format={"actual": ",.0f", "plan": ",.0f"},
         style={
-            "background": "rgb(15 23 42 / 94%)",
+            "background": "rgb(24 24 27 / 94%)",
             "color": "#f8fafc",
             "border-radius": 8,
             "padding": "8px 10px",
@@ -119,7 +119,7 @@ legend_tooltip_chart = xy.line_chart(
     },
     class_name=(
         "[--legend-bg:#fffffff0] [--legend-text:#0f172a] "
-        "[--legend-border:#e2e8f0] dark:[--legend-bg:#1e293bf0] "
+        "[--legend-border:#e2e8f0] dark:[--legend-bg:#27272af0] "
         "dark:[--legend-text:#e2e8f0] dark:[--legend-border:#475569]"
     ),
 )
@@ -280,7 +280,7 @@ reference_chart = xy.chart(
         "[--warning-label:#92400e] [--warning-bg:#fffbeb] "
         "[--warning-border:#fde68a] [--teal-label:#115e59] "
         "[--teal-bg:#f0fdfa] [--success-label:#166534] "
-        "[--success-bg:#f0fdf4] dark:[--axes-bg:#0f172a] "
+        "[--success-bg:#f0fdf4] dark:[--axes-bg:#18181b] "
         "dark:[--axes-text:#e2e8f0] dark:[--axes-grid:#e2e8f01f] "
         "dark:[--axes-neutral:#94a3b8] dark:[--axes-purple:#c4b5fd] "
         "dark:[--axes-blue:#93c5fd] dark:[--axes-red:#fda4af] "
@@ -464,7 +464,7 @@ interaction_chart = xy.scatter_chart(
     xy.modebar(
         class_name=(
             "rounded-lg border border-slate-200 bg-white/95 shadow-md "
-            "dark:border-slate-700 dark:bg-slate-900/95"
+            "dark:border-zinc-700 dark:bg-zinc-900/95"
         ),
         button_class_name=(
             "rounded-md hover:bg-violet-50 focus:ring-2 focus:ring-violet-500 "
@@ -578,7 +578,7 @@ def interaction_chrome_styling_preview():
             align="start",
             class_name=(
                 "rounded-lg border border-slate-200 bg-white p-4 "
-                "dark:border-slate-700 dark:bg-slate-950"
+                "dark:border-zinc-700 dark:bg-zinc-950"
             ),
         ),
         width="100%",

--- a/docs/styling/component-variations.md
+++ b/docs/styling/component-variations.md
@@ -1,0 +1,674 @@
+---
+title: Component Variations
+description: Style legends, tooltips, axes, reference lines, annotations, and interaction chrome.
+---
+
+# Component Variations
+
+Styling is split by what the renderer owns. Built-in chart chrome is browser
+DOM, axes combine canvas geometry with DOM labels, and annotations combine
+painted shapes with DOM labels. Custom framework components are a separate
+integration boundary.
+
+## Choose a component task
+
+| I want to style... | Continue with |
+| --- | --- |
+| A built-in legend or tooltip | [Built-in legend and tooltip](#built-in-legend-and-tooltip) |
+| Axes, secondary axes, rules, or bands | [Axes and reference lines or bands](#axes-and-reference-lines-or-bands) |
+| Labels, markers, arrows, and callouts | [Annotation variants](#annotation-variants) |
+| Crosshairs or selection feedback | [Crosshair and selection](#crosshair-and-selection) |
+| A host-owned legend, tooltip, or color scale | [Custom component replacements](#custom-component-replacements) |
+| Reduction badges or facet wrappers | [Conditional badges and facet wrappers](#conditional-badges-and-facet-wrappers) |
+
+The key boundary is ownership: built-in chrome can be restyled through XY
+slots, while a genuinely custom Reflex component must be rendered and updated
+by the host application.
+
+## Coverage matrix
+
+| Surface | Configure content or behavior | Style it |
+| --- | --- | --- |
+| Built-in legend | `legend(loc=..., ncols=..., title=...)` | `legend(class_name=..., style=...)`; `legend`, `legend_item`, and `legend_swatch` slots |
+| Built-in tooltip | `tooltip(fields=..., title=..., format=...)` | `tooltip(class_name=..., style=...)` or the `tooltip` slot |
+| Colorbar chrome | `colorbar(title=..., orientation=..., ticks=...)` on a supported continuous mark | `colorbar`, `colorbar_bar`, `colorbar_tick`, and `colorbar_title` slots |
+| X and Y axes | `x_axis(...)`, `y_axis(...)`, including named secondary axes | Validated axis `style`; `tick_label` and `axis_title` DOM slots |
+| Reference lines | `vline(x)` and `hline(y)` | Geometry through `color`, `width`, and `opacity`; label through `class_name` and `style` |
+| Reference bands | `x_band(...)`, `y_band(...)`, and `threshold_zone(...)` | Geometry through `color` and `opacity`; label through `class_name` and `style` |
+| Labels and callouts | `text`, `label`, `marker`, `arrow`, and `callout` | Shape props plus the `annotation_label` slot or per-annotation class/style |
+| Crosshair and selection | `interaction_config(crosshair=True, select=True, brush=True)` | Theme tokens or `crosshair_x`, `crosshair_y`, and `selection` slots |
+| Modebar | `modebar(show=...)` | `modebar` and `modebar_button` slots or component-local class/style |
+| Chart frame | Chart `class_name`, `class_names`, `style`, and `styles` | `root`, `title`, `chrome`, `canvas`, and `labels` slots |
+| Reduction badges | Emitted automatically when XY reduces, samples, or rasterizes data | `badge` and `badge_item` slots plus badge theme tokens |
+| Facets | `facet_chart(..., gap=...)` and the shared child chart styles | Per-panel chart slots; standalone grid selectors are `.xy-facet-grid`, `.xy-facet-panel`, and `.xy-facet-title` |
+| Data marks | Mark factories such as `line`, `scatter`, and `bar` | The validated mark `style` subset, not DOM classes |
+
+`vline` is the vertical **x reference line** and `hline` is the horizontal
+**y reference line**. XY does not expose separate `x_line` or `y_line` names.
+
+## Built-in legend and tooltip
+
+Hover a point to see the formatted tooltip. The legend container, rows,
+swatches, and tooltip use independent styling surfaces.
+
+~~~python demo exec
+import reflex_xy
+import xy
+
+data = {
+    "month": [1, 2, 3, 4, 5, 6],
+    "actual": [42_000, 47_000, 45_000, 53_000, 58_000, 64_000],
+    "plan": [40_000, 44_000, 48_000, 52_000, 56_000, 60_000],
+}
+
+legend_tooltip_chart = xy.line_chart(
+    xy.line(
+        x="month",
+        y="actual",
+        data=data,
+        name="Actual",
+        style={"stroke": "#6e56cf", "stroke-width": 2.5},
+    ),
+    xy.line(
+        x="month",
+        y="plan",
+        data=data,
+        name="Plan",
+        style={
+            "stroke": "#0ea5e9",
+            "stroke-width": 2,
+            "stroke-dasharray": "6px 4px",
+        },
+    ),
+    xy.scatter(
+        x="month",
+        y="actual",
+        data=data,
+        name="Observed",
+        size=8,
+        style={"fill": "#ffffff", "stroke": "#6e56cf", "stroke-width": 2},
+    ),
+    xy.legend(
+        loc="upper left",
+        ncols=3,
+        title="Revenue",
+        style={
+            "background": "var(--legend-bg, rgb(255 255 255 / 92%))",
+            "color": "var(--legend-text, #0f172a)",
+            "border": "1px solid var(--legend-border, #e2e8f0)",
+            "border-radius": 10,
+            "box-shadow": "0 8px 24px rgb(15 23 42 / 10%)",
+        },
+    ),
+    xy.tooltip(
+        fields=["month", "actual", "plan"],
+        title="Month {month}",
+        format={"actual": ",.0f", "plan": ",.0f"},
+        style={
+            "background": "rgb(15 23 42 / 94%)",
+            "color": "#f8fafc",
+            "border-radius": 8,
+            "padding": "8px 10px",
+        },
+    ),
+    xy.x_axis(label="month", tick_count=6),
+    xy.y_axis(label="revenue", format=",.0f"),
+    styles={
+        "legend_item": {"gap": 6, "padding": "3px 5px"},
+        "legend_swatch": {"border-radius": 3},
+    },
+    class_name=(
+        "[--legend-bg:#fffffff0] [--legend-text:#0f172a] "
+        "[--legend-border:#e2e8f0] dark:[--legend-bg:#1e293bf0] "
+        "dark:[--legend-text:#e2e8f0] dark:[--legend-border:#475569]"
+    ),
+)
+
+
+def legend_tooltip_styling_preview():
+    return reflex_xy.chart(legend_tooltip_chart, height="380px")
+~~~
+
+The tooltip can only display values resident in the browser payload. Fields
+used by x, y, color, size, or heatmap value channels are resident; naming an
+otherwise-unused source column in `fields` does not ship it automatically.
+
+## Axes and reference lines or bands
+
+This example covers bottom and top x axes, left and right y axes, independently
+styled named scales, both reference-line directions, and both band directions.
+Annotation geometry uses explicit props, while its text box uses normal DOM
+styles.
+
+~~~python demo exec
+import reflex_xy
+import xy
+
+x = [0, 1, 2, 3, 4, 5, 6]
+latency = [82, 76, 71, 68, 64, 61, 58]
+errors = [1.4, 1.7, 1.3, 2.1, 1.8, 1.2, 0.9]
+
+reference_chart = xy.chart(
+    xy.line(
+        x,
+        latency,
+        name="Latency",
+        style={"stroke": "#2563eb", "stroke-width": 2.5},
+    ),
+    xy.line(
+        x,
+        errors,
+        y_axis="y2",
+        name="Errors",
+        style={"stroke": "#e11d48", "stroke-width": 2},
+    ),
+    xy.line(
+        [10, 20, 30, 40, 50, 60, 70],
+        [78, 74, 72, 69, 66, 63, 60],
+        x_axis="x2",
+        name="Load-index projection",
+        style={
+            "stroke": "#7c3aed",
+            "stroke-width": 1.8,
+            "stroke-dasharray": "5px 4px",
+        },
+    ),
+    xy.x_band(
+        3.3,
+        4.3,
+        text="deploy window",
+        color="#f59e0b",
+        opacity=0.12,
+        style={
+            "label_color": "var(--warning-label, #92400e)",
+            "background": "var(--warning-bg, #fffbeb)",
+            "padding": "2px 5px",
+        },
+    ),
+    xy.y_band(
+        72,
+        77,
+        text="watch band",
+        color="#0d9488",
+        opacity=0.10,
+        style={
+            "label_color": "var(--teal-label, #115e59)",
+            "background": "var(--teal-bg, #f0fdfa)",
+            "padding": "2px 5px",
+        },
+    ),
+    xy.vline(
+        2,
+        text="release",
+        color="#d97706",
+        width=2,
+        style={
+            "label_color": "var(--warning-label, #92400e)",
+            "background": "var(--warning-bg, #fffbeb)",
+            "border": "1px solid var(--warning-border, #fde68a)",
+            "border-radius": 5,
+            "padding": "2px 5px",
+        },
+    ),
+    xy.hline(
+        65,
+        text="SLO",
+        color="#16a34a",
+        width=2,
+        style={
+            "label_color": "var(--success-label, #166534)",
+            "background": "var(--success-bg, #f0fdf4)",
+            "border-radius": 5,
+            "padding": "2px 5px",
+        },
+    ),
+    xy.x_axis(
+        label="release",
+        style={
+            "grid_color": "var(--axes-grid, rgb(148 163 184 / 20%))",
+            "grid_dash": "dotted",
+            "axis_color": "var(--axes-neutral, #475569)",
+            "tick_color": "var(--axes-neutral, #475569)",
+            "tick_direction": "out",
+            "tick_length": 6,
+        },
+    ),
+    xy.x_axis(
+        id="x2",
+        side="top",
+        label="load index",
+        domain=(10, 70),
+        tick_count=4,
+        style={
+            "axis_color": "var(--axes-purple, #7c3aed)",
+            "tick_color": "var(--axes-purple, #7c3aed)",
+            "tick_label_color": "var(--axes-purple, #6d28d9)",
+            "label_color": "var(--axes-purple, #6d28d9)",
+        },
+    ),
+    xy.y_axis(
+        label="latency (ms)",
+        style={
+            "label_color": "var(--axes-blue, #1d4ed8)",
+            "tick_label_color": "var(--axes-blue, #1d4ed8)",
+        },
+    ),
+    xy.y_axis(
+        id="y2",
+        side="right",
+        label="errors (%)",
+        domain=(0, 3),
+        format=".1f",
+        style={
+            "axis_color": "var(--axes-red, #be123c)",
+            "tick_color": "var(--axes-red, #be123c)",
+            "tick_label_color": "var(--axes-red, #be123c)",
+            "label_color": "var(--axes-red, #be123c)",
+        },
+    ),
+    xy.legend(loc="upper right"),
+    xy.theme(
+        plot_background="var(--axes-bg, #ffffff)",
+        text_color="var(--axes-text, #334155)",
+        grid_color="var(--axes-grid, rgb(148 163 184 / 20%))",
+        axis_color="var(--axes-neutral, #64748b)",
+    ),
+    class_name=(
+        "[--axes-bg:#ffffff] [--axes-text:#334155] [--axes-grid:#94a3b833] "
+        "[--axes-neutral:#475569] [--axes-purple:#6d28d9] "
+        "[--axes-blue:#1d4ed8] [--axes-red:#be123c] "
+        "[--warning-label:#92400e] [--warning-bg:#fffbeb] "
+        "[--warning-border:#fde68a] [--teal-label:#115e59] "
+        "[--teal-bg:#f0fdfa] [--success-label:#166534] "
+        "[--success-bg:#f0fdf4] dark:[--axes-bg:#0f172a] "
+        "dark:[--axes-text:#e2e8f0] dark:[--axes-grid:#e2e8f01f] "
+        "dark:[--axes-neutral:#94a3b8] dark:[--axes-purple:#c4b5fd] "
+        "dark:[--axes-blue:#93c5fd] dark:[--axes-red:#fda4af] "
+        "dark:[--warning-label:#fde68a] dark:[--warning-bg:#451a03] "
+        "dark:[--warning-border:#92400e] dark:[--teal-label:#99f6e4] "
+        "dark:[--teal-bg:#134e4a] dark:[--success-label:#bbf7d0] "
+        "dark:[--success-bg:#14532d]"
+    ),
+    style={"background": "var(--axes-bg, #ffffff)"},
+    title="Axes and reference geometry",
+)
+
+
+def axis_reference_styling_preview():
+    return reflex_xy.chart(reference_chart, height="430px")
+~~~
+
+## Annotation variants
+
+Every annotation splits into up to two styling layers: its canvas-painted
+geometry and its DOM label. This example exercises the positioned text alias,
+marker, arrow, semantic threshold, semantic threshold zone, and callout. The
+preceding example covers the underlying rule and band primitives directly.
+Geometry `opacity` does not fade label text; set `label_opacity` in the
+annotation style when that label should also be translucent.
+
+~~~python demo exec
+import reflex_xy
+import xy
+
+annotation_chart = xy.line_chart(
+    xy.line(
+        [0, 1, 2, 3, 4, 5],
+        [3, 5, 4, 7, 6, 9],
+        style={"stroke": "#94a3b8", "stroke-width": 1.5},
+    ),
+    xy.text(
+        0,
+        3,
+        "text",
+        dx=0,
+        dy=-14,
+        anchor="middle",
+        color="var(--chart-text)",
+        class_name="font-medium",
+    ),
+    xy.label(
+        1,
+        5,
+        "label alias",
+        dx=0,
+        dy=-16,
+        anchor="middle",
+        color="var(--purple-label, #7c3aed)",
+        style={
+            "background": "var(--purple-bg, #f5f3ff)",
+            "padding": "2px 5px",
+        },
+    ),
+    xy.marker(
+        2,
+        4,
+        text="marker",
+        symbol="diamond",
+        size=11,
+        color="#0ea5e9",
+        stroke_color="#ffffff",
+        stroke_width=2,
+        dx=0,
+        dy=20,
+        anchor="middle",
+    ),
+    xy.arrow(
+        2.2,
+        5.0,
+        3,
+        7,
+        text="arrow",
+        color="#e11d48",
+        width=2,
+        style={
+            "label_color": "var(--rose-label, #9f1239)",
+            "background": "var(--rose-bg, #fff1f2)",
+            "border-radius": 4,
+            "padding": "1px 4px",
+            "font_weight": 600,
+        },
+    ),
+    xy.threshold(
+        8,
+        axis="y",
+        text="threshold",
+        color="#ea580c",
+        width=2,
+        style={
+            "label_color": "var(--orange-label, #9a3412)",
+            "background": "var(--orange-bg, #fff7ed)",
+            "padding": "2px 5px",
+        },
+    ),
+    xy.threshold_zone(
+        3.5,
+        4.5,
+        axis="x",
+        text="threshold zone",
+        color="#14b8a6",
+        opacity=0.12,
+        style={
+            "label_color": "var(--teal-label, #115e59)",
+            "background": "var(--teal-bg, #f0fdfa)",
+            "border": "1px solid var(--teal-border, #99f6e4)",
+            "border-radius": 4,
+            "padding": "1px 4px",
+        },
+    ),
+    xy.callout(
+        5,
+        9,
+        "callout",
+        dx=-18,
+        dy=-28,
+        anchor="end",
+        color="#6e56cf",
+        width=2,
+        style={
+            "label_color": "var(--purple-label, #6b21a8)",
+            "background": "var(--purple-bg, #faf5ff)",
+            "border": "1px solid var(--purple-border, #d8b4fe)",
+            "border-radius": 6,
+            "padding": "3px 6px",
+        },
+    ),
+    xy.x_axis(domain=(-0.35, 5.35)),
+    xy.y_axis(domain=(2, 10)),
+    styles={"annotation_label": {"line_height": 1.2}},
+    class_name=(
+        "[--purple-label:#6b21a8] [--purple-bg:#faf5ff] "
+        "[--purple-border:#d8b4fe] [--rose-label:#9f1239] "
+        "[--rose-bg:#fff1f2] [--orange-label:#9a3412] "
+        "[--orange-bg:#fff7ed] [--teal-label:#115e59] "
+        "[--teal-bg:#f0fdfa] [--teal-border:#99f6e4] "
+        "dark:[--purple-label:#e9d5ff] dark:[--purple-bg:#3b0764] "
+        "dark:[--purple-border:#7e22ce] dark:[--rose-label:#fecdd3] "
+        "dark:[--rose-bg:#4c0519] dark:[--orange-label:#fed7aa] "
+        "dark:[--orange-bg:#431407] dark:[--teal-label:#99f6e4] "
+        "dark:[--teal-bg:#134e4a] dark:[--teal-border:#0f766e]"
+    ),
+    padding=[48, 88, 52, 88],
+    title="Annotation styling layers",
+)
+
+
+def annotation_variants_styling_preview():
+    return reflex_xy.chart(annotation_chart, height="400px")
+~~~
+
+`label(...)` is a semantic alias of `text(...)`; it does not create a separate
+DOM slot. `threshold(...)` resolves to `vline` or `hline`, and
+`threshold_zone(...)` resolves to `x_band` or `y_band`, according to `axis`.
+The alias names are useful for intent, while the renderer and styling contract
+stay identical to the underlying primitive.
+
+## Crosshair and selection
+
+Move across the plot to show the crosshair. Shift-drag to reveal the styled
+selection rectangle.
+
+~~~python demo exec
+import reflex as rx
+import reflex_xy
+import xy
+
+interaction_chart = xy.scatter_chart(
+    xy.scatter(
+        [0, 1, 2, 3, 4, 5, 6, 7],
+        [2, 5, 3, 7, 6, 9, 8, 11],
+        size=10,
+        style={"fill": "#7c3aed", "stroke": "#ffffff", "stroke-width": 1.5},
+    ),
+    xy.interaction_config(crosshair=True, select=True, brush=True),
+    xy.modebar(
+        class_name=(
+            "rounded-lg border border-slate-200 bg-white/95 shadow-md "
+            "dark:border-slate-700 dark:bg-slate-900/95"
+        ),
+        button_class_name=(
+            "rounded-md hover:bg-violet-50 focus:ring-2 focus:ring-violet-500 "
+            "dark:hover:bg-violet-950"
+        ),
+        style={"padding": 4},
+        button_style={"color": "var(--chart-text)"},
+    ),
+    xy.theme(
+        crosshair_color="#e11d48",
+        selection_color="#7c3aed",
+        selection_fill="rgb(124 58 237 / 16%)",
+    ),
+    xy.x_axis(label="sample"),
+    xy.y_axis(label="value"),
+    styles={
+        "crosshair_x": {"width": 2},
+        "crosshair_y": {"height": 2},
+        "selection": {"border-radius": 6},
+    },
+)
+
+interaction_token = reflex_xy.inline(interaction_chart)
+
+
+class InteractionChromeState(rx.State):
+    selected_count: int = 0
+    selected_share: str = "0%"
+    selection_shape: str = "None"
+    selection_region: str = "Draw a box or lasso around a cohort."
+
+    @rx.event
+    def record_selection(self, selection: dict):
+        total = int(selection.get("total") or 0)
+        if selection.get("cleared"):
+            self.selected_count = 0
+            self.selected_share = "0%"
+            self.selection_shape = "None"
+            self.selection_region = "Selection cleared."
+            return
+
+        self.selected_count = total
+        self.selected_share = f"{100 * total / 8:.0f}%"
+        polygon = selection.get("polygon")
+        if polygon:
+            self.selection_shape = "Lasso"
+            self.selection_region = f"Free-form region with {len(polygon)} vertices"
+        else:
+            self.selection_shape = "Box / range"
+            bounds = [selection.get(key) for key in ("x0", "x1", "y0", "y1")]
+            if all(isinstance(value, (int, float)) for value in bounds):
+                x0, x1, y0, y1 = bounds
+                self.selection_region = f"x: {x0:.1f}–{x1:.1f}; y: {y0:.1f}–{y1:.1f}"
+            else:
+                self.selection_region = "Selected chart region"
+
+
+def interaction_chrome_styling_preview():
+    return rx.vstack(
+        reflex_xy.chart(
+            interaction_token,
+            on_select_end=InteractionChromeState.record_selection,
+            height="360px",
+        ),
+        rx.hstack(
+            rx.vstack(
+                rx.text(
+                    "Selected",
+                    class_name="text-xs text-slate-500 dark:text-slate-400",
+                ),
+                rx.text(
+                    InteractionChromeState.selected_count,
+                    class_name=(
+                        "text-2xl font-semibold text-violet-700 dark:text-violet-300"
+                    ),
+                ),
+                align="start",
+            ),
+            rx.vstack(
+                rx.text(
+                    "Dataset share",
+                    class_name="text-xs text-slate-500 dark:text-slate-400",
+                ),
+                rx.text(
+                    InteractionChromeState.selected_share,
+                    class_name=(
+                        "text-2xl font-semibold text-violet-700 dark:text-violet-300"
+                    ),
+                ),
+                align="start",
+            ),
+            rx.vstack(
+                rx.text(
+                    "Selection",
+                    class_name="text-xs text-slate-500 dark:text-slate-400",
+                ),
+                rx.text(
+                    InteractionChromeState.selection_shape,
+                    class_name=(
+                        "text-sm font-semibold text-slate-800 dark:text-slate-100"
+                    ),
+                ),
+                rx.text(
+                    InteractionChromeState.selection_region,
+                    class_name="text-xs text-slate-500 dark:text-slate-400",
+                ),
+                align="start",
+            ),
+            width="100%",
+            justify="between",
+            align="start",
+            class_name=(
+                "rounded-lg border border-slate-200 bg-white p-4 "
+                "dark:border-slate-700 dark:bg-slate-950"
+            ),
+        ),
+        width="100%",
+        align="stretch",
+    )
+~~~
+
+The component-local modebar props merge into the same `modebar` and
+`modebar_button` slots as chart-level `class_names` / `styles`. Open the
+selection menu to choose box, lasso, X-range, or Y-range selection; Shift-drag
+remains a shortcut for box selection. The analysis panel turns the compact
+`on_select_end` summary into a selected count, dataset share, selection type,
+and region readout. A production dashboard can use the same event to update
+filters, aggregate cards, or related views.
+
+## Custom component replacements
+
+There are two different meanings of “custom”:
+
+1. **Restyle built-in chrome.** Use the component and slot APIs demonstrated
+   above. This works in the shipped browser client, Reflex adapter, standalone
+   HTML, and Chromium export.
+2. **Replace chrome with a framework component.** The built-in
+   `reflex_xy.chart` adapter does not render components passed through
+   `legend(render=...)`, `tooltip(render=...)`, or `colorbar(render=...)`.
+   Standalone exports cannot include framework-owned components either.
+
+For a framework-owned legend with the shipped Reflex adapter, compose it next
+to the chart and hide XY's built-in legend:
+
+~~~python demo exec
+import reflex as rx
+import reflex_xy
+import xy
+
+custom_legend_chart = xy.line_chart(
+    xy.line([0, 1, 2, 3], [2, 5, 3, 7], color="#6e56cf"),
+    xy.line([0, 1, 2, 3], [1, 3, 4, 6], color="#0ea5e9"),
+    xy.legend(show=False),
+    title="Framework-owned legend",
+)
+
+
+def legend_key(color: str, label: str) -> rx.Component:
+    return rx.hstack(
+        rx.box(width="0.75rem", height="0.75rem", border_radius="3px", bg=color),
+        rx.text(label, size="2"),
+        align="center",
+        spacing="2",
+    )
+
+
+def custom_reflex_legend_preview():
+    return rx.vstack(
+        reflex_xy.chart(custom_legend_chart, height="300px"),
+        rx.hstack(
+            legend_key("#6e56cf", "Actual"),
+            legend_key("#0ea5e9", "Plan"),
+            spacing="4",
+        ),
+        width="100%",
+        align="center",
+    )
+~~~
+
+A truly custom hover tooltip needs host state: handle Reflex
+`on_point_hover`, render your own component from the received row, and disable
+the built-in tooltip with `tooltip(show=False)`. See the
+[Reflex integration](/docs/xy/integrations/reflex/#events-and-streaming) for
+the state-backed event contract.
+
+## Conditional badges and facet wrappers
+
+Reduction badges are not author-created children. They appear only when the
+selected representation reports reduction, sampling, or density metadata, so
+small examples commonly have no `badge` element to style. Configure both the
+container and item slots up front when a dashboard may cross that threshold:
+
+~~~python
+chart = xy.scatter_chart(
+    xy.scatter(x, y),
+    class_names={"badge": "gap-1", "badge_item": "font-mono text-[10px]"},
+    styles={"badge_item": {"border": "1px solid rgb(148 163 184 / 35%)"}},
+)
+~~~
+
+`facet_chart` repeats the same child chart contract in every panel, so mark,
+axis, annotation, legend, tooltip, theme, and chart-slot styling are shared by
+default. Its standalone HTML wrapper additionally emits `.xy-facet-grid`,
+`.xy-facet-panel`, and `.xy-facet-title`; target those through `custom_css`
+when styling the layout around panels. These selectors belong to the facet
+wrapper rather than a chart slot, so do not put them in `class_names` or
+`styles`.

--- a/docs/styling/gallery.md
+++ b/docs/styling/gallery.md
@@ -68,9 +68,9 @@ def shell_chart(accent: str, title: str):
             loc="upper left",
             title="Series",
             style={
-                "background": "var(--shell-legend-bg, rgb(255 255 255 / 86%))",
-                "color": "var(--shell-text, #0f172a)",
-                "border": "1px solid var(--shell-border, #e2e8f0)",
+                "background": "var(--secondary-3)",
+                "color": "var(--secondary-12)",
+                "border": "1px solid var(--secondary-5)",
             },
         ),
         xy.tooltip(title="Sample {x}", format={"y": ".1f"}),
@@ -78,23 +78,18 @@ def shell_chart(accent: str, title: str):
         xy.y_axis(label="value"),
         xy.theme(
             style={
-                "--chart-bg": "var(--shell-bg, #ffffff)",
-                "--chart-text": "var(--shell-text, #0f172a)",
-                "--chart-grid": "var(--shell-grid, rgb(148 163 184 / 22%))",
-                "--chart-axis": "var(--shell-axis, #64748b)",
-                "--chart-legend-bg": "var(--shell-legend-bg, rgb(255 255 255 / 86%))",
-                "--chart-tooltip-bg": "#020617",
-                "--chart-tooltip-text": "#f8fafc",
+                "--chart-bg": "var(--secondary-2)",
+                "--chart-text": "var(--secondary-11)",
+                "--chart-grid": "var(--secondary-a5)",
+                "--chart-axis": "var(--secondary-a8)",
+                "--chart-legend-bg": "var(--secondary-3)",
+                "--chart-tooltip-bg": "var(--secondary-3)",
+                "--chart-tooltip-text": "var(--secondary-12)",
             }
         ),
         class_name=(
-            "rounded-2xl border bg-[var(--shell-bg)] text-[var(--shell-text)] "
-            "shadow-sm [--shell-bg:#ffffff] [--shell-text:#0f172a] "
-            "[--shell-grid:#94a3b838] [--shell-axis:#64748b] "
-            "[--shell-border:#e2e8f0] [--shell-legend-bg:#ffffffdb] "
-            "dark:[--shell-bg:#0f172a] dark:[--shell-text:#e2e8f0] "
-            "dark:[--shell-grid:#e2e8f01f] dark:[--shell-axis:#94a3b8] "
-            "dark:[--shell-border:#334155] dark:[--shell-legend-bg:#020617db]"
+            "rounded-2xl border border-secondary-5 bg-secondary-2 "
+            "text-secondary-12 shadow-sm"
         ),
         class_names={
             "title": "font-semibold tracking-tight",
@@ -103,11 +98,11 @@ def shell_chart(accent: str, title: str):
             "modebar_button": "rounded-md focus:ring-2",
         },
         styles={
-            "root": {"border_color": "var(--shell-border, #e2e8f0)"},
+            "root": {"border_color": "var(--secondary-5)"},
             "legend_item": {"padding": "2px 4px"},
             "legend_swatch": {"border_radius": 999},
         },
-        style={"background": "var(--shell-bg, #ffffff)"},
+        style={"background": "var(--secondary-2)"},
         width="100%",
         height=350,
         padding=[42, 40, 64, 58],
@@ -146,9 +141,9 @@ Python conditionals:
 ~~~css
 @media (prefers-color-scheme: dark) {
   .xy {
-    --chart-bg: #0f172a;
-    --chart-text: #e2e8f0;
-    --chart-grid: rgb(226 232 240 / 12%);
+    --chart-bg: #18181b;
+    --chart-text: #e4e4e7;
+    --chart-grid: rgb(212 212 216 / 12%);
   }
 }
 ~~~
@@ -244,15 +239,12 @@ responsive_chrome_chart = xy.chart(
         selection_color="#7c3aed",
         selection_fill="rgb(124 58 237 / 16%)",
     ),
-    class_name=(
-        "rounded-2xl border border-slate-200 bg-white text-slate-900 shadow-sm "
-        "dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
-    ),
+    class_name="text-slate-900 dark:text-slate-100",
     class_names={
         "legend": (
-            "rounded-xl bg-white/90 shadow-lg backdrop-blur-sm dark:bg-slate-900/90"
+            "rounded-xl bg-white/90 shadow-lg backdrop-blur-sm dark:bg-zinc-900/90"
         ),
-        "tooltip": "rounded-xl bg-slate-950/95 px-3 py-2 text-white shadow-2xl",
+        "tooltip": "rounded-xl bg-zinc-950/95 px-3 py-2 text-white shadow-2xl",
     },
     styles={
         "legend_item": {"padding": "2px 5px"},
@@ -293,11 +285,15 @@ trend_atlas = xy.chart(
         x,
         [2, 3, 3, 5, 4, 6, 7],
         name="Area",
-        color="#c4b5fd",
-        fill="linear-gradient(to top, transparent, currentColor)",
-        opacity=0.46,
-        line_color="#7c3aed",
+        color="#8b5cf6",
+        fill=(
+            "linear-gradient(to top, rgb(124 58 237 / 0%), "
+            "rgb(124 58 237 / 14%) 55%, rgb(167 139 250 / 38%))"
+        ),
+        opacity=1,
+        line_color="#8b5cf6",
         line_width=1.5,
+        line_opacity=0.9,
     ),
     xy.line(
         x,
@@ -445,12 +441,15 @@ histogram_chart = xy.histogram_chart(
         [2, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 7, 8, 9],
         bins=7,
         name="Histogram",
-        color="#c4b5fd",
-        fill="linear-gradient(to top, #ede9fe, #7c3aed)",
-        opacity=0.82,
+        color="#8b5cf6",
+        fill=(
+            "linear-gradient(to top, rgb(109 40 217 / 38%), "
+            "rgb(139 92 246 / 92%))"
+        ),
+        opacity=1,
         corner_radius=(5, 1),
-        stroke="#6d28d9",
-        stroke_width=0.8,
+        stroke="#7c3aed",
+        stroke_width=0.9,
     ),
     title="Rounded histogram",
 )
@@ -895,7 +894,7 @@ reduction_chart = xy.scatter_chart(
     },
     styles={
         "badge_item": {
-            "background": "rgb(15 23 42 / 88%)",
+            "background": "rgb(24 24 27 / 88%)",
             "border": "1px solid rgb(148 163 184 / 40%)",
             "color": "#f8fafc",
             "padding": "3px 7px",
@@ -959,15 +958,15 @@ def styled_facet_preview():
     return rx.html(
         styled_facets.to_svg(),
         class_name=(
-            "w-full overflow-hidden rounded-xl border border-slate-200 "
-            "bg-[var(--facet-bg)] p-2 [--facet-bg:#ffffff] "
+            "w-full [--facet-bg:#ffffff] "
             "[--facet-text:#334155] [--facet-grid:#94a3b838] "
             "[--facet-axis:#64748b] [--facet-accent:#a78bfa] "
             "[--facet-line:#6d28d9] [&>svg]:h-auto [&>svg]:w-full "
-            "dark:border-slate-700 dark:[--facet-bg:#0f172a] "
-            "dark:[--facet-text:#e2e8f0] dark:[--facet-grid:#e2e8f01f] "
-            "dark:[--facet-axis:#94a3b8] dark:[--facet-accent:#c4b5fd] "
-            "dark:[--facet-line:#a78bfa]"
+            "dark:[--facet-bg:#18181b] dark:[--facet-text:#e4e4e7] "
+            "dark:[--facet-grid:#d4d4d81f] dark:[--facet-axis:#a1a1aa] "
+            "dark:[--facet-accent:#c4b5fd] dark:[--facet-line:#a78bfa] "
+            "dark:[&_text]:fill-zinc-200 "
+            "dark:[&_path[stroke]]:stroke-violet-400"
         ),
     )
 ~~~
@@ -977,7 +976,7 @@ For standalone HTML, style the grid itself at export time:
 ~~~python
 html = styled_facets.to_html(
     custom_css="""
-.xy-facet-grid { gap: 1rem; padding: 1rem; background: #f8fafc; }
+.xy-facet-grid { gap: 1rem; padding: 1rem; background: #fafafa; }
 .xy-facet-panel { overflow: hidden; border: 1px solid #e2e8f0; border-radius: 12px; }
 .xy-facet-title { color: #312e81; letter-spacing: .02em; }
 """

--- a/docs/styling/gallery.md
+++ b/docs/styling/gallery.md
@@ -1,0 +1,1064 @@
+---
+title: Styling Gallery
+description: Exercise every XY mark family, chart shell, facet, badge, axis, and custom-chrome boundary.
+---
+
+# Styling Gallery
+
+This gallery demonstrates the full range of XY's public styling features. The
+examples combine mark styles, DOM slots, theme tokens, responsive sizing, and
+less common axis and annotation configurations. Use the shorter
+[recipes](/docs/xy/styling/recipes/) when you want one polished treatment;
+use this page when you need to see how far a styling surface reaches.
+
+## Complete coverage map
+
+| Family | Components exercised here | Useful styling variations |
+| --- | --- | --- |
+| Trend | `line`, `area`, `step`, `stairs`, `ecdf` | smooth and stepped geometry, gradients, outlines, dashes, opacity |
+| Points | `scatter` | all symbols, fill/stroke separation, continuous color and size |
+| Categories | `bar`, `column` | horizontal/vertical layout, gradients, outline, asymmetric corner radii |
+| Distributions | `histogram` / `hist`, `box`, `violin` | rounded bins, density fill, translucent comparison layers |
+| Grids and density | `heatmap`, `hexbin`, `contour` | colormaps, cell alpha, contour strokes, layered scalar fields |
+| Uncertainty | `error_band`, `errorbar` | translucent interval fill, boundary strokes, caps, estimate overlays |
+| Explicit geometry | `segments`, `stem`, `triangle_mesh` | per-item color, stroke width, marker paint, mesh borders |
+| Annotations | `vline`, `hline`, `x_band`, `y_band`, `text`, `label`, `marker`, `arrow`, `threshold`, `threshold_zone`, `callout` | geometry paint plus independently styled DOM labels |
+| Chrome | `x_axis`, `y_axis`, `legend`, `tooltip`, `colorbar`, `modebar`, `theme`, `interaction_config` | classes, inline slot styles, tokens, crosshair, selection |
+| Composition | `chart`, typed chart factories, `facet_chart` | layered marks, shared panel styles, responsive wrappers, export CSS |
+
+`hist` is an alias of `histogram`; `label` is an alias of `text`; and
+`threshold` / `threshold_zone` resolve to the corresponding rule or band.
+The aliases are listed for completeness; they use the same rendering behavior
+as their corresponding components.
+
+## Responsive chart shells
+
+Both cards use `width="100%"`; resize the page to exercise the chart's
+`ResizeObserver`. They use different accent colors while their background,
+text, axes, legend, tooltip, and modebar follow the page's light or dark theme.
+Hover the live marks to inspect the tooltip.
+
+~~~python demo exec
+import reflex as rx
+import reflex_xy
+import xy
+
+
+def shell_chart(accent: str, title: str):
+    return xy.line_chart(
+        xy.area(
+            [0, 1, 2, 3, 4, 5],
+            [3, 5, 4, 7, 6, 9],
+            color=accent,
+            curve="smooth",
+            fill="linear-gradient(currentColor, transparent)",
+            opacity=0.42,
+            line_width=2,
+        ),
+        xy.scatter(
+            [0, 1, 2, 3, 4, 5],
+            [3, 5, 4, 7, 6, 9],
+            name="Observed",
+            color=accent,
+            size=7,
+            stroke="#ffffff",
+            stroke_width=1.5,
+        ),
+        xy.legend(
+            loc="upper left",
+            title="Series",
+            style={
+                "background": "var(--shell-legend-bg, rgb(255 255 255 / 86%))",
+                "color": "var(--shell-text, #0f172a)",
+                "border": "1px solid var(--shell-border, #e2e8f0)",
+            },
+        ),
+        xy.tooltip(title="Sample {x}", format={"y": ".1f"}),
+        xy.x_axis(label="sample", tick_count=6),
+        xy.y_axis(label="value"),
+        xy.theme(
+            style={
+                "--chart-bg": "var(--shell-bg, #ffffff)",
+                "--chart-text": "var(--shell-text, #0f172a)",
+                "--chart-grid": "var(--shell-grid, rgb(148 163 184 / 22%))",
+                "--chart-axis": "var(--shell-axis, #64748b)",
+                "--chart-legend-bg": "var(--shell-legend-bg, rgb(255 255 255 / 86%))",
+                "--chart-tooltip-bg": "#020617",
+                "--chart-tooltip-text": "#f8fafc",
+            }
+        ),
+        class_name=(
+            "rounded-2xl border bg-[var(--shell-bg)] text-[var(--shell-text)] "
+            "shadow-sm [--shell-bg:#ffffff] [--shell-text:#0f172a] "
+            "[--shell-grid:#94a3b838] [--shell-axis:#64748b] "
+            "[--shell-border:#e2e8f0] [--shell-legend-bg:#ffffffdb] "
+            "dark:[--shell-bg:#0f172a] dark:[--shell-text:#e2e8f0] "
+            "dark:[--shell-grid:#e2e8f01f] dark:[--shell-axis:#94a3b8] "
+            "dark:[--shell-border:#334155] dark:[--shell-legend-bg:#020617db]"
+        ),
+        class_names={
+            "title": "font-semibold tracking-tight",
+            "legend": "rounded-lg backdrop-blur-sm",
+            "tooltip": "rounded-lg shadow-2xl",
+            "modebar_button": "rounded-md focus:ring-2",
+        },
+        styles={
+            "root": {"border_color": "var(--shell-border, #e2e8f0)"},
+            "legend_item": {"padding": "2px 4px"},
+            "legend_swatch": {"border_radius": 999},
+        },
+        style={"background": "var(--shell-bg, #ffffff)"},
+        width="100%",
+        height=350,
+        padding=[42, 40, 64, 58],
+        title=title,
+    )
+
+
+def responsive_shells_preview():
+    return rx.el.div(
+        rx.box(
+            reflex_xy.chart(
+                shell_chart("#7c3aed", "Responsive shell"),
+                height="350px",
+            ),
+            class_name="min-w-0",
+        ),
+        rx.box(
+            reflex_xy.chart(
+                shell_chart("#38bdf8", "Alternate accent"),
+                height="350px",
+            ),
+            class_name="min-w-0",
+        ),
+        class_name="flex w-full flex-col gap-5",
+    )
+~~~
+
+Do not put `overflow-hidden` on the XY root when axis titles or annotation
+labels may reach its edge; those labels are DOM chrome and can be clipped by
+normal CSS overflow. Put clipping on an outer host wrapper only when that is
+the visual effect you actually want.
+
+In a standalone document, system dark mode belongs in author CSS rather than
+Python conditionals:
+
+~~~css
+@media (prefers-color-scheme: dark) {
+  .xy {
+    --chart-bg: #0f172a;
+    --chart-text: #e2e8f0;
+    --chart-grid: rgb(226 232 240 / 12%);
+  }
+}
+~~~
+
+## Long legends and edge tooltips
+
+This example keeps a few operational series in a centered legend and puts four
+resident fields in the tooltip. Resize the page until the chart crosses 520 px.
+The legend stays centered on the new plot without escaping the chart; the
+tooltip wraps horizontally and flips above points near the bottom edge.
+
+Tab to the plot and press Home, End, or an arrow key for a deterministic
+tooltip readout. Move the pointer to inspect the styled crosshair, or
+Shift-drag across the plot to inspect the box-selection slot.
+
+~~~python demo exec
+import reflex_xy
+import xy
+
+
+stress_x = [0, 1, 2, 3, 4, 5, 6, 7]
+stress_names = [
+    "Authentication reconciliation",
+    "Payments settlement",
+    "Inventory replication coordinator",
+]
+stress_colors = [
+    "#2563eb",
+    "#7c3aed",
+    "#db2777",
+]
+incident_data = {
+    "sample": stress_x,
+    "latency_ms": [8.4, 7.1, 6.3, 5.8, 4.7, 3.6, 2.4, 1.0],
+    "service_tier": [
+        "edge",
+        "edge",
+        "core",
+        "core",
+        "priority",
+        "priority",
+        "critical",
+        "critical-payments-reconciliation-with-extra-long-label",
+    ],
+    "requests_per_minute": [1200, 1800, 2400, 3300, 4700, 6800, 9100, 12400],
+}
+
+responsive_chrome_chart = xy.chart(
+    *(
+        xy.line(
+            stress_x,
+            [2.2 + index * 0.35 + ((point + index) % 3) * 0.24 for point in stress_x],
+            name=name,
+            color=color,
+            width=1.2,
+            opacity=0.58,
+        )
+        for index, (name, color) in enumerate(zip(stress_names, stress_colors))
+    ),
+    xy.scatter(
+        x="sample",
+        y="latency_ms",
+        color="#f97316",
+        size="requests_per_minute",
+        data=incident_data,
+        name="Incident samples",
+        opacity=0.92,
+        stroke="#ffffff",
+        stroke_width=1.5,
+    ),
+    xy.legend(
+        loc="upper center",
+        ncols=2,
+        title="Operational series",
+    ),
+    xy.tooltip(
+        fields=["sample", "latency_ms", "service_tier", "requests_per_minute"],
+        title="{service_tier}",
+        format={"latency_ms": ".1f", "requests_per_minute": ",.0f"},
+    ),
+    xy.interaction_config(
+        hover=True,
+        click=True,
+        select=True,
+        brush=True,
+        crosshair=True,
+        view_change=True,
+    ),
+    # Keep this example focused on legend, tooltip, and interaction overlays.
+    xy.modebar(show=False),
+    xy.theme(
+        crosshair_color="#e11d48",
+        selection_color="#7c3aed",
+        selection_fill="rgb(124 58 237 / 16%)",
+    ),
+    class_name=(
+        "rounded-2xl border border-slate-200 bg-white text-slate-900 shadow-sm "
+        "dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+    ),
+    class_names={
+        "legend": (
+            "rounded-xl bg-white/90 shadow-lg backdrop-blur-sm dark:bg-slate-900/90"
+        ),
+        "tooltip": "rounded-xl bg-slate-950/95 px-3 py-2 text-white shadow-2xl",
+    },
+    styles={
+        "legend_item": {"padding": "2px 5px"},
+        "crosshair_x": {"width": 2},
+        "crosshair_y": {"height": 2},
+        "selection": {"border_radius": 6},
+    },
+    width="100%",
+    height=360,
+    title="Responsive legend and tooltip",
+)
+
+
+def long_legend_edge_tooltip_preview():
+    return reflex_xy.chart(responsive_chrome_chart, height="360px")
+~~~
+
+The automatic legend width and height are browser defaults, not inline
+author styles. `class_names["legend"]`, `styles["legend"]`, or the
+component-local `legend(style=...)` can therefore replace either limit. The
+same is true for tooltip wrapping and maximum size. If you remove those
+limits intentionally, overflow becomes the responsibility of your CSS.
+
+## Trend and cumulative marks
+
+One coordinate system can layer the entire line-like paint vocabulary. The
+lower-opacity area goes first, followed by smooth, dashed, and stepped strokes.
+The `ecdf` uses a named right axis so its 0–1 range stays legible.
+
+~~~python demo exec
+import reflex_xy
+import xy
+
+x = [0, 1, 2, 3, 4, 5, 6]
+
+trend_atlas = xy.chart(
+    xy.area(
+        x,
+        [2, 3, 3, 5, 4, 6, 7],
+        name="Area",
+        color="#c4b5fd",
+        fill="linear-gradient(to top, transparent, currentColor)",
+        opacity=0.46,
+        line_color="#7c3aed",
+        line_width=1.5,
+    ),
+    xy.line(
+        x,
+        [3, 4, 4, 6, 5, 7, 8],
+        name="Line",
+        color="#2563eb",
+        width=2.5,
+        curve="smooth",
+    ),
+    xy.step(
+        x,
+        [1, 2, 2, 4, 3, 5, 6],
+        name="Step",
+        color="#ea580c",
+        width=2,
+        dash="dashed",
+    ),
+    xy.stairs(
+        [1.4, 2.1, 1.8, 3.2, 2.7, 4.1, 4.8],
+        edges=[0, 1, 2, 3, 4, 5, 6, 7],
+        name="Stairs",
+        color="#0f766e",
+        width=1.8,
+        dash="dotted",
+    ),
+    xy.ecdf(
+        [0.3, 0.8, 1.1, 1.9, 2.7, 3.4, 4.8, 5.2, 5.9],
+        name="ECDF",
+        color="#be123c",
+        width=2,
+        y_axis="y2",
+    ),
+    xy.x_axis(label="ordered domain"),
+    xy.y_axis(label="value"),
+    xy.y_axis(
+        id="y2",
+        side="right",
+        label="cumulative share",
+        domain=(0, 1),
+        format=".0%",
+        style={"label_color": "#be123c", "tick_label_color": "#be123c"},
+    ),
+    xy.legend(loc="upper left", ncols=3),
+    title="Line, area, step, stairs, and ECDF",
+)
+
+
+def trend_mark_atlas_preview():
+    return reflex_xy.chart(trend_atlas, height="430px")
+~~~
+
+## Points, categories, and distributions
+
+The first chart uses all 17 scatter symbols and separates fill from stroke.
+The remaining cards show `column`, `histogram`, `box`, and `violin`
+treatments at independent scales so each filled-geometry path can be judged at
+a useful size. `bar` uses the same paint contract as `column`, with horizontal
+layout.
+
+~~~python demo exec
+import reflex as rx
+import reflex_xy
+import xy
+
+
+symbol_names = [
+    "circle",
+    "square",
+    "diamond",
+    "triangle",
+    "triangle_down",
+    "triangle_left",
+    "triangle_right",
+    "cross",
+    "x",
+    "hexagon",
+    "pentagon",
+    "star",
+    "point",
+    "pixel",
+    "thin_diamond",
+    "plus_line",
+    "x_line",
+]
+symbol_colors = ["#2563eb", "#7c3aed", "#db2777", "#ea580c", "#0f766e"]
+symbol_children = []
+for index, symbol in enumerate(symbol_names):
+    symbol_x = (index % 3) * 4
+    symbol_y = 5 - index // 3
+    symbol_color = symbol_colors[index % len(symbol_colors)]
+    symbol_stroke = symbol_color if symbol in {"plus_line", "x_line"} else "#ffffff"
+    symbol_children.extend([
+        xy.scatter(
+            [symbol_x],
+            [symbol_y],
+            symbol=symbol,
+            size=14,
+            color=symbol_color,
+            stroke=symbol_stroke,
+            stroke_width=2,
+        ),
+        xy.text(
+            symbol_x + 0.35,
+            symbol_y,
+            symbol,
+            dy=3,
+            color="var(--chart-text)",
+            style={"font_size": 10},
+        ),
+    ])
+
+symbol_chart = xy.scatter_chart(
+    *symbol_children,
+    xy.legend(show=False),
+    xy.x_axis(
+        domain=(-0.5, 11.8),
+        tick_label_strategy="none",
+        style={"axis_color": "transparent", "tick_color": "transparent"},
+    ),
+    xy.y_axis(
+        domain=(-0.5, 5.5),
+        tick_label_strategy="none",
+        style={"axis_color": "transparent", "tick_color": "transparent"},
+    ),
+    padding=[42, 20, 24, 20],
+    title="All 17 scatter symbols",
+)
+
+column_chart = xy.column_chart(
+    xy.column(
+        ["Starter", "Team", "Business", "Enterprise"],
+        [34, 58, 76, 93],
+        name="Adoption",
+        fill="linear-gradient(to top, #2563eb, #93c5fd)",
+        stroke="#1e3a8a",
+        stroke_width=1,
+        corner_radius=(8, 1),
+    ),
+    xy.y_axis(domain=(0, 100), format=".0f"),
+    title="Gradient columns",
+)
+
+histogram_chart = xy.histogram_chart(
+    xy.histogram(
+        [2, 3, 3, 4, 4, 4, 5, 5, 5, 6, 6, 7, 8, 9],
+        bins=7,
+        name="Histogram",
+        color="#c4b5fd",
+        fill="linear-gradient(to top, #ede9fe, #7c3aed)",
+        opacity=0.82,
+        corner_radius=(5, 1),
+        stroke="#6d28d9",
+        stroke_width=0.8,
+    ),
+    title="Rounded histogram",
+)
+
+distribution_chart = xy.chart(
+    xy.violin(
+        [2, 3, 3, 4, 4, 4.5, 5, 5, 5.5, 6, 6, 7, 8, 9],
+        name="Violin",
+        color="#0ea5e9",
+        opacity=0.38,
+        width=0.9,
+    ),
+    xy.box(
+        [2, 3, 3, 4, 4, 5, 5, 6, 7, 9],
+        name="Box",
+        color="#7c3aed",
+        opacity=0.62,
+        width=0.42,
+    ),
+    xy.legend(loc="upper right"),
+    title="Violin with box overlay",
+)
+
+matrix_categories = ["Starter", "Team", "Business", "Enterprise"]
+matrix_values = [
+    [18, 27, 34, 43],
+    [11, 19, 28, 37],
+    [7, 13, 22, 31],
+]
+matrix_colors = ["#2563eb", "#7c3aed", "#db2777"]
+
+grouped_bar_chart = xy.bar_chart(
+    xy.bar(
+        matrix_categories,
+        matrix_values,
+        orientation="horizontal",
+        mode="grouped",
+        series=["Core", "Growth", "New"],
+        colors=matrix_colors,
+        corner_radius=(7, 2),
+        stroke="#ffffff",
+        stroke_width=0.8,
+    ),
+    xy.legend(loc="lower right", ncols=3),
+    padding=[42, 30, 54, 88],
+    title="Grouped horizontal bars",
+)
+
+normalized_column_chart = xy.column_chart(
+    xy.column(
+        matrix_categories,
+        matrix_values,
+        mode="normalized",
+        series=["Core", "Growth", "New"],
+        colors=matrix_colors,
+        corner_radius=(6, 1),
+        stroke="#ffffff",
+        stroke_width=0.8,
+    ),
+    xy.legend(loc="upper left", ncols=3),
+    xy.y_axis(domain=(0, 1), format=".0%"),
+    title="Normalized stacked columns",
+)
+
+
+def categorical_distribution_atlas_preview():
+    return rx.el.div(
+        reflex_xy.chart(symbol_chart, height="430px"),
+        reflex_xy.chart(column_chart, height="310px"),
+        reflex_xy.chart(histogram_chart, height="310px"),
+        reflex_xy.chart(distribution_chart, height="310px"),
+        reflex_xy.chart(grouped_bar_chart, height="330px"),
+        reflex_xy.chart(normalized_column_chart, height="330px"),
+        class_name="grid w-full grid-cols-1 gap-5 xl:grid-cols-2",
+    )
+~~~
+
+Grouped, stacked, and normalized matrix modes share the same per-series color,
+stroke, gradient, and asymmetric-corner contract. The final two cards make the
+grouped and normalized paths visible; use `mode="stacked"` for absolute stacks.
+`hist(values, ...)` is the short spelling for `histogram(values, ...)`.
+
+## Scalar fields and density
+
+`heatmap` supplies the filled scalar field and `contour` supplies its crisp
+isolines. The second chart shows screen-bounded `hexbin` geometry. These marks
+accept deliberately narrower paint vocabularies than DOM chrome because their
+color is data-driven.
+
+~~~python demo exec
+import reflex as rx
+import reflex_xy
+import xy
+
+field = [
+    [0.0, 0.2, 0.4, 0.1],
+    [0.2, 0.8, 1.1, 0.5],
+    [0.1, 0.6, 0.9, 0.4],
+    [0.0, 0.2, 0.3, 0.1],
+]
+
+field_chart = xy.chart(
+    xy.heatmap(field, colormap="purples", opacity=0.86),
+    xy.contour(
+        field,
+        levels=7,
+        color="#312e81",
+        colormap="purples",
+        width=1.4,
+        opacity=0.9,
+    ),
+    xy.colorbar(
+        title="Intensity",
+        orientation="vertical",
+        ticks=[0.0, 0.5, 1.1],
+        style={
+            "background": "var(--chart-bg)",
+            "border": "1px solid var(--chart-axis)",
+            "color": "var(--chart-text)",
+            "border-radius": 8,
+        },
+    ),
+    styles={
+        "colorbar_bar": {"border_radius": 4},
+        "colorbar_tick": {"color": "var(--chart-text)"},
+        "colorbar_title": {"font_weight": 700},
+    },
+    title="Heatmap with contour overlay",
+)
+
+hex_x = (
+    [
+        -1.8,
+        -1.5,
+        -1.3,
+        -1.1,
+        -0.9,
+        -0.7,
+        -0.5,
+        -0.3,
+        -0.1,
+        0.1,
+        0.3,
+        0.5,
+        0.7,
+        0.9,
+        1.1,
+        1.3,
+        1.5,
+        1.8,
+    ]
+    + [-0.3] * 4
+    + [0.9] * 6
+)
+hex_y = (
+    [
+        -0.9,
+        -0.5,
+        -0.7,
+        -0.2,
+        -0.4,
+        0.1,
+        -0.1,
+        0.4,
+        0.2,
+        0.7,
+        0.4,
+        0.9,
+        0.6,
+        1.2,
+        0.8,
+        1.4,
+        1.1,
+        1.6,
+    ]
+    + [0.4] * 4
+    + [1.2] * 6
+)
+
+hexbin_chart = xy.hexbin_chart(
+    xy.hexbin(
+        hex_x,
+        hex_y,
+        gridsize=9,
+        mincnt=1,
+        colormap="viridis",
+        opacity=0.9,
+        style={"fill-opacity": 0.9},
+    ),
+    xy.colorbar(
+        title="Points per hexagon",
+        orientation="horizontal",
+        ticks=[1, 3, 6],
+    ),
+    xy.x_axis(style={"grid_dash": "dotted"}),
+    title="Hexagonal density",
+)
+
+
+def scalar_field_atlas_preview():
+    return rx.el.div(
+        reflex_xy.chart(field_chart, height="350px"),
+        reflex_xy.chart(hexbin_chart, height="350px"),
+        class_name="grid w-full grid-cols-1 gap-5 xl:grid-cols-2",
+    )
+~~~
+
+## Uncertainty and explicit geometry
+
+This pair covers the remaining renderer paths: `error_band`, `errorbar`,
+`segments`, `stem`, and `triangle_mesh`. The mesh demonstrates data-driven
+fills with a constant border; segments demonstrate per-item color; stem keeps
+its marker visually distinct from its shaft.
+
+~~~python demo exec
+import reflex as rx
+import reflex_xy
+import xy
+
+x = [0, 1, 2, 3, 4, 5]
+estimate = [3, 4, 4.5, 6, 6.5, 8]
+
+uncertainty_chart = xy.chart(
+    xy.error_band(
+        x,
+        [value - 0.8 for value in estimate],
+        [value + 0.8 for value in estimate],
+        name="90% interval",
+        color="#a78bfa",
+        fill="linear-gradient(to top, transparent, currentColor)",
+        opacity=0.38,
+        line_width=1,
+        line_opacity=0.65,
+    ),
+    xy.errorbar(
+        x,
+        estimate,
+        yerr=[0.4, 0.7, 0.5, 0.8, 0.6, 0.5],
+        name="Observed error",
+        color="#6d28d9",
+        width=1.7,
+        cap_size=5,
+    ),
+    xy.line(x, estimate, name="Estimate", color="#312e81", width=2.4),
+    xy.legend(loc="upper left"),
+    title="Uncertainty layers",
+)
+
+geometry_chart = xy.chart(
+    xy.triangle_mesh(
+        [0, 1, 1],
+        [0, 0, 1],
+        [1, 2, 2],
+        [0, 0, 1],
+        [0.5, 1.5, 1.5],
+        [1.2, 1.3, 2.1],
+        color=[0.2, 0.65, 1.0],
+        colormap="purples",
+        domain=(0, 1),
+        opacity=0.42,
+        stroke="#6d28d9",
+        stroke_width=1,
+        name="Mesh",
+    ),
+    xy.segments(
+        [0.1, 0.6, 1.1],
+        [0.3, 0.7, 1.1],
+        [0.8, 1.3, 1.9],
+        [0.8, 1.2, 1.7],
+        color=[0.1, 0.55, 1.0],
+        colormap="viridis",
+        domain=(0, 1),
+        width=4,
+        name="Segments",
+    ),
+    xy.stem(
+        [0.25, 0.9, 1.55],
+        [0.7, 1.45, 1.9],
+        base=0,
+        color="#e11d48",
+        width=1.8,
+        marker_size=7,
+        name="Stems",
+    ),
+    xy.legend(loc="upper left"),
+    title="Segments, stems, and triangle mesh",
+)
+
+
+def uncertainty_geometry_atlas_preview():
+    return rx.el.div(
+        reflex_xy.chart(uncertainty_chart, height="380px"),
+        reflex_xy.chart(geometry_chart, height="380px"),
+        class_name="grid w-full grid-cols-1 gap-5 xl:grid-cols-2",
+    )
+~~~
+
+## Categorical and time axis styling
+
+Rotated category labels, explicit time axes, and annotation labels are common
+places for spacing bugs. This example keeps both cases live and gives labels
+opaque backgrounds so overlap and clipping are easy to spot.
+
+~~~python demo exec
+import datetime as dt
+
+import reflex as rx
+import reflex_xy
+import xy
+
+category_chart = xy.bar_chart(
+    xy.bar(
+        ["Design review", "Build candidate", "Security review", "General release"],
+        [46, 72, 61, 88],
+        orientation="horizontal",
+        fill="linear-gradient(to top, #bfdbfe, #2563eb)",
+        corner_radius=(7, 1),
+    ),
+    xy.threshold(70, axis="x", text="target", color="#16a34a", width=2),
+    xy.x_axis(label="completion", domain=(0, 100), format=".0f"),
+    xy.y_axis(
+        tick_label_angle=-8,
+        tick_label_strategy="rotate",
+        style={"tick_label_color": "var(--chart-text)", "tick_label_size": 12},
+    ),
+    padding=[44, 28, 54, 128],
+    title="Categorical labels",
+)
+
+dates = [dt.datetime(2026, 7, day) for day in range(1, 8)]
+time_chart = xy.line_chart(
+    xy.line(
+        dates,
+        [42, 48, 45, 56, 54, 63, 68],
+        color="#7c3aed",
+        width=2.5,
+        curve="smooth",
+    ),
+    xy.x_band(
+        dt.datetime(2026, 7, 3),
+        dt.datetime(2026, 7, 4),
+        text="deploy",
+        color="#f59e0b",
+        opacity=0.14,
+        style={
+            "background": "var(--time-warning-bg, #fffbeb)",
+            "label_color": "var(--time-warning-text, #92400e)",
+            "padding": "2px 5px",
+        },
+    ),
+    xy.hline(
+        60,
+        text="SLO",
+        color="#16a34a",
+        style={
+            "background": "var(--time-success-bg, #f0fdf4)",
+            "label_color": "var(--time-success-text, #166534)",
+            "padding": "2px 5px",
+        },
+    ),
+    xy.marker(dates[5], 63, text="marker", color="#0ea5e9", symbol="diamond"),
+    xy.arrow(dates[4], 52, dates[5], 63, text="arrow", color="#e11d48"),
+    xy.callout(
+        dates[6],
+        68,
+        "callout",
+        dx=-62,
+        dy=-28,
+        color="#7c3aed",
+        style={
+            "label_color": "var(--time-callout-text, #6b21a8)",
+            "background": "var(--time-callout-bg, #faf5ff)",
+            "border": "1px solid var(--time-callout-border, #d8b4fe)",
+            "padding": "3px 6px",
+        },
+    ),
+    xy.text(
+        dates[1],
+        48,
+        "text / label",
+        dx=8,
+        dy=-18,
+        color="var(--chart-text)",
+    ),
+    xy.x_axis(type_="time", label="July 2026", label_offset=12, tick_count=7),
+    xy.y_axis(label="requests"),
+    class_name=(
+        "[--time-warning-bg:#fffbeb] [--time-warning-text:#92400e] "
+        "[--time-success-bg:#f0fdf4] [--time-success-text:#166534] "
+        "[--time-callout-bg:#faf5ff] [--time-callout-text:#6b21a8] "
+        "[--time-callout-border:#d8b4fe] "
+        "dark:[--time-warning-bg:#451a03] dark:[--time-warning-text:#fde68a] "
+        "dark:[--time-success-bg:#14532d] dark:[--time-success-text:#bbf7d0] "
+        "dark:[--time-callout-bg:#3b0764] dark:[--time-callout-text:#e9d5ff] "
+        "dark:[--time-callout-border:#7e22ce]"
+    ),
+    padding=[48, 82, 76, 58],
+    title="Time axis and annotation labels",
+)
+
+
+def axis_edge_cases_preview():
+    return rx.el.div(
+        reflex_xy.chart(category_chart, height="390px"),
+        reflex_xy.chart(time_chart, height="390px"),
+        class_name="grid w-full grid-cols-1 gap-5 xl:grid-cols-2",
+    )
+~~~
+
+`y_band`, `vline`, `label`, `threshold_zone`, and the corresponding x/y alias
+directions use the same geometry/label split demonstrated above. The complete
+annotation atlas is in [Component Variations](/docs/xy/styling/component-variations/#annotation-variants).
+
+## A real reduction badge
+
+Badges exist only when the representation reports a real quality tradeoff.
+Enabling density while supplying per-point color produces an “aggregated
+channels” badge. This example styles the badge generated from that real data
+reduction.
+
+~~~python demo exec
+import numpy as np
+import reflex_xy
+import xy
+
+rng = np.random.default_rng(17)
+x = rng.normal(size=12_000)
+y = 0.65 * x + rng.normal(scale=0.7, size=x.size)
+
+reduction_chart = xy.scatter_chart(
+    xy.scatter(
+        x,
+        y,
+        color=np.hypot(x, y),
+        density=True,
+        colormap="viridis",
+        opacity=0.9,
+    ),
+    class_names={
+        "badge": "gap-1",
+        "badge_item": "rounded-full font-mono text-[10px] shadow-sm",
+    },
+    styles={
+        "badge_item": {
+            "background": "rgb(15 23 42 / 88%)",
+            "border": "1px solid rgb(148 163 184 / 40%)",
+            "color": "#f8fafc",
+            "padding": "3px 7px",
+        }
+    },
+    title="Density with disclosed aggregation",
+)
+
+
+def reduction_badge_preview():
+    return reflex_xy.chart(reduction_chart, height="380px")
+~~~
+
+## Styled facets
+
+`facet_chart` applies the same mark, axis, annotation, theme, and chart-slot
+styles to every panel. XY's standalone wrapper owns the grid, so wrapper
+layout selectors belong in export CSS. The docs preview below uses XY's own
+SVG compositor, avoiding multiple live WebGL contexts just to demonstrate the
+panel layout.
+
+~~~python demo exec
+import reflex as rx
+import xy
+
+facet_data = {
+    "x": [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3],
+    "y": [1, 3, 2, 4, 4, 2, 3, 1, 2, 4, 3, 5],
+    "region": ["West"] * 4 + ["East"] * 4 + ["Central"] * 4,
+}
+
+styled_facets = xy.facet_chart(
+    xy.area(
+        x="x",
+        y="y",
+        color="var(--facet-accent, #a78bfa)",
+        fill="linear-gradient(currentColor, transparent)",
+        line_color="var(--facet-line, #6d28d9)",
+        line_width=2,
+    ),
+    xy.x_axis(style={"grid_dash": "dotted"}),
+    xy.theme(
+        plot_background="var(--facet-bg, #ffffff)",
+        grid_color="var(--facet-grid, rgb(148 163 184 / 22%))",
+        axis_color="var(--facet-axis, #64748b)",
+        text_color="var(--facet-text, #334155)",
+    ),
+    xy.modebar(show=False),
+    by="region",
+    data=facet_data,
+    cols=3,
+    gap=16,
+    width=900,
+    height=230,
+    padding=[28, 18, 34, 40],
+    title="Regional trend",
+)
+
+
+def styled_facet_preview():
+    return rx.html(
+        styled_facets.to_svg(),
+        class_name=(
+            "w-full overflow-hidden rounded-xl border border-slate-200 "
+            "bg-[var(--facet-bg)] p-2 [--facet-bg:#ffffff] "
+            "[--facet-text:#334155] [--facet-grid:#94a3b838] "
+            "[--facet-axis:#64748b] [--facet-accent:#a78bfa] "
+            "[--facet-line:#6d28d9] [&>svg]:h-auto [&>svg]:w-full "
+            "dark:border-slate-700 dark:[--facet-bg:#0f172a] "
+            "dark:[--facet-text:#e2e8f0] dark:[--facet-grid:#e2e8f01f] "
+            "dark:[--facet-axis:#94a3b8] dark:[--facet-accent:#c4b5fd] "
+            "dark:[--facet-line:#a78bfa]"
+        ),
+    )
+~~~
+
+For standalone HTML, style the grid itself at export time:
+
+~~~python
+html = styled_facets.to_html(
+    custom_css="""
+.xy-facet-grid { gap: 1rem; padding: 1rem; background: #f8fafc; }
+.xy-facet-panel { overflow: hidden; border: 1px solid #e2e8f0; border-radius: 12px; }
+.xy-facet-title { color: #312e81; letter-spacing: .02em; }
+"""
+)
+~~~
+
+## Custom legend and custom tooltip
+
+XY can fully restyle its built-in legend and tooltip. A genuinely custom
+legend or custom tooltip is host-owned UI: hide the built-ins, keep the chart
+in Reflex state, and render ordinary Reflex components from that same state.
+This requires no change to Reflex or XY, but it intentionally does not become
+part of a standalone XY export.
+
+~~~python demo exec
+import reflex as rx
+import reflex_xy
+import xy
+
+
+class StyledChromeState(rx.State):
+    show_plan: bool = True
+    hovered: dict = {}
+
+    @reflex_xy.figure
+    def figure(self) -> xy.Chart:
+        marks = [xy.line([0, 1, 2, 3], [2, 5, 3, 7], name="Actual", color="#7c3aed")]
+        if self.show_plan:
+            marks.append(
+                xy.line([0, 1, 2, 3], [1, 3, 4, 6], name="Plan", color="#0ea5e9")
+            )
+        return xy.line_chart(
+            *marks,
+            xy.legend(show=False),
+            xy.tooltip(show=False),
+        )
+
+    @rx.event
+    def record_hover(self, row: dict):
+        self.hovered = row
+
+    @rx.event
+    def set_show_plan(self, value: bool):
+        self.show_plan = value
+
+
+def custom_chrome():
+    return rx.vstack(
+        reflex_xy.chart(
+            StyledChromeState.figure,
+            on_point_hover=StyledChromeState.record_hover,
+            height="340px",
+        ),
+        rx.hstack(
+            rx.badge("Actual", color_scheme="purple"),
+            rx.checkbox(
+                "Plan",
+                checked=StyledChromeState.show_plan,
+                on_change=StyledChromeState.set_show_plan,
+            ),
+        ),
+        rx.callout(StyledChromeState.hovered.to_string(), icon="info"),
+        width="100%",
+    )
+~~~
+
+That pattern makes the legend interactive and the tooltip layout arbitrary.
+For a fixed chart, a simpler host-owned key can sit next to
+`reflex_xy.chart(...)`, as shown in
+[Component Variations](/docs/xy/styling/component-variations/#custom-component-replacements).
+
+## Export parity checklist
+
+- Keep mark paint in typed props or mark `style`; WebGL, SVG, and native raster
+  can all consume that contract.
+- Keep essential colors in chart tokens when the export must be self-contained.
+- Pass ordinary compiled CSS with `to_html(custom_css=...)` for standalone DOM
+  chrome, facets, media queries, or a portable design system.
+- Tailwind class names remain in the exported markup, but Tailwind's compiled
+  rules are not bundled automatically.
+- Host-owned Reflex components and interaction state are application UI, not
+  serializable XY chart content.
+- Compare live HTML with `to_svg()` and both native and Chromium `to_png()`
+  when exact renderer parity matters.

--- a/docs/styling/index.md
+++ b/docs/styling/index.md
@@ -11,65 +11,132 @@ CSS cascade. Data marks are painted by WebGL, SVG, or the native rasterizer, so
 XY compiles a deliberate CSS-property subset for them instead of claiming that
 arbitrary browser selectors can reach a canvas.
 
-## Five ways to style
+## Choose the styling surface
 
-| Mechanism | Scope | Best for |
+Start with the thing you want to change. DOM chrome can use classes or arbitrary
+safe DOM declarations; rendered geometry must use XY's validated mark or axis
+vocabulary.
+
+| Mechanism | Small example | Best for |
 | --- | --- | --- |
-| `class_names={slot: "..."}` | One stable chrome slot | Tailwind utilities or existing classes |
-| `styles={slot: {...}}` | One stable chrome slot | Computed inline DOM styles |
-| Mark `style={...}` | One rendered mark | Cross-renderer CSS paint vocabulary |
-| Annotation `class_name=` / `style=` | One annotation | Label classes and explicit annotation appearance |
-| `custom_css=` on `to_html()` | One exported document | Raw author CSS and attribute selectors |
+| Chart root class | `class_name="rounded-xl border"` | Host layout, card chrome, and Tailwind utilities on one chart |
+| Chart root style | `style={"--brand": "#6e56cf"}` | Root CSS declarations and custom variables |
+| Theme component | `xy.theme(grid_color="#e2e8f0")` | Portable chart tokens shared by chrome and exports |
+| Slot classes | `class_names={"tooltip": "rounded-lg"}` | Tailwind utilities or existing classes on stable DOM slots |
+| Slot styles | `styles={"title": {"font_size": 18}}` | Computed inline DOM styles on stable slots |
+| Component-local style | `xy.legend(class_name="text-xs")` | Keeping one legend, tooltip, colorbar, or modebar configuration self-contained |
+| Mark style | `xy.line(..., style={"stroke-width": 3})` | Cross-renderer paint for lines, points, areas, bars, and grids |
+| Annotation style | `xy.hline(5, style={"label_color": "red"})` | Annotation geometry and its DOM label |
+| Export CSS | `chart.to_html(custom_css="...")` | Raw author CSS and attribute selectors in one browser export |
 
-Chart-level `class_name=` styles the root, while chart-level `style=` supplies
-root CSS declarations and custom properties. Component helpers such as
-`legend()`, `tooltip()`, and `modebar()` also accept local class/style props
-that merge into their corresponding slots.
+If you are unsure, use this shortcut:
 
-~~~python
+- Styling a line, point, area, bar, or grid? Use its typed props or mark
+  `style=`.
+- Styling a title, legend, tooltip, control, tick label, or annotation label?
+  Use a slot class/style or the component's local class/style.
+- Styling the chart as a whole or defining reusable colors? Use chart
+  `class_name`/`style` or `xy.theme()`.
+- Styling only a self-contained HTML or Chromium export? Use `custom_css`.
+
+~~~python demo exec
+import reflex_xy
 import xy
+
+weeks = list(range(1, 13))
+conversion = [3.2, 4.7, 4.1, 6.0, 5.4, 7.1, 6.7, 8.3, 7.8, 9.1, 8.7, 10.2]
+traffic = [120, 180, 150, 260, 210, 340, 280, 420, 360, 510, 450, 620]
 
 chart = xy.scatter_chart(
     xy.scatter(
-        [1, 2, 3],
-        [3, 5, 4],
+        weeks,
+        conversion,
+        size=traffic,
+        size_range=(8, 18),
         style={
             "fill": "var(--accent)",
-            "stroke": "currentColor",
-            "stroke-width": "1px",
+            "fill-opacity": 0.88,
+            "stroke": "#ffffff",
+            "stroke-width": 2,
         },
+        name="Weekly signal",
     ),
-    class_name="analytics-card",
+    xy.x_axis(label="week", tick_count=6),
+    xy.y_axis(label="conversion (%)", domain=(2, 11)),
+    xy.legend(loc="upper left"),
+    class_name=(
+        "rounded-xl border border-slate-200 bg-white text-slate-900 shadow-sm "
+        "dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+    ),
     class_names={
         "tooltip": "rounded-lg bg-slate-900/90 text-white shadow-xl",
-        "legend": "text-xs font-medium",
-        "modebar_button": "hover:bg-slate-200",
+        "legend": (
+            "rounded-md border border-slate-200 bg-white/90 text-xs font-medium "
+            "dark:border-slate-700 dark:bg-slate-900/90"
+        ),
+        "modebar_button": "hover:bg-slate-200 dark:hover:bg-slate-800",
     },
     styles={"title": {"font_size": 18, "letter_spacing": "0.02em"}},
-    style={"--accent": "#6e56cf"},
-    title="Styled scatter",
+    style={
+        "--accent": "#6e56cf",
+        "--chart-grid": "rgb(148 163 184 / 22%)",
+    },
+    padding=[48, 48, 54, 62],
+    title="Weekly conversion signals",
 )
+
+
+def styling_overview_preview():
+    return reflex_xy.chart(chart, height="340px")
 ~~~
 
 ## What “your styles win” means
 
-XY's built-in **visual** chrome rules use `:where(...)`, which has zero CSS
-specificity. A utility class or ordinary author selector therefore overrides
-the default background, color, padding, border, font, shadow, or cursor without
-`!important`, even when the default stylesheet appears later.
+XY's built-in **visual** chrome rules live in the low-priority `base` cascade
+layer and use `:where(...)`, which has zero CSS specificity. A later utility
+layer or ordinary unlayered author selector therefore overrides the default
+background, color, padding, border, font, shadow, or cursor without
+`!important`.
 
 The promise is scoped to built-in visual defaults. XY still applies structural
 inline layout—position, size, z-index, and interaction state—and an explicit
 inline `styles[slot]` or per-annotation style naturally outranks a class. Marks
 follow their compiled style contract rather than the DOM cascade.
 
+## Styling troubleshooting
+
+Start by identifying whether the thing you want to change is DOM chrome or a
+rendered mark. Inspect titles, legends, tooltips, controls, ticks, and labels as
+ordinary elements with `data-xy-slot`; style lines, areas, points, bars, and
+other canvas geometry through typed props or mark `style=`.
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Tailwind classes are present but have no effect | The utility was not emitted by the host's Tailwind build, or the Tailwind plugin is missing. | Enable Reflex's `TailwindV4Plugin`, keep fixed-chart classes literal, and follow [Classes and Tailwind in Reflex](/docs/xy/styling/chrome-slots/#classes-and-tailwind-in-reflex). |
+| A custom font silently falls back | `font-family` names a face the browser has not loaded. | Register it in host CSS with `@font-face`, then apply the family to the chart root; see [Custom fonts and export limitations](/docs/xy/styling/themes-and-tokens/#custom-fonts-and-export-limitations). |
+| A class changes the legend but not a line or point | Marks are WebGL/canvas geometry, not DOM nodes. | Use the mark's typed paint props or supported `style=` declarations from [Mark styles](/docs/xy/styling/mark-styles/). |
+| Standalone HTML looks different from the application | The exported document cannot inherit the host page's stylesheet or design-system variables. | Put essential tokens on the chart and pass author rules with `to_html(custom_css=...)`. |
+| Native PNG ignores CSS or a custom font | The native renderer does not run a browser cascade and uses XY's baked bitmap font. | Use `engine=Engine.chromium` with `custom_css` when browser CSS/font fidelity is required. |
+| Axis titles or annotation labels are clipped | `overflow-hidden` is applied to the XY root or a tight ancestor. | Leave the chart root visible; apply intentional clipping to an outer wrapper and provide enough padding. |
+| A responsive chart is blank or collapsed | `height="100%"` has no ancestor with a defined height, or the container initially measures zero. | Give the chart/component an explicit height while debugging; `width="100%"` can remain fluid. |
+| A class loses to another declaration | Inline `styles`, component-local styles, or later author rules win through the normal cascade. | Remove the competing declaration or move the intended value to the same/higher-priority styling surface instead of adding `!important`. |
+
+For build, export, and adapter failures beyond styling, continue with the
+[Troubleshooting guide](/docs/xy/guides/troubleshooting/).
+
 ## Choose the next page
 
+- [Styling gallery](/docs/xy/styling/gallery/) exercises every mark family,
+  responsive shells, facets, reduction badges, custom host chrome, and
+  categorical/time-axis treatments in live or XY-rendered examples.
 - [Chrome slots](/docs/xy/styling/chrome-slots/) lists every stable DOM hook
   and shows the Tailwind workflow.
+- [Component variations](/docs/xy/styling/component-variations/) shows built-in
+  legends and tooltips, dual axes, reference lines, bands, and interaction
+  chrome, and states the custom-component boundary.
 - [Mark styles](/docs/xy/styling/mark-styles/) documents the compiled CSS
   subset, axis styles, validation, and canvas boundary.
 - [Themes and tokens](/docs/xy/styling/themes-and-tokens/) defines reusable
   `--chart-*` variables and dark-mode patterns.
-- [Recipes](/docs/xy/styling/recipes/) provides visual, copy-pasteable chart
+- [Recipes](/docs/xy/styling/recipes/) provides polished, ready-to-use chart
   treatments.

--- a/docs/styling/index.md
+++ b/docs/styling/index.md
@@ -66,15 +66,15 @@ chart = xy.scatter_chart(
     xy.legend(loc="upper left"),
     class_name=(
         "rounded-xl border border-slate-200 bg-white text-slate-900 shadow-sm "
-        "dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+        "dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-100"
     ),
     class_names={
-        "tooltip": "rounded-lg bg-slate-900/90 text-white shadow-xl",
+        "tooltip": "rounded-lg bg-zinc-900/90 text-white shadow-xl",
         "legend": (
             "rounded-md border border-slate-200 bg-white/90 text-xs font-medium "
-            "dark:border-slate-700 dark:bg-slate-900/90"
+            "dark:border-zinc-700 dark:bg-zinc-900/90"
         ),
-        "modebar_button": "hover:bg-slate-200 dark:hover:bg-slate-800",
+        "modebar_button": "hover:bg-zinc-200 dark:hover:bg-zinc-800",
     },
     styles={"title": {"font_size": 18, "letter_spacing": "0.02em"}},
     style={

--- a/docs/styling/mark-styles.md
+++ b/docs/styling/mark-styles.md
@@ -14,14 +14,14 @@ renderer cannot silently ignore a declaration that another honors.
 
 | Mark family | Supported properties in `style=` |
 | --- | --- |
-| line, step, stairs, ECDF | `stroke`, `stroke-width`, `stroke-opacity`, `stroke-dasharray`, `opacity` |
-| area, error band | `fill`, `fill-opacity`, `stroke`, `stroke-width`, `stroke-opacity`, `opacity`; area also supports `stroke-dasharray` |
-| scatter | `fill`, `fill-opacity`, `stroke`, `stroke-width`, `stroke-opacity`, `opacity` |
-| histogram, bar, column | `fill`, `fill-opacity`, `stroke`, `stroke-width`, `stroke-opacity`, `border-radius`, `opacity` |
-| segments, error bars, contour, stem | `stroke`, `stroke-width`, `stroke-opacity`, `opacity` |
-| box, violin | `fill`, `fill-opacity`, `opacity` |
-| triangle mesh | `fill`, `fill-opacity`, `stroke`, `stroke-width`, `stroke-opacity`, `opacity` |
-| heatmap, hexbin | `fill-opacity`, `opacity` |
+| `line`, `step`, `stairs`, `ecdf` | `stroke`, `stroke-width`, `stroke-opacity`, `stroke-dasharray`, `opacity` |
+| `area`, `error_band` | `fill`, `fill-opacity`, `stroke`, `stroke-width`, `stroke-opacity`, `opacity`; `area` also supports `stroke-dasharray` |
+| `scatter` | `fill`, `fill-opacity`, `stroke`, `stroke-width`, `stroke-opacity`, `opacity` |
+| `histogram`, `bar`, `column` | `fill`, `fill-opacity`, `stroke`, `stroke-width`, `stroke-opacity`, `border-radius`, `opacity` |
+| `segments`, `errorbar`, `contour`, `stem` | `stroke`, `stroke-width`, `stroke-opacity`, `opacity` |
+| `box`, `violin` | `fill`, `fill-opacity`, `opacity` |
+| `triangle_mesh` | `fill`, `fill-opacity`, `stroke`, `stroke-width`, `stroke-opacity`, `opacity` |
+| `heatmap`, `hexbin` | `fill-opacity`, `opacity` |
 
 Use canonical CSS kebab-case when sharing styles with web code; Python
 snake_case aliases remain accepted.
@@ -58,6 +58,63 @@ surfaces set the same rendered property. Inside `style`, use `stroke` for
 line-like geometry and `fill` for filled geometry; `color` is deliberately not
 a CSS paint alias there.
 
+## Live renderer check
+
+This example combines the main paint paths in one chart: a gradient area, a
+dashed line, bordered diamond markers, and explicitly styled axes.
+
+~~~python demo exec
+import reflex_xy
+import xy
+
+x = [0, 1, 2, 3, 4, 5]
+y = [2, 4, 3, 6, 5, 8]
+
+styled_marks = xy.chart(
+    xy.area(
+        x,
+        y,
+        style={
+            "fill": "linear-gradient(currentColor, transparent)",
+            "fill-opacity": 0.45,
+            "stroke": "#6e56cf",
+            "stroke-width": 2,
+        },
+        color="#6e56cf",
+    ),
+    xy.line(
+        x,
+        y,
+        style={
+            "stroke": "#6e56cf",
+            "stroke-width": 2,
+            "stroke-dasharray": "7px 4px",
+        },
+    ),
+    xy.scatter(
+        x,
+        y,
+        symbol="diamond",
+        size=9,
+        style={
+            "fill": "#f8fafc",
+            "stroke": "#6e56cf",
+            "stroke-width": 2,
+        },
+    ),
+    xy.x_axis(
+        label="sample",
+        style={"grid_dash": "dotted", "tick_direction": "out"},
+    ),
+    xy.y_axis(label="value"),
+    title="Compiled mark styles",
+)
+
+
+def mark_style_preview():
+    return reflex_xy.chart(styled_marks, height="340px")
+~~~
+
 ## Mark-specific appearance
 
 Some visual features are clearer as typed mark props rather than CSS
@@ -71,8 +128,11 @@ declarations:
   Use `{"gradient": "...", "space": "plot"}` for one plot-space gradient.
 - `corner_radius=(tip, base)` rounds value and baseline ends independently for
   bars, columns, and histograms.
-- Scatter `symbol` accepts `circle`, `square`, `diamond`, `triangle`, or
-  `cross`, and combines with `stroke`/`stroke_width`.
+- Scatter `symbol` accepts all 17 renderer-backed shapes: `circle`, `square`,
+  `diamond`, `triangle`, `triangle_down`, `triangle_left`, `triangle_right`,
+  `cross`, `x`, `hexagon`, `pentagon`, `star`, `point`, `pixel`,
+  `thin_diamond`, `plus_line`, and `x_line`. Every shape combines with
+  `stroke` / `stroke_width`; the last two are intentionally line-only glyphs.
 
 All CSS gradients accept two to eight color stops and the four axis-aligned
 directions. `currentColor` resolves to the mark's color; `transparent` retains
@@ -92,20 +152,45 @@ Axes are partly canvas-painted and partly DOM, so `x_axis(style=...)` and
 | `grid_opacity` | Number from 0 through 1 |
 | `tick_direction` | `in`, `out`, or `inout` |
 
+Use the axis component's `style` mapping when the x and y axes need different
+colors or sizes. Tick marks use `tick_*`, tick text uses `tick_label_*`, and the
+axis title uses `label_*`:
+
 ~~~python
-axis = xy.x_axis(
-    label="time",
+xy.x_axis(
+    label="month",
     style={
-        "grid-color": "rgb(148 163 184 / 25%)",
-        "grid-width": "1px",
-        "grid-dash": "dashed",
-        "axis-color": "var(--chart-axis)",
-        "tick-length": "6px",
-        "tick-direction": "out",
-        "label-size": "13px",
+        "axis_color": "#475569",
+        "axis_width": 1,
+        "tick_color": "#64748b",
+        "tick_width": 1,
+        "tick_length": 6,
+        "tick_direction": "out",
+        "tick_label_color": "#334155",
+        "tick_label_size": 12,
+        "label_color": "#0f172a",
+        "label_size": 14,
+    },
+)
+
+xy.y_axis(
+    label="revenue",
+    style={
+        "grid_color": "rgb(148 163 184 / 25%)",
+        "grid_width": 1,
+        "grid_dash": "dashed",
+        "axis_color": "#7c3aed",
+        "tick_color": "#7c3aed",
+        "tick_label_color": "#6d28d9",
+        "label_color": "#5b21b6",
     },
 )
 ~~~
+
+The `tick_label` and `axis_title` DOM slots provide chart-wide CSS or Tailwind
+hooks for tick text and axis titles. Use per-axis `style` as above when x and y
+must differ. Grid lines, axis lines, and tick marks are canvas-painted, so style
+them through the axis component rather than a CSS selector.
 
 ## Validation
 
@@ -125,8 +210,9 @@ and declaration safety at chart-build time:
 
 CSS selectors cannot target individual canvas points, bars, line segments, or
 annotation shapes. A mark `class_name` does not turn its geometry into a DOM
-element. Use mark props, channels, and the compiled `style=` subset for data
-geometry.
+element. It is retained as adapter-only trace metadata; the shipped browser,
+Reflex, SVG, and native renderers do not interpret it as a paint selector. Use
+mark props, channels, and the compiled `style=` subset for data geometry.
 
 Arrow shafts, markers, rules, and filled annotation zones are also
 canvas-painted; use their `color`, `stroke_color`, `stroke_width`, and

--- a/docs/styling/recipes.md
+++ b/docs/styling/recipes.md
@@ -1,18 +1,19 @@
 ---
 title: Styling Recipes
-description: Copy visual recipes for dashboard areas, gradient bars, and dark charts.
+description: Ready-to-use styling examples for dashboard areas, gradient bars, and dark charts.
 ---
 
 # Styling Recipes
 
-These recipes use only shipped styling surfaces. Copy the chart construction
-into a script or notebook; the small `reflex_xy.chart(...)` wrapper exists only
-to render the live documentation preview.
+Each recipe uses public XY styling APIs. Copy the chart construction into a
+script or notebook; the `reflex_xy.chart(...)` function simply displays the
+interactive preview on this page.
 
 ## Dashboard sparkline
 
-Remove chart chrome, tighten the plot padding, and fade a smooth area into its
-baseline:
+Build a compact trend chart by hiding the axes, legend, tooltip, and toolbar.
+The reduced padding saves space, while the gradient makes the area fill fade
+toward the baseline:
 
 ~~~python demo exec
 import numpy as np
@@ -87,6 +88,121 @@ For one continuous gradient across the whole plot, pass
 `fill={"gradient": "linear-gradient(to right, #2563eb, #a78bfa)",
 "space": "plot"}`.
 
+## Accessible monochrome comparison
+
+Do not rely on hue alone when a chart must survive grayscale printing or serve
+users with color-vision differences. Combine stroke dash, marker shape, and a
+clear legend so each series has multiple visual identifiers:
+
+~~~python demo exec
+import reflex_xy
+import xy
+
+periods = ["Q1", "Q2", "Q3", "Q4", "Q5", "Q6"]
+
+monochrome = xy.line_chart(
+    xy.line(
+        periods,
+        [42, 48, 51, 57, 61, 68],
+        name="Actual",
+        color="var(--mono-text, #111111)",
+        width=2.5,
+    ),
+    xy.scatter(
+        periods,
+        [42, 48, 51, 57, 61, 68],
+        symbol="circle",
+        color="var(--mono-bg, #ffffff)",
+        stroke="var(--mono-text, #111111)",
+        stroke_width=2,
+        size=8,
+    ),
+    xy.line(
+        periods,
+        [40, 46, 53, 55, 63, 66],
+        name="Plan",
+        color="var(--mono-muted, #555555)",
+        width=2.5,
+        dash="dashed",
+    ),
+    xy.scatter(
+        periods,
+        [40, 46, 53, 55, 63, 66],
+        symbol="square",
+        color="var(--mono-muted, #555555)",
+        size=7,
+    ),
+    xy.legend(loc="upper left", ncols=2),
+    xy.tooltip(title="{x}"),
+    xy.theme(
+        plot_background="var(--mono-bg, #ffffff)",
+        grid_color="var(--mono-grid, #d4d4d4)",
+        axis_color="var(--mono-axis, #525252)",
+        text_color="var(--mono-text, #171717)",
+    ),
+    class_name=(
+        "[--mono-bg:#ffffff] [--mono-grid:#d4d4d4] [--mono-axis:#525252] "
+        "[--mono-text:#171717] [--mono-muted:#555555] "
+        "dark:[--mono-bg:#0f172a] dark:[--mono-grid:#334155] "
+        "dark:[--mono-axis:#94a3b8] dark:[--mono-text:#f8fafc] "
+        "dark:[--mono-muted:#cbd5e1]"
+    ),
+    style={"background": "var(--mono-bg, #ffffff)"},
+    title="Actual versus plan",
+)
+
+
+def accessible_monochrome_recipe():
+    return reflex_xy.chart(monochrome, height="320px")
+~~~
+
+The points intentionally have no legend names, so they reinforce the two line
+series without creating duplicate legend rows.
+
+## Dense categorical labels
+
+Long category names can overlap or be clipped. Rotate the x-axis labels and
+reserve extra space below the plot so every region name remains readable. If
+showing every label is unnecessary, use `tick_label_strategy="hide"` instead.
+
+~~~python demo exec
+import reflex_xy
+import xy
+
+dense_categories = xy.column_chart(
+    xy.column(
+        [
+            "North America",
+            "Latin America",
+            "Western Europe",
+            "Eastern Europe",
+            "Middle East",
+            "Asia Pacific",
+        ],
+        [78, 54, 69, 47, 58, 83],
+        fill="linear-gradient(to top, #4338ca, #a5b4fc)",
+        corner_radius=(6, 0),
+    ),
+    xy.x_axis(
+        tick_label_strategy="rotate",
+        tick_label_angle=-35,
+        tick_label_min_gap=8,
+    ),
+    xy.y_axis(label="adoption (%)", domain=(0, 100)),
+    width="100%",
+    height=360,
+    padding=[38, 24, 92, 54],
+    title="Regional adoption",
+)
+
+
+def dense_categorical_axis_recipe():
+    return reflex_xy.chart(dense_categories, height="360px")
+~~~
+
+Keep the chart root's overflow visible. Axis labels are DOM chrome and can be
+clipped when `overflow-hidden` is applied directly to the XY root.
+
 ## Dark chart card
 
 Keep every export-critical color on the chart. Marks can consume a custom
@@ -130,3 +246,118 @@ def dark_chart_card_recipe():
 To follow system dark mode rather than fixing one palette, move the token
 values into the `@media (prefers-color-scheme: dark)` stylesheet shown in
 [Themes and tokens](/docs/xy/styling/themes-and-tokens/#dark-mode-in-a-standalone-export).
+
+## Export-safe brand theme
+
+Put export-critical variables on the chart itself. Browser-only host CSS is
+appropriate for application decoration, but native SVG and PNG cannot inherit
+from the page that happened to contain the chart.
+
+~~~python demo exec
+import reflex_xy
+import xy
+
+branded = xy.area_chart(
+    xy.area(
+        [0, 1, 2, 3, 4, 5],
+        [18, 24, 22, 31, 35, 43],
+        name="Active teams",
+        color="var(--brand-primary, #2563eb)",
+        curve="smooth",
+        line_width=2.5,
+        fill="linear-gradient(currentColor, transparent)",
+    ),
+    xy.legend(loc="upper left"),
+    xy.tooltip(title="Month {x}"),
+    xy.theme(
+        plot_background="var(--brand-surface, #f8fafc)",
+        text_color="var(--brand-text, #172554)",
+        grid_color="var(--brand-grid, rgb(37 99 235 / 14%))",
+        axis_color="var(--brand-axis, rgb(30 64 175 / 55%))",
+        style={
+            "--brand-primary": "var(--brand-accent, #2563eb)",
+            "--chart-tooltip-bg": "var(--brand-tooltip, #172554)",
+            "--chart-tooltip-text": "var(--brand-tooltip-text, #eff6ff)",
+            "--chart-legend-bg": "var(--brand-legend, rgb(248 250 252 / 88%))",
+        },
+    ),
+    class_name=(
+        "[--brand-surface:#f8fafc] [--brand-text:#172554] "
+        "[--brand-grid:#2563eb24] [--brand-axis:#1e40af8c] "
+        "[--brand-accent:#2563eb] [--brand-tooltip:#172554] "
+        "[--brand-tooltip-text:#eff6ff] [--brand-legend:#f8fafce0] "
+        "dark:[--brand-surface:#0f172a] dark:[--brand-text:#dbeafe] "
+        "dark:[--brand-grid:#93c5fd33] dark:[--brand-axis:#93c5fd99] "
+        "dark:[--brand-accent:#60a5fa] dark:[--brand-tooltip:#020617] "
+        "dark:[--brand-tooltip-text:#eff6ff] dark:[--brand-legend:#1e293be6]"
+    ),
+    style={"background": "var(--brand-surface, #f8fafc)"},
+    title="Branded growth",
+)
+
+
+def export_safe_brand_recipe():
+    return reflex_xy.chart(branded, height="320px")
+~~~
+
+The same chart can now use `to_svg()` or native `to_png()` without depending on
+an ancestor stylesheet. Use `custom_css` with the Chromium engine only when an
+export intentionally needs browser selectors or a host-loaded font.
+
+## Responsive dashboard card
+
+Make the chart fluid horizontally but give it a real height. Constrain an outer
+host card—not the XY root—so labels remain free to extend into the chart's
+padding and the chart can remeasure when its container changes.
+
+~~~python demo exec
+import reflex as rx
+import reflex_xy
+import xy
+
+dashboard_card = xy.line_chart(
+    xy.line(
+        ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+        [82, 91, 87, 104, 112, 108, 126],
+        name="Requests",
+        color="#0f766e",
+        width=2.5,
+        curve="smooth",
+    ),
+    xy.line(
+        ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+        [76, 84, 90, 96, 102, 108, 114],
+        name="Expected",
+        color="#94a3b8",
+        dash="dashed",
+    ),
+    xy.legend(loc="upper left", ncols=2),
+    xy.tooltip(title="{x}", format={"y": ".0f"}),
+    xy.theme(grid_color="rgb(148 163 184 / 20%)"),
+    class_names={
+        "legend": "rounded-md bg-white/90 text-xs dark:bg-slate-900/90",
+        "tooltip": "rounded-lg bg-slate-950 px-3 py-2 text-white shadow-xl",
+    },
+    width="100%",
+    height=280,
+    padding=[42, 22, 48, 48],
+    title="Weekly traffic",
+)
+
+
+def responsive_dashboard_card_recipe():
+    return rx.box(
+        reflex_xy.chart(dashboard_card, height="280px"),
+        width="100%",
+        max_width="36rem",
+        margin_x="auto",
+        padding="3",
+        border="1px solid var(--gray-a5)",
+        border_radius="12px",
+        box_shadow="0 8px 24px rgb(15 23 42 / 8%)",
+    )
+~~~
+
+Avoid `height="100%"` unless every ancestor has a defined height. An explicit
+component height with chart `width="100%"` is the most reliable responsive
+starting point.

--- a/docs/styling/recipes.md
+++ b/docs/styling/recipes.md
@@ -105,15 +105,15 @@ monochrome = xy.line_chart(
         periods,
         [42, 48, 51, 57, 61, 68],
         name="Actual",
-        color="var(--mono-text, #111111)",
+        color="var(--secondary-12)",
         width=2.5,
     ),
     xy.scatter(
         periods,
         [42, 48, 51, 57, 61, 68],
         symbol="circle",
-        color="var(--mono-bg, #ffffff)",
-        stroke="var(--mono-text, #111111)",
+        color="var(--secondary-2)",
+        stroke="var(--secondary-12)",
         stroke_width=2,
         size=8,
     ),
@@ -121,7 +121,7 @@ monochrome = xy.line_chart(
         periods,
         [40, 46, 53, 55, 63, 66],
         name="Plan",
-        color="var(--mono-muted, #555555)",
+        color="var(--secondary-10)",
         width=2.5,
         dash="dashed",
     ),
@@ -129,25 +129,19 @@ monochrome = xy.line_chart(
         periods,
         [40, 46, 53, 55, 63, 66],
         symbol="square",
-        color="var(--mono-muted, #555555)",
+        color="var(--secondary-10)",
         size=7,
     ),
     xy.legend(loc="upper left", ncols=2),
     xy.tooltip(title="{x}"),
     xy.theme(
-        plot_background="var(--mono-bg, #ffffff)",
-        grid_color="var(--mono-grid, #d4d4d4)",
-        axis_color="var(--mono-axis, #525252)",
-        text_color="var(--mono-text, #171717)",
+        plot_background="var(--secondary-2)",
+        grid_color="var(--secondary-a5)",
+        axis_color="var(--secondary-a8)",
+        text_color="var(--secondary-11)",
     ),
-    class_name=(
-        "[--mono-bg:#ffffff] [--mono-grid:#d4d4d4] [--mono-axis:#525252] "
-        "[--mono-text:#171717] [--mono-muted:#555555] "
-        "dark:[--mono-bg:#0f172a] dark:[--mono-grid:#334155] "
-        "dark:[--mono-axis:#94a3b8] dark:[--mono-text:#f8fafc] "
-        "dark:[--mono-muted:#cbd5e1]"
-    ),
-    style={"background": "var(--mono-bg, #ffffff)"},
+    class_name="bg-secondary-2 text-secondary-11",
+    style={"background": "var(--secondary-2)"},
     title="Actual versus plan",
 )
 
@@ -225,16 +219,16 @@ dark_card = xy.scatter_chart(
     ),
     xy.theme(
         style={
-            "--chart-bg": "#0f172a",
-            "--chart-text": "#e2e8f0",
-            "--chart-grid": "rgb(226 232 240 / 12%)",
-            "--chart-axis": "rgb(226 232 240 / 55%)",
-            "--chart-tooltip-bg": "#020617",
-            "--chart-tooltip-text": "#f8fafc",
+            "--chart-bg": "#18181b",
+            "--chart-text": "#e4e4e7",
+            "--chart-grid": "rgb(212 212 216 / 12%)",
+            "--chart-axis": "rgb(212 212 216 / 55%)",
+            "--chart-tooltip-bg": "#09090b",
+            "--chart-tooltip-text": "#fafafa",
             "--chart-accent": "#a78bfa",
         }
     ),
-    style={"background": "#0f172a", "border_radius": 14},
+    style={"background": "#18181b", "border_radius": 14},
     title="Dark-mode card",
 )
 
@@ -270,28 +264,28 @@ branded = xy.area_chart(
     xy.legend(loc="upper left"),
     xy.tooltip(title="Month {x}"),
     xy.theme(
-        plot_background="var(--brand-surface, #f8fafc)",
+        plot_background="var(--brand-surface, #fafafa)",
         text_color="var(--brand-text, #172554)",
         grid_color="var(--brand-grid, rgb(37 99 235 / 14%))",
         axis_color="var(--brand-axis, rgb(30 64 175 / 55%))",
         style={
             "--brand-primary": "var(--brand-accent, #2563eb)",
-            "--chart-tooltip-bg": "var(--brand-tooltip, #172554)",
-            "--chart-tooltip-text": "var(--brand-tooltip-text, #eff6ff)",
-            "--chart-legend-bg": "var(--brand-legend, rgb(248 250 252 / 88%))",
+            "--chart-tooltip-bg": "var(--brand-tooltip, #27272a)",
+            "--chart-tooltip-text": "var(--brand-tooltip-text, #fafafa)",
+            "--chart-legend-bg": "var(--brand-legend, rgb(250 250 250 / 88%))",
         },
     ),
     class_name=(
-        "[--brand-surface:#f8fafc] [--brand-text:#172554] "
+        "[--brand-surface:#fafafa] [--brand-text:#172554] "
         "[--brand-grid:#2563eb24] [--brand-axis:#1e40af8c] "
-        "[--brand-accent:#2563eb] [--brand-tooltip:#172554] "
-        "[--brand-tooltip-text:#eff6ff] [--brand-legend:#f8fafce0] "
-        "dark:[--brand-surface:#0f172a] dark:[--brand-text:#dbeafe] "
+        "[--brand-accent:#2563eb] [--brand-tooltip:#27272a] "
+        "[--brand-tooltip-text:#fafafa] [--brand-legend:#fafafae0] "
+        "dark:[--brand-surface:#18181b] dark:[--brand-text:#dbeafe] "
         "dark:[--brand-grid:#93c5fd33] dark:[--brand-axis:#93c5fd99] "
-        "dark:[--brand-accent:#60a5fa] dark:[--brand-tooltip:#020617] "
-        "dark:[--brand-tooltip-text:#eff6ff] dark:[--brand-legend:#1e293be6]"
+        "dark:[--brand-accent:#60a5fa] dark:[--brand-tooltip:#09090b] "
+        "dark:[--brand-tooltip-text:#eff6ff] dark:[--brand-legend:#27272ae6]"
     ),
-    style={"background": "var(--brand-surface, #f8fafc)"},
+    style={"background": "var(--brand-surface, #fafafa)"},
     title="Branded growth",
 )
 
@@ -335,8 +329,8 @@ dashboard_card = xy.line_chart(
     xy.tooltip(title="{x}", format={"y": ".0f"}),
     xy.theme(grid_color="rgb(148 163 184 / 20%)"),
     class_names={
-        "legend": "rounded-md bg-white/90 text-xs dark:bg-slate-900/90",
-        "tooltip": "rounded-lg bg-slate-950 px-3 py-2 text-white shadow-xl",
+        "legend": "rounded-md bg-white/90 text-xs dark:bg-zinc-900/90",
+        "tooltip": "rounded-lg bg-zinc-950 px-3 py-2 text-white shadow-xl",
     },
     width="100%",
     height=280,

--- a/docs/styling/themes-and-tokens.md
+++ b/docs/styling/themes-and-tokens.md
@@ -31,21 +31,15 @@ chart = xy.line_chart(
     xy.legend(loc="upper left"),
     xy.tooltip(title="{x}", format={"y": ".1f"}),
     xy.theme(
-        plot_background="var(--demo-bg, #ffffff)",
-        grid_color="var(--demo-grid, #e2e8f0)",
-        axis_color="var(--demo-axis, #64748b)",
-        text_color="var(--demo-text, #1e293b)",
+        plot_background="var(--secondary-2)",
+        grid_color="var(--secondary-a5)",
+        axis_color="var(--secondary-a8)",
+        text_color="var(--secondary-11)",
         # Custom variables belong in style and can be reused by marks.
-        style={"--series-primary": "var(--demo-series, #6e56cf)"},
+        style={"--series-primary": "var(--primary-9)"},
     ),
-    class_name=(
-        "[--demo-bg:#ffffff] [--demo-grid:#e2e8f0] [--demo-axis:#64748b] "
-        "[--demo-text:#1e293b] [--demo-series:#6e56cf] "
-        "dark:[--demo-bg:#0f172a] dark:[--demo-grid:#334155] "
-        "dark:[--demo-axis:#94a3b8] dark:[--demo-text:#e2e8f0] "
-        "dark:[--demo-series:#a78bfa]"
-    ),
-    style={"background": "var(--demo-bg, #ffffff)"},
+    class_name="bg-secondary-2 text-secondary-11",
+    style={"background": "var(--secondary-2)"},
     title="Monthly revenue",
 )
 
@@ -129,7 +123,7 @@ resolves it against the chart root on each render.
   --chart-text: #e5e7eb;
   --chart-grid: rgb(255 255 255 / 12%);
   --chart-axis: rgb(255 255 255 / 50%);
-  --chart-tooltip-bg: #0b1220;
+  --chart-tooltip-bg: #09090b;
   --chart-tooltip-text: #f8fafc;
   --chart-accent: #a78bfa;
 }
@@ -287,7 +281,7 @@ chart.to_html(
       .xy { --chart-accent: #6e56cf; }
       @media (prefers-color-scheme: dark) {
         .xy {
-          --chart-bg: #0f172a;
+          --chart-bg: #18181b;
           --chart-text: #e2e8f0;
           --chart-grid: rgb(226 232 240 / 12%);
           --chart-axis: rgb(226 232 240 / 55%);

--- a/docs/styling/themes-and-tokens.md
+++ b/docs/styling/themes-and-tokens.md
@@ -9,31 +9,94 @@ XY routes its default chrome colors through `--chart-*` CSS custom properties.
 Set common tokens with `theme()`, add any token through chart/theme `style=`, or
 let a host application's CSS cascade them from an ancestor.
 
-## Theme component
+## Start with the theme component
 
-~~~python
+Use `xy.theme()` when the value belongs to the chart rather than one specific
+mark. Its named arguments are readable aliases for the standard tokens: for
+example, `plot_background` writes `--chart-bg`, while `grid_color` writes
+`--chart-grid`.
+
+~~~python demo exec
+import reflex_xy
 import xy
 
 chart = xy.line_chart(
     xy.line(
-        [0, 1, 2, 3],
+        ["Jan", "Feb", "Mar", "Apr"],
         [2, 5, 3, 8],
-        style={"stroke": "var(--chart-accent)", "stroke-width": 2.5},
+        name="Revenue",
+        color="var(--series-primary, #6e56cf)",
+        width=2.5,
     ),
+    xy.legend(loc="upper left"),
+    xy.tooltip(title="{x}", format={"y": ".1f"}),
     xy.theme(
-        plot_background="#ffffff",
-        grid_color="#e2e8f0",
-        axis_color="#64748b",
-        text_color="#1e293b",
-        style={"--chart-accent": "#6e56cf"},
+        plot_background="var(--demo-bg, #ffffff)",
+        grid_color="var(--demo-grid, #e2e8f0)",
+        axis_color="var(--demo-axis, #64748b)",
+        text_color="var(--demo-text, #1e293b)",
+        # Custom variables belong in style and can be reused by marks.
+        style={"--series-primary": "var(--demo-series, #6e56cf)"},
     ),
+    class_name=(
+        "[--demo-bg:#ffffff] [--demo-grid:#e2e8f0] [--demo-axis:#64748b] "
+        "[--demo-text:#1e293b] [--demo-series:#6e56cf] "
+        "dark:[--demo-bg:#0f172a] dark:[--demo-grid:#334155] "
+        "dark:[--demo-axis:#94a3b8] dark:[--demo-text:#e2e8f0] "
+        "dark:[--demo-series:#a78bfa]"
+    ),
+    style={"background": "var(--demo-bg, #ffffff)"},
+    title="Monthly revenue",
+)
+
+
+def theme_component_preview():
+    return reflex_xy.chart(chart, height="320px")
+~~~
+
+There are two kinds of values in this example:
+
+- `plot_background`, `grid_color`, `axis_color`, and `text_color` configure
+  standard XY chrome.
+- `--series-primary` is an application token. XY does not assign it a meaning;
+  the line opts into it with `var(--series-primary)`.
+
+Use a fallback when a custom variable may not be defined by every host:
+
+~~~python
+xy.line(
+    x,
+    y,
+    color="var(--series-primary, #6e56cf)",
 )
 ~~~
 
-`plot_background`, `grid_color`, `axis_color`, `text_color`,
-`crosshair_color`, `selection_color`, and `selection_fill` are readable aliases
-for their CSS tokens. Later theme values override earlier theme values, and the
-chart's own `style=` is the final root-level override.
+## Where should a token be set?
+
+| Goal | Recommended location |
+| --- | --- |
+| Keep browser, SVG, and PNG exports consistent | `xy.theme(...)` or chart `style={...}` |
+| Share a palette across many browser charts | CSS variables on a common host ancestor |
+| Let Reflex state choose a palette | Resolve the state to a chart class or `style` mapping |
+| Change only one mark | Use the mark's `color`, `fill`, `stroke`, or `style` directly |
+
+If the same token is set in more than one place, XY resolves it in this order:
+
+1. A chart inherits the host ancestor's value when it has no local value.
+2. `xy.theme()` writes a local chart value; later theme components win over
+   earlier ones.
+3. The chart's own `style=` mapping is the final XY-level override.
+
+For example, this line is red because chart `style=` wins over the earlier
+theme value:
+
+~~~python
+chart = xy.line_chart(
+    xy.line([0, 1, 2], [2, 5, 3], color="var(--series-primary)"),
+    xy.theme(style={"--series-primary": "#2563eb"}),  # blue default
+    style={"--series-primary": "#dc2626"},  # final red override
+)
+~~~
 
 ## Token reference
 
@@ -81,6 +144,122 @@ chart = xy.line_chart(
 
 In Reflex, resolve reactive theme choices into ordinary classes, styles, or CSS
 variables. XY does not duplicate Reflex conditions or application state.
+
+## What survives each output
+
+Browser-backed output can preserve computed host styling that browser-free
+exporters cannot evaluate. Use this table when choosing where to define a
+visual treatment:
+
+| Styling surface | Browser / HTML | Toolbar PNG / SVG | Python SVG | Native PNG |
+| --- | --- | --- | --- | --- |
+| Theme tokens | Yes | Yes | Resolved subset | Resolved subset |
+| Slot classes and CSS | Yes | Computed snapshot | No | No |
+| Mark styles | Yes | Yes | Yes | Yes |
+| Custom fonts | Host-loaded | Usually | Limited | Bitmap fallback |
+| Custom `render=` chrome | Adapter-dependent | Adapter-dependent | No | No |
+
+“Resolved subset” means the browser-free exporter understands the tokens it
+uses directly, but it does not run a general CSS cascade. “Computed snapshot”
+means the toolbar export reads the live chart’s computed browser styles at the
+moment of export. For exporter selection and code examples, see
+[Display and Export](/docs/xy/guides/display-and-export/).
+
+## Custom fonts and export limitations
+
+Browser charts inherit fonts from the chart root. Load the font in the host
+application first, then set `font_family` through chart `style=` or apply a
+class that defines `font-family`. The live example uses a system serif so it
+does not depend on a network font; replace that stack with the family your host
+loads.
+
+~~~python demo exec
+import reflex_xy
+import xy
+
+font_chart = xy.line_chart(
+    xy.line(
+        [0, 1, 2, 3, 4],
+        [3, 6, 4, 8, 7],
+        name="Revenue",
+        color="#7c3aed",
+        width=2.5,
+        curve="smooth",
+    ),
+    xy.legend(),
+    xy.tooltip(),
+    xy.x_axis(label="quarter"),
+    xy.y_axis(label="revenue"),
+    style={"font_family": "Georgia, 'Times New Roman', serif"},
+    styles={
+        "title": {"font_weight": 700, "letter_spacing": "0.02em"},
+        "legend": {"font_style": "italic"},
+    },
+    title="Host font family",
+)
+
+
+def custom_font_preview():
+    return reflex_xy.chart(font_chart, height="320px")
+~~~
+
+For a downloaded or self-hosted font, define `@font-face` in the Reflex
+application's global stylesheet and use the same family on the chart:
+
+~~~css
+@font-face {
+  font-family: "Acme Sans";
+  src: url("/fonts/acme-sans.woff2") format("woff2");
+  font-display: swap;
+}
+
+.xy-font-brand {
+  font-family: "Acme Sans", system-ui, sans-serif;
+}
+~~~
+
+~~~python
+chart = xy.line_chart(
+    xy.line([0, 1, 2], [2, 5, 3]),
+    class_name="xy-font-brand",
+)
+~~~
+
+Tailwind users can apply a configured font utility through `class_name` in the
+same way. XY does not download, register, or rewrite font files itself.
+
+Standalone HTML and Chromium PNG accept the font declaration through
+`custom_css`. Embed the font as a data URL when the HTML file must remain fully
+portable; an ordinary URL still depends on that resource being reachable.
+
+~~~python
+from xy import Engine
+
+font_css = """
+  @font-face {
+    font-family: "Acme Sans";
+    src: url("data:font/woff2;base64,...") format("woff2");
+  }
+  .xy { font-family: "Acme Sans", system-ui, sans-serif; }
+"""
+
+chart.to_html("chart.html", custom_css=font_css)
+chart.to_png(
+    "chart.png",
+    engine=Engine.chromium,
+    custom_css=font_css,
+)
+~~~
+
+| Output | Custom-font behavior |
+| --- | --- |
+| Live browser / Reflex | Uses a font already loaded by the host page. |
+| Toolbar PNG | Captures the browser-rendered font into pixels. |
+| Toolbar SVG | Preserves the computed family and font styles, but does not embed the font file. |
+| Standalone HTML | Supports `@font-face` and root `font-family` through `custom_css`. |
+| Chromium PNG | Supports the same browser CSS through `custom_css`. |
+| Native PNG | Uses XY's baked bitmap font; custom fonts are not supported. |
+| Python `to_svg()` | Uses XY's fixed system font stack and cannot embed a custom font. |
 
 ## Dark mode in a standalone export
 

--- a/js/src/20_theme.js
+++ b/js/src/20_theme.js
@@ -67,18 +67,18 @@ function cssColor([r, g, b, a]) {
   return `rgba(${Math.round(r * 255)},${Math.round(g * 255)},${Math.round(b * 255)},${a})`;
 }
 
-// Chrome *visual* defaults, one stylesheet per document. Every rule is wrapped
-// in :where(...) so it carries ZERO specificity — any user utility class
-// (`class_names[slot]`, specificity ≥ 0,1,0) or inline `styles[slot]` beats it
-// without needing !important, regardless of stylesheet source order. This is
-// what makes Tailwind actually win on the chrome: the elements now carry only
-// *structural* inline styles (position/size/z-index/state), while background,
-// color, padding, border, font, box-shadow live here as overridable defaults.
+// Chrome *visual* defaults, one stylesheet per document. Rules live in the
+// low-priority `base` cascade layer and use :where(...) for ZERO specificity.
+// Unlayered author CSS, later utility layers (including Tailwind), and inline
+// `styles[slot]` therefore beat them without !important. The elements carry
+// only structural inline styles (position/size/z-index/state); background,
+// color, padding, border, font, and box-shadow stay overridable here.
 // All colors flow through --chart-* tokens so container theming still cascades.
 const XY_CHROME_CSS = `
+@layer base{
 :where(.xy [data-xy-slot="title"]){text-align:center;font-size:14px;font-weight:600;color:var(--chart-text,inherit)}
-:where(.xy [data-xy-slot="tooltip"]){background:var(--chart-tooltip-bg,rgba(20,24,33,.92));color:var(--chart-tooltip-text,#fff);padding:5px 8px;border-radius:4px;font-size:11px;line-height:1.35;box-shadow:0 2px 8px rgba(0,0,0,.3)}
-:where(.xy [data-xy-slot="legend"]){gap:2px;font-size:11px;background:var(--chart-legend-bg,rgba(128,128,128,.08));border-radius:4px;padding:4px 8px;color:var(--chart-text,inherit)}
+:where(.xy [data-xy-slot="tooltip"]){max-width:calc(100% - 8px);max-height:calc(100% - 8px);box-sizing:border-box;white-space:normal;overflow-wrap:anywhere;overflow:auto;background:var(--chart-tooltip-bg,rgba(20,24,33,.92));color:var(--chart-tooltip-text,#fff);padding:5px 8px;border-radius:4px;font-size:11px;line-height:1.35;box-shadow:0 2px 8px rgba(0,0,0,.3)}
+:where(.xy [data-xy-slot="legend"]){left:var(--xy-legend-left,auto);right:var(--xy-legend-right,auto);top:var(--xy-legend-top,auto);bottom:var(--xy-legend-bottom,auto);transform:var(--xy-legend-transform,none);max-width:var(--xy-legend-max-width);max-height:var(--xy-legend-max-height);gap:2px;font-size:11px;background:var(--chart-legend-bg,rgba(128,128,128,.08));border-radius:4px;padding:4px 8px;color:var(--chart-text,inherit)}
 :where(.xy [data-xy-slot="legend_swatch"]){width:12px;height:10px;border-radius:2px;margin-right:5px}
 :where(.xy [data-xy-slot="colorbar"]){color:var(--chart-text,inherit);font-size:10px}
 :where(.xy [data-xy-slot="colorbar_bar"]){background:var(--xy-colorbar-gradient);border:1px solid currentColor;box-sizing:border-box}
@@ -90,8 +90,9 @@ const XY_CHROME_CSS = `
 :where(.xy [data-xy-modebar-drag-handle]){position:relative;width:22px;margin-right:4px;cursor:move}
 :where(.xy [data-xy-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-3px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
 :where(.xy [data-xy-modebar-menu-trigger]){width:auto;min-width:48px;gap:1px;padding:0 4px;font-size:11px;font-variant-numeric:tabular-nums}
-:where(.xy [data-xy-modebar-select-trigger]){width:auto;min-width:30px;gap:0;padding:0 2px}
-:where(.xy [data-xy-modebar-menu-indicator]){display:flex;transition:transform .15s}
+:where(.xy [data-xy-modebar-select-trigger]){width:auto;min-width:42px;gap:2px;padding:0 4px}
+:where(.xy [data-xy-modebar-select-icon]){display:flex;flex:0 0 auto}
+:where(.xy [data-xy-modebar-menu-indicator]){display:flex;flex:0 0 auto;transition:transform .15s}
 :where(.xy [data-xy-modebar-menu-indicator] svg){width:11px;height:11px}
 :where(.xy [data-xy-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}
 :where(.xy [data-xy-modebar-menu-item]){width:100%;height:28px;justify-content:flex-start;padding:0 9px;border-radius:4px;text-align:left;white-space:nowrap}
@@ -114,6 +115,7 @@ const XY_CHROME_CSS = `
 :where(.xy [data-xy-slot="canvas"]:focus-visible,.xy [data-xy-slot="modebar_button"]:focus-visible){outline:2px solid var(--chart-focus,#2563eb);outline-offset:2px}
 @media (prefers-reduced-motion:reduce){:where(.xy [data-xy-slot="modebar"]){transition-duration:0s!important}}
 @media (forced-colors:active){:where(.xy [data-xy-slot="modebar"],.xy [data-xy-slot="tooltip"]){border:1px solid CanvasText}:where(.xy [data-xy-slot="modebar_button"].xy-active){outline:2px solid Highlight}:where(.xy [data-xy-slot="canvas"]:focus){outline:2px solid Highlight}}
+}
 `;
 
 // Inject XY_CHROME_CSS once per DOM root (document head or shadow root), so

--- a/js/src/30_ticks.js
+++ b/js/src/30_ticks.js
@@ -134,6 +134,27 @@ function fmtLinear(v, step) {
   return v.toFixed(Math.min(dec, 8));
 }
 
+// Match Python's default ``:g`` formatting used by the SVG/native colorbar
+// exporters. Explicit ticks are authored values, so their precision must not
+// be inferred from the unrelated automatic tick step for the whole domain.
+function fmtGeneral(v, precision = 6) {
+  const value = Number(v);
+  if (!Number.isFinite(value)) return String(v);
+  if (value === 0) return Object.is(value, -0) ? "-0" : "0";
+  // %g picks fixed vs exponential from the exponent AFTER rounding to
+  // `precision` significant digits (999999.5 -> 1e+06, 0.00009999995 -> 0.0001).
+  let [coefficient, exponentText] = value.toExponential(precision - 1).split("e");
+  const exponent = Number(exponentText);
+  if (exponent < -4 || exponent >= precision) {
+    coefficient = coefficient.replace(/0+$/, "").replace(/\.$/, "");
+    return `${coefficient}e${exponent >= 0 ? "+" : "-"}${String(Math.abs(exponent)).padStart(2, "0")}`;
+  }
+  const decimals = Math.max(0, precision - exponent - 1);
+  let text = Number(value.toPrecision(precision)).toFixed(decimals);
+  if (text.includes(".")) text = text.replace(/0+$/, "").replace(/\.$/, "");
+  return text;
+}
+
 function fmtCategory(v, categories) {
   const i = Math.round(v);
   return i >= 0 && i < categories.length ? String(categories[i]) : "";

--- a/js/src/50_chartview.js
+++ b/js/src/50_chartview.js
@@ -217,6 +217,19 @@ class ChartView {
     this._themeWatch = window.matchMedia("(prefers-color-scheme: dark)");
     this._onScheme = () => this.refreshTheme();
     this._themeWatch.addEventListener?.("change", this._onScheme);
+    // Framework theme switches usually toggle a class (for example `.dark`)
+    // on the chart or one of its ancestors without changing the OS color
+    // scheme. Watch that cascade path as well so canvas/SVG paint refreshed
+    // from --chart-* tokens stays in sync with the CSS-owned chart chrome.
+    if (typeof MutationObserver !== "undefined") {
+      this._themeMutationObserver = new MutationObserver(() => this.refreshTheme());
+      for (let node = this.root; node; node = node.parentElement) {
+        this._themeMutationObserver.observe(node, {
+          attributes: true,
+          attributeFilter: ["class", "style"],
+        });
+      }
+    }
 
     this._unsubscribeComm = comm ? comm.onMessage((msg, buffers) => this._onKernelMsg(msg, buffers)) : null;
     this.draw();
@@ -3699,6 +3712,8 @@ class ChartView {
     this._io?.disconnect();
     this._io = null;
     this._themeWatch?.removeEventListener?.("change", this._onScheme);
+    this._themeMutationObserver?.disconnect();
+    this._themeMutationObserver = null;
     this._dprMq?.removeEventListener?.("change", this._onDprChange);
     this._dprMq = null;
     this._unsubscribeComm?.();

--- a/js/src/50_chartview.js
+++ b/js/src/50_chartview.js
@@ -152,7 +152,7 @@ class ChartView {
     this._hoverTarget = null;
     this._viewEventRaf = null;
     this._linkedSource = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
-    // pan | zoom | select (box) | select-lasso | select-x | select-y
+    // pan | zoom | internal selection modes (the modebar exposes only pan/zoom)
     this.dragMode = "pan";
 
     // Responsive size: "100%" means the *container* owns that axis — measure
@@ -237,11 +237,27 @@ class ChartView {
     const marginRight = (pad ? pad[1] : compact ? 8 : MARGIN.r) + colorbarRightRoom;
     const marginTop = pad ? pad[0] : compact ? 6 : MARGIN.t;
     const marginBottom = (pad ? pad[2] : compact ? 36 : MARGIN.b) + colorbarBottomRoom;
-    const topAxisRoom = this._axis("x").side === "top" ? (compact ? 26 : 32) : 0;
+    const hasBottomAxis = Object.values(this.axes || {}).some((axis) =>
+      axis && String(axis.id || "").startsWith("x") && axis.side !== "top" &&
+      this._axisTickLabelStrategy(axis) !== "none");
+    this._bottomAxisRoom = hasBottomAxis ? (compact ? 36 : MARGIN.b) : 0;
+    // A named x axis can own the top edge even when the primary x axis stays
+    // on the bottom. Reserve one shared gutter for every top-side x axis;
+    // multiple axes on the same side intentionally overlay until axis offsets
+    // become part of the public API (the same rule used by secondary y axes).
+    const topAxisRoom = Object.values(this.axes || {}).some((axis) =>
+      axis && String(axis.id || "").startsWith("x") && axis.side === "top" &&
+      this._axisTickLabelStrategy(axis) !== "none")
+      ? (compact ? 26 : 32)
+      : 0;
     const top = marginTop + (this.spec.title ? (compact ? 26 : 30) : 0) + topAxisRoom;
-    const extraRightAxes = Object.values(this.axes || {}).filter((axis) =>
-      axis && axis.id !== "y" && String(axis.id || "").startsWith("y") && axis.side === "right");
-    const right = marginRight + (extraRightAxes.length ? (compact ? 42 : 54) : 0);
+    const rightAxes = Object.values(this.axes || {}).filter((axis) =>
+      axis && String(axis.id || "").startsWith("y") &&
+      axis.side === "right" && this._axisTickLabelStrategy(axis) !== "none");
+    // The vertical colorbar shifts right by this room (see _positionColorbar);
+    // the Python SVG/raster exporters apply the identical 42/54 rule.
+    this._rightAxisRoom = rightAxes.length ? (compact ? 42 : 54) : 0;
+    const right = marginRight + this._rightAxisRoom;
     this.plot = {
       x: marginLeft,
       y: top,
@@ -297,7 +313,8 @@ class ChartView {
     const axis = this._axis(axisId);
     const [lo, hi] = this._axisRange(axisId);
     if (Array.isArray(axis.tick_values)) {
-      const ticks = axis.tick_values.map(Number).filter((v) => Number.isFinite(v) && v >= lo && v <= hi);
+      const a = Math.min(lo, hi), b = Math.max(lo, hi);
+      const ticks = axis.tick_values.map(Number).filter((v) => Number.isFinite(v) && v >= a && v <= b);
       return { ticks, labels: ticks, step: ticks.length > 1 ? Math.abs(ticks[1] - ticks[0]) : 1 };
     }
     if (axis.kind === "time") return timeTicks(lo, hi, target);
@@ -782,6 +799,10 @@ class ChartView {
     this.size.h = h;
     this._layout();
     const p = this.plot;
+    this.root.style.setProperty("--xy-legend-max-width", Math.max(40, p.w - 12) + "px");
+    this.root.style.setProperty("--xy-legend-max-height", Math.max(40, p.h - 12) + "px");
+    this.canvas.style.left = p.x + "px";
+    this.canvas.style.top = p.y + "px";
     this.canvas.style.width = p.w + "px";
     this.canvas.style.height = p.h + "px";
     this.canvas.width = p.w * this.dpr;
@@ -790,11 +811,8 @@ class ChartView {
     this.chrome.style.height = this.size.h + "px";
     this.chrome.width = this.size.w * this.dpr;
     this.chrome.height = this.size.h * this.dpr;
-    if (this._legends && this._legends.length && this._slotStyleValue("legend", "max-height") == null) {
-      // _slotStyleValue canonicalizes keys, so this one check honors snake_case
-      // / camelCase / kebab author styles alike (no separate maxHeight probe).
-      // Extra legend boxes share the primary's slot, so all get the refresh.
-      for (const lg of this._legends) lg.style.maxHeight = p.h - 12 + "px";
+    for (const lg of this._legends || []) {
+      this._positionLegend(lg, lg.dataset.xyLegendLoc || "upper right");
     }
     this._positionReductionBadges();
     this._positionColorbar();
@@ -811,6 +829,8 @@ class ChartView {
     root.style.cssText =
       `position:relative;width:${this.fluid ? "100%" : this.size.w + "px"};` +
       `height:${this.fluidH ? "100%" : this.size.h + "px"};` +
+      `--xy-legend-max-width:${Math.max(40, this.plot.w - 12)}px;` +
+      `--xy-legend-max-height:${Math.max(40, this.plot.h - 12)}px;` +
       (this.fluidH ? "min-height:120px;" : "") + // parent without a height -> visible floor
       "font:12px system-ui,sans-serif;user-select:none;";
     this._applySlot(root, "root");
@@ -878,7 +898,7 @@ class ChartView {
     // styling is in the shared stylesheet; only position/state stays inline.
     this.tooltip = document.createElement("div");
     this.tooltip.style.cssText =
-      "position:absolute;display:none;pointer-events:none;z-index:5;white-space:nowrap;";
+      "position:absolute;display:none;pointer-events:none;z-index:5;";
     this._applySlot(this.tooltip, "tooltip");
     this.tooltip.setAttribute("aria-hidden", "true");
     root.appendChild(this.tooltip);
@@ -1023,26 +1043,12 @@ class ChartView {
     const lg = document.createElement("div");
     const loc = options.loc || "upper right";
     const ncols = Math.max(1, Number(options.ncols) || 1);
-    const rightInset = this.size.w - (this.plot.x + this.plot.w);
     const horizontal = ncols > 1;
-    // Parse the loc into independent horizontal/vertical anchors. "center" is
-    // the fallback on each axis, so "center right" reads as right-edge +
-    // vertical-center and "upper center" as top + horizontal-center. Both
-    // translate offsets go into ONE transform (two `transform:` declarations
-    // would clobber each other, dropping the horizontal recenter on "center").
-    const h = loc.includes("left") ? "left" : loc.includes("right") ? "right" : "center";
-    const v = loc.includes("upper") ? "upper" : loc.includes("lower") ? "lower" : "center";
-    let xPos, yPos, tx = "0", ty = "0";
-    if (h === "left") xPos = `left:${this.plot.x + 6}px;`;
-    else if (h === "right") xPos = `right:${rightInset + 6}px;`;
-    else { xPos = `left:${this.plot.x + this.plot.w / 2}px;`; tx = "-50%"; }
-    if (v === "upper") yPos = `top:${this.plot.y + 6}px;`;
-    else if (v === "lower") yPos = `bottom:${this.size.h - (this.plot.y + this.plot.h) + 6}px;`;
-    else { yPos = `top:${this.plot.y + this.plot.h / 2}px;`; ty = "-50%"; }
-    const transform = tx === "0" && ty === "0" ? "" : `transform:translate(${tx},${ty});`;
-    lg.style.cssText = `position:absolute;${xPos}${yPos}${transform}` +
+    lg.style.cssText = "position:absolute;" +
       `display:grid;grid-template-columns:repeat(${horizontal ? ncols : 1},max-content);` +
-      "overflow:auto;" + `max-height:${this.plot.h - 12}px;`;
+      "overflow:auto;";
+    lg.dataset.xyLegendLoc = loc;
+    this._positionLegend(lg, loc);
     this._applySlot(lg, "legend");
     if (options.title) {
       const title = document.createElement("div");
@@ -1124,8 +1130,29 @@ class ChartView {
       lg.appendChild(row);
     }
     root.appendChild(lg);
-    this._legends.push(lg); // _resize refreshes every box's max-height
+    this._legends.push(lg); // _resize refreshes each box's responsive anchor
     return lg;
+  }
+
+  _positionLegend(lg, loc) {
+    if (!lg) return;
+    // Responsive anchors flow through private custom properties consumed by a
+    // zero-specificity rule. Author classes or component styles can still set
+    // real left/right/top/bottom/transform declarations and win normally.
+    const rightInset = this.size.w - (this.plot.x + this.plot.w);
+    const h = loc.includes("left") ? "left" : loc.includes("right") ? "right" : "center";
+    const v = loc.includes("upper") ? "upper" : loc.includes("lower") ? "lower" : "center";
+    const left = h === "left" ? this.plot.x + 6 : h === "center" ? this.plot.x + this.plot.w / 2 : null;
+    const right = h === "right" ? rightInset + 6 : null;
+    const top = v === "upper" ? this.plot.y + 6 : v === "center" ? this.plot.y + this.plot.h / 2 : null;
+    const bottom = v === "lower" ? this.size.h - (this.plot.y + this.plot.h) + 6 : null;
+    lg.style.setProperty("--xy-legend-left", left == null ? "auto" : left + "px");
+    lg.style.setProperty("--xy-legend-right", right == null ? "auto" : right + "px");
+    lg.style.setProperty("--xy-legend-top", top == null ? "auto" : top + "px");
+    lg.style.setProperty("--xy-legend-bottom", bottom == null ? "auto" : bottom + "px");
+    const tx = h === "center" ? "-50%" : "0";
+    const ty = v === "center" ? "-50%" : "0";
+    lg.style.setProperty("--xy-legend-transform", `translate(${tx},${ty})`);
   }
 
   _buildColorbar(root) {
@@ -1164,13 +1191,14 @@ class ChartView {
     const lo = Number(domain[0]), hi = Number(domain[1]);
     const span = hi - lo || 1;
     const tickResult = linearTicks(lo, hi, 8);
-    const tickValues = Array.isArray(cb.ticks) ? cb.ticks : tickResult.ticks;
+    const hasExplicitTicks = Array.isArray(cb.ticks);
+    const tickValues = hasExplicitTicks ? cb.ticks : tickResult.ticks;
     const tickStep = tickResult.step;
     for (const raw of tickValues) {
       const value = Number(raw);
       if (!Number.isFinite(value) || value < Math.min(lo, hi) || value > Math.max(lo, hi)) continue;
       const tick = document.createElement("span");
-      tick.textContent = fmtLinear(value, tickStep);
+      tick.textContent = hasExplicitTicks ? fmtGeneral(value) : fmtLinear(value, tickStep);
       const fraction = (value - lo) / span;
       tick.style.cssText = horizontal
         ? `position:absolute;left:${100 * fraction}%;top:${COLORBAR_THICKNESS + 2}px;transform:translateX(-50%);white-space:nowrap;`
@@ -1197,8 +1225,12 @@ class ChartView {
   _positionColorbar() {
     if (!this._colorbar) return;
     const horizontal = this._colorbarHorizontal;
-    this._colorbar.style.left = (horizontal ? this.plot.x : this.plot.x + this.plot.w + COLORBAR_GAP) + "px";
-    this._colorbar.style.top = (horizontal ? this.plot.y + this.plot.h + 8 : this.plot.y) + "px";
+    this._colorbar.style.left = (horizontal
+      ? this.plot.x
+      : this.plot.x + this.plot.w + this._rightAxisRoom + COLORBAR_GAP) + "px";
+    this._colorbar.style.top = (horizontal
+      ? this.plot.y + this.plot.h + (this._bottomAxisRoom || 8)
+      : this.plot.y) + "px";
     this._colorbar.style.width = (horizontal ? this.plot.w : 66) + "px";
     this._colorbar.style.height = (horizontal ? 50 : Math.max(24, this.plot.h)) + "px";
   }
@@ -1369,11 +1401,13 @@ class ChartView {
     g.color = parseColor(this.root, t.color && t.color.color, [0.3, 0.47, 0.66, 1]);
     if (t.color && t.color.mode === "continuous") {
       g.colorMode = 1;
-      g.cBuf = this._upload(this._columnView(buffer, this.spec.columns[t.color.buf]));
+      g._cpu.color = this._columnView(buffer, this.spec.columns[t.color.buf]);
+      g.cBuf = this._upload(g._cpu.color);
       g.lut = this._lut(t.color.colormap);
     } else if (t.color && t.color.mode === "categorical") {
       g.colorMode = 2;
-      g.cBuf = this._upload(this._columnView(buffer, this.spec.columns[t.color.buf]));
+      g._cpu.color = this._columnView(buffer, this.spec.columns[t.color.buf]);
+      g.cBuf = this._upload(g._cpu.color);
       g.lut = this._paletteLut(t.color.palette);
     }
     g.sizeMode = 0;
@@ -1381,7 +1415,8 @@ class ChartView {
     g.sizeRange = [2, 18];
     if (t.size && t.size.mode === "continuous") {
       g.sizeMode = 1;
-      g.sBuf = this._upload(this._columnView(buffer, this.spec.columns[t.size.buf]));
+      g._cpu.size = this._columnView(buffer, this.spec.columns[t.size.buf]);
+      g.sBuf = this._upload(g._cpu.size);
       g.sizeRange = t.size.range_px;
     }
     this._pointMarkStyle(g, t);
@@ -2800,26 +2835,17 @@ class ChartView {
   }
 
   _axisTickLabelStrategy(axis) {
-    const raw = axis && axis.tick_label_strategy !== undefined
-      ? axis.tick_label_strategy
-      : this._axisStyleValue(axis, "tick_label_strategy");
-    const value = String(raw || "auto").replace(/-/g, "_");
+    const value = String((axis && axis.tick_label_strategy) || "auto").replace(/-/g, "_");
     return ["auto", "hide", "rotate", "stagger", "none", "off"].includes(value) ? value : "auto";
   }
 
   _axisTickLabelAngle(axis) {
-    const raw = axis && axis.tick_label_angle !== undefined
-      ? axis.tick_label_angle
-      : this._axisStyleValue(axis, "tick_label_angle");
-    const angle = Number(raw);
+    const angle = Number(axis ? axis.tick_label_angle : undefined);
     return Number.isFinite(angle) ? angle : null;
   }
 
   _axisTickLabelMinGap(axis, dim) {
-    const raw = axis && axis.tick_label_min_gap !== undefined
-      ? axis.tick_label_min_gap
-      : this._axisStyleValue(axis, "tick_label_min_gap");
-    const gap = Number(raw);
+    const gap = Number(axis ? axis.tick_label_min_gap : undefined);
     return Number.isFinite(gap) && gap >= 0 ? gap : (dim === "x" ? 8 : 4);
   }
 
@@ -2867,7 +2893,12 @@ class ChartView {
   }
 
   _layoutTickLabels(axis, dim, labels) {
-    if (labels.length <= 1) return labels.map((label) => ({ ...label, angle: 0, row: 0 }));
+    const strategyValue = this._axisTickLabelStrategy(axis);
+    if (strategyValue === "none" || strategyValue === "off") return [];
+    if (labels.length <= 1) {
+      const angle = this._axisTickLabelAngle(axis);
+      return labels.map((label) => ({ ...label, angle: angle === null ? 0 : angle, row: 0 }));
+    }
     const fontSize = Math.max(
       8,
       this._axisStyleNumber(axis, "tick_label_size", this._axisStyleNumber(axis, "tick_size", 11)),
@@ -2876,9 +2907,7 @@ class ChartView {
     const explicitAngle = this._axisTickLabelAngle(axis);
     const baseAngle = explicitAngle === null ? 0 : explicitAngle;
     const withBase = labels.map((label) => ({ ...label, angle: baseAngle, row: 0 }));
-    let strategy = this._axisTickLabelStrategy(axis);
-    if (strategy === "none") return []; // hide every tick label (sparklines)
-    if (strategy === "off") return []; // labels only; grid/baselines stay (mpl shared axes)
+    let strategy = strategyValue;
     if (strategy === "auto") {
       if (!this._tickLabelsCollide(withBase, dim, fontSize, minGap)) return withBase;
       if (dim === "x" && axis.kind === "category" && labels.length <= 16) strategy = "rotate";
@@ -2894,10 +2923,29 @@ class ChartView {
       out = labels.map((label, i) => ({ ...label, angle: baseAngle, row: i % 2 }));
     }
 
-    if (strategy === "hide" || this._tickLabelsCollide(out, dim, fontSize, minGap)) {
+    // Strategies handle collisions; a non-colliding label set stays intact
+    // even under an explicit "hide" (matches the Python exporters).
+    if (this._tickLabelsCollide(out, dim, fontSize, minGap)) {
       out = this._downsampleTickLabels(out, dim, fontSize, minGap);
     }
     return out;
+  }
+
+  _xTickLabelTransform(axis, angle) {
+    const value = Number(angle || 0);
+    const side = axis && axis.side === "top" ? "top" : "bottom";
+    if (value === 0) {
+      return {
+        transform: "translateX(-50%)",
+        origin: side === "top" ? "bottom center" : "top center",
+      };
+    }
+    const anchorAtEnd = (side === "bottom" && value < 0) || (side === "top" && value > 0);
+    const verticalOrigin = side === "top" ? "bottom" : "top";
+    return {
+      transform: `${anchorAtEnd ? "translateX(-100%) " : ""}rotate(${value}deg)`,
+      origin: `${verticalOrigin} ${anchorAtEnd ? "right" : "left"}`,
+    };
   }
 
   _axisLabelCss(axis, dim, fallbackCss) {
@@ -2983,6 +3031,10 @@ class ChartView {
     }
     const xAxis = this._axis("x");
     const yAxis = this._axis("y");
+    const extraXAxes = Object.values(this.axes).filter((axis) =>
+      axis && axis.id !== "x" && String(axis.id || "").startsWith("x"));
+    const extraYAxes = Object.values(this.axes).filter((axis) =>
+      axis && axis.id !== "y" && String(axis.id || "").startsWith("y"));
     const hideX = this._axisTickLabelStrategy(xAxis) === "none";
     const hideY = this._axisTickLabelStrategy(yAxis) === "none";
     const xt = this._axisTicks(
@@ -3052,8 +3104,14 @@ class ChartView {
         if (frameSides.includes("top")) rule(xAxis, p.x, p.y, p.w, xHeight);
         if (frameSides.includes("bottom")) rule(xAxis, p.x, p.y + p.h - xHeight, p.w, xHeight);
       }
-      for (const axis of Object.values(this.axes)) {
-        if (!axis || axis.id === "y" || !String(axis.id || "").startsWith("y")) continue;
+      for (const axis of extraXAxes) {
+        if (this._axisTickLabelStrategy(axis) === "none") continue;
+        const h = Math.max(1, this._axisStyleNumber(axis, "axis_width", 1));
+        const y = axis.side === "top" ? p.y : p.y + p.h - h;
+        rule(axis, p.x, y, p.w, h);
+      }
+      for (const axis of extraYAxes) {
+        if (this._axisTickLabelStrategy(axis) === "none") continue;
         const w = Math.max(1, this._axisStyleNumber(axis, "axis_width", 1));
         const x = axis.side === "left" ? p.x : p.x + p.w - w;
         rule(axis, x, p.y, w, p.h);
@@ -3087,6 +3145,38 @@ class ChartView {
           if (!Number.isFinite(y) || y < p.y - 1 || y > p.y + p.h + 1) continue;
           const left = side === "right" ? edge - tick.inward : edge - tick.outward;
           rule(yAxis, left, y - tick.width / 2, tick.inward + tick.outward, tick.width, "tick_color");
+        }
+      }
+      for (const axis of extraXAxes) {
+        if (this._axisTickLabelStrategy(axis) === "none") continue;
+        const ticks = this._axisTicks(
+          axis.id,
+          this._axisTickTarget(axis.id, Math.max(3, p.w / (axis.kind === "time" ? 90 : 80))),
+        );
+        const tick = tickParts(axis);
+        const side = axis.side || "bottom";
+        const edge = side === "top" ? p.y : p.y + p.h;
+        for (const value of ticks.ticks) {
+          const x = this._dataPx(axis.id, value);
+          if (!Number.isFinite(x) || x < p.x - 1 || x > p.x + p.w + 1) continue;
+          const top = side === "top" ? edge - tick.outward : edge - tick.inward;
+          rule(axis, x - tick.width / 2, top, tick.width, tick.inward + tick.outward, "tick_color");
+        }
+      }
+      for (const axis of extraYAxes) {
+        if (this._axisTickLabelStrategy(axis) === "none") continue;
+        const ticks = this._axisTicks(
+          axis.id,
+          this._axisTickTarget(axis.id, Math.max(3, p.h / 45)),
+        );
+        const tick = tickParts(axis);
+        const side = axis.side || "right";
+        const edge = side === "right" ? p.x + p.w : p.x;
+        for (const value of ticks.ticks) {
+          const y = this._dataPx(axis.id, value);
+          if (!Number.isFinite(y) || y < p.y - 1 || y > p.y + p.h + 1) continue;
+          const left = side === "right" ? edge - tick.inward : edge - tick.outward;
+          rule(axis, left, y - tick.width / 2, tick.inward + tick.outward, tick.width, "tick_color");
         }
       }
     }
@@ -3137,13 +3227,48 @@ class ChartView {
       );
       const rowOffset = Number(item.row || 0) * (Math.max(8, tickLabelSize) + 4);
       const top = xAxis.side === "top" ? p.y - 18 - rowOffset : p.y + p.h + 6 + rowOffset;
-      const transform = `translateX(-50%) rotate(${Number(item.angle || 0)}deg)`;
-      const origin = xAxis.side === "top" ? "bottom center" : "top center";
+      const placement = this._xTickLabelTransform(xAxis, item.angle);
       label(
         item.text,
-        `left:${item.pos}px;top:${top}px;transform:${transform};transform-origin:${origin};`,
+        `left:${item.pos}px;top:${top}px;transform:${placement.transform};` +
+          `transform-origin:${placement.origin};`,
         xAxis,
       );
+    }
+    for (const axis of extraXAxes) {
+      const ticks = this._axisTicks(
+        axis.id,
+        this._axisTickTarget(axis.id, Math.max(3, p.w / (axis.kind === "time" ? 90 : 80))),
+      );
+      const labelCandidates = [];
+      for (const value of (ticks.labels || ticks.ticks)) {
+        const px = this._dataPx(axis.id, value);
+        if (px < p.x - 1 || px > p.x + p.w + 1) continue;
+        labelCandidates.push({ pos: px, text: this._axisTickText(axis, value, ticks.step) });
+      }
+      for (const item of this._layoutTickLabels(axis, "x", labelCandidates)) {
+        const tickLabelSize = this._axisStyleNumber(
+          axis,
+          "tick_label_size",
+          this._axisStyleNumber(axis, "tick_size", 11),
+        );
+        const rowOffset = Number(item.row || 0) * (Math.max(8, tickLabelSize) + 4);
+        const top = axis.side === "top" ? p.y - 18 - rowOffset : p.y + p.h + 6 + rowOffset;
+        const placement = this._xTickLabelTransform(axis, item.angle);
+        label(
+          item.text,
+          `left:${item.pos}px;top:${top}px;transform:${placement.transform};` +
+            `transform-origin:${placement.origin};`,
+          axis,
+        );
+      }
+      if (axis.label && this._axisTickLabelStrategy(axis) !== "none") {
+        const top = axis.side === "top" ? p.y - 34 : p.y + p.h + 24;
+        const fallbackCss =
+          `left:${p.x + p.w / 2}px;top:${top}px;transform:translateX(-50%);font-weight:500;`;
+        const placement = this._axisLabelCss(axis, "x", fallbackCss);
+        label(axis.label, placement.css, axis, "label", placement.style);
+      }
     }
     const yLabelCandidates = [];
     for (const v of (yt.labels || yt.ticks)) {
@@ -3159,8 +3284,7 @@ class ChartView {
         : `right:${this.size.w - p.x + 8}px;top:${item.pos}px;transform:translateY(-50%) rotate(${angle}deg);transform-origin:right center;`;
       label(item.text, css, yAxis);
     }
-    for (const axis of Object.values(this.axes)) {
-      if (!axis || axis.id === "y" || !String(axis.id || "").startsWith("y")) continue;
+    for (const axis of extraYAxes) {
       const ticks = this._axisTicks(axis.id, this._axisTickTarget(axis.id, Math.max(3, p.h / 45)));
       const labelCandidates = [];
       for (const v of (ticks.labels || ticks.ticks)) {
@@ -3176,7 +3300,7 @@ class ChartView {
           : `left:${p.x + p.w + 8}px;top:${item.pos}px;transform:translateY(-50%) rotate(${angle}deg);transform-origin:left center;`;
         label(item.text, css, axis);
       }
-      if (axis.label) {
+      if (axis.label && this._axisTickLabelStrategy(axis) !== "none") {
         const fallbackCss = axis.side === "left"
           ? `left:10px;top:${p.y + p.h / 2}px;transform:rotate(-90deg) translateX(50%);transform-origin:left;font-weight:500;`
           : `left:${p.x + p.w + 40}px;top:${p.y + p.h / 2}px;transform:rotate(90deg) translateX(-50%);transform-origin:left;font-weight:500;`;
@@ -3184,13 +3308,13 @@ class ChartView {
         label(axis.label, placement.css, axis, "label", placement.style);
       }
     }
-    if (s.x_axis.label) {
+    if (s.x_axis.label && !hideX) {
       const top = xAxis.side === "top" ? p.y - 34 : p.y + p.h + 24;
       const fallbackCss = `left:${p.x + p.w / 2}px;top:${top}px;transform:translateX(-50%);font-weight:500;`;
       const placement = this._axisLabelCss(xAxis, "x", fallbackCss);
       label(s.x_axis.label, placement.css, xAxis, "label", placement.style);
     }
-    if (s.y_axis.label) {
+    if (s.y_axis.label && !hideY) {
       const fallbackCss = yAxis.side === "right"
         ? `left:${p.x + p.w + 40}px;top:${p.y + p.h / 2}px;transform:rotate(90deg) translateX(-50%);transform-origin:left;font-weight:500;`
         : `left:10px;top:${p.y + p.h / 2}px;transform:rotate(-90deg) translateX(50%);transform-origin:left;font-weight:500;`;

--- a/js/src/51_annotations.js
+++ b/js/src/51_annotations.js
@@ -8,6 +8,8 @@
 const XY_ANNOTATION_SHAPE_STYLE_KEYS = new Set([
   "color",
   "label_color",
+  "label_opacity",
+  "opacity",
   "width",
   "head_size",
   "head_style",
@@ -426,7 +428,18 @@ Object.assign(ChartView.prototype, {
       d.textContent = text;
       const dx = Number.isFinite(Number(ann.dx)) ? Number(ann.dx) : 0;
       const dy = Number.isFinite(Number(ann.dy)) ? Number(ann.dy) : 0;
-      const anchor = ann.anchor === "middle" ? "-50%" : ann.anchor === "end" ? "-100%" : "0px";
+      // Arrow labels and x-oriented rule/band labels are positioned at their
+      // geometric midpoint.  With the generic start fallback their left edge
+      // landed on that midpoint, visibly shifting the label to the right.
+      // Point labels and right-edge y rule/band labels keep their existing
+      // explicit/start semantics.
+      const anchorName = ["start", "middle", "end"].includes(ann.anchor)
+        ? ann.anchor
+        : ann.kind === "arrow" ||
+            ((ann.kind === "rule" || ann.kind === "band") && ann.axis === "x")
+          ? "middle"
+          : "start";
+      const anchor = anchorName === "middle" ? "-50%" : anchorName === "end" ? "-100%" : "0px";
       const rot = Number.isFinite(Number(style.rotation))
         ? ((Number(style.rotation) % 360) + 360) % 360
         : 0;
@@ -452,7 +465,7 @@ Object.assign(ChartView.prototype, {
           : va === "bottom" ? (cw ? "-100%" : "0")
           : cw ? "0" : "-100%";
         const cross =
-          ann.anchor === "middle" ? "-50%" : ann.anchor === "end" ? (cw ? "0" : "-100%") : cw ? "-100%" : "0";
+          anchorName === "middle" ? "-50%" : anchorName === "end" ? (cw ? "0" : "-100%") : cw ? "-100%" : "0";
         transform = `rotate(${cw ? 90 : -90}deg) translate(${along},${cross})`;
       } else if (rot) {
         transform = `rotate(${-rot}deg) translate(${anchor},${vAnchor})`;
@@ -473,6 +486,10 @@ Object.assign(ChartView.prototype, {
       // e.g. an arrow's shaft `width` must not become CSS width on the label.
       const labelStyle = {};
       for (const [key, value] of Object.entries(style)) {
+        if (key === "opacity" && ann.kind === "text") {
+          labelStyle[key] = value;
+          continue;
+        }
         if (XY_ANNOTATION_SHAPE_STYLE_KEYS.has(key)) continue;
         labelStyle[key] = value;
       }
@@ -481,6 +498,12 @@ Object.assign(ChartView.prototype, {
       // stylesheet's --chart-annotation-text default stays overridable by CSS.
       if (style && (style.label_color || style.color)) {
         d.style.color = this._annotationLabelPaint(style, this.theme.label);
+      }
+      if (style && style.label_opacity !== undefined) {
+        const labelOpacity = Number(style.label_opacity);
+        if (Number.isFinite(labelOpacity)) {
+          d.style.opacity = String(Math.max(0, Math.min(1, labelOpacity)));
+        }
       }
       this.labels.appendChild(d);
       // matplotlib anchors the TEXT at its position; a bbox patch grows

--- a/js/src/52_tooltip.js
+++ b/js/src/52_tooltip.js
@@ -238,7 +238,15 @@ Object.assign(ChartView.prototype, {
     }
     this.tooltip.style.display = "block";
     const tw = this.tooltip.offsetWidth;
-    this.tooltip.style.left = Math.min(lx + 12, this.size.w - tw - 4) + "px";
-    this.tooltip.style.top = ly + 12 + "px";
+    const th = this.tooltip.offsetHeight;
+    const edge = 4;
+    const gap = 12;
+    const maxLeft = Math.max(edge, this.size.w - tw - edge);
+    const left = Math.max(edge, Math.min(lx + gap, maxLeft));
+    const below = ly + gap;
+    const above = ly - th - gap;
+    const top = below + th <= this.size.h - edge ? below : Math.max(edge, above);
+    this.tooltip.style.left = left + "px";
+    this.tooltip.style.top = top + "px";
   },
 });

--- a/js/src/53_interaction.js
+++ b/js/src/53_interaction.js
@@ -126,12 +126,12 @@ Object.assign(ChartView.prototype, {
           points: firstLassoPoint ? [firstLassoPoint] : null,
           previousLasso,
         };
-        c.setPointerCapture(e.pointerId);
+        try { c.setPointerCapture(e.pointerId); } catch (_err) { /* synthetic event */ }
         this.tooltip.style.display = "none";
         return;
       }
       drag = { px: e.clientX, py: e.clientY, view: { ...this.view }, moved: false };
-      c.setPointerCapture(e.pointerId);
+      try { c.setPointerCapture(e.pointerId); } catch (_err) { /* synthetic event */ }
       this.tooltip.style.display = "none";
     });
     this._listen(c, "pointermove", (e) => {
@@ -161,10 +161,17 @@ Object.assign(ChartView.prototype, {
     });
     const end = (e) => {
       if (band) {
+        // Pointermove is not guaranteed to run at the pointer-up coordinate.
+        // Capture that final vertex before deciding whether the gesture moved;
+        // a naturally closed lasso finishes near its start and therefore has
+        // almost no *net* displacement despite enclosing a real area.
+        if (band.mode === "select-lasso") this._updateBand(band, e);
         this.selRect.style.display = "none";
         this.selLasso.style.display = "none";
         const d1 = dataAt(e.clientX, e.clientY);
-        const moved = Math.abs(e.clientX - band.sx) > 3 || Math.abs(e.clientY - band.sy) > 3;
+        const moved = band.mode === "select-lasso"
+          ? band.points.length >= 3
+          : Math.abs(e.clientX - band.sx) > 3 || Math.abs(e.clientY - band.sy) > 3;
         if (moved) {
           if (band.mode === "zoom") this._zoomToBox(band.d0, d1, true);
           else if (band.mode === "select-lasso") {
@@ -835,6 +842,7 @@ Object.assign(ChartView.prototype, {
       && this._interactionFlag("select", true);
     let selectTrigger = null;
     let selectIndicator = null;
+    let selectModeIcon = null;
     if (canSelect) {
       selectTrigger = mk("select", "Selection controls", () => {
         setSelectMenuOpen(!this._selectMenuOpen);
@@ -843,11 +851,17 @@ Object.assign(ChartView.prototype, {
       selectTrigger.dataset.xyModebarSelectTrigger = "";
       selectTrigger.setAttribute("aria-haspopup", "menu");
       selectTrigger.setAttribute("aria-expanded", "false");
+      selectTrigger.replaceChildren();
+      selectModeIcon = document.createElement("span");
+      selectModeIcon.dataset.xyModebarSelectIcon = "";
+      selectModeIcon.innerHTML = this._icon("select");
+      selectTrigger.appendChild(selectModeIcon);
       selectIndicator = document.createElement("span");
       selectIndicator.dataset.xyModebarMenuIndicator = "";
       selectIndicator.innerHTML = this._icon("chevrondown");
       selectTrigger.appendChild(selectIndicator);
       this._selectMenuButton = selectTrigger;
+      this._selectMenuIcon = selectModeIcon;
     }
     mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
     const zoomMenu = document.createElement("div");
@@ -1202,6 +1216,18 @@ Object.assign(ChartView.prototype, {
     }
     this._zoomMenuButton?.classList.toggle("xy-active", mode === "zoom");
     this._selectMenuButton?.classList.toggle("xy-active", mode.startsWith("select"));
+    const selectionMode = {
+      select: ["select", "Box Select"],
+      "select-lasso": ["lasso", "Lasso Select"],
+      "select-x": ["selectx", "X Range"],
+      "select-y": ["selecty", "Y Range"],
+    }[mode];
+    if (selectionMode && this._selectMenuButton && this._selectMenuIcon) {
+      const [iconName, label] = selectionMode;
+      this._selectMenuIcon.innerHTML = this._icon(iconName);
+      this._selectMenuButton.title = `Selection controls: ${label}`;
+      this._selectMenuButton.setAttribute("aria-label", `Selection controls: ${label}`);
+    }
   },
 
   _updateZoomMenuLabel() {
@@ -1591,24 +1617,25 @@ Object.assign(ChartView.prototype, {
           '<path d="M10 17 L8 15 M10 17 L12 15"/><path d="M3 10 L5 8 M3 10 L5 12"/>' +
           '<path d="M17 10 L15 8 M17 10 L15 12"/>');
       case "zoom":
-        return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
-          'stroke-dasharray="3 2"/>');
+        return svg('<path d="M7 3.5 H3.5 V7 M13 3.5 H16.5 V7 ' +
+          'M3.5 13 V16.5 H7 M16.5 13 V16.5 H13"/>');
       case "select":
-        return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
-          'stroke-dasharray="2.5 2"/><circle cx="7" cy="7" r="1" fill="currentColor" ' +
+        return svg('<path d="M7 4 H4 V7 M13 4 H16 V7 M4 13 V16 H7 ' +
+          'M16 13 V16 H13"/><circle cx="7" cy="8" r="1" fill="currentColor" ' +
           'stroke="none"/><circle cx="12.5" cy="9" r="1" fill="currentColor" stroke="none"/>' +
           '<circle cx="9.5" cy="13" r="1" fill="currentColor" stroke="none"/>');
       case "lasso":
-        return svg('<path d="M4 6 C6 2 15 3 16 8 C17 13 11 17 6 14 C2 12 2 8 4 6 Z" ' +
-          'stroke-dasharray="2.5 2"/><circle cx="6" cy="8" r="1" fill="currentColor" ' +
-          'stroke="none"/><circle cx="12" cy="7" r="1" fill="currentColor" stroke="none"/>' +
-          '<circle cx="10" cy="12" r="1" fill="currentColor" stroke="none"/>');
+        return svg('<path d="M5 5.5 C7 3 13.5 3.5 15.5 7 C17 10 14 15.5 9 15.5 ' +
+          'C4.5 15.5 2.5 11 4 7.5 Z"/><circle cx="5" cy="5.5" r="1" ' +
+          'fill="currentColor" stroke="none"/><circle cx="15.5" cy="7" r="1" ' +
+          'fill="currentColor" stroke="none"/><circle cx="9" cy="15.5" r="1" ' +
+          'fill="currentColor" stroke="none"/>');
       case "selectx":
-        return svg('<rect x="3" y="5" width="14" height="10" rx="1" stroke-dasharray="2.5 2"/>' +
-          '<path d="M6 10 H14 M6 10 L8 8 M6 10 L8 12 M14 10 L12 8 M14 10 L12 12"/>');
+        return svg('<path d="M5 4 V16 M15 4 V16 M7 10 H13 ' +
+          'M7 10 L9 8 M7 10 L9 12 M13 10 L11 8 M13 10 L11 12"/>');
       case "selecty":
-        return svg('<rect x="5" y="3" width="10" height="14" rx="1" stroke-dasharray="2.5 2"/>' +
-          '<path d="M10 6 V14 M10 6 L8 8 M10 6 L12 8 M10 14 L8 12 M10 14 L12 12"/>');
+        return svg('<path d="M4 5 H16 M4 15 H16 M10 7 V13 ' +
+          'M10 7 L8 9 M10 7 L12 9 M10 13 L8 11 M10 13 L12 11"/>');
       case "chevrondown":
         return svg('<path d="M6 8 L10 12 L14 8"/>');
       case "collapse":

--- a/js/src/54_kernel.js
+++ b/js/src/54_kernel.js
@@ -307,6 +307,20 @@ Object.assign(ChartView.prototype, {
     } else if (msg.type === "pick_result") {
       if (msg.seq !== undefined && msg.seq !== this._pickSeq) return;
       if (!msg.row) { this.tooltip.style.display = "none"; return; }
+      // The kernel returns exact values for the picked trace only. Rehydrate
+      // tooltip fields sourced from sibling traces before replacing the local
+      // approximate row, otherwise a rich layered tooltip visibly collapses.
+      // _localRow already resolved those fields for this same hover; reuse
+      // them (fields the kernel row lacks are exactly the sibling-sourced
+      // ones) so _applySharedTooltipFields finds nothing missing and skips
+      // its O(n) sibling scans. It stays as the mismatch fallback.
+      const local = this._lastRow;
+      if (local && local.trace === msg.row.trace && local.index === msg.row.index) {
+        for (const [key, value] of Object.entries(local)) {
+          if (msg.row[key] === undefined) msg.row[key] = value;
+        }
+      }
+      this._applySharedTooltipFields(msg.row);
       this._lastRow = msg.row;
       const xy = this._lastHoverXY;
       // Exact values replace the visible approximate tooltip. A keyboard

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,6 @@ exclude = [
 line-length = 100
 target-version = "py311"
 src = ["python", "tests", "scripts", "benchmarks"]
-extend-exclude = ["docs/app"]
 
 [tool.ruff.lint]
 select = [

--- a/python/reflex-xy/reflex_xy/assets/XYChart.jsx
+++ b/python/reflex-xy/reflex_xy/assets/XYChart.jsx
@@ -93,9 +93,14 @@ export function XYChart(props) {
     onPointClick,
     onSelectEnd,
     onViewChange,
+    // Compile-time-only literal scanned by Reflex's TailwindV4Plugin. The
+    // runtime chart receives the same classes from its XYBF payload; keeping
+    // this prop out of divProps prevents an unknown attribute or class leak.
+    tailwindClassTokens: _tailwindClassTokens,
     ref: externalRef, // reflex attaches its own ref to id-bearing components
     ...divProps
   } = props;
+  void _tailwindClassTokens;
   const elRef = useRef(null);
   dbg("render", { id: divProps.id, token: String(token).slice(0, 30), src });
   // Live callback refs so socket handlers never close over stale props.
@@ -162,8 +167,8 @@ export function XYChart(props) {
           cbRef.current.onViewChange?.(m);
           return;
         }
-        if (m.type === "select" || m.type === "select_clear") {
-          lastSelect = m.type === "select" ? m : null;
+        if (m.type === "select" || m.type === "select_polygon" || m.type === "select_clear") {
+          lastSelect = m.type === "select_clear" ? null : m;
         }
         socket.emit("msg", { fig: token, mid, m });
         if (m.type === "click" && cbRef.current.onPointClick) {
@@ -235,6 +240,7 @@ export function XYChart(props) {
           x1: lastSelect?.x1 ?? null,
           y0: lastSelect?.y0 ?? null,
           y1: lastSelect?.y1 ?? null,
+          polygon: lastSelect?.type === "select_polygon" ? lastSelect.points : null,
           cleared: message.total === 0 && lastSelect === null,
         });
       }

--- a/python/reflex-xy/reflex_xy/component.py
+++ b/python/reflex-xy/reflex_xy/component.py
@@ -43,6 +43,7 @@ import reflex as rx
 
 from .assets import WRAPPER_TAG, register
 from .payload_asset import payload_asset
+from .registry import _figure_of
 
 __all__ = ["chart"]
 
@@ -69,6 +70,13 @@ def _build_component_cls() -> Any:
         # kernel-less.
         src: rx.Var[str]
 
+        # Static charts carry their DOM class strings inside the binary XYBF
+        # payload, where Reflex's TailwindV4Plugin cannot discover them.  This
+        # compile-only prop mirrors those literal strings into the generated
+        # JSX source so Tailwind can emit the corresponding utilities.  The
+        # wrapper destructures and discards it; it never reaches the DOM.
+        tailwind_class_tokens: rx.Var[str]
+
         # Semantic events out (small JSON by construction — §1). Live mode
         # only; the static tier has no kernel to resolve rows.
         on_point_hover: rx.EventHandler[lambda row: [row]]
@@ -91,6 +99,16 @@ def _is_chart_like(source: Any) -> bool:
     )
 
 
+def _tailwind_class_manifest(figure: Any) -> str:
+    """Return every static-chart DOM class string as one scan-only literal.
+
+    The inventory itself is core-Figure knowledge and lives on
+    :meth:`xy.Figure.dom_class_strings`; reading the built figure avoids a
+    second payload compilation (which can be expensive for large charts).
+    """
+    return " ".join(figure.dom_class_strings())
+
+
 def chart(source: Any, **props: Any) -> Any:
     """Place a xy chart.
 
@@ -111,7 +129,15 @@ def chart(source: Any, **props: Any) -> Any:
     if isinstance(source, (str, rx.Var)):
         props["token"] = source
     elif _is_chart_like(source):
-        props["src"] = payload_asset(source)
+        # Build a public Chart once, then reuse the cached Figure for both the
+        # payload and its Tailwind scan manifest.  In particular, do not call
+        # build_payload() just to discover classes: that would duplicate the
+        # largest part of static-chart compilation.
+        figure = _figure_of(source)
+        props["src"] = payload_asset(figure)
+        class_manifest = _tailwind_class_manifest(figure)
+        if class_manifest:
+            props["tailwind_class_tokens"] = class_manifest
     else:
         msg = (
             "reflex_xy.chart() takes a figure token (state var or string) or a "

--- a/python/xy/_annotations.py
+++ b/python/xy/_annotations.py
@@ -546,6 +546,10 @@ class AnnotationsMixin(_Host):
             raise ValueError("annotation style must be a dict[str, str | int | float]")
         raw_style = {key: value for key, value in raw_style.items() if value is not None}
         style = self._style_mapping(raw_style, "annotation style")
+        if "label_opacity" in style:
+            style["label_opacity"] = self._opacity(
+                style["label_opacity"], "annotation style label_opacity"
+            )
         if style:
             out["style"] = style
         return out

--- a/python/xy/_figure.py
+++ b/python/xy/_figure.py
@@ -124,6 +124,11 @@ class Figure(AnnotationsMixin, PayloadMixin):
         self.mark_style: dict[str, dict[str, str | int | float]] = {}
         self.annotations: list[dict[str, Any]] = []
         self._axis_categories: dict[str, list[str]] = {}
+        # Declarative marks still call the shared fluent mark bodies with the
+        # channel dimensions ("x"/"y").  Chart temporarily points those
+        # dimensions at the mark's bound axis ids while it applies each mark,
+        # so category registries stay independent for x, x2, y, y2, ... .
+        self._active_axis_ids: dict[str, str] = {"x": "x", "y": "y"}
         self._widget: Any = None
 
     # -- axis config --------------------------------------------------------
@@ -618,15 +623,20 @@ class Figure(AnnotationsMixin, PayloadMixin):
             return np.asarray(values)
         return values
 
+    def _category_axis_id(self, axis: str) -> str:
+        """Resolve a mark channel dimension to its active declarative axis id."""
+        return self._active_axis_ids.get(axis, axis)
+
     def _axis_positions(self, values: Any, axis: str, *, commit: bool = True) -> np.ndarray:
         values = self._materialize_sequence(values)
         if not self._is_category_like(values):
             return self._as_1d_float(values, f"{axis} values")
         raw_labels = self._category_axis_labels(values, axis)
+        axis_id = self._category_axis_id(axis)
         labels = (
-            self._axis_categories.setdefault(axis, [])
+            self._axis_categories.setdefault(axis_id, [])
             if commit
-            else list(self._axis_categories.get(axis, []))
+            else list(self._axis_categories.get(axis_id, []))
         )
         return self._category_positions(raw_labels, labels)
 
@@ -661,12 +671,14 @@ class Figure(AnnotationsMixin, PayloadMixin):
         if not self._is_category_like(values):
             return self._as_1d_float(values, f"{axis} values"), None
         raw_labels = self._category_axis_labels(values, axis)
-        return self._category_positions(raw_labels, list(self._axis_categories.get(axis, []))), (
-            raw_labels
-        )
+        axis_id = self._category_axis_id(axis)
+        return self._category_positions(
+            raw_labels, list(self._axis_categories.get(axis_id, []))
+        ), raw_labels
 
     def _commit_category_labels(self, raw_labels: list[str], axis: str) -> None:
-        labels = self._axis_categories.setdefault(axis, [])
+        axis_id = self._category_axis_id(axis)
+        labels = self._axis_categories.setdefault(axis_id, [])
         # Insertion-ordered union: existing labels first, then new ones in
         # first-appearance order — identical to the provisioning loop above.
         merged = dict.fromkeys(labels)
@@ -884,7 +896,7 @@ class Figure(AnnotationsMixin, PayloadMixin):
         forced = self.axis_options.get(axis_id, {}).get("type")
         if forced == "time":
             return "time"
-        if axis in self._axis_categories:
+        if axis_id in self._axis_categories:
             return "category"
         for t in self.traces:
             if axis == "x" and t.x_axis != axis_id:
@@ -969,7 +981,7 @@ class Figure(AnnotationsMixin, PayloadMixin):
         if style:
             spec["style"] = style
         if kind == "category":
-            spec["categories"] = list(self._axis_categories.get(axis, []))
+            spec["categories"] = list(self._axis_categories.get(axis_id, []))
         return spec
 
     def _range_columns(self, t: Trace, axis_id: str) -> list[Column]:
@@ -1015,6 +1027,35 @@ class Figure(AnnotationsMixin, PayloadMixin):
             if style:
                 spec[state] = style
         return spec
+
+    def dom_class_strings(self) -> list[str]:
+        """Every DOM class string this figure emits, deduped in insertion order.
+
+        Contract: this is the *complete* set of class strings that can reach
+        the DOM — the chart root (``class_name``), the chrome slots
+        (``class_names`` values), per-trace mark styles
+        (``trace.style["class_name"]``), and annotation nodes
+        (``annotation["class_name"]``). The Reflex adapter joins it into the
+        Tailwind scan manifest for static charts (XYBF payloads are opaque to
+        Tailwind's source scan), so this method must be extended whenever a
+        new class-carrying surface is added to the figure.
+        """
+        class_strings: list[str] = []
+        seen: set[str] = set()
+
+        def add(value: Any) -> None:
+            if isinstance(value, str) and value.strip() and value not in seen:
+                seen.add(value)
+                class_strings.append(value)
+
+        add(self.class_name)
+        for value in self.class_names.values():
+            add(value)
+        for trace in self.traces:
+            add(trace.style.get("class_name"))
+        for annotation in self.annotations:
+            add(annotation.get("class_name"))
+        return class_strings
 
     def _dom_spec(self) -> dict[str, Any]:
         dom: dict[str, Any] = {}

--- a/python/xy/_raster.py
+++ b/python/xy/_raster.py
@@ -26,15 +26,21 @@ from ._svg import (
     _STATIC_COLOR_FALLBACK,
     _TEXT,
     DEFAULT_PALETTE,
+    _axis_label_geometry,
+    _axis_scales,
+    _axis_tick_font_size,
+    _axis_tick_label_layout,
+    _axis_tick_label_strategy,
+    _colorbar_right_axis_room,
     _colormap_stops,
     _column,
     _corner_radii,
     _css,
+    _legend_layout,
     _lut,
     _resolve_static_css_vars,
     _Scale,
     _step_arrays,
-    _tick_text,
     axis_ticks,
     hexbin_ring,
     layout,
@@ -518,8 +524,7 @@ def render_raster(
     spec = _resolve_static_css_vars(spec)
     width, height, compact, plot = layout(spec)
     xa, ya = spec["x_axis"], spec["y_axis"]
-    sx = _Scale(xa, plot["x"], plot["x"] + plot["w"])
-    sy = _Scale(ya, plot["y"] + plot["h"], plot["y"])
+    x_scales, y_scales, sx, sy, extra_x_axes, extra_y_axes = _axis_scales(spec, plot)
     cols = spec["columns"]
     cmd = _Cmd(scale)
 
@@ -544,6 +549,12 @@ def render_raster(
 
     xt, xlab, xstep = axis_ticks(xa, plot["w"], True)
     yt, ylab, ystep = axis_ticks(ya, plot["h"], False)
+    extra_x_ticks = {
+        axis_id: axis_ticks(axis, plot["w"], True) for axis_id, axis, _axis_scale in extra_x_axes
+    }
+    extra_y_ticks = {
+        axis_id: axis_ticks(axis, plot["h"], False) for axis_id, axis, _axis_scale in extra_y_axes
+    }
     xstyle, ystyle = xa.get("style") or {}, ya.get("style") or {}
     default_grid = _css(dom_style.get("--chart-grid"), _GRID)
     default_axis = _css(dom_style.get("--chart-axis"), _AXIS)
@@ -553,8 +564,6 @@ def render_raster(
 
     hide_x = xa.get("tick_label_strategy") == "none"
     hide_y = ya.get("tick_label_strategy") == "none"
-    hide_x_labels = hide_x or xa.get("tick_label_strategy") == "off"
-    hide_y_labels = hide_y or ya.get("tick_label_strategy") == "off"
 
     cmd.clip(px0, py0, plot["w"], plot["h"])
     for v in [] if hide_x else xt:
@@ -584,26 +593,28 @@ def render_raster(
         style = t.get("style") or {}
         color = _css(style.get("color"), DEFAULT_PALETTE[palette_i % len(DEFAULT_PALETTE)])
         kind = t["kind"]
+        trace_sx = x_scales.get(t.get("x_axis", "x"), sx)
+        trace_sy = y_scales.get(t.get("y_axis", "y"), sy)
         if t.get("tier") == "density" and t.get("density"):
-            _emit_grid(cmd, "density", t["density"], blob, cols, sx, sy, style)
+            _emit_grid(cmd, "density", t["density"], blob, cols, trace_sx, trace_sy, style)
         elif kind == "line":
-            _emit_line(cmd, t, blob, cols, sx, sy, style, color)
+            _emit_line(cmd, t, blob, cols, trace_sx, trace_sy, style, color)
         elif kind in ("area", "error_band"):
-            _emit_area(cmd, t, blob, cols, sx, sy, style, color, plot)
+            _emit_area(cmd, t, blob, cols, trace_sx, trace_sy, style, color, plot)
         elif kind == "scatter":
-            _emit_scatter(cmd, t, blob, cols, sx, sy, style, color)
+            _emit_scatter(cmd, t, blob, cols, trace_sx, trace_sy, style, color)
         elif kind == "hexbin":
-            _emit_hexbin(cmd, t, blob, cols, sx, sy, style, color)
+            _emit_hexbin(cmd, t, blob, cols, trace_sx, trace_sy, style, color)
         elif kind in {"errorbar", "stem", "box_whisker", "box_median", "contour", "segments"}:
-            _emit_segments(cmd, t, blob, cols, sx, sy, style, color)
+            _emit_segments(cmd, t, blob, cols, trace_sx, trace_sy, style, color)
         elif kind in ("bar", "column") and t.get("bar"):
-            _emit_bars(cmd, t, blob, cols, sx, sy, style, color, plot)
+            _emit_bars(cmd, t, blob, cols, trace_sx, trace_sy, style, color, plot)
         elif kind == "heatmap" and t.get("heatmap"):
-            _emit_grid(cmd, "heatmap", t["heatmap"], blob, cols, sx, sy, style)
+            _emit_grid(cmd, "heatmap", t["heatmap"], blob, cols, trace_sx, trace_sy, style)
         elif kind == "triangle_mesh":
-            _emit_triangle_mesh(cmd, t, blob, cols, sx, sy, style, color)
+            _emit_triangle_mesh(cmd, t, blob, cols, trace_sx, trace_sy, style, color)
         elif all(k in t for k in ("x0", "x1", "y0", "y1")):
-            _emit_rects(cmd, t, blob, cols, sx, sy, style, color, plot)
+            _emit_rects(cmd, t, blob, cols, trace_sx, trace_sy, style, color, plot)
 
     _emit_annotations(cmd, spec.get("annotations") or [], sx, sy, plot, width, height)
 
@@ -643,6 +654,26 @@ def render_raster(
                 float(xstyle.get("axis_width", 1)),
                 _parse_color(_css(xstyle.get("axis_color"), default_axis)),
             )
+    for _axis_id, axis, _axis_scale in extra_x_axes:
+        if _axis_tick_label_strategy(axis) == "none":
+            continue
+        axis_style = axis.get("style") or {}
+        edge = py0 if axis.get("side", "bottom") == "top" else py1
+        cmd.stroke(
+            [(px0, edge), (px1, edge)],
+            float(axis_style.get("axis_width", 1)),
+            _parse_color(_css(axis_style.get("axis_color"), default_axis)),
+        )
+    for _axis_id, axis, _axis_scale in extra_y_axes:
+        if _axis_tick_label_strategy(axis) == "none":
+            continue
+        axis_style = axis.get("style") or {}
+        edge = px1 if axis.get("side", "right") == "right" else px0
+        cmd.stroke(
+            [(edge, py0), (edge, py1)],
+            float(axis_style.get("axis_width", 1)),
+            _parse_color(_css(axis_style.get("axis_color"), default_axis)),
+        )
 
     def tick_span(style):
         length = max(0.0, float(style.get("tick_length", 0)))
@@ -685,66 +716,158 @@ def render_raster(
                 float(ystyle.get("tick_width", 1)),
                 _parse_color(_css(ystyle.get("tick_color"), default_axis)),
             )
+    for axis_id, axis, axis_scale in extra_x_axes:
+        if _axis_tick_label_strategy(axis) == "none":
+            continue
+        axis_style = axis.get("style") or {}
+        inward, outward = tick_span(axis_style)
+        side = axis.get("side", "bottom")
+        edge = py0 if side == "top" else py1
+        for value in extra_x_ticks[axis_id][0]:
+            x = float(axis_scale(value))
+            y0, y1 = (
+                (edge - outward, edge + inward)
+                if side == "top"
+                else (edge - inward, edge + outward)
+            )
+            cmd.stroke(
+                [(x, y0), (x, y1)],
+                float(axis_style.get("tick_width", 1)),
+                _parse_color(_css(axis_style.get("tick_color"), default_axis)),
+            )
+    for axis_id, axis, axis_scale in extra_y_axes:
+        if _axis_tick_label_strategy(axis) == "none":
+            continue
+        axis_style = axis.get("style") or {}
+        inward, outward = tick_span(axis_style)
+        side = axis.get("side", "right")
+        edge = px1 if side == "right" else px0
+        for value in extra_y_ticks[axis_id][0]:
+            y = float(axis_scale(value))
+            x0, x1 = (
+                (edge - inward, edge + outward)
+                if side == "right"
+                else (edge - outward, edge + inward)
+            )
+            cmd.stroke(
+                [(x0, y), (x1, y)],
+                float(axis_style.get("tick_width", 1)),
+                _parse_color(_css(axis_style.get("tick_color"), default_axis)),
+            )
 
     text_c = _parse_color(default_text)
-    if not hide_x_labels:
-        x_tick_c = _parse_color(
-            _css(xstyle.get("tick_label_color", xstyle.get("tick_color")), default_text)
-        )
-        for v in xlab:
-            label_y = py0 - 7 if xa.get("side") == "top" else py1 + 15
-            cmd.text(
-                float(sx(v)),
-                label_y,
-                1,
-                float(xstyle.get("tick_label_size", xstyle.get("tick_size", 11))),
-                x_tick_c,
-                _tick_text(xa, v, xstep),
+
+    def rotation_flag(angle: float) -> int:
+        normalized = angle % 360.0
+        if abs(normalized - 90.0) < 1e-9:
+            return _TEXT_ROT_CW
+        if abs(normalized - 270.0) < 1e-9:
+            return _TEXT_ROT_CCW
+        return 0
+
+    def emit_tick_labels(
+        axis: dict[str, Any],
+        values: list[float],
+        step: float,
+        axis_scale: _Scale,
+        *,
+        is_x: bool,
+    ) -> None:
+        axis_style = axis.get("style") or {}
+        items = _axis_tick_label_layout(axis, values, step, axis_scale, is_x)
+        # The native glyph protocol supports quarter-turns, not arbitrary
+        # angles. When SVG/browser collision relief chose a diagonal rotation,
+        # fall back to horizontal downsampling rather than paint overlapping text.
+        if any(rotation_flag(float(item["angle"])) == 0 and item["angle"] for item in items):
+            fallback_axis = {
+                **axis,
+                "tick_label_angle": 0,
+                "tick_label_strategy": "hide",
+            }
+            items = _axis_tick_label_layout(fallback_axis, values, step, axis_scale, is_x)
+        tick_color = _parse_color(
+            _css(
+                axis_style.get("tick_label_color", axis_style.get("tick_color")),
+                default_text,
             )
-    if not hide_y_labels:
-        y_tick_c = _parse_color(
-            _css(ystyle.get("tick_label_color", ystyle.get("tick_color")), default_text)
         )
-        for v in ylab:
-            cmd.text(
-                px0 - 8,
-                float(sy(v)) + 4,
-                2,
-                float(ystyle.get("tick_label_size", ystyle.get("tick_size", 11))),
-                y_tick_c,
-                _tick_text(ya, v, ystep),
-            )
+        font_size = _axis_tick_font_size(axis)
+        side = axis.get("side", "bottom" if is_x else "left")
+        for item in items:
+            flag = rotation_flag(float(item["angle"]))
+            if is_x:
+                row_offset = float(item["row"]) * (font_size + 4)
+                x = float(item["pos"])
+                y = py0 - 7 - row_offset if side == "top" else py1 + 15 + row_offset
+                anchor = 1
+            else:
+                x = px1 + 8 if side == "right" else px0 - 8
+                y = float(item["pos"]) + 4
+                anchor = 0 if side == "right" else 2
+            cmd.text(x, y, anchor | flag, font_size, tick_color, item["text"])
+
+    emit_tick_labels(xa, xlab, xstep, sx, is_x=True)
+    emit_tick_labels(ya, ylab, ystep, sy, is_x=False)
+    for axis_id, axis, axis_scale in extra_x_axes:
+        _ticks, tick_labels, step = extra_x_ticks[axis_id]
+        emit_tick_labels(axis, tick_labels, step, axis_scale, is_x=True)
+    for axis_id, axis, axis_scale in extra_y_axes:
+        _ticks, tick_labels, step = extra_y_ticks[axis_id]
+        emit_tick_labels(axis, tick_labels, step, axis_scale, is_x=False)
     if spec.get("title"):
-        cmd.text(width / 2, plot["y"] - (10 if compact else 12), 1, 14, text_c, str(spec["title"]))
-    if xa.get("label") and not hide_x:
         cmd.text(
-            px0 + plot["w"] / 2,
-            py1 + 33,
+            width / 2,
+            plot["y"] - plot["top_axis_room"] - (10 if compact else 12),
             1,
-            float(xstyle.get("label_size", 12)),
-            _parse_color(_css(xstyle.get("label_color"), default_text)),
-            str(xa["label"]),
-        )
-    if ya.get("label") and not hide_y:
-        # Rotated 90° CCW alongside the axis, matching the SVG export.
-        cmd.text(
             14,
-            plot["y"] + plot["h"] / 2,
-            1 | 0x80,
-            float(ystyle.get("label_size", 12)),
-            _parse_color(_css(ystyle.get("label_color"), default_text)),
-            str(ya["label"]),
+            text_c,
+            str(spec["title"]),
         )
 
+    def emit_axis_title(axis: dict[str, Any], *, is_x: bool) -> None:
+        if not axis.get("label") or _axis_tick_label_strategy(axis) == "none":
+            return
+        axis_style = axis.get("style") or {}
+        geometry = _axis_label_geometry(axis, plot, is_x=is_x)
+        anchor = {"start": 0, "middle": 1, "end": 2}[geometry["anchor"]]
+        cmd.text(
+            geometry["x"],
+            geometry["y"],
+            anchor | rotation_flag(float(geometry["angle"])),
+            geometry["font_size"],
+            _parse_color(_css(axis_style.get("label_color"), default_text)),
+            str(axis["label"]),
+        )
+
+    emit_axis_title(xa, is_x=True)
+    emit_axis_title(ya, is_x=False)
+    for _axis_id, axis, _axis_scale in extra_x_axes:
+        emit_axis_title(axis, is_x=True)
+    for _axis_id, axis, _axis_scale in extra_y_axes:
+        emit_axis_title(axis, is_x=False)
+
     named = [t for t in spec["traces"] if t.get("name")]
-    if spec.get("show_legend", True) and named:
+    show_main_legend = spec.get("show_legend", True) and bool(named)
+    extra_legends = [(extra, extra.get("items") or []) for extra in spec.get("extra_legends") or []]
+    legend_present = show_main_legend or any(items for _extra, items in extra_legends)
+    if legend_present:
+        # The browser scrolls an oversized legend. Static files cannot, so
+        # clip the bounded/truncated equivalent to the plot rectangle.
+        cmd.clip(px0, py0, plot["w"], plot["h"])
+    if show_main_legend:
         _emit_legend(cmd, named, plot, spec.get("legend") or {})
-    for extra in spec.get("extra_legends") or []:
-        items = extra.get("items") or []
+    for extra, items in extra_legends:
         if items:
             _emit_legend(cmd, items, plot, extra)
+    if legend_present:
+        cmd.clip(0, 0, width, height)
     if spec.get("colorbar"):
-        _emit_colorbar(cmd, spec["colorbar"], plot)
+        _emit_colorbar(
+            cmd,
+            spec["colorbar"],
+            plot,
+            _colorbar_right_axis_room(ya, extra_y_axes, compact),
+        )
 
     w_px, h_px = max(1, round(width * scale)), max(1, round(height * scale))
     from . import _native
@@ -860,7 +983,11 @@ def _emit_annotations(cmd, annotations, sx, sy, plot, width, height, *, phase="m
             line_height = font_size * 1.2
             # A callout's `color` paints its arrow; the label prefers its own.
             label_color = style.get("label_color") or style.get("color")
-            color = _rgba(label_color, _TEXT, float(style.get("opacity", 1.0)))
+            label_opacity = style.get(
+                "label_opacity",
+                style.get("opacity", 1.0) if ann.get("kind") == "text" else 1.0,
+            )
+            color = _rgba(label_color, _TEXT, float(label_opacity))
             rotation = float(style.get("rotation", 0.0)) % 360.0
             if rotation in (90.0, 270.0):
                 # Vertical text via the rasterizer's rotated glyph paths.
@@ -1295,33 +1422,17 @@ _LEGEND_LINE_KINDS = frozenset({"line", "segments", "step", "stairs", "errorbar"
 
 
 def _emit_legend(cmd, named, plot, options):
-    style_opts = options.get("style") or {}
-    pad, handle, gap, line_h = 8.0, 20, 5, 16.0
-    if str(style_opts.get("padding", "")).endswith("em"):
-        pad = 11.0 * float(str(style_opts["padding"])[:-2])
-    if str(style_opts.get("rowGap", "")).endswith("em"):
-        line_h = 11.0 * (1.0 + float(str(style_opts["rowGap"])[:-2]))
-    ncols = min(len(named), max(1, int(options.get("ncols", 1))))
-    nrows = (len(named) + ncols - 1) // ncols
-    title = options.get("title")
-    title_h = 16 if title else 0
-    cell_w = max(len(str(t["name"])) for t in named) * 6.2 + handle + gap + 2 * pad
-    box_w, box_h = ncols * cell_w + pad, nrows * line_h + pad + title_h
-    loc = options.get("loc") or "upper right"
-    # "center" is the per-axis fallback: "center right" is the right edge at
-    # vertical center, "upper center" the top edge at horizontal center.
-    if "left" in loc:
-        x = plot["x"] + 6
-    elif "right" in loc:
-        x = plot["x"] + plot["w"] - box_w - 6
-    else:
-        x = plot["x"] + (plot["w"] - box_w) / 2
-    if "upper" in loc:
-        y = plot["y"] + 6
-    elif "lower" in loc:
-        y = plot["y"] + plot["h"] - box_h - 6
-    else:
-        y = plot["y"] + (plot["h"] - box_h) / 2
+    legend = _legend_layout(named, plot, options)
+    if not legend["visible_count"]:
+        # A plot too short for even one entry: no floating frame/title either.
+        return
+    style_opts = legend["style"]
+    pad, handle, gap = legend["pad"], legend["handle"], legend["gap"]
+    line_h, ncols = legend["line_h"], legend["ncols"]
+    title, title_h = legend["title"], legend["title_h"]
+    cell_w = legend["cell_w"]
+    box_w, box_h = legend["box_w"], legend["box_h"]
+    x, y = legend["x"], legend["y"]
     # frameon=False (background transparent) drops the box entirely (§ mpl parity).
     if style_opts.get("background") != "transparent":
         if style_opts.get("boxShadow"):
@@ -1336,7 +1447,7 @@ def _emit_legend(cmd, named, plot, options):
         cmd.fill(_rect_pts(x, y, x + box_w, y + box_h), frame)
     if title:
         cmd.text(x + pad, y + pad / 2 + 11, 0, 11, _parse_color(_TEXT), str(title))
-    for i, t in enumerate(named):
+    for i, t in enumerate(named[: legend["visible_count"]]):
         style = t.get("style") or {}
         color_str = _css(
             style.get("color") or (t.get("color") or {}).get("color"),
@@ -1361,17 +1472,22 @@ def _emit_legend(cmd, named, plot, options):
             )
         else:
             cmd.fill(_rect_pts(hx0, cy - 4, hx1, cy + 4), c)
-        cmd.text(hx1 + gap, ry + 11, 0, 11, _parse_color(_TEXT), str(t["name"]))
+        cmd.text(hx1 + gap, ry + 11, 0, 11, _parse_color(_TEXT), legend["names"][i])
 
 
-def _emit_colorbar(cmd, options, plot):
+def _emit_colorbar(cmd, options, plot, right_axis_room=0.0):
     from ._svg import _linear_ticks, _lut
 
     orientation = options.get("orientation", "vertical")
     if orientation == "horizontal":
-        x, y, width, height = plot["x"], plot["y"] + plot["h"] + 10, plot["w"], 18
+        x = plot["x"]
+        y = plot["y"] + plot["h"] + (plot["bottom_axis_room"] or 10)
+        width, height = plot["w"], 18
     else:
-        x, y, width, height = plot["x"] + plot["w"] + 24, plot["y"], 18, plot["h"]
+        # right_axis_room shifts the whole colorbar clear of right-side named
+        # y-axis chrome (layout() reserves room for both additively).
+        x = plot["x"] + plot["w"] + right_axis_room + 24
+        y, width, height = plot["y"], 18, plot["h"]
     # A discrete (resampled) colormap paints N solid bands; otherwise a smooth
     # 64-step gradient approximates the continuous ramp.
     levels = options.get("levels")

--- a/python/xy/_svg.py
+++ b/python/xy/_svg.py
@@ -18,6 +18,7 @@ browser-dependent in SVG and use the native PNG fallback.
 from __future__ import annotations
 
 import base64
+import math
 import re
 from datetime import UTC, datetime
 from os import PathLike
@@ -927,6 +928,80 @@ def _dash_attr(style: dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _axes_by_id(spec: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Return every configured axis keyed by its wire id.
+
+    Older payloads only carried the primary ``x_axis``/``y_axis`` fields;
+    current payloads additionally carry an ``axes`` mapping for named axes.
+    Static exporters accept both shapes and let the primary compatibility
+    fields win, matching the browser client's normalization.
+    """
+    axes = dict(spec.get("axes") or {})
+    axes["x"] = spec["x_axis"]
+    axes["y"] = spec["y_axis"]
+    return axes
+
+
+def _axis_scales(
+    spec: dict[str, Any], plot: dict[str, float]
+) -> tuple[
+    dict[str, _Scale],
+    dict[str, _Scale],
+    _Scale,
+    _Scale,
+    list[tuple[str, dict[str, Any], _Scale]],
+    list[tuple[str, dict[str, Any], _Scale]],
+]:
+    """Pixel scales for every configured axis plus the named-axis lists —
+    shared by the SVG and native exporters so their geometry stays identical.
+
+    Returns ``(x_scales, y_scales, sx, sy, extra_x_axes, extra_y_axes)``.
+    """
+    axes = _axes_by_id(spec)
+    x_scales = {
+        axis_id: _Scale(axis, plot["x"], plot["x"] + plot["w"])
+        for axis_id, axis in axes.items()
+        if axis_id.startswith("x")
+    }
+    y_scales = {
+        axis_id: _Scale(axis, plot["y"] + plot["h"], plot["y"])
+        for axis_id, axis in axes.items()
+        if axis_id.startswith("y")
+    }
+    sx = x_scales["x"]
+    sy = y_scales["y"]  # y grows downward in raster space
+    extra_x_axes = [
+        (axis_id, axis, x_scales[axis_id])
+        for axis_id, axis in axes.items()
+        if axis_id != "x" and axis_id.startswith("x")
+    ]
+    extra_y_axes = [
+        (axis_id, axis, y_scales[axis_id])
+        for axis_id, axis in axes.items()
+        if axis_id != "y" and axis_id.startswith("y")
+    ]
+    return x_scales, y_scales, sx, sy, extra_x_axes, extra_y_axes
+
+
+def _colorbar_right_axis_room(
+    y_axis: dict[str, Any],
+    extra_y_axes: list[tuple[str, dict[str, Any], _Scale]],
+    compact: bool,
+) -> float:
+    """Gutter layout() reserves for visible right-side named y axes.
+
+    The vertical colorbar shifts right by this amount so its bar/ticks/label
+    clear the axis tick labels (plot-right+8) and rotated axis title
+    (plot-right+40); the JS client applies the identical rule."""
+    axes = [y_axis, *(axis for _axis_id, axis, _axis_scale in extra_y_axes)]
+    if any(
+        axis.get("side", "left") == "right" and _axis_tick_label_strategy(axis) != "none"
+        for axis in axes
+    ):
+        return 42.0 if compact else 54.0
+    return 0.0
+
+
 def layout(spec: dict[str, Any]) -> tuple[int, int, bool, dict[str, float]]:
     """Concrete pixel dimensions + plot rect from a spec — shared by the SVG and
     native-PNG exporters so their chrome/plot geometry stays identical."""
@@ -947,16 +1022,50 @@ def layout(spec: dict[str, Any]) -> tuple[int, int, bool, dict[str, float]]:
         bottom = 36 if compact else 42
     if spec.get("title"):
         top += 26 if compact else 30
+    axes = _axes_by_id(spec)
+    bottom_axis_room = 0.0
+    if any(
+        axis_id.startswith("x")
+        and axis.get("side", "bottom") == "bottom"
+        and _axis_tick_label_strategy(axis) != "none"
+        for axis_id, axis in axes.items()
+    ):
+        bottom_axis_room = 36 if compact else 42
+    top_axis_room = 0.0
+    if any(
+        axis_id.startswith("x")
+        and axis.get("side", "bottom") == "top"
+        and _axis_tick_label_strategy(axis) != "none"
+        for axis_id, axis in axes.items()
+    ):
+        # One shared top gutter mirrors ChartView. Multiple named x axes on
+        # the same edge intentionally overlap until per-axis offsets exist.
+        top_axis_room = 26 if compact else 32
+        top += top_axis_room
     colorbar = spec.get("colorbar") or {}
     if colorbar.get("orientation") == "horizontal":
         bottom += 38 + (16 if colorbar.get("label") else 0)
     elif colorbar:
         right += 86 + (18 if colorbar.get("label") else 0)
+    if any(
+        axis_id.startswith("y")
+        and axis.get("side", "right") == "right"
+        and _axis_tick_label_strategy(axis) != "none"
+        for axis_id, axis in axes.items()
+    ):
+        # Match ChartView._layout(): one shared right-side gutter contains the
+        # secondary-y tick labels/title. Multiple right axes intentionally
+        # overlay in both renderers until offset axes become part of the API.
+        right += 42 if compact else 54
     plot = {
         "x": left,
         "y": top,
         "w": max(40, width - left - right),
         "h": max(40, height - top - bottom),
+        # Emitters place the figure title above this gutter; recording it here
+        # keeps layout() the single source of the top-axis reservation.
+        "top_axis_room": top_axis_room,
+        "bottom_axis_room": bottom_axis_room,
     }
     return width, height, compact, plot
 
@@ -968,10 +1077,15 @@ def axis_ticks(
     tick density so SVG and PNG label the same values."""
     if axis.get("tick_values") is not None:
         lo, hi = axis["range"]
-        ticks = [float(v) for v in axis["tick_values"] if lo <= float(v) <= hi]
+        low, high = min(lo, hi), max(lo, hi)
+        ticks = [float(v) for v in axis["tick_values"] if low <= float(v) <= high]
         step = abs(ticks[1] - ticks[0]) if len(ticks) > 1 else 1.0
         return ticks, ticks, step
-    target = max(3, int(length_px / 80)) if is_x else max(3, int(length_px / 45))
+    requested = axis.get("tick_count")
+    if isinstance(requested, (int, float)) and not isinstance(requested, bool) and requested > 0:
+        target = max(1, min(200, int(requested)))
+    else:
+        target = max(3, int(length_px / 80)) if is_x else max(3, int(length_px / 45))
     kind = axis.get("kind")
     lo, hi = axis["range"]
     if axis.get("scale") == "log" or kind == "log":
@@ -986,14 +1100,174 @@ def axis_ticks(
     return t, t, step
 
 
+def _axis_tick_label_strategy(axis: dict[str, Any]) -> str:
+    value = str(axis.get("tick_label_strategy") or "auto").replace("-", "_")
+    return value if value in {"auto", "hide", "rotate", "stagger", "none", "off"} else "auto"
+
+
+def _axis_tick_font_size(axis: dict[str, Any]) -> float:
+    style = axis.get("style") or {}
+    return max(8.0, float(style.get("tick_label_size", style.get("tick_size", 11))))
+
+
+def _axis_tick_label_layout(
+    axis: dict[str, Any],
+    values: list[float],
+    step: float,
+    scale: _Scale,
+    is_x: bool,
+) -> list[dict[str, Any]]:
+    """Port ChartView._layoutTickLabels for deterministic static chrome."""
+    strategy = _axis_tick_label_strategy(axis)
+    if strategy in {"none", "off"}:
+        return []
+
+    font_size = _axis_tick_font_size(axis)
+    min_gap = float(axis.get("tick_label_min_gap", 8 if is_x else 4))
+    raw_angle = axis.get("tick_label_angle")
+    explicit_angle = float(raw_angle) if raw_angle is not None else None
+    base_angle = explicit_angle or 0.0
+    labels = [
+        {
+            "value": value,
+            "pos": float(scale(value)),
+            "text": _tick_text(axis, value, step),
+            "angle": base_angle,
+            "row": 0,
+        }
+        for value in values
+    ]
+    if len(labels) <= 1:
+        return labels
+
+    def extent(label: dict[str, Any]) -> float:
+        width = max(font_size * 0.7, len(str(label["text"])) * font_size * 0.62)
+        height = font_size * 1.2
+        angle = abs(float(label.get("angle", 0.0))) * math.pi / 180.0
+        if is_x:
+            return abs(math.cos(angle)) * width + abs(math.sin(angle)) * height
+        return abs(math.sin(angle)) * width + abs(math.cos(angle)) * height
+
+    def collide(items: list[dict[str, Any]]) -> bool:
+        rows: dict[int, list[dict[str, Any]]] = {}
+        for item in items:
+            rows.setdefault(int(item.get("row", 0)), []).append(item)
+        for row in rows.values():
+            last_end = -math.inf
+            for item in sorted(row, key=lambda candidate: float(candidate["pos"])):
+                half = extent(item) / 2.0
+                start = float(item["pos"]) - half
+                if start < last_end + min_gap:
+                    return True
+                last_end = float(item["pos"]) + half
+        return False
+
+    if strategy == "auto":
+        if not collide(labels):
+            return labels
+        if is_x and axis.get("kind") == "category" and len(labels) <= 16:
+            strategy = "rotate"
+        elif is_x and len(labels) <= 24:
+            strategy = "stagger"
+        else:
+            strategy = "hide"
+
+    if strategy == "rotate" and is_x:
+        angle = (
+            explicit_angle
+            if explicit_angle is not None
+            else (35.0 if axis.get("side") == "top" else -35.0)
+        )
+        labels = [{**label, "angle": angle, "row": 0} for label in labels]
+    elif strategy == "stagger" and is_x:
+        labels = [{**label, "row": index % 2} for index, label in enumerate(labels)]
+
+    # "hide" is a collision-handling strategy: the stride loop engages only
+    # when the full label set actually overlaps, so relayouts that force
+    # strategy="hide" (native diagonal-angle fallback) keep fitting labels.
+    if collide(labels):
+        for stride in range(2, len(labels) + 1):
+            reduced = labels[::stride]
+            if not collide(reduced):
+                return reduced
+        return labels[:1]
+    return labels
+
+
+def _axis_label_geometry(
+    axis: dict[str, Any],
+    plot: dict[str, float],
+    *,
+    is_x: bool,
+) -> dict[str, Any]:
+    """Resolve named axis-title placement shared by SVG and native output.
+
+    Named positions, offsets, and angles mirror ChartView. Structured CSS
+    dictionaries remain a browser-only escape hatch because native exporters
+    do not have a CSS layout engine.
+    """
+    style = axis.get("style") or {}
+    font_size = float(style.get("label_size", 12))
+    raw_position = axis.get("label_position")
+    position = raw_position if isinstance(raw_position, str) else "center"
+    position = position.replace("-", "_")
+    inside = position.startswith("inside_")
+    anchor = position.removeprefix("inside_") if inside else position
+    anchor_fraction = 0.0 if anchor == "start" else 1.0 if anchor == "end" else 0.5
+    offset = float(axis.get("label_offset", 0.0))
+    side = axis.get("side", "bottom" if is_x else "left")
+
+    if is_x:
+        x = plot["x"] + plot["w"] * anchor_fraction
+        outside_top = plot["y"] - 34
+        outside_bottom = plot["y"] + plot["h"] + 24
+        inside_top = plot["y"] + 12
+        inside_bottom = plot["y"] + plot["h"] - 12
+        y = (
+            (inside_top if side == "top" else inside_bottom)
+            if inside
+            else (outside_top if side == "top" else outside_bottom)
+        )
+        y += (
+            (-offset if not inside else offset)
+            if side == "top"
+            else (offset if not inside else -offset)
+        )
+        # DOM labels use top positioning; static text commands use a baseline.
+        y += font_size * 0.82
+        text_anchor = "start" if anchor == "start" else "end" if anchor == "end" else "middle"
+        angle = float(axis.get("label_angle", 0.0))
+    else:
+        outside_x = plot["x"] + plot["w"] + 40 if side == "right" else 10
+        inside_x = plot["x"] + plot["w"] - 12 if side == "right" else plot["x"] + 12
+        x = inside_x if inside else outside_x
+        x += (-offset if inside else offset) if side == "right" else (offset if inside else -offset)
+        y = plot["y"] + plot["h"] * (1.0 - anchor_fraction)
+        text_anchor = "middle"
+        angle = float(axis.get("label_angle", 90.0 if side == "right" else -90.0))
+
+    return {
+        "x": x,
+        "y": y,
+        "anchor": text_anchor,
+        "angle": angle,
+        "font_size": font_size,
+    }
+
+
 def render_svg(spec: dict[str, Any], blob: bytes, *, id_prefix: str = "") -> str:
     spec = _resolve_static_css_vars(spec)
     width, height, compact, plot = layout(spec)
     xa, ya = spec["x_axis"], spec["y_axis"]
-    sx = _Scale(xa, plot["x"], plot["x"] + plot["w"])
-    sy = _Scale(ya, plot["y"] + plot["h"], plot["y"])  # y grows downward in SVG
+    x_scales, y_scales, sx, sy, extra_x_axes, extra_y_axes = _axis_scales(spec, plot)
     svg = _Svg(id_prefix)
     cols = spec["columns"]
+    # One plot-rect clipPath serves the marks group and every legend.
+    clip_id = svg.uid("clip")
+    svg.defs.append(
+        f'<clipPath id="{clip_id}"><rect x="{_num(plot["x"])}" y="{_num(plot["y"])}" '
+        f'width="{_num(plot["w"])}" height="{_num(plot["h"])}"/></clipPath>'
+    )
 
     def ticks_for(axis: dict[str, Any], length_px: float) -> tuple[list[float], list[float], float]:
         return axis_ticks(axis, length_px, axis is xa)
@@ -1012,8 +1286,6 @@ def render_svg(spec: dict[str, Any], blob: bytes, *, id_prefix: str = "") -> str
     # label text and keeps grid, baselines and the axis title (mpl shared axes).
     hide_x = xa.get("tick_label_strategy") == "none"
     hide_y = ya.get("tick_label_strategy") == "none"
-    hide_x_labels = hide_x or xa.get("tick_label_strategy") == "off"
-    hide_y_labels = hide_y or ya.get("tick_label_strategy") == "off"
     for v in xt:
         if hide_x:
             break
@@ -1035,37 +1307,63 @@ def render_svg(spec: dict[str, Any], blob: bytes, *, id_prefix: str = "") -> str
             f'stroke-width="{_num(float(ystyle.get("grid_width", 1)))}"'
             f"{_axis_grid_attrs(ystyle)}/>"
         )
-    if not hide_x_labels:
-        for v in xlab:
-            tick_y = plot["y"] - 7 if xa.get("side") == "top" else plot["y"] + plot["h"] + 16
-            labels.append(
-                f'<text x="{_num(float(sx(v)))}" y="{_num(tick_y)}" '
-                f'fill="{escape(_css(xstyle.get("tick_label_color", xstyle.get("tick_color")), default_text))}" '
-                f'font-size="{_num(float(xstyle.get("tick_label_size", xstyle.get("tick_size", 11))))}" '
-                f'text-anchor="middle"'
-                + (
-                    f' transform="rotate({_num(float(xa["tick_label_angle"]))} '
-                    f'{_num(float(sx(v)))} {_num(tick_y)})"'
-                    if xa.get("tick_label_angle") is not None
-                    else ""
-                )
-                + f">{escape(_tick_text(xa, v, xstep))}</text>"
+
+    def append_tick_labels(
+        axis: dict[str, Any],
+        values: list[float],
+        step: float,
+        axis_scale: _Scale,
+        *,
+        is_x: bool,
+    ) -> None:
+        axis_style = axis.get("style") or {}
+        color = escape(
+            _css(
+                axis_style.get("tick_label_color", axis_style.get("tick_color")),
+                default_text,
             )
-    if not hide_y_labels:
-        for v in ylab:
-            labels.append(
-                f'<text x="{_num(plot["x"] - 8)}" y="{_num(float(sy(v)) + 4)}" '
-                f'fill="{escape(_css(ystyle.get("tick_label_color", ystyle.get("tick_color")), default_text))}" '
-                f'font-size="{_num(float(ystyle.get("tick_label_size", ystyle.get("tick_size", 11))))}" '
-                f'text-anchor="end"'
-                + (
-                    f' transform="rotate({_num(float(ya["tick_label_angle"]))} '
-                    f'{_num(plot["x"] - 8)} {_num(float(sy(v)) + 4)})"'
-                    if ya.get("tick_label_angle") is not None
-                    else ""
+        )
+        font_size = _axis_tick_font_size(axis)
+        side = axis.get("side", "bottom" if is_x else "left")
+        for item in _axis_tick_label_layout(axis, values, step, axis_scale, is_x):
+            angle = float(item["angle"])
+            if is_x:
+                row_offset = float(item["row"]) * (font_size + 4)
+                x = float(item["pos"])
+                y = (
+                    plot["y"] - 7 - row_offset
+                    if side == "top"
+                    else plot["y"] + plot["h"] + 16 + row_offset
                 )
-                + f">{escape(_tick_text(ya, v, ystep))}</text>"
+                if angle == 0:
+                    anchor = "middle"
+                elif (side == "bottom" and angle < 0) or (side == "top" and angle > 0):
+                    anchor = "end"
+                else:
+                    anchor = "start"
+            else:
+                x = plot["x"] + plot["w"] + 8 if side == "right" else plot["x"] - 8
+                y = float(item["pos"]) + 4
+                anchor = "start" if side == "right" else "end"
+            transform = f' transform="rotate({_num(angle)} {_num(x)} {_num(y)})"' if angle else ""
+            labels.append(
+                f'<text x="{_num(x)}" y="{_num(y)}" fill="{color}" '
+                f'font-size="{_num(font_size)}" text-anchor="{anchor}"{transform}>'
+                f"{escape(str(item['text']))}</text>"
             )
+
+    append_tick_labels(xa, xlab, xstep, sx, is_x=True)
+    append_tick_labels(ya, ylab, ystep, sy, is_x=False)
+    extra_x_ticks: dict[str, tuple[list[float], list[float], float]] = {}
+    for axis_id, axis, axis_scale in extra_x_axes:
+        ticks, tick_labels, step = axis_ticks(axis, plot["w"], True)
+        extra_x_ticks[axis_id] = (ticks, tick_labels, step)
+        append_tick_labels(axis, tick_labels, step, axis_scale, is_x=True)
+    extra_y_ticks: dict[str, tuple[list[float], list[float], float]] = {}
+    for axis_id, axis, axis_scale in extra_y_axes:
+        ticks, tick_labels, step = axis_ticks(axis, plot["h"], False)
+        extra_y_ticks[axis_id] = (ticks, tick_labels, step)
+        append_tick_labels(axis, tick_labels, step, axis_scale, is_x=False)
 
     # -- marks --------------------------------------------------------------
     marks: list[str] = []
@@ -1087,9 +1385,11 @@ def render_svg(spec: dict[str, Any], blob: bytes, *, id_prefix: str = "") -> str
         tier = t.get("tier")
         color = _css(style.get("color"), DEFAULT_PALETTE[palette_cycle % len(DEFAULT_PALETTE)])
         palette_cycle += 1
+        trace_sx = x_scales.get(t.get("x_axis", "x"), sx)
+        trace_sy = y_scales.get(t.get("y_axis", "y"), sy)
 
         if tier == "density" and t.get("density"):
-            marks.append(_density_image(t["density"], blob, cols, sx, sy, style, svg))
+            marks.append(_density_image(t["density"], blob, cols, trace_sx, trace_sy, style, svg))
             continue
 
         if kind == "line":
@@ -1097,7 +1397,7 @@ def render_svg(spec: dict[str, Any], blob: bytes, *, id_prefix: str = "") -> str
             yv = _column(blob, cols[t["y"]])
             if style.get("step"):
                 xv, yv = _step_arrays(xv, yv, style["step"])
-            d = _curve_path(xv, yv, sx, sy, style.get("curve") == "smooth")
+            d = _curve_path(xv, yv, trace_sx, trace_sy, style.get("curve") == "smooth")
             marks.append(f'<path d="{d}" {line_attrs(style, color)}/>')
 
         elif kind in ("area", "error_band"):
@@ -1105,8 +1405,8 @@ def render_svg(spec: dict[str, Any], blob: bytes, *, id_prefix: str = "") -> str
             yv = _column(blob, cols[t["y"]])
             bv = _column(blob, cols[t["base"]])
             smooth = style.get("curve") == "smooth"
-            top_path = _curve_path(xv, yv, sx, sy, smooth)
-            base_path = _curve_path(xv[::-1], bv[::-1], sx, sy, smooth)
+            top_path = _curve_path(xv, yv, trace_sx, trace_sy, smooth)
+            base_path = _curve_path(xv[::-1], bv[::-1], trace_sx, trace_sy, smooth)
             fill_spec = style.get("fill")
             fill = (
                 svg.gradient(fill_spec, color, plot)
@@ -1130,58 +1430,72 @@ def render_svg(spec: dict[str, Any], blob: bytes, *, id_prefix: str = "") -> str
                 )
 
         elif kind == "scatter":
-            marks.append(_scatter_marks(t, blob, cols, sx, sy, style, color))
+            marks.append(_scatter_marks(t, blob, cols, trace_sx, trace_sy, style, color))
 
         elif kind == "hexbin":
-            marks.append(_hexbin_marks(t, blob, cols, sx, sy, style, color))
+            marks.append(_hexbin_marks(t, blob, cols, trace_sx, trace_sy, style, color))
 
         elif kind in {"errorbar", "stem", "box_whisker", "box_median", "contour", "segments"}:
-            marks.append(_segment_marks(t, blob, cols, sx, sy, style, color))
+            marks.append(_segment_marks(t, blob, cols, trace_sx, trace_sy, style, color))
 
         elif kind in ("bar", "column") and t.get("bar"):
-            marks.append(_bar_marks(t, blob, cols, sx, sy, style, color, svg, plot))
+            marks.append(_bar_marks(t, blob, cols, trace_sx, trace_sy, style, color, svg, plot))
 
         elif kind == "heatmap" and t.get("heatmap"):
-            marks.append(_heatmap_image(t["heatmap"], blob, cols, sx, sy, style))
+            marks.append(_heatmap_image(t["heatmap"], blob, cols, trace_sx, trace_sy, style))
 
         elif kind == "triangle_mesh":
-            marks.append(_triangle_mesh_marks(t, blob, cols, sx, sy, style, color))
+            marks.append(_triangle_mesh_marks(t, blob, cols, trace_sx, trace_sy, style, color))
 
         elif all(k in t for k in ("x0", "x1", "y0", "y1")):  # histogram / rect family
-            marks.append(_rect_marks(t, blob, cols, sx, sy, style, color, svg, plot))
+            marks.append(_rect_marks(t, blob, cols, trace_sx, trace_sy, style, color, svg, plot))
 
     # -- chrome text ----------------------------------------------------------
     chrome: list[str] = []
     if spec.get("title"):
         chrome.append(
-            f'<text x="{_num(width / 2)}" y="{_num(plot["y"] - (10 if compact else 12))}" '
+            f'<text x="{_num(width / 2)}" '
+            f'y="{_num(plot["y"] - plot["top_axis_room"] - (10 if compact else 12))}" '
             f'text-anchor="middle" font-size="14" font-weight="600" '
             f'fill="{escape(default_text)}">{escape(str(spec["title"]))}</text>'
         )
-    if xa.get("label") and not hide_x:
+
+    def append_axis_title(axis: dict[str, Any], *, is_x: bool) -> None:
+        if not axis.get("label") or _axis_tick_label_strategy(axis) == "none":
+            return
+        axis_style = axis.get("style") or {}
+        geometry = _axis_label_geometry(axis, plot, is_x=is_x)
+        x, y = float(geometry["x"]), float(geometry["y"])
+        angle = float(geometry["angle"])
+        transform = f' transform="rotate({_num(angle)} {_num(x)} {_num(y)})"' if angle else ""
         chrome.append(
-            f'<text x="{_num(plot["x"] + plot["w"] / 2)}" y="{_num(plot["y"] + plot["h"] + 34)}" '
-            f'text-anchor="middle" font-size="{_num(float(xstyle.get("label_size", 12)))}" '
-            f'font-weight="500" fill="{escape(_css(xstyle.get("label_color"), default_text))}">'
-            f"{escape(str(xa['label']))}</text>"
+            f'<text x="{_num(x)}" y="{_num(y)}" text-anchor="{geometry["anchor"]}" '
+            f'font-size="{_num(float(geometry["font_size"]))}" font-weight="500" '
+            f'fill="{escape(_css(axis_style.get("label_color"), default_text))}"{transform}>'
+            f"{escape(str(axis['label']))}</text>"
         )
-    if ya.get("label") and not hide_y:
-        cx, cy = 14, plot["y"] + plot["h"] / 2
-        chrome.append(
-            f'<text x="{_num(cx)}" y="{_num(cy)}" text-anchor="middle" '
-            f'font-size="{_num(float(ystyle.get("label_size", 12)))}" '
-            f'font-weight="500" fill="{escape(_css(ystyle.get("label_color"), default_text))}" '
-            f'transform="rotate(-90 {_num(cx)} {_num(cy)})">{escape(str(ya["label"]))}</text>'
-        )
+
+    append_axis_title(xa, is_x=True)
+    append_axis_title(ya, is_x=False)
+    for _axis_id, axis, _axis_scale in extra_x_axes:
+        append_axis_title(axis, is_x=True)
+    for _axis_id, axis, _axis_scale in extra_y_axes:
+        append_axis_title(axis, is_x=False)
     named = [t for t in spec["traces"] if t.get("name")]
     if spec.get("show_legend", True) and named:
-        chrome.append(_legend(named, plot, spec.get("legend") or {}))
+        chrome.append(_legend(named, plot, spec.get("legend") or {}, clip_id))
     for extra in spec.get("extra_legends") or []:
         items = extra.get("items") or []
         if items:
-            chrome.append(_legend(items, plot, extra))
+            chrome.append(_legend(items, plot, extra, clip_id))
     if spec.get("colorbar"):
-        chrome.append(_colorbar(spec["colorbar"], plot))
+        chrome.append(
+            _colorbar(
+                spec["colorbar"],
+                plot,
+                _colorbar_right_axis_room(ya, extra_y_axes, compact),
+            )
+        )
 
     annotation_marks, annotation_labels = _annotation_svg(
         spec.get("annotations") or [], sx, sy, plot, width, height
@@ -1212,6 +1526,28 @@ def render_svg(spec: dict[str, Any], blob: bytes, *, id_prefix: str = "") -> str
                     f'stroke="{escape(_css(xstyle.get("axis_color"), default_axis))}" '
                     f'stroke-width="{_num(float(xstyle.get("axis_width", 1)))}"/>'
                 )
+    for _axis_id, axis, _axis_scale in extra_x_axes:
+        if _axis_tick_label_strategy(axis) == "none":
+            continue
+        axis_style = axis.get("style") or {}
+        edge = plot["y"] if axis.get("side", "bottom") == "top" else plot["y"] + plot["h"]
+        baselines += (
+            f'<line x1="{_num(plot["x"])}" y1="{_num(edge)}" '
+            f'x2="{_num(plot["x"] + plot["w"])}" y2="{_num(edge)}" '
+            f'stroke="{escape(_css(axis_style.get("axis_color"), default_axis))}" '
+            f'stroke-width="{_num(float(axis_style.get("axis_width", 1)))}"/>'
+        )
+    for _axis_id, axis, _axis_scale in extra_y_axes:
+        if _axis_tick_label_strategy(axis) == "none":
+            continue
+        axis_style = axis.get("style") or {}
+        edge = plot["x"] + plot["w"] if axis.get("side", "right") == "right" else plot["x"]
+        baselines += (
+            f'<line x1="{_num(edge)}" y1="{_num(plot["y"])}" x2="{_num(edge)}" '
+            f'y2="{_num(plot["y"] + plot["h"])}" '
+            f'stroke="{escape(_css(axis_style.get("axis_color"), default_axis))}" '
+            f'stroke-width="{_num(float(axis_style.get("axis_width", 1)))}"/>'
+        )
 
     def tick_span(style: dict[str, Any]) -> tuple[float, float, float]:
         length = max(0.0, float(style.get("tick_length", 0)))
@@ -1254,12 +1590,45 @@ def render_svg(spec: dict[str, Any], blob: bytes, *, id_prefix: str = "") -> str
                 f'stroke="{escape(_css(ystyle.get("tick_color"), default_axis))}" '
                 f'stroke-width="{_num(tick_width)}"/>'
             )
+    for axis_id, axis, axis_scale in extra_x_axes:
+        if _axis_tick_label_strategy(axis) == "none":
+            continue
+        axis_style = axis.get("style") or {}
+        inward, outward, tick_width = tick_span(axis_style)
+        side = axis.get("side", "bottom")
+        edge = plot["y"] if side == "top" else plot["y"] + plot["h"]
+        for value in extra_x_ticks[axis_id][0]:
+            x = float(axis_scale(value))
+            y1, y2 = (
+                (edge - outward, edge + inward)
+                if side == "top"
+                else (edge - inward, edge + outward)
+            )
+            baselines += (
+                f'<line x1="{_num(x)}" y1="{_num(y1)}" x2="{_num(x)}" y2="{_num(y2)}" '
+                f'stroke="{escape(_css(axis_style.get("tick_color"), default_axis))}" '
+                f'stroke-width="{_num(tick_width)}"/>'
+            )
+    for axis_id, axis, axis_scale in extra_y_axes:
+        if _axis_tick_label_strategy(axis) == "none":
+            continue
+        axis_style = axis.get("style") or {}
+        inward, outward, tick_width = tick_span(axis_style)
+        side = axis.get("side", "right")
+        edge = plot["x"] + plot["w"] if side == "right" else plot["x"]
+        for value in extra_y_ticks[axis_id][0]:
+            y = float(axis_scale(value))
+            x1, x2 = (
+                (edge - inward, edge + outward)
+                if side == "right"
+                else (edge - outward, edge + inward)
+            )
+            baselines += (
+                f'<line x1="{_num(x1)}" y1="{_num(y)}" x2="{_num(x2)}" y2="{_num(y)}" '
+                f'stroke="{escape(_css(axis_style.get("tick_color"), default_axis))}" '
+                f'stroke-width="{_num(tick_width)}"/>'
+            )
 
-    clip_id = svg.uid("clip")
-    svg.defs.append(
-        f'<clipPath id="{clip_id}"><rect x="{_num(plot["x"])}" y="{_num(plot["y"])}" '
-        f'width="{_num(plot["w"])}" height="{_num(plot["h"])}"/></clipPath>'
-    )
     defs = f"<defs>{''.join(svg.defs)}</defs>" if svg.defs else ""
     return (
         f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" '
@@ -1384,7 +1753,12 @@ def _annotation_svg(annotations, sx, sy, plot, width, height):
                     base = {"middle": (ascent - descent) / 2, "end": -descent}.get(anchor, ascent)
                 stack = -line_height if cw else line_height  # later lines: glyph-down
                 by = ty + float(ann.get("dy", 0))
-                text_opacity = float(style.get("opacity", 1.0))
+                text_opacity = float(
+                    style.get(
+                        "label_opacity",
+                        style.get("opacity", 1.0) if kind == "text" else 1.0,
+                    )
+                )
                 for index, line in enumerate(lines):
                     bx = tx + float(ann.get("dx", 0)) + base + index * stack
                     labels.append(
@@ -1407,7 +1781,12 @@ def _annotation_svg(annotations, sx, sy, plot, width, height):
                 f"{escape(line)}</tspan>"
                 for index, line in enumerate(lines)
             )
-            text_opacity = float(style.get("opacity", 1.0))
+            text_opacity = float(
+                style.get(
+                    "label_opacity",
+                    style.get("opacity", 1.0) if kind == "text" else 1.0,
+                )
+            )
             # A callout's `color` paints its arrow; the label prefers its own.
             label_color = escape(_css(style.get("label_color"), "")) or color
             labels.append(
@@ -1773,35 +2152,121 @@ def _heatmap_image(hm: dict, blob: bytes, cols: list, sx: _Scale, sy: _Scale, st
 _LEGEND_LINE_KINDS = frozenset({"line", "segments", "step", "stairs", "errorbar"})
 
 
-def _legend(named: list[dict], plot: dict, options: dict) -> str:
-    rows = []
+_LEGEND_CHAR_WIDTH = 6.2
+
+
+def _legend_text(value: Any, max_width: float) -> str:
+    """Conservatively ellipsize a static legend string to a pixel budget."""
+    text = str(value)
+    # ``cell_w`` is itself derived from ``len(text) * _LEGEND_CHAR_WIDTH``;
+    # compensate for the tiny binary-float underflow at exact-fit boundaries.
+    max_chars = max(0, int((max_width + 1e-9) / _LEGEND_CHAR_WIDTH))
+    if len(text) <= max_chars:
+        return text
+    if max_chars <= 3:
+        return "." * max_chars
+    return text[: max_chars - 3] + "..."
+
+
+def _legend_layout(named: list[dict], plot: dict, options: dict) -> dict[str, Any]:
+    """Shared bounded legend geometry for SVG and native raster exports.
+
+    Static files cannot offer the browser legend's scrollbar, so an oversized
+    legend is kept inside the plot and its labels are visibly ellipsized. A
+    legend that already fits keeps its historical geometry byte-for-byte.
+    """
     style_opts = options.get("style") or {}
-    pad, handle, gap, line_h = 8.0, 20, 5, 16.0
+    pad, handle, gap, line_h = 8.0, 20.0, 5.0, 16.0
     if str(style_opts.get("padding", "")).endswith("em"):
         pad = 11.0 * float(str(style_opts["padding"])[:-2])
     if str(style_opts.get("rowGap", "")).endswith("em"):
         line_h = 11.0 * (1.0 + float(str(style_opts["rowGap"])[:-2]))
-    ncols = min(len(named), max(1, int(options.get("ncols", 1))))
-    nrows = (len(named) + ncols - 1) // ncols
+
+    requested_cols = min(len(named), max(1, int(options.get("ncols", 1))))
     title = options.get("title")
-    title_h = 16 if title else 0
-    cell_w = max(len(str(t["name"])) for t in named) * 6.2 + handle + gap + 2 * pad
-    box_w, box_h = ncols * cell_w + pad, nrows * line_h + pad + title_h
+    title_h = 16.0 if title else 0.0
+    natural_cell_w = (
+        max(len(str(t.get("name", ""))) for t in named) * _LEGEND_CHAR_WIDTH
+        + handle
+        + gap
+        + 2 * pad
+    )
+    inset = 6.0
+    available_w = max(1.0, float(plot["w"]) - 2 * inset)
+    ncols = requested_cols
+    if ncols * natural_cell_w + pad > available_w:
+        # A cell must at least retain its handle and a visible ellipsis. Reduce
+        # an impossible column count before shortening the individual labels.
+        min_cell_w = handle + gap + 2 * pad + 4 * _LEGEND_CHAR_WIDTH
+        max_fit_cols = max(1, int(max(0.0, available_w - pad) // min_cell_w))
+        ncols = min(ncols, max_fit_cols)
+    cell_w = min(natural_cell_w, max(1.0, (available_w - pad) / ncols))
+    box_w = min(available_w, ncols * cell_w + pad)
+
+    nrows = (len(named) + ncols - 1) // ncols
+    available_h = max(1.0, float(plot["h"]) - 2 * inset)
+    visible_rows = nrows
+    natural_box_h = nrows * line_h + pad + title_h
+    if natural_box_h > available_h:
+        visible_rows = max(0, int((available_h - pad - title_h) // line_h))
+    visible_count = min(len(named), visible_rows * ncols)
+    box_h = min(available_h, visible_rows * line_h + pad + title_h)
+
     loc = options.get("loc") or "upper right"
-    # "center" is the per-axis fallback: "center right" is the right edge at
-    # vertical center, "upper center" the top edge at horizontal center.
     if "left" in loc:
-        x = plot["x"] + 6
+        x = float(plot["x"]) + inset
     elif "right" in loc:
-        x = plot["x"] + plot["w"] - box_w - 6
+        x = float(plot["x"]) + float(plot["w"]) - box_w - inset
     else:
-        x = plot["x"] + (plot["w"] - box_w) / 2
+        x = float(plot["x"]) + (float(plot["w"]) - box_w) / 2
     if "upper" in loc:
-        y = plot["y"] + 6
+        y = float(plot["y"]) + inset
     elif "lower" in loc:
-        y = plot["y"] + plot["h"] - box_h - 6
+        y = float(plot["y"]) + float(plot["h"]) - box_h - inset
     else:
-        y = plot["y"] + (plot["h"] - box_h) / 2
+        y = float(plot["y"]) + (float(plot["h"]) - box_h) / 2
+    x = min(
+        max(x, float(plot["x"]) + inset),
+        float(plot["x"]) + float(plot["w"]) - box_w - inset,
+    )
+    y = min(
+        max(y, float(plot["y"]) + inset),
+        float(plot["y"]) + float(plot["h"]) - box_h - inset,
+    )
+
+    text_width = max(0.0, cell_w - handle - gap - 2 * pad)
+    return {
+        "style": style_opts,
+        "pad": pad,
+        "handle": handle,
+        "gap": gap,
+        "line_h": line_h,
+        "ncols": ncols,
+        "title": _legend_text(title, max(0.0, box_w - 2 * pad)) if title else None,
+        "title_h": title_h,
+        "cell_w": cell_w,
+        "box_w": box_w,
+        "box_h": box_h,
+        "x": x,
+        "y": y,
+        "visible_count": visible_count,
+        "names": [_legend_text(t.get("name", ""), text_width) for t in named[:visible_count]],
+    }
+
+
+def _legend(named: list[dict], plot: dict, options: dict, clip_id: str) -> str:
+    legend = _legend_layout(named, plot, options)
+    if not legend["visible_count"]:
+        # A plot too short for even one entry: no floating frame/title either.
+        return ""
+    rows = []
+    style_opts = legend["style"]
+    pad, handle, gap = legend["pad"], legend["handle"], legend["gap"]
+    line_h, ncols = legend["line_h"], legend["ncols"]
+    title, title_h = legend["title"], legend["title_h"]
+    cell_w = legend["cell_w"]
+    box_w, box_h = legend["box_w"], legend["box_h"]
+    x, y = legend["x"], legend["y"]
     if style_opts.get("background") != "transparent":
         if style_opts.get("boxShadow"):
             rows.append(
@@ -1825,7 +2290,7 @@ def _legend(named: list[dict], plot: dict, options: dict) -> str:
             f'<text x="{_num(x + pad)}" y="{_num(y + pad / 2 + 11)}" '
             f'font-weight="600" fill="{_TEXT}">{escape(str(title))}</text>'
         )
-    for i, t in enumerate(named):
+    for i, t in enumerate(named[: legend["visible_count"]]):
         style = t.get("style") or {}
         color = _css(
             style.get("color") or (t.get("color") or {}).get("color"),
@@ -1869,12 +2334,12 @@ def _legend(named: list[dict], plot: dict, options: dict) -> str:
             )
         rows.append(
             f'<text x="{_num(hx1 + gap)}" y="{_num(ry + 11)}" '
-            f'fill="{_TEXT}">{escape(str(t["name"]))}</text>'
+            f'fill="{_TEXT}">{escape(legend["names"][i])}</text>'
         )
-    return "".join(rows)
+    return f'<g clip-path="url(#{clip_id})">{"".join(rows)}</g>'
 
 
-def _colorbar(options: dict, plot: dict) -> str:
+def _colorbar(options: dict, plot: dict, right_axis_room: float = 0.0) -> str:
     cmap = str(options.get("colormap", "viridis"))
     gradient_id = f"xy-colorbar-{sum(map(ord, cmap))}"
     stops = _colormap_stops(cmap)
@@ -1886,10 +2351,15 @@ def _colorbar(options: dict, plot: dict) -> str:
     orientation = options.get("orientation", "vertical")
     domain = options.get("domain", [0.0, 1.0])
     if orientation == "horizontal":
-        x, y, width, height = plot["x"], plot["y"] + plot["h"] + 10, plot["w"], 18
+        x = plot["x"]
+        y = plot["y"] + plot["h"] + (plot["bottom_axis_room"] or 10)
+        width, height = plot["w"], 18
         gradient_attrs = 'x1="0" y1="0" x2="100%" y2="0"'
     else:
-        x, y, width, height = plot["x"] + plot["w"] + 24, plot["y"], 18, plot["h"]
+        # right_axis_room shifts the whole colorbar clear of right-side named
+        # y-axis chrome (layout() reserves room for both additively).
+        x = plot["x"] + plot["w"] + right_axis_room + 24
+        y, width, height = plot["y"], 18, plot["h"]
         gradient_attrs = 'x1="0" y1="100%" x2="0" y2="0"'
     label = str(options.get("label") or "")
     label_node = (

--- a/python/xy/_svg.py
+++ b/python/xy/_svg.py
@@ -762,10 +762,49 @@ class _Svg:
             units = f'gradientUnits="userSpaceOnUse" x1="{_num(x0)}" y1="{_num(y0)}" x2="{_num(x1)}" y2="{_num(y1)}"'
         else:
             units = f'x1="{ends[0]}" y1="{ends[1]}" x2="{ends[2]}" y2="{ends[3]}"'
-        stops = "".join(
-            f'<stop offset="{_num(t * 100)}%" stop-color="{escape(_css(c, mark_color), {chr(34): "&quot;"})}"/>'
-            for t, c in fill.get("stops", [])
-        )
+        raw_stops = fill.get("stops", [])
+        resolved = [_css(c, mark_color) for _t, c in raw_stops]
+        stops_out: list[str] = []
+        for index, ((t, raw_color), color) in enumerate(zip(raw_stops, resolved, strict=True)):
+            offset = _num(t * 100)
+            if str(raw_color).strip().lower() != "transparent":
+                escaped = escape(color, {chr(34): "&quot;"})
+                stops_out.append(f'<stop offset="{offset}%" stop-color="{escaped}"/>')
+                continue
+
+            # SVG interpolates stop RGB independently from stop opacity. A
+            # literal `transparent` stop is transparent black, which makes a
+            # colored fade pass through a muddy gray fringe. Give the zero-
+            # opacity stop the adjacent visible hue instead, matching the
+            # browser renderer's premultiplied-alpha interpolation. When a
+            # transparent stop sits between two different colors, duplicate
+            # it at the same offset; the invisible color switch preserves the
+            # hue on both segments.
+            previous = next(
+                (
+                    resolved[i]
+                    for i in range(index - 1, -1, -1)
+                    if str(raw_stops[i][1]).strip().lower() != "transparent"
+                ),
+                None,
+            )
+            following = next(
+                (
+                    resolved[i]
+                    for i in range(index + 1, len(raw_stops))
+                    if str(raw_stops[i][1]).strip().lower() != "transparent"
+                ),
+                None,
+            )
+            transparent_colors = [previous or following or mark_color]
+            if previous and following and previous != following:
+                transparent_colors.append(following)
+            for transparent_color in transparent_colors:
+                escaped = escape(transparent_color, {chr(34): "&quot;"})
+                stops_out.append(
+                    f'<stop offset="{offset}%" stop-color="{escaped}" stop-opacity="0"/>'
+                )
+        stops = "".join(stops_out)
         self.defs.append(f'<linearGradient id="{gid}" {units}>{stops}</linearGradient>')
         return f"url(#{gid})"
 

--- a/python/xy/components.py
+++ b/python/xy/components.py
@@ -217,6 +217,9 @@ class Colorbar(Component):
     """Color scale chrome; ``render`` remains opaque for Reflex adapters."""
 
     show: bool = True
+    title: Optional[str] = None
+    orientation: str = "vertical"
+    ticks: Optional[list[float]] = None
     class_name: Optional[str] = None
     style: dict[str, StyleValue] = field(default_factory=dict)
     render: Any = None
@@ -292,7 +295,7 @@ def scatter(
         stroke: Optional marker outline color.
         stroke_width: Marker outline width in pixels.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -350,7 +353,7 @@ def line(
         curve: Interpolation mode, such as ``linear`` or ``smooth``.
         dash: Optional line dash pattern.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -413,7 +416,7 @@ def area(
         curve: Interpolation mode, such as ``linear`` or ``smooth``.
         dash: Optional outline dash pattern.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -473,7 +476,7 @@ def error_band(
         line_opacity: Boundary-line opacity from zero to one.
         fill: CSS fill value or linear gradient.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -529,7 +532,7 @@ def errorbar(
         cap_size: Optional cap length in pixels.
         opacity: Stroke opacity from zero to one.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -587,7 +590,7 @@ def segments(
         width: Segment width in pixels.
         opacity: Segment opacity from zero to one.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -652,7 +655,7 @@ def triangle_mesh(
         stroke: Optional triangle outline color.
         stroke_width: Triangle outline width in pixels.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -710,7 +713,7 @@ def step(
         opacity: Line opacity from zero to one.
         dash: Optional line dash pattern.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -763,7 +766,7 @@ def stairs(
         opacity: Line opacity from zero to one.
         dash: Optional line dash pattern.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -820,7 +823,7 @@ def stem(
         marker_size: Marker size in pixels.
         symbol: Marker symbol name.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -873,7 +876,7 @@ def ecdf(
         opacity: Line opacity from zero to one.
         dash: Optional line dash pattern.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -929,7 +932,7 @@ def box(
         show_outliers: Whether to render outlier points.
         outlier_size: Outlier marker size in pixels.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -986,7 +989,7 @@ def violin(
         opacity: Violin opacity from zero to one.
         orientation: ``vertical`` or ``horizontal`` orientation.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -1046,7 +1049,7 @@ def hexbin(
         colormap: Colormap used for bin values.
         opacity: Hexagon opacity from zero to one.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -1108,7 +1111,7 @@ def contour(
         opacity: Contour opacity from zero to one.
         dash_negative: Whether negative isolines use a dashed stroke.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -1172,7 +1175,7 @@ def histogram(
         stroke_width: Bar outline width in pixels.
         fill: CSS fill value or linear gradient.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -1285,7 +1288,7 @@ def bar(
         stroke_width: Bar outline width in pixels.
         fill: CSS fill value or linear gradient.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -1359,7 +1362,7 @@ def column(
         stroke_width: Column outline width in pixels.
         fill: CSS fill value or linear gradient.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -1417,7 +1420,7 @@ def heatmap(
         domain: Explicit minimum and maximum for the color scale.
         opacity: Cell opacity from zero to one.
         style: Mark style overrides.
-        class_name: DOM class name applied to the mark.
+        class_name: Adapter-only trace metadata; it does not style canvas geometry.
         x_axis: Identifier of the x axis used by this mark.
         y_axis: Identifier of the y axis used by this mark.
     """
@@ -2099,6 +2102,9 @@ def colorbar(
     *children: Any,
     show: bool = True,
     render: Any = None,
+    title: Optional[str] = None,
+    orientation: str = "vertical",
+    ticks: Optional[list[float]] = None,
     class_name: Optional[str] = None,
     style: Optional[dict[str, StyleValue]] = None,
 ) -> Colorbar:
@@ -2108,16 +2114,74 @@ def colorbar(
         *children: Optional opaque replacement content.
         show: Whether to display the colorbar.
         render: Opaque renderer supplied by an adapter.
+        title: Optional colorbar title. By default XY uses the color field or
+            mark name when one is available.
+        orientation: ``vertical`` or ``horizontal`` placement.
+        ticks: Optional finite numeric tick positions.
         class_name: DOM class name applied to the colorbar.
         style: Colorbar style overrides.
     """
     show, render = _chrome_render_args(children, show, render, "colorbar")
+    show, title, orientation, ticks, class_name, style = _validated_colorbar_fields(
+        show, title, orientation, ticks, class_name, style
+    )
     return Colorbar(
-        show=_strict_bool(show, "colorbar show"),
-        class_name=_optional_string(class_name, "colorbar class_name"),
-        style=_style_dict(style, "colorbar style"),
+        show=show,
+        title=title,
+        orientation=orientation,
+        ticks=ticks,
+        class_name=class_name,
+        style=style,
         render=render,
     )
+
+
+def _validated_colorbar_fields(
+    show: Any,
+    title: Any,
+    orientation: Any,
+    ticks: Any,
+    class_name: Any,
+    style: Any,
+) -> tuple[
+    bool,
+    Optional[str],
+    str,
+    Optional[list[float]],
+    Optional[str],
+    dict[str, StyleValue],
+]:
+    """Validate the public ``Colorbar`` fields; the single validation body.
+
+    Called by the ``colorbar()`` factory and by Chart's apply path, so a
+    directly constructed ``Colorbar`` node cannot put malformed chrome
+    options on the wire.
+    """
+    return (
+        _strict_bool(show, "colorbar show"),
+        _optional_string(title, "colorbar title"),
+        _colorbar_orientation(orientation),
+        _colorbar_ticks(ticks),
+        _optional_string(class_name, "colorbar class_name"),
+        _style_dict(style, "colorbar style"),
+    )
+
+
+def _colorbar_orientation(value: Any) -> str:
+    if not isinstance(value, str) or value not in {"vertical", "horizontal"}:
+        raise ValueError("colorbar orientation must be 'vertical' or 'horizontal'")
+    return value
+
+
+def _colorbar_ticks(value: Any) -> Optional[list[float]]:
+    if value is None:
+        return None
+    if isinstance(value, (str, bytes)):
+        raise ValueError("colorbar ticks must be an iterable of finite numbers or None")
+    try:
+        return [_finite_number(tick, "colorbar tick") for tick in value]
+    except TypeError as exc:
+        raise ValueError("colorbar ticks must be an iterable of finite numbers or None") from exc
 
 
 def modebar(
@@ -2429,8 +2493,8 @@ class Chart(Component):
         # attribute by FacetChart) so shared categorical domains align the
         # same categories at the same positions across panels; positions are
         # committed at ingest, so this must land before the marks apply.
-        for axis_dim, categories in self._facet_axis_categories.items():
-            fig._axis_categories[axis_dim] = list(categories)
+        for axis_id, categories in self._facet_axis_categories.items():
+            fig._axis_categories[axis_id] = list(categories)
         fig.class_name = self.class_name
         fig.class_names = dict(self.class_names)
         fig.style = {}
@@ -2478,6 +2542,7 @@ class Chart(Component):
         )
         tooltip_aliases: dict[str, str] = {}
         tooltip_sources: dict[str, list[dict[str, Any]]] = {}
+        colorbar_candidates: list[dict[str, Any]] = []
         for m in marks:
             data = m.data if m.data is not None else self.data
             applier = _MARK_APPLIERS.get(m.kind)
@@ -2485,7 +2550,12 @@ class Chart(Component):
                 raise TypeError(f"no applier registered for mark kind {m.kind!r}")
             x_axis_id, y_axis_id = _mark_axis_ids(m, axes)
             before = len(fig.traces)
-            applier(fig, m, data)
+            previous_axis_ids = fig._active_axis_ids
+            fig._active_axis_ids = {"x": x_axis_id, "y": y_axis_id}
+            try:
+                applier(fig, m, data)
+            finally:
+                fig._active_axis_ids = previous_axis_ids
             new_traces = fig.traces[before:]
             for trace in new_traces:
                 trace.x_axis = x_axis_id
@@ -2496,6 +2566,9 @@ class Chart(Component):
                     trace.style["class_name"] = class_name
             _merge_tooltip_aliases(tooltip_aliases, m, new_traces)
             _merge_tooltip_sources(tooltip_sources, m, new_traces)
+            colorbar_candidate = _declarative_colorbar_options(m, new_traces)
+            if colorbar_candidate is not None:
+                colorbar_candidates.append(colorbar_candidate)
 
         for annotation in annotations:
             applier = _ANNOTATION_APPLIERS.get(annotation.kind)
@@ -2528,9 +2601,40 @@ class Chart(Component):
             fig.tooltip = _tooltip_spec(node, tooltip_aliases, tooltip_sources)
         if colorbars:
             node = colorbars[-1]
-            _apply_chrome_node(fig, "colorbar", node.class_name, node.style)
-            if not node.show:
+            # ``Colorbar`` is a public dataclass as well as the return type of
+            # ``colorbar()``. Re-run the shared validators here so direct
+            # construction cannot put malformed chrome options on the wire.
+            (
+                node_show,
+                node_title,
+                node_orientation,
+                node_ticks,
+                node_class_name,
+                node_style,
+            ) = _validated_colorbar_fields(
+                node.show,
+                node.title,
+                node.orientation,
+                node.ticks,
+                node.class_name,
+                node.style,
+            )
+            _apply_chrome_node(fig, "colorbar", node_class_name, node_style)
+            if not node_show:
                 fig.colorbar_options = None
+            elif node.render is None:
+                options = (
+                    dict(colorbar_candidates[-1])
+                    if colorbar_candidates
+                    else (dict(fig.colorbar_options) if fig.colorbar_options else None)
+                )
+                if options is not None:
+                    options["orientation"] = node_orientation
+                    if node_title is not None:
+                        options["label"] = node_title
+                    if node_ticks is not None:
+                        options["ticks"] = node_ticks
+                    fig.colorbar_options = options
         self._figure = fig
         return fig
 
@@ -2696,6 +2800,87 @@ def _resolve_color(data: Any, color: Any, *, context: Optional[str] = None) -> A
             # misleading column-lookup error.
             _validate.css_color(color, context or "color")
         raise
+
+
+def _colorbar_source_title(mark: Mark) -> Optional[str]:
+    """Human-readable title for the scalar channel represented by a mark.
+
+    Column-name channels are more precise than a trace name (a scatter named
+    ``"observations"`` can still be colored by ``"temperature"``). For
+    array-backed scalar fields the mark name is the only declarative label.
+    Hexbin's implicit metric is named explicitly because it is derived rather
+    than supplied by the caller.
+    """
+    if mark.kind in {"scatter", "segments", "triangle_mesh"}:
+        color = mark.props.get("color")
+        if isinstance(color, str) and not _looks_like_css(color):
+            return color
+    elif mark.kind in {"heatmap", "contour"}:
+        z = mark.props.get("z")
+        if isinstance(z, str):
+            return z
+    elif mark.kind == "hexbin":
+        values = mark.props.get("C")
+        if isinstance(values, str):
+            return values
+        if values is None:
+            return "log(count + 1)" if mark.props.get("bins") == "log" else "count"
+    return mark.name
+
+
+def _declarative_colorbar_options(mark: Mark, traces: list[Any]) -> Optional[dict[str, Any]]:
+    """Infer built-in colorbar metadata from the mark's compiled scalar channel.
+
+    The compiled trace is authoritative: it owns the post-validation domain
+    and colormap and distinguishes continuous, categorical, constant, and
+    true-color channels. A mark can expand to multiple traces, so the last
+    compatible trace mirrors the chart's last-mappable-wins composition rule.
+    """
+    options: Optional[dict[str, Any]] = None
+    for trace in traces:
+        if trace.kind == "heatmap":
+            if trace.style.get("truecolor"):
+                continue
+            domain = trace.style.get("domain")
+            colormap = trace.style.get("colormap")
+        else:
+            channel = trace.color_ch
+            if channel is None or channel.mode != "continuous":
+                continue
+            # A density-tier scatter colors aggregate counts; its original
+            # per-row color channel is explicitly dropped, so advertising that
+            # channel's domain beside the density ramp would be misleading.
+            if trace.kind == "scatter" and trace.use_density():
+                continue
+            domain = channel.domain
+            colormap = channel.colormap
+        if domain is None or colormap is None:
+            continue
+        options = {
+            "domain": [float(domain[0]), float(domain[1])],
+            "colormap": str(colormap),
+        }
+
+    if options is None:
+        return None
+    title = _colorbar_source_title(mark)
+    if title is not None:
+        options["label"] = title
+    if mark.kind == "contour" and mark.props.get("filled"):
+        levels = mark.props.get("levels")
+        if isinstance(levels, (int, np.integer)):
+            count = int(levels)
+        elif levels is None:
+            count = 0
+        else:
+            try:
+                count = len(levels)
+            except TypeError:
+                count = 0
+        # Filled contour intervals lie between adjacent level boundaries.
+        if count > 1:
+            options["levels"] = count - 1
+    return options
 
 
 def _string_list(value: Any, label: str) -> Optional[list[str]]:
@@ -3022,21 +3207,31 @@ class FacetChart(Component):
 
         figures = build_panels({})
         shared_dims = [dim for dim, shared in (("x", self.share_x), ("y", self.share_y)) if shared]
+        shared_axis_ids = [
+            axis_id
+            for dim in shared_dims
+            for axis_id in dict.fromkeys(
+                axis_id
+                for fig in figures
+                for axis_id in fig.axis_options
+                if fig._axis_dim(axis_id) == dim
+            )
+        ]
         unshareable: set[str] = set()
         preseed: dict[str, list[str]] = {}
-        for dim in shared_dims:
-            per_panel = [fig._axis_categories.get(dim) for fig in figures]
+        for axis_id in shared_axis_ids:
+            per_panel = [fig._axis_categories.get(axis_id) for fig in figures]
             if all(categories is None for categories in per_panel):
                 continue
             if any(categories is None for categories in per_panel):
                 warnings.warn(
-                    f"facet_chart cannot share the {dim} axis: the {dim} channel is "
+                    f"facet_chart cannot share the {axis_id} axis: the {axis_id} channel is "
                     "categorical in some panels but numeric in others; skipping "
-                    f"{dim} domain sharing",
+                    f"{axis_id} domain sharing",
                     UserWarning,
                     stacklevel=2,
                 )
-                unshareable.add(dim)
+                unshareable.add(axis_id)
                 continue
             union: list[str] = []
             seen: set[str] = set()
@@ -3046,23 +3241,23 @@ class FacetChart(Component):
                         seen.add(category)
                         union.append(category)
             if any(categories != union for categories in per_panel):
-                preseed[dim] = union
+                preseed[axis_id] = union
         if preseed:
             # Category positions commit at ingest, so panels with differing
             # category sets must be rebuilt with the union order pre-seeded —
             # otherwise a shared numeric domain aligns different categories
             # at the same position.
             figures = build_panels(preseed)
-        for dim in shared_dims:
-            if dim in unshareable:
+        for axis_id in shared_axis_ids:
+            if axis_id in unshareable:
                 continue
-            ranges = [fig.x_range() if dim == "x" else fig.y_range() for fig in figures]
+            ranges = [fig._range(axis_id) for fig in figures]
             # Reversed axes report descending (hi, lo) pairs; take the pairwise
             # min/max so the merged domain is always increasing.
             lo = min(min(pair) for pair in ranges)
             hi = max(max(pair) for pair in ranges)
             for fig in figures:
-                fig._set_axis_domain(dim, (lo, hi))
+                fig._set_axis_domain(axis_id, (lo, hi))
         if shared_dims and not any("link_group" in fig.interaction for fig in figures):
             # Shared-axis panels pan/zoom together in live outputs.
             group = f"xy-facet-{uuid.uuid4().hex[:8]}"

--- a/python/xy/marks.py
+++ b/python/xy/marks.py
@@ -1022,8 +1022,8 @@ def scatter(
     `color` may be a CSS color (constant), a numeric array (continuous →
     colormap), or a categorical array (factorized → palette). `size` may be
     a scalar or a numeric array (mapped to `size_range` px). `symbol` picks
-    the marker shape (circle/square/diamond/triangle/cross); `stroke` /
-    `stroke_width` draw a point border. Large scatters auto-switch to a
+    one of the 17 renderer-backed marker shapes; `stroke` / `stroke_width`
+    draw a point border. Large scatters auto-switch to a
     Tier-2 density surface (§5); pass `density=True/False` to force it.
     """
     css = styles.compile_mark_style("scatter", style)

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -1871,6 +1871,15 @@ this._initLinkedCharts();
 this._themeWatch = window.matchMedia("(prefers-color-scheme: dark)");
 this._onScheme = () => this.refreshTheme();
 this._themeWatch.addEventListener?.("change", this._onScheme);
+if (typeof MutationObserver !== "undefined") {
+this._themeMutationObserver = new MutationObserver(() => this.refreshTheme());
+for (let node = this.root; node; node = node.parentElement) {
+this._themeMutationObserver.observe(node, {
+attributes: true,
+attributeFilter: ["class", "style"],
+});
+}
+}
 this._unsubscribeComm = comm ? comm.onMessage((msg, buffers) => this._onKernelMsg(msg, buffers)) : null;
 this.draw();
 }
@@ -4878,6 +4887,8 @@ this._ro?.disconnect();
 this._io?.disconnect();
 this._io = null;
 this._themeWatch?.removeEventListener?.("change", this._onScheme);
+this._themeMutationObserver?.disconnect();
+this._themeMutationObserver = null;
 this._dprMq?.removeEventListener?.("change", this._onDprChange);
 this._dprMq = null;
 this._unsubscribeComm?.();

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -231,9 +231,10 @@ function cssColor([r, g, b, a]) {
 return `rgba(${Math.round(r * 255)},${Math.round(g * 255)},${Math.round(b * 255)},${a})`;
 }
 const XY_CHROME_CSS = `
+@layer base{
 :where(.xy [data-xy-slot="title"]){text-align:center;font-size:14px;font-weight:600;color:var(--chart-text,inherit)}
-:where(.xy [data-xy-slot="tooltip"]){background:var(--chart-tooltip-bg,rgba(20,24,33,.92));color:var(--chart-tooltip-text,#fff);padding:5px 8px;border-radius:4px;font-size:11px;line-height:1.35;box-shadow:0 2px 8px rgba(0,0,0,.3)}
-:where(.xy [data-xy-slot="legend"]){gap:2px;font-size:11px;background:var(--chart-legend-bg,rgba(128,128,128,.08));border-radius:4px;padding:4px 8px;color:var(--chart-text,inherit)}
+:where(.xy [data-xy-slot="tooltip"]){max-width:calc(100% - 8px);max-height:calc(100% - 8px);box-sizing:border-box;white-space:normal;overflow-wrap:anywhere;overflow:auto;background:var(--chart-tooltip-bg,rgba(20,24,33,.92));color:var(--chart-tooltip-text,#fff);padding:5px 8px;border-radius:4px;font-size:11px;line-height:1.35;box-shadow:0 2px 8px rgba(0,0,0,.3)}
+:where(.xy [data-xy-slot="legend"]){left:var(--xy-legend-left,auto);right:var(--xy-legend-right,auto);top:var(--xy-legend-top,auto);bottom:var(--xy-legend-bottom,auto);transform:var(--xy-legend-transform,none);max-width:var(--xy-legend-max-width);max-height:var(--xy-legend-max-height);gap:2px;font-size:11px;background:var(--chart-legend-bg,rgba(128,128,128,.08));border-radius:4px;padding:4px 8px;color:var(--chart-text,inherit)}
 :where(.xy [data-xy-slot="legend_swatch"]){width:12px;height:10px;border-radius:2px;margin-right:5px}
 :where(.xy [data-xy-slot="colorbar"]){color:var(--chart-text,inherit);font-size:10px}
 :where(.xy [data-xy-slot="colorbar_bar"]){background:var(--xy-colorbar-gradient);border:1px solid currentColor;box-sizing:border-box}
@@ -245,8 +246,9 @@ const XY_CHROME_CSS = `
 :where(.xy [data-xy-modebar-drag-handle]){position:relative;width:22px;margin-right:4px;cursor:move}
 :where(.xy [data-xy-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-3px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
 :where(.xy [data-xy-modebar-menu-trigger]){width:auto;min-width:48px;gap:1px;padding:0 4px;font-size:11px;font-variant-numeric:tabular-nums}
-:where(.xy [data-xy-modebar-select-trigger]){width:auto;min-width:30px;gap:0;padding:0 2px}
-:where(.xy [data-xy-modebar-menu-indicator]){display:flex;transition:transform .15s}
+:where(.xy [data-xy-modebar-select-trigger]){width:auto;min-width:42px;gap:2px;padding:0 4px}
+:where(.xy [data-xy-modebar-select-icon]){display:flex;flex:0 0 auto}
+:where(.xy [data-xy-modebar-menu-indicator]){display:flex;flex:0 0 auto;transition:transform .15s}
 :where(.xy [data-xy-modebar-menu-indicator] svg){width:11px;height:11px}
 :where(.xy [data-xy-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}
 :where(.xy [data-xy-modebar-menu-item]){width:100%;height:28px;justify-content:flex-start;padding:0 9px;border-radius:4px;text-align:left;white-space:nowrap}
@@ -269,6 +271,7 @@ const XY_CHROME_CSS = `
 :where(.xy [data-xy-slot="canvas"]:focus-visible,.xy [data-xy-slot="modebar_button"]:focus-visible){outline:2px solid var(--chart-focus,#2563eb);outline-offset:2px}
 @media (prefers-reduced-motion:reduce){:where(.xy [data-xy-slot="modebar"]){transition-duration:0s!important}}
 @media (forced-colors:active){:where(.xy [data-xy-slot="modebar"],.xy [data-xy-slot="tooltip"]){border:1px solid CanvasText}:where(.xy [data-xy-slot="modebar_button"].xy-active){outline:2px solid Highlight}:where(.xy [data-xy-slot="canvas"]:focus){outline:2px solid Highlight}}
+}
 `;
 function ensureChromeStylesheet(node) {
 let root = node && node.getRootNode ? node.getRootNode() : document;
@@ -411,6 +414,21 @@ if (av >= 1e6 || (av !== 0 && av < 1e-4)) return v.toExponential(1).replace("e+"
 let dec = step ? Math.max(0, Math.ceil(-Math.log10(Math.abs(step)))) : 0;
 while (dec < 8 && Math.abs(Number(step.toFixed(dec)) - step) > Math.abs(step) / 1000) dec++;
 return v.toFixed(Math.min(dec, 8));
+}
+function fmtGeneral(v, precision = 6) {
+const value = Number(v);
+if (!Number.isFinite(value)) return String(v);
+if (value === 0) return Object.is(value, -0) ? "-0" : "0";
+let [coefficient, exponentText] = value.toExponential(precision - 1).split("e");
+const exponent = Number(exponentText);
+if (exponent < -4 || exponent >= precision) {
+coefficient = coefficient.replace(/0+$/, "").replace(/\.$/, "");
+return `${coefficient}e${exponent >= 0 ? "+" : "-"}${String(Math.abs(exponent)).padStart(2, "0")}`;
+}
+const decimals = Math.max(0, precision - exponent - 1);
+let text = Number(value.toPrecision(precision)).toFixed(decimals);
+if (text.includes(".")) text = text.replace(/0+$/, "").replace(/\.$/, "");
+return text;
 }
 function fmtCategory(v, categories) {
 const i = Math.round(v);
@@ -1866,11 +1884,21 @@ const colorbarBottomRoom = horizontalColorbar ? 38 + (colorbar.label ? 16 : 0) :
 const marginRight = (pad ? pad[1] : compact ? 8 : MARGIN.r) + colorbarRightRoom;
 const marginTop = pad ? pad[0] : compact ? 6 : MARGIN.t;
 const marginBottom = (pad ? pad[2] : compact ? 36 : MARGIN.b) + colorbarBottomRoom;
-const topAxisRoom = this._axis("x").side === "top" ? (compact ? 26 : 32) : 0;
+const hasBottomAxis = Object.values(this.axes || {}).some((axis) =>
+axis && String(axis.id || "").startsWith("x") && axis.side !== "top" &&
+this._axisTickLabelStrategy(axis) !== "none");
+this._bottomAxisRoom = hasBottomAxis ? (compact ? 36 : MARGIN.b) : 0;
+const topAxisRoom = Object.values(this.axes || {}).some((axis) =>
+axis && String(axis.id || "").startsWith("x") && axis.side === "top" &&
+this._axisTickLabelStrategy(axis) !== "none")
+? (compact ? 26 : 32)
+: 0;
 const top = marginTop + (this.spec.title ? (compact ? 26 : 30) : 0) + topAxisRoom;
-const extraRightAxes = Object.values(this.axes || {}).filter((axis) =>
-axis && axis.id !== "y" && String(axis.id || "").startsWith("y") && axis.side === "right");
-const right = marginRight + (extraRightAxes.length ? (compact ? 42 : 54) : 0);
+const rightAxes = Object.values(this.axes || {}).filter((axis) =>
+axis && String(axis.id || "").startsWith("y") &&
+axis.side === "right" && this._axisTickLabelStrategy(axis) !== "none");
+this._rightAxisRoom = rightAxes.length ? (compact ? 42 : 54) : 0;
+const right = marginRight + this._rightAxisRoom;
 this.plot = {
 x: marginLeft,
 y: top,
@@ -1918,7 +1946,8 @@ _axisTicks(axisId, target) {
 const axis = this._axis(axisId);
 const [lo, hi] = this._axisRange(axisId);
 if (Array.isArray(axis.tick_values)) {
-const ticks = axis.tick_values.map(Number).filter((v) => Number.isFinite(v) && v >= lo && v <= hi);
+const a = Math.min(lo, hi), b = Math.max(lo, hi);
+const ticks = axis.tick_values.map(Number).filter((v) => Number.isFinite(v) && v >= a && v <= b);
 return { ticks, labels: ticks, step: ticks.length > 1 ? Math.abs(ticks[1] - ticks[0]) : 1 };
 }
 if (axis.kind === "time") return timeTicks(lo, hi, target);
@@ -2299,6 +2328,10 @@ this.size.w = w;
 this.size.h = h;
 this._layout();
 const p = this.plot;
+this.root.style.setProperty("--xy-legend-max-width", Math.max(40, p.w - 12) + "px");
+this.root.style.setProperty("--xy-legend-max-height", Math.max(40, p.h - 12) + "px");
+this.canvas.style.left = p.x + "px";
+this.canvas.style.top = p.y + "px";
 this.canvas.style.width = p.w + "px";
 this.canvas.style.height = p.h + "px";
 this.canvas.width = p.w * this.dpr;
@@ -2307,8 +2340,8 @@ this.chrome.style.width = this.size.w + "px";
 this.chrome.style.height = this.size.h + "px";
 this.chrome.width = this.size.w * this.dpr;
 this.chrome.height = this.size.h * this.dpr;
-if (this._legends && this._legends.length && this._slotStyleValue("legend", "max-height") == null) {
-for (const lg of this._legends) lg.style.maxHeight = p.h - 12 + "px";
+for (const lg of this._legends || []) {
+this._positionLegend(lg, lg.dataset.xyLegendLoc || "upper right");
 }
 this._positionReductionBadges();
 this._positionColorbar();
@@ -2324,6 +2357,8 @@ root.className = "xy";
 root.style.cssText =
 `position:relative;width:${this.fluid ? "100%" : this.size.w + "px"};` +
 `height:${this.fluidH ? "100%" : this.size.h + "px"};` +
+`--xy-legend-max-width:${Math.max(40, this.plot.w - 12)}px;` +
+`--xy-legend-max-height:${Math.max(40, this.plot.h - 12)}px;` +
 (this.fluidH ? "min-height:120px;" : "") +
 "font:12px system-ui,sans-serif;user-select:none;";
 this._applySlot(root, "root");
@@ -2376,7 +2411,7 @@ this._applySlot(this.labels, "labels");
 root.appendChild(this.labels);
 this.tooltip = document.createElement("div");
 this.tooltip.style.cssText =
-"position:absolute;display:none;pointer-events:none;z-index:5;white-space:nowrap;";
+"position:absolute;display:none;pointer-events:none;z-index:5;";
 this._applySlot(this.tooltip, "tooltip");
 this.tooltip.setAttribute("aria-hidden", "true");
 root.appendChild(this.tooltip);
@@ -2504,21 +2539,12 @@ _legendBox(root, items, options) {
 const lg = document.createElement("div");
 const loc = options.loc || "upper right";
 const ncols = Math.max(1, Number(options.ncols) || 1);
-const rightInset = this.size.w - (this.plot.x + this.plot.w);
 const horizontal = ncols > 1;
-const h = loc.includes("left") ? "left" : loc.includes("right") ? "right" : "center";
-const v = loc.includes("upper") ? "upper" : loc.includes("lower") ? "lower" : "center";
-let xPos, yPos, tx = "0", ty = "0";
-if (h === "left") xPos = `left:${this.plot.x + 6}px;`;
-else if (h === "right") xPos = `right:${rightInset + 6}px;`;
-else { xPos = `left:${this.plot.x + this.plot.w / 2}px;`; tx = "-50%"; }
-if (v === "upper") yPos = `top:${this.plot.y + 6}px;`;
-else if (v === "lower") yPos = `bottom:${this.size.h - (this.plot.y + this.plot.h) + 6}px;`;
-else { yPos = `top:${this.plot.y + this.plot.h / 2}px;`; ty = "-50%"; }
-const transform = tx === "0" && ty === "0" ? "" : `transform:translate(${tx},${ty});`;
-lg.style.cssText = `position:absolute;${xPos}${yPos}${transform}` +
+lg.style.cssText = "position:absolute;" +
 `display:grid;grid-template-columns:repeat(${horizontal ? ncols : 1},max-content);` +
-"overflow:auto;" + `max-height:${this.plot.h - 12}px;`;
+"overflow:auto;";
+lg.dataset.xyLegendLoc = loc;
+this._positionLegend(lg, loc);
 this._applySlot(lg, "legend");
 if (options.title) {
 const title = document.createElement("div");
@@ -2599,6 +2625,23 @@ root.appendChild(lg);
 this._legends.push(lg);
 return lg;
 }
+_positionLegend(lg, loc) {
+if (!lg) return;
+const rightInset = this.size.w - (this.plot.x + this.plot.w);
+const h = loc.includes("left") ? "left" : loc.includes("right") ? "right" : "center";
+const v = loc.includes("upper") ? "upper" : loc.includes("lower") ? "lower" : "center";
+const left = h === "left" ? this.plot.x + 6 : h === "center" ? this.plot.x + this.plot.w / 2 : null;
+const right = h === "right" ? rightInset + 6 : null;
+const top = v === "upper" ? this.plot.y + 6 : v === "center" ? this.plot.y + this.plot.h / 2 : null;
+const bottom = v === "lower" ? this.size.h - (this.plot.y + this.plot.h) + 6 : null;
+lg.style.setProperty("--xy-legend-left", left == null ? "auto" : left + "px");
+lg.style.setProperty("--xy-legend-right", right == null ? "auto" : right + "px");
+lg.style.setProperty("--xy-legend-top", top == null ? "auto" : top + "px");
+lg.style.setProperty("--xy-legend-bottom", bottom == null ? "auto" : bottom + "px");
+const tx = h === "center" ? "-50%" : "0";
+const ty = v === "center" ? "-50%" : "0";
+lg.style.setProperty("--xy-legend-transform", `translate(${tx},${ty})`);
+}
 _buildColorbar(root) {
 const cb = this.spec.colorbar;
 if (!cb) return;
@@ -2633,13 +2676,14 @@ const domain = cb.domain || [0, 1];
 const lo = Number(domain[0]), hi = Number(domain[1]);
 const span = hi - lo || 1;
 const tickResult = linearTicks(lo, hi, 8);
-const tickValues = Array.isArray(cb.ticks) ? cb.ticks : tickResult.ticks;
+const hasExplicitTicks = Array.isArray(cb.ticks);
+const tickValues = hasExplicitTicks ? cb.ticks : tickResult.ticks;
 const tickStep = tickResult.step;
 for (const raw of tickValues) {
 const value = Number(raw);
 if (!Number.isFinite(value) || value < Math.min(lo, hi) || value > Math.max(lo, hi)) continue;
 const tick = document.createElement("span");
-tick.textContent = fmtLinear(value, tickStep);
+tick.textContent = hasExplicitTicks ? fmtGeneral(value) : fmtLinear(value, tickStep);
 const fraction = (value - lo) / span;
 tick.style.cssText = horizontal
 ? `position:absolute;left:${100 * fraction}%;top:${COLORBAR_THICKNESS + 2}px;transform:translateX(-50%);white-space:nowrap;`
@@ -2665,8 +2709,12 @@ this._positionColorbar();
 _positionColorbar() {
 if (!this._colorbar) return;
 const horizontal = this._colorbarHorizontal;
-this._colorbar.style.left = (horizontal ? this.plot.x : this.plot.x + this.plot.w + COLORBAR_GAP) + "px";
-this._colorbar.style.top = (horizontal ? this.plot.y + this.plot.h + 8 : this.plot.y) + "px";
+this._colorbar.style.left = (horizontal
+? this.plot.x
+: this.plot.x + this.plot.w + this._rightAxisRoom + COLORBAR_GAP) + "px";
+this._colorbar.style.top = (horizontal
+? this.plot.y + this.plot.h + (this._bottomAxisRoom || 8)
+: this.plot.y) + "px";
 this._colorbar.style.width = (horizontal ? this.plot.w : 66) + "px";
 this._colorbar.style.height = (horizontal ? 50 : Math.max(24, this.plot.h)) + "px";
 }
@@ -2810,11 +2858,13 @@ g.colorMode = 0;
 g.color = parseColor(this.root, t.color && t.color.color, [0.3, 0.47, 0.66, 1]);
 if (t.color && t.color.mode === "continuous") {
 g.colorMode = 1;
-g.cBuf = this._upload(this._columnView(buffer, this.spec.columns[t.color.buf]));
+g._cpu.color = this._columnView(buffer, this.spec.columns[t.color.buf]);
+g.cBuf = this._upload(g._cpu.color);
 g.lut = this._lut(t.color.colormap);
 } else if (t.color && t.color.mode === "categorical") {
 g.colorMode = 2;
-g.cBuf = this._upload(this._columnView(buffer, this.spec.columns[t.color.buf]));
+g._cpu.color = this._columnView(buffer, this.spec.columns[t.color.buf]);
+g.cBuf = this._upload(g._cpu.color);
 g.lut = this._paletteLut(t.color.palette);
 }
 g.sizeMode = 0;
@@ -2822,7 +2872,8 @@ g.size = (t.size && t.size.size) || 4.0;
 g.sizeRange = [2, 18];
 if (t.size && t.size.mode === "continuous") {
 g.sizeMode = 1;
-g.sBuf = this._upload(this._columnView(buffer, this.spec.columns[t.size.buf]));
+g._cpu.size = this._columnView(buffer, this.spec.columns[t.size.buf]);
+g.sBuf = this._upload(g._cpu.size);
 g.sizeRange = t.size.range_px;
 }
 this._pointMarkStyle(g, t);
@@ -4084,24 +4135,15 @@ if (value === "dashdot") return [6, 3, 1, 3];
 return [];
 }
 _axisTickLabelStrategy(axis) {
-const raw = axis && axis.tick_label_strategy !== undefined
-? axis.tick_label_strategy
-: this._axisStyleValue(axis, "tick_label_strategy");
-const value = String(raw || "auto").replace(/-/g, "_");
+const value = String((axis && axis.tick_label_strategy) || "auto").replace(/-/g, "_");
 return ["auto", "hide", "rotate", "stagger", "none", "off"].includes(value) ? value : "auto";
 }
 _axisTickLabelAngle(axis) {
-const raw = axis && axis.tick_label_angle !== undefined
-? axis.tick_label_angle
-: this._axisStyleValue(axis, "tick_label_angle");
-const angle = Number(raw);
+const angle = Number(axis ? axis.tick_label_angle : undefined);
 return Number.isFinite(angle) ? angle : null;
 }
 _axisTickLabelMinGap(axis, dim) {
-const raw = axis && axis.tick_label_min_gap !== undefined
-? axis.tick_label_min_gap
-: this._axisStyleValue(axis, "tick_label_min_gap");
-const gap = Number(raw);
+const gap = Number(axis ? axis.tick_label_min_gap : undefined);
 return Number.isFinite(gap) && gap >= 0 ? gap : (dim === "x" ? 8 : 4);
 }
 _estimateTickLabel(text, fontSize) {
@@ -4144,7 +4186,12 @@ if (!this._tickLabelsCollide(out, dim, fontSize, minGap)) return out;
 return labels.slice(0, 1);
 }
 _layoutTickLabels(axis, dim, labels) {
-if (labels.length <= 1) return labels.map((label) => ({ ...label, angle: 0, row: 0 }));
+const strategyValue = this._axisTickLabelStrategy(axis);
+if (strategyValue === "none" || strategyValue === "off") return [];
+if (labels.length <= 1) {
+const angle = this._axisTickLabelAngle(axis);
+return labels.map((label) => ({ ...label, angle: angle === null ? 0 : angle, row: 0 }));
+}
 const fontSize = Math.max(
 8,
 this._axisStyleNumber(axis, "tick_label_size", this._axisStyleNumber(axis, "tick_size", 11)),
@@ -4153,9 +4200,7 @@ const minGap = this._axisTickLabelMinGap(axis, dim);
 const explicitAngle = this._axisTickLabelAngle(axis);
 const baseAngle = explicitAngle === null ? 0 : explicitAngle;
 const withBase = labels.map((label) => ({ ...label, angle: baseAngle, row: 0 }));
-let strategy = this._axisTickLabelStrategy(axis);
-if (strategy === "none") return [];
-if (strategy === "off") return [];
+let strategy = strategyValue;
 if (strategy === "auto") {
 if (!this._tickLabelsCollide(withBase, dim, fontSize, minGap)) return withBase;
 if (dim === "x" && axis.kind === "category" && labels.length <= 16) strategy = "rotate";
@@ -4169,10 +4214,26 @@ out = labels.map((label) => ({ ...label, angle, row: 0 }));
 } else if (strategy === "stagger" && dim === "x") {
 out = labels.map((label, i) => ({ ...label, angle: baseAngle, row: i % 2 }));
 }
-if (strategy === "hide" || this._tickLabelsCollide(out, dim, fontSize, minGap)) {
+if (this._tickLabelsCollide(out, dim, fontSize, minGap)) {
 out = this._downsampleTickLabels(out, dim, fontSize, minGap);
 }
 return out;
+}
+_xTickLabelTransform(axis, angle) {
+const value = Number(angle || 0);
+const side = axis && axis.side === "top" ? "top" : "bottom";
+if (value === 0) {
+return {
+transform: "translateX(-50%)",
+origin: side === "top" ? "bottom center" : "top center",
+};
+}
+const anchorAtEnd = (side === "bottom" && value < 0) || (side === "top" && value > 0);
+const verticalOrigin = side === "top" ? "bottom" : "top";
+return {
+transform: `${anchorAtEnd ? "translateX(-100%) " : ""}rotate(${value}deg)`,
+origin: `${verticalOrigin} ${anchorAtEnd ? "right" : "left"}`,
+};
 }
 _axisLabelCss(axis, dim, fallbackCss) {
 const rawPosition = axis && axis.label_position;
@@ -4242,6 +4303,10 @@ ctx.fillRect(p.x, p.y, p.w, p.h);
 }
 const xAxis = this._axis("x");
 const yAxis = this._axis("y");
+const extraXAxes = Object.values(this.axes).filter((axis) =>
+axis && axis.id !== "x" && String(axis.id || "").startsWith("x"));
+const extraYAxes = Object.values(this.axes).filter((axis) =>
+axis && axis.id !== "y" && String(axis.id || "").startsWith("y"));
 const hideX = this._axisTickLabelStrategy(xAxis) === "none";
 const hideY = this._axisTickLabelStrategy(yAxis) === "none";
 const xt = this._axisTicks(
@@ -4302,8 +4367,14 @@ const xHeight = Math.max(1, this._axisStyleNumber(xAxis, "axis_width", 1));
 if (frameSides.includes("top")) rule(xAxis, p.x, p.y, p.w, xHeight);
 if (frameSides.includes("bottom")) rule(xAxis, p.x, p.y + p.h - xHeight, p.w, xHeight);
 }
-for (const axis of Object.values(this.axes)) {
-if (!axis || axis.id === "y" || !String(axis.id || "").startsWith("y")) continue;
+for (const axis of extraXAxes) {
+if (this._axisTickLabelStrategy(axis) === "none") continue;
+const h = Math.max(1, this._axisStyleNumber(axis, "axis_width", 1));
+const y = axis.side === "top" ? p.y : p.y + p.h - h;
+rule(axis, p.x, y, p.w, h);
+}
+for (const axis of extraYAxes) {
+if (this._axisTickLabelStrategy(axis) === "none") continue;
 const w = Math.max(1, this._axisStyleNumber(axis, "axis_width", 1));
 const x = axis.side === "left" ? p.x : p.x + p.w - w;
 rule(axis, x, p.y, w, p.h);
@@ -4336,6 +4407,38 @@ const y = this._dataPx("y", value);
 if (!Number.isFinite(y) || y < p.y - 1 || y > p.y + p.h + 1) continue;
 const left = side === "right" ? edge - tick.inward : edge - tick.outward;
 rule(yAxis, left, y - tick.width / 2, tick.inward + tick.outward, tick.width, "tick_color");
+}
+}
+for (const axis of extraXAxes) {
+if (this._axisTickLabelStrategy(axis) === "none") continue;
+const ticks = this._axisTicks(
+axis.id,
+this._axisTickTarget(axis.id, Math.max(3, p.w / (axis.kind === "time" ? 90 : 80))),
+);
+const tick = tickParts(axis);
+const side = axis.side || "bottom";
+const edge = side === "top" ? p.y : p.y + p.h;
+for (const value of ticks.ticks) {
+const x = this._dataPx(axis.id, value);
+if (!Number.isFinite(x) || x < p.x - 1 || x > p.x + p.w + 1) continue;
+const top = side === "top" ? edge - tick.outward : edge - tick.inward;
+rule(axis, x - tick.width / 2, top, tick.width, tick.inward + tick.outward, "tick_color");
+}
+}
+for (const axis of extraYAxes) {
+if (this._axisTickLabelStrategy(axis) === "none") continue;
+const ticks = this._axisTicks(
+axis.id,
+this._axisTickTarget(axis.id, Math.max(3, p.h / 45)),
+);
+const tick = tickParts(axis);
+const side = axis.side || "right";
+const edge = side === "right" ? p.x + p.w : p.x;
+for (const value of ticks.ticks) {
+const y = this._dataPx(axis.id, value);
+if (!Number.isFinite(y) || y < p.y - 1 || y > p.y + p.h + 1) continue;
+const left = side === "right" ? edge - tick.inward : edge - tick.outward;
+rule(axis, left, y - tick.width / 2, tick.inward + tick.outward, tick.width, "tick_color");
 }
 }
 }
@@ -4382,13 +4485,48 @@ this._axisStyleNumber(xAxis, "tick_size", 11),
 );
 const rowOffset = Number(item.row || 0) * (Math.max(8, tickLabelSize) + 4);
 const top = xAxis.side === "top" ? p.y - 18 - rowOffset : p.y + p.h + 6 + rowOffset;
-const transform = `translateX(-50%) rotate(${Number(item.angle || 0)}deg)`;
-const origin = xAxis.side === "top" ? "bottom center" : "top center";
+const placement = this._xTickLabelTransform(xAxis, item.angle);
 label(
 item.text,
-`left:${item.pos}px;top:${top}px;transform:${transform};transform-origin:${origin};`,
+`left:${item.pos}px;top:${top}px;transform:${placement.transform};` +
+`transform-origin:${placement.origin};`,
 xAxis,
 );
+}
+for (const axis of extraXAxes) {
+const ticks = this._axisTicks(
+axis.id,
+this._axisTickTarget(axis.id, Math.max(3, p.w / (axis.kind === "time" ? 90 : 80))),
+);
+const labelCandidates = [];
+for (const value of (ticks.labels || ticks.ticks)) {
+const px = this._dataPx(axis.id, value);
+if (px < p.x - 1 || px > p.x + p.w + 1) continue;
+labelCandidates.push({ pos: px, text: this._axisTickText(axis, value, ticks.step) });
+}
+for (const item of this._layoutTickLabels(axis, "x", labelCandidates)) {
+const tickLabelSize = this._axisStyleNumber(
+axis,
+"tick_label_size",
+this._axisStyleNumber(axis, "tick_size", 11),
+);
+const rowOffset = Number(item.row || 0) * (Math.max(8, tickLabelSize) + 4);
+const top = axis.side === "top" ? p.y - 18 - rowOffset : p.y + p.h + 6 + rowOffset;
+const placement = this._xTickLabelTransform(axis, item.angle);
+label(
+item.text,
+`left:${item.pos}px;top:${top}px;transform:${placement.transform};` +
+`transform-origin:${placement.origin};`,
+axis,
+);
+}
+if (axis.label && this._axisTickLabelStrategy(axis) !== "none") {
+const top = axis.side === "top" ? p.y - 34 : p.y + p.h + 24;
+const fallbackCss =
+`left:${p.x + p.w / 2}px;top:${top}px;transform:translateX(-50%);font-weight:500;`;
+const placement = this._axisLabelCss(axis, "x", fallbackCss);
+label(axis.label, placement.css, axis, "label", placement.style);
+}
 }
 const yLabelCandidates = [];
 for (const v of (yt.labels || yt.ticks)) {
@@ -4404,8 +4542,7 @@ const css = yAxis.side === "right"
 : `right:${this.size.w - p.x + 8}px;top:${item.pos}px;transform:translateY(-50%) rotate(${angle}deg);transform-origin:right center;`;
 label(item.text, css, yAxis);
 }
-for (const axis of Object.values(this.axes)) {
-if (!axis || axis.id === "y" || !String(axis.id || "").startsWith("y")) continue;
+for (const axis of extraYAxes) {
 const ticks = this._axisTicks(axis.id, this._axisTickTarget(axis.id, Math.max(3, p.h / 45)));
 const labelCandidates = [];
 for (const v of (ticks.labels || ticks.ticks)) {
@@ -4421,7 +4558,7 @@ const css = axis.side === "left"
 : `left:${p.x + p.w + 8}px;top:${item.pos}px;transform:translateY(-50%) rotate(${angle}deg);transform-origin:left center;`;
 label(item.text, css, axis);
 }
-if (axis.label) {
+if (axis.label && this._axisTickLabelStrategy(axis) !== "none") {
 const fallbackCss = axis.side === "left"
 ? `left:10px;top:${p.y + p.h / 2}px;transform:rotate(-90deg) translateX(50%);transform-origin:left;font-weight:500;`
 : `left:${p.x + p.w + 40}px;top:${p.y + p.h / 2}px;transform:rotate(90deg) translateX(-50%);transform-origin:left;font-weight:500;`;
@@ -4429,13 +4566,13 @@ const placement = this._axisLabelCss(axis, "y", fallbackCss);
 label(axis.label, placement.css, axis, "label", placement.style);
 }
 }
-if (s.x_axis.label) {
+if (s.x_axis.label && !hideX) {
 const top = xAxis.side === "top" ? p.y - 34 : p.y + p.h + 24;
 const fallbackCss = `left:${p.x + p.w / 2}px;top:${top}px;transform:translateX(-50%);font-weight:500;`;
 const placement = this._axisLabelCss(xAxis, "x", fallbackCss);
 label(s.x_axis.label, placement.css, xAxis, "label", placement.style);
 }
-if (s.y_axis.label) {
+if (s.y_axis.label && !hideY) {
 const fallbackCss = yAxis.side === "right"
 ? `left:${p.x + p.w + 40}px;top:${p.y + p.h / 2}px;transform:rotate(90deg) translateX(-50%);transform-origin:left;font-weight:500;`
 : `left:10px;top:${p.y + p.h / 2}px;transform:rotate(-90deg) translateX(50%);transform-origin:left;font-weight:500;`;
@@ -4835,6 +4972,8 @@ this.gpuTraces = [];
 const XY_ANNOTATION_SHAPE_STYLE_KEYS = new Set([
 "color",
 "label_color",
+"label_opacity",
+"opacity",
 "width",
 "head_size",
 "head_style",
@@ -5218,7 +5357,13 @@ const d = document.createElement("div");
 d.textContent = text;
 const dx = Number.isFinite(Number(ann.dx)) ? Number(ann.dx) : 0;
 const dy = Number.isFinite(Number(ann.dy)) ? Number(ann.dy) : 0;
-const anchor = ann.anchor === "middle" ? "-50%" : ann.anchor === "end" ? "-100%" : "0px";
+const anchorName = ["start", "middle", "end"].includes(ann.anchor)
+? ann.anchor
+: ann.kind === "arrow" ||
+((ann.kind === "rule" || ann.kind === "band") && ann.axis === "x")
+? "middle"
+: "start";
+const anchor = anchorName === "middle" ? "-50%" : anchorName === "end" ? "-100%" : "0px";
 const rot = Number.isFinite(Number(style.rotation))
 ? ((Number(style.rotation) % 360) + 360) % 360
 : 0;
@@ -5237,7 +5382,7 @@ va === "center" || va === "middle" ? "-50%"
 : va === "bottom" ? (cw ? "-100%" : "0")
 : cw ? "0" : "-100%";
 const cross =
-ann.anchor === "middle" ? "-50%" : ann.anchor === "end" ? (cw ? "0" : "-100%") : cw ? "-100%" : "0";
+anchorName === "middle" ? "-50%" : anchorName === "end" ? (cw ? "0" : "-100%") : cw ? "-100%" : "0";
 transform = `rotate(${cw ? 90 : -90}deg) translate(${along},${cross})`;
 } else if (rot) {
 transform = `rotate(${-rot}deg) translate(${anchor},${vAnchor})`;
@@ -5250,12 +5395,22 @@ this._applySlot(d, "annotation_label");
 this._applyClass(d, ann.class_name);
 const labelStyle = {};
 for (const [key, value] of Object.entries(style)) {
+if (key === "opacity" && ann.kind === "text") {
+labelStyle[key] = value;
+continue;
+}
 if (XY_ANNOTATION_SHAPE_STYLE_KEYS.has(key)) continue;
 labelStyle[key] = value;
 }
 this._applyStyle(d, labelStyle);
 if (style && (style.label_color || style.color)) {
 d.style.color = this._annotationLabelPaint(style, this.theme.label);
+}
+if (style && style.label_opacity !== undefined) {
+const labelOpacity = Number(style.label_opacity);
+if (Number.isFinite(labelOpacity)) {
+d.style.opacity = String(Math.max(0, Math.min(1, labelOpacity)));
+}
 }
 this.labels.appendChild(d);
 const cs = getComputedStyle(d);
@@ -5488,8 +5643,16 @@ if (this.a11yLive.textContent !== announcement) this.a11yLive.textContent = anno
 }
 this.tooltip.style.display = "block";
 const tw = this.tooltip.offsetWidth;
-this.tooltip.style.left = Math.min(lx + 12, this.size.w - tw - 4) + "px";
-this.tooltip.style.top = ly + 12 + "px";
+const th = this.tooltip.offsetHeight;
+const edge = 4;
+const gap = 12;
+const maxLeft = Math.max(edge, this.size.w - tw - edge);
+const left = Math.max(edge, Math.min(lx + gap, maxLeft));
+const below = ly + gap;
+const above = ly - th - gap;
+const top = below + th <= this.size.h - edge ? below : Math.max(edge, above);
+this.tooltip.style.left = left + "px";
+this.tooltip.style.top = top + "px";
 },
 });
 Object.assign(ChartView.prototype, {
@@ -5606,12 +5769,12 @@ mode, sx: e.clientX, sy: e.clientY, d0,
 points: firstLassoPoint ? [firstLassoPoint] : null,
 previousLasso,
 };
-c.setPointerCapture(e.pointerId);
+try { c.setPointerCapture(e.pointerId); } catch (_err) {   }
 this.tooltip.style.display = "none";
 return;
 }
 drag = { px: e.clientX, py: e.clientY, view: { ...this.view }, moved: false };
-c.setPointerCapture(e.pointerId);
+try { c.setPointerCapture(e.pointerId); } catch (_err) {   }
 this.tooltip.style.display = "none";
 });
 this._listen(c, "pointermove", (e) => {
@@ -5641,10 +5804,13 @@ this._hover(e);
 });
 const end = (e) => {
 if (band) {
+if (band.mode === "select-lasso") this._updateBand(band, e);
 this.selRect.style.display = "none";
 this.selLasso.style.display = "none";
 const d1 = dataAt(e.clientX, e.clientY);
-const moved = Math.abs(e.clientX - band.sx) > 3 || Math.abs(e.clientY - band.sy) > 3;
+const moved = band.mode === "select-lasso"
+? band.points.length >= 3
+: Math.abs(e.clientX - band.sx) > 3 || Math.abs(e.clientY - band.sy) > 3;
 if (moved) {
 if (band.mode === "zoom") this._zoomToBox(band.d0, d1, true);
 else if (band.mode === "select-lasso") {
@@ -6260,6 +6426,7 @@ const canSelect = this._pickable
 && this._interactionFlag("select", true);
 let selectTrigger = null;
 let selectIndicator = null;
+let selectModeIcon = null;
 if (canSelect) {
 selectTrigger = mk("select", "Selection controls", () => {
 setSelectMenuOpen(!this._selectMenuOpen);
@@ -6268,11 +6435,17 @@ selectTrigger.dataset.xyModebarSelect = "";
 selectTrigger.dataset.xyModebarSelectTrigger = "";
 selectTrigger.setAttribute("aria-haspopup", "menu");
 selectTrigger.setAttribute("aria-expanded", "false");
+selectTrigger.replaceChildren();
+selectModeIcon = document.createElement("span");
+selectModeIcon.dataset.xyModebarSelectIcon = "";
+selectModeIcon.innerHTML = this._icon("select");
+selectTrigger.appendChild(selectModeIcon);
 selectIndicator = document.createElement("span");
 selectIndicator.dataset.xyModebarMenuIndicator = "";
 selectIndicator.innerHTML = this._icon("chevrondown");
 selectTrigger.appendChild(selectIndicator);
 this._selectMenuButton = selectTrigger;
+this._selectMenuIcon = selectModeIcon;
 }
 mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
 const zoomMenu = document.createElement("div");
@@ -6610,6 +6783,18 @@ btn.setAttribute("aria-pressed", String(name === mode));
 }
 this._zoomMenuButton?.classList.toggle("xy-active", mode === "zoom");
 this._selectMenuButton?.classList.toggle("xy-active", mode.startsWith("select"));
+const selectionMode = {
+select: ["select", "Box Select"],
+"select-lasso": ["lasso", "Lasso Select"],
+"select-x": ["selectx", "X Range"],
+"select-y": ["selecty", "Y Range"],
+}[mode];
+if (selectionMode && this._selectMenuButton && this._selectMenuIcon) {
+const [iconName, label] = selectionMode;
+this._selectMenuIcon.innerHTML = this._icon(iconName);
+this._selectMenuButton.title = `Selection controls: ${label}`;
+this._selectMenuButton.setAttribute("aria-label", `Selection controls: ${label}`);
+}
 },
 _updateZoomMenuLabel() {
 if (!this._zoomMenuLabel || !this.view || !this.view0) return;
@@ -6970,24 +7155,25 @@ return svg('<path d="M10 3 V17 M3 10 H17"/><path d="M10 3 L8 5 M10 3 L12 5"/>' +
 '<path d="M10 17 L8 15 M10 17 L12 15"/><path d="M3 10 L5 8 M3 10 L5 12"/>' +
 '<path d="M17 10 L15 8 M17 10 L15 12"/>');
 case "zoom":
-return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
-'stroke-dasharray="3 2"/>');
+return svg('<path d="M7 3.5 H3.5 V7 M13 3.5 H16.5 V7 ' +
+'M3.5 13 V16.5 H7 M16.5 13 V16.5 H13"/>');
 case "select":
-return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
-'stroke-dasharray="2.5 2"/><circle cx="7" cy="7" r="1" fill="currentColor" ' +
+return svg('<path d="M7 4 H4 V7 M13 4 H16 V7 M4 13 V16 H7 ' +
+'M16 13 V16 H13"/><circle cx="7" cy="8" r="1" fill="currentColor" ' +
 'stroke="none"/><circle cx="12.5" cy="9" r="1" fill="currentColor" stroke="none"/>' +
 '<circle cx="9.5" cy="13" r="1" fill="currentColor" stroke="none"/>');
 case "lasso":
-return svg('<path d="M4 6 C6 2 15 3 16 8 C17 13 11 17 6 14 C2 12 2 8 4 6 Z" ' +
-'stroke-dasharray="2.5 2"/><circle cx="6" cy="8" r="1" fill="currentColor" ' +
-'stroke="none"/><circle cx="12" cy="7" r="1" fill="currentColor" stroke="none"/>' +
-'<circle cx="10" cy="12" r="1" fill="currentColor" stroke="none"/>');
+return svg('<path d="M5 5.5 C7 3 13.5 3.5 15.5 7 C17 10 14 15.5 9 15.5 ' +
+'C4.5 15.5 2.5 11 4 7.5 Z"/><circle cx="5" cy="5.5" r="1" ' +
+'fill="currentColor" stroke="none"/><circle cx="15.5" cy="7" r="1" ' +
+'fill="currentColor" stroke="none"/><circle cx="9" cy="15.5" r="1" ' +
+'fill="currentColor" stroke="none"/>');
 case "selectx":
-return svg('<rect x="3" y="5" width="14" height="10" rx="1" stroke-dasharray="2.5 2"/>' +
-'<path d="M6 10 H14 M6 10 L8 8 M6 10 L8 12 M14 10 L12 8 M14 10 L12 12"/>');
+return svg('<path d="M5 4 V16 M15 4 V16 M7 10 H13 ' +
+'M7 10 L9 8 M7 10 L9 12 M13 10 L11 8 M13 10 L11 12"/>');
 case "selecty":
-return svg('<rect x="5" y="3" width="10" height="14" rx="1" stroke-dasharray="2.5 2"/>' +
-'<path d="M10 6 V14 M10 6 L8 8 M10 6 L12 8 M10 14 L8 12 M10 14 L12 12"/>');
+return svg('<path d="M4 5 H16 M4 15 H16 M10 7 V13 ' +
+'M10 7 L8 9 M10 7 L12 9 M10 13 L8 11 M10 13 L12 11"/>');
 case "chevrondown":
 return svg('<path d="M6 8 L10 12 L14 8"/>');
 case "collapse":
@@ -7281,6 +7467,13 @@ this._applyAppend(msg, buffers);
 } else if (msg.type === "pick_result") {
 if (msg.seq !== undefined && msg.seq !== this._pickSeq) return;
 if (!msg.row) { this.tooltip.style.display = "none"; return; }
+const local = this._lastRow;
+if (local && local.trace === msg.row.trace && local.index === msg.row.index) {
+for (const [key, value] of Object.entries(local)) {
+if (msg.row[key] === undefined) msg.row[key] = value;
+}
+}
+this._applySharedTooltipFields(msg.row);
 this._lastRow = msg.row;
 const xy = this._lastHoverXY;
 if (xy) this._renderTooltip(msg.row, xy.clientX, xy.clientY, {

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -1872,6 +1872,15 @@ this._initLinkedCharts();
 this._themeWatch = window.matchMedia("(prefers-color-scheme: dark)");
 this._onScheme = () => this.refreshTheme();
 this._themeWatch.addEventListener?.("change", this._onScheme);
+if (typeof MutationObserver !== "undefined") {
+this._themeMutationObserver = new MutationObserver(() => this.refreshTheme());
+for (let node = this.root; node; node = node.parentElement) {
+this._themeMutationObserver.observe(node, {
+attributes: true,
+attributeFilter: ["class", "style"],
+});
+}
+}
 this._unsubscribeComm = comm ? comm.onMessage((msg, buffers) => this._onKernelMsg(msg, buffers)) : null;
 this.draw();
 }
@@ -4879,6 +4888,8 @@ this._ro?.disconnect();
 this._io?.disconnect();
 this._io = null;
 this._themeWatch?.removeEventListener?.("change", this._onScheme);
+this._themeMutationObserver?.disconnect();
+this._themeMutationObserver = null;
 this._dprMq?.removeEventListener?.("change", this._onDprChange);
 this._dprMq = null;
 this._unsubscribeComm?.();

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -232,9 +232,10 @@ function cssColor([r, g, b, a]) {
 return `rgba(${Math.round(r * 255)},${Math.round(g * 255)},${Math.round(b * 255)},${a})`;
 }
 const XY_CHROME_CSS = `
+@layer base{
 :where(.xy [data-xy-slot="title"]){text-align:center;font-size:14px;font-weight:600;color:var(--chart-text,inherit)}
-:where(.xy [data-xy-slot="tooltip"]){background:var(--chart-tooltip-bg,rgba(20,24,33,.92));color:var(--chart-tooltip-text,#fff);padding:5px 8px;border-radius:4px;font-size:11px;line-height:1.35;box-shadow:0 2px 8px rgba(0,0,0,.3)}
-:where(.xy [data-xy-slot="legend"]){gap:2px;font-size:11px;background:var(--chart-legend-bg,rgba(128,128,128,.08));border-radius:4px;padding:4px 8px;color:var(--chart-text,inherit)}
+:where(.xy [data-xy-slot="tooltip"]){max-width:calc(100% - 8px);max-height:calc(100% - 8px);box-sizing:border-box;white-space:normal;overflow-wrap:anywhere;overflow:auto;background:var(--chart-tooltip-bg,rgba(20,24,33,.92));color:var(--chart-tooltip-text,#fff);padding:5px 8px;border-radius:4px;font-size:11px;line-height:1.35;box-shadow:0 2px 8px rgba(0,0,0,.3)}
+:where(.xy [data-xy-slot="legend"]){left:var(--xy-legend-left,auto);right:var(--xy-legend-right,auto);top:var(--xy-legend-top,auto);bottom:var(--xy-legend-bottom,auto);transform:var(--xy-legend-transform,none);max-width:var(--xy-legend-max-width);max-height:var(--xy-legend-max-height);gap:2px;font-size:11px;background:var(--chart-legend-bg,rgba(128,128,128,.08));border-radius:4px;padding:4px 8px;color:var(--chart-text,inherit)}
 :where(.xy [data-xy-slot="legend_swatch"]){width:12px;height:10px;border-radius:2px;margin-right:5px}
 :where(.xy [data-xy-slot="colorbar"]){color:var(--chart-text,inherit);font-size:10px}
 :where(.xy [data-xy-slot="colorbar_bar"]){background:var(--xy-colorbar-gradient);border:1px solid currentColor;box-sizing:border-box}
@@ -246,8 +247,9 @@ const XY_CHROME_CSS = `
 :where(.xy [data-xy-modebar-drag-handle]){position:relative;width:22px;margin-right:4px;cursor:move}
 :where(.xy [data-xy-modebar-drag-handle])::after{content:"";position:absolute;top:4px;right:-3px;bottom:4px;width:1px;background:rgba(128,128,128,.28);pointer-events:none}
 :where(.xy [data-xy-modebar-menu-trigger]){width:auto;min-width:48px;gap:1px;padding:0 4px;font-size:11px;font-variant-numeric:tabular-nums}
-:where(.xy [data-xy-modebar-select-trigger]){width:auto;min-width:30px;gap:0;padding:0 2px}
-:where(.xy [data-xy-modebar-menu-indicator]){display:flex;transition:transform .15s}
+:where(.xy [data-xy-modebar-select-trigger]){width:auto;min-width:42px;gap:2px;padding:0 4px}
+:where(.xy [data-xy-modebar-select-icon]){display:flex;flex:0 0 auto}
+:where(.xy [data-xy-modebar-menu-indicator]){display:flex;flex:0 0 auto;transition:transform .15s}
 :where(.xy [data-xy-modebar-menu-indicator] svg){width:11px;height:11px}
 :where(.xy [data-xy-modebar-menu]){min-width:148px;gap:1px;padding:4px;background:var(--chart-modebar-bg,rgba(255,255,255,.94));border:1px solid rgba(128,128,128,.22);border-radius:7px;box-shadow:0 5px 18px rgba(15,23,42,.18);backdrop-filter:blur(8px)}
 :where(.xy [data-xy-modebar-menu-item]){width:100%;height:28px;justify-content:flex-start;padding:0 9px;border-radius:4px;text-align:left;white-space:nowrap}
@@ -270,6 +272,7 @@ const XY_CHROME_CSS = `
 :where(.xy [data-xy-slot="canvas"]:focus-visible,.xy [data-xy-slot="modebar_button"]:focus-visible){outline:2px solid var(--chart-focus,#2563eb);outline-offset:2px}
 @media (prefers-reduced-motion:reduce){:where(.xy [data-xy-slot="modebar"]){transition-duration:0s!important}}
 @media (forced-colors:active){:where(.xy [data-xy-slot="modebar"],.xy [data-xy-slot="tooltip"]){border:1px solid CanvasText}:where(.xy [data-xy-slot="modebar_button"].xy-active){outline:2px solid Highlight}:where(.xy [data-xy-slot="canvas"]:focus){outline:2px solid Highlight}}
+}
 `;
 function ensureChromeStylesheet(node) {
 let root = node && node.getRootNode ? node.getRootNode() : document;
@@ -412,6 +415,21 @@ if (av >= 1e6 || (av !== 0 && av < 1e-4)) return v.toExponential(1).replace("e+"
 let dec = step ? Math.max(0, Math.ceil(-Math.log10(Math.abs(step)))) : 0;
 while (dec < 8 && Math.abs(Number(step.toFixed(dec)) - step) > Math.abs(step) / 1000) dec++;
 return v.toFixed(Math.min(dec, 8));
+}
+function fmtGeneral(v, precision = 6) {
+const value = Number(v);
+if (!Number.isFinite(value)) return String(v);
+if (value === 0) return Object.is(value, -0) ? "-0" : "0";
+let [coefficient, exponentText] = value.toExponential(precision - 1).split("e");
+const exponent = Number(exponentText);
+if (exponent < -4 || exponent >= precision) {
+coefficient = coefficient.replace(/0+$/, "").replace(/\.$/, "");
+return `${coefficient}e${exponent >= 0 ? "+" : "-"}${String(Math.abs(exponent)).padStart(2, "0")}`;
+}
+const decimals = Math.max(0, precision - exponent - 1);
+let text = Number(value.toPrecision(precision)).toFixed(decimals);
+if (text.includes(".")) text = text.replace(/0+$/, "").replace(/\.$/, "");
+return text;
 }
 function fmtCategory(v, categories) {
 const i = Math.round(v);
@@ -1867,11 +1885,21 @@ const colorbarBottomRoom = horizontalColorbar ? 38 + (colorbar.label ? 16 : 0) :
 const marginRight = (pad ? pad[1] : compact ? 8 : MARGIN.r) + colorbarRightRoom;
 const marginTop = pad ? pad[0] : compact ? 6 : MARGIN.t;
 const marginBottom = (pad ? pad[2] : compact ? 36 : MARGIN.b) + colorbarBottomRoom;
-const topAxisRoom = this._axis("x").side === "top" ? (compact ? 26 : 32) : 0;
+const hasBottomAxis = Object.values(this.axes || {}).some((axis) =>
+axis && String(axis.id || "").startsWith("x") && axis.side !== "top" &&
+this._axisTickLabelStrategy(axis) !== "none");
+this._bottomAxisRoom = hasBottomAxis ? (compact ? 36 : MARGIN.b) : 0;
+const topAxisRoom = Object.values(this.axes || {}).some((axis) =>
+axis && String(axis.id || "").startsWith("x") && axis.side === "top" &&
+this._axisTickLabelStrategy(axis) !== "none")
+? (compact ? 26 : 32)
+: 0;
 const top = marginTop + (this.spec.title ? (compact ? 26 : 30) : 0) + topAxisRoom;
-const extraRightAxes = Object.values(this.axes || {}).filter((axis) =>
-axis && axis.id !== "y" && String(axis.id || "").startsWith("y") && axis.side === "right");
-const right = marginRight + (extraRightAxes.length ? (compact ? 42 : 54) : 0);
+const rightAxes = Object.values(this.axes || {}).filter((axis) =>
+axis && String(axis.id || "").startsWith("y") &&
+axis.side === "right" && this._axisTickLabelStrategy(axis) !== "none");
+this._rightAxisRoom = rightAxes.length ? (compact ? 42 : 54) : 0;
+const right = marginRight + this._rightAxisRoom;
 this.plot = {
 x: marginLeft,
 y: top,
@@ -1919,7 +1947,8 @@ _axisTicks(axisId, target) {
 const axis = this._axis(axisId);
 const [lo, hi] = this._axisRange(axisId);
 if (Array.isArray(axis.tick_values)) {
-const ticks = axis.tick_values.map(Number).filter((v) => Number.isFinite(v) && v >= lo && v <= hi);
+const a = Math.min(lo, hi), b = Math.max(lo, hi);
+const ticks = axis.tick_values.map(Number).filter((v) => Number.isFinite(v) && v >= a && v <= b);
 return { ticks, labels: ticks, step: ticks.length > 1 ? Math.abs(ticks[1] - ticks[0]) : 1 };
 }
 if (axis.kind === "time") return timeTicks(lo, hi, target);
@@ -2300,6 +2329,10 @@ this.size.w = w;
 this.size.h = h;
 this._layout();
 const p = this.plot;
+this.root.style.setProperty("--xy-legend-max-width", Math.max(40, p.w - 12) + "px");
+this.root.style.setProperty("--xy-legend-max-height", Math.max(40, p.h - 12) + "px");
+this.canvas.style.left = p.x + "px";
+this.canvas.style.top = p.y + "px";
 this.canvas.style.width = p.w + "px";
 this.canvas.style.height = p.h + "px";
 this.canvas.width = p.w * this.dpr;
@@ -2308,8 +2341,8 @@ this.chrome.style.width = this.size.w + "px";
 this.chrome.style.height = this.size.h + "px";
 this.chrome.width = this.size.w * this.dpr;
 this.chrome.height = this.size.h * this.dpr;
-if (this._legends && this._legends.length && this._slotStyleValue("legend", "max-height") == null) {
-for (const lg of this._legends) lg.style.maxHeight = p.h - 12 + "px";
+for (const lg of this._legends || []) {
+this._positionLegend(lg, lg.dataset.xyLegendLoc || "upper right");
 }
 this._positionReductionBadges();
 this._positionColorbar();
@@ -2325,6 +2358,8 @@ root.className = "xy";
 root.style.cssText =
 `position:relative;width:${this.fluid ? "100%" : this.size.w + "px"};` +
 `height:${this.fluidH ? "100%" : this.size.h + "px"};` +
+`--xy-legend-max-width:${Math.max(40, this.plot.w - 12)}px;` +
+`--xy-legend-max-height:${Math.max(40, this.plot.h - 12)}px;` +
 (this.fluidH ? "min-height:120px;" : "") +
 "font:12px system-ui,sans-serif;user-select:none;";
 this._applySlot(root, "root");
@@ -2377,7 +2412,7 @@ this._applySlot(this.labels, "labels");
 root.appendChild(this.labels);
 this.tooltip = document.createElement("div");
 this.tooltip.style.cssText =
-"position:absolute;display:none;pointer-events:none;z-index:5;white-space:nowrap;";
+"position:absolute;display:none;pointer-events:none;z-index:5;";
 this._applySlot(this.tooltip, "tooltip");
 this.tooltip.setAttribute("aria-hidden", "true");
 root.appendChild(this.tooltip);
@@ -2505,21 +2540,12 @@ _legendBox(root, items, options) {
 const lg = document.createElement("div");
 const loc = options.loc || "upper right";
 const ncols = Math.max(1, Number(options.ncols) || 1);
-const rightInset = this.size.w - (this.plot.x + this.plot.w);
 const horizontal = ncols > 1;
-const h = loc.includes("left") ? "left" : loc.includes("right") ? "right" : "center";
-const v = loc.includes("upper") ? "upper" : loc.includes("lower") ? "lower" : "center";
-let xPos, yPos, tx = "0", ty = "0";
-if (h === "left") xPos = `left:${this.plot.x + 6}px;`;
-else if (h === "right") xPos = `right:${rightInset + 6}px;`;
-else { xPos = `left:${this.plot.x + this.plot.w / 2}px;`; tx = "-50%"; }
-if (v === "upper") yPos = `top:${this.plot.y + 6}px;`;
-else if (v === "lower") yPos = `bottom:${this.size.h - (this.plot.y + this.plot.h) + 6}px;`;
-else { yPos = `top:${this.plot.y + this.plot.h / 2}px;`; ty = "-50%"; }
-const transform = tx === "0" && ty === "0" ? "" : `transform:translate(${tx},${ty});`;
-lg.style.cssText = `position:absolute;${xPos}${yPos}${transform}` +
+lg.style.cssText = "position:absolute;" +
 `display:grid;grid-template-columns:repeat(${horizontal ? ncols : 1},max-content);` +
-"overflow:auto;" + `max-height:${this.plot.h - 12}px;`;
+"overflow:auto;";
+lg.dataset.xyLegendLoc = loc;
+this._positionLegend(lg, loc);
 this._applySlot(lg, "legend");
 if (options.title) {
 const title = document.createElement("div");
@@ -2600,6 +2626,23 @@ root.appendChild(lg);
 this._legends.push(lg);
 return lg;
 }
+_positionLegend(lg, loc) {
+if (!lg) return;
+const rightInset = this.size.w - (this.plot.x + this.plot.w);
+const h = loc.includes("left") ? "left" : loc.includes("right") ? "right" : "center";
+const v = loc.includes("upper") ? "upper" : loc.includes("lower") ? "lower" : "center";
+const left = h === "left" ? this.plot.x + 6 : h === "center" ? this.plot.x + this.plot.w / 2 : null;
+const right = h === "right" ? rightInset + 6 : null;
+const top = v === "upper" ? this.plot.y + 6 : v === "center" ? this.plot.y + this.plot.h / 2 : null;
+const bottom = v === "lower" ? this.size.h - (this.plot.y + this.plot.h) + 6 : null;
+lg.style.setProperty("--xy-legend-left", left == null ? "auto" : left + "px");
+lg.style.setProperty("--xy-legend-right", right == null ? "auto" : right + "px");
+lg.style.setProperty("--xy-legend-top", top == null ? "auto" : top + "px");
+lg.style.setProperty("--xy-legend-bottom", bottom == null ? "auto" : bottom + "px");
+const tx = h === "center" ? "-50%" : "0";
+const ty = v === "center" ? "-50%" : "0";
+lg.style.setProperty("--xy-legend-transform", `translate(${tx},${ty})`);
+}
 _buildColorbar(root) {
 const cb = this.spec.colorbar;
 if (!cb) return;
@@ -2634,13 +2677,14 @@ const domain = cb.domain || [0, 1];
 const lo = Number(domain[0]), hi = Number(domain[1]);
 const span = hi - lo || 1;
 const tickResult = linearTicks(lo, hi, 8);
-const tickValues = Array.isArray(cb.ticks) ? cb.ticks : tickResult.ticks;
+const hasExplicitTicks = Array.isArray(cb.ticks);
+const tickValues = hasExplicitTicks ? cb.ticks : tickResult.ticks;
 const tickStep = tickResult.step;
 for (const raw of tickValues) {
 const value = Number(raw);
 if (!Number.isFinite(value) || value < Math.min(lo, hi) || value > Math.max(lo, hi)) continue;
 const tick = document.createElement("span");
-tick.textContent = fmtLinear(value, tickStep);
+tick.textContent = hasExplicitTicks ? fmtGeneral(value) : fmtLinear(value, tickStep);
 const fraction = (value - lo) / span;
 tick.style.cssText = horizontal
 ? `position:absolute;left:${100 * fraction}%;top:${COLORBAR_THICKNESS + 2}px;transform:translateX(-50%);white-space:nowrap;`
@@ -2666,8 +2710,12 @@ this._positionColorbar();
 _positionColorbar() {
 if (!this._colorbar) return;
 const horizontal = this._colorbarHorizontal;
-this._colorbar.style.left = (horizontal ? this.plot.x : this.plot.x + this.plot.w + COLORBAR_GAP) + "px";
-this._colorbar.style.top = (horizontal ? this.plot.y + this.plot.h + 8 : this.plot.y) + "px";
+this._colorbar.style.left = (horizontal
+? this.plot.x
+: this.plot.x + this.plot.w + this._rightAxisRoom + COLORBAR_GAP) + "px";
+this._colorbar.style.top = (horizontal
+? this.plot.y + this.plot.h + (this._bottomAxisRoom || 8)
+: this.plot.y) + "px";
 this._colorbar.style.width = (horizontal ? this.plot.w : 66) + "px";
 this._colorbar.style.height = (horizontal ? 50 : Math.max(24, this.plot.h)) + "px";
 }
@@ -2811,11 +2859,13 @@ g.colorMode = 0;
 g.color = parseColor(this.root, t.color && t.color.color, [0.3, 0.47, 0.66, 1]);
 if (t.color && t.color.mode === "continuous") {
 g.colorMode = 1;
-g.cBuf = this._upload(this._columnView(buffer, this.spec.columns[t.color.buf]));
+g._cpu.color = this._columnView(buffer, this.spec.columns[t.color.buf]);
+g.cBuf = this._upload(g._cpu.color);
 g.lut = this._lut(t.color.colormap);
 } else if (t.color && t.color.mode === "categorical") {
 g.colorMode = 2;
-g.cBuf = this._upload(this._columnView(buffer, this.spec.columns[t.color.buf]));
+g._cpu.color = this._columnView(buffer, this.spec.columns[t.color.buf]);
+g.cBuf = this._upload(g._cpu.color);
 g.lut = this._paletteLut(t.color.palette);
 }
 g.sizeMode = 0;
@@ -2823,7 +2873,8 @@ g.size = (t.size && t.size.size) || 4.0;
 g.sizeRange = [2, 18];
 if (t.size && t.size.mode === "continuous") {
 g.sizeMode = 1;
-g.sBuf = this._upload(this._columnView(buffer, this.spec.columns[t.size.buf]));
+g._cpu.size = this._columnView(buffer, this.spec.columns[t.size.buf]);
+g.sBuf = this._upload(g._cpu.size);
 g.sizeRange = t.size.range_px;
 }
 this._pointMarkStyle(g, t);
@@ -4085,24 +4136,15 @@ if (value === "dashdot") return [6, 3, 1, 3];
 return [];
 }
 _axisTickLabelStrategy(axis) {
-const raw = axis && axis.tick_label_strategy !== undefined
-? axis.tick_label_strategy
-: this._axisStyleValue(axis, "tick_label_strategy");
-const value = String(raw || "auto").replace(/-/g, "_");
+const value = String((axis && axis.tick_label_strategy) || "auto").replace(/-/g, "_");
 return ["auto", "hide", "rotate", "stagger", "none", "off"].includes(value) ? value : "auto";
 }
 _axisTickLabelAngle(axis) {
-const raw = axis && axis.tick_label_angle !== undefined
-? axis.tick_label_angle
-: this._axisStyleValue(axis, "tick_label_angle");
-const angle = Number(raw);
+const angle = Number(axis ? axis.tick_label_angle : undefined);
 return Number.isFinite(angle) ? angle : null;
 }
 _axisTickLabelMinGap(axis, dim) {
-const raw = axis && axis.tick_label_min_gap !== undefined
-? axis.tick_label_min_gap
-: this._axisStyleValue(axis, "tick_label_min_gap");
-const gap = Number(raw);
+const gap = Number(axis ? axis.tick_label_min_gap : undefined);
 return Number.isFinite(gap) && gap >= 0 ? gap : (dim === "x" ? 8 : 4);
 }
 _estimateTickLabel(text, fontSize) {
@@ -4145,7 +4187,12 @@ if (!this._tickLabelsCollide(out, dim, fontSize, minGap)) return out;
 return labels.slice(0, 1);
 }
 _layoutTickLabels(axis, dim, labels) {
-if (labels.length <= 1) return labels.map((label) => ({ ...label, angle: 0, row: 0 }));
+const strategyValue = this._axisTickLabelStrategy(axis);
+if (strategyValue === "none" || strategyValue === "off") return [];
+if (labels.length <= 1) {
+const angle = this._axisTickLabelAngle(axis);
+return labels.map((label) => ({ ...label, angle: angle === null ? 0 : angle, row: 0 }));
+}
 const fontSize = Math.max(
 8,
 this._axisStyleNumber(axis, "tick_label_size", this._axisStyleNumber(axis, "tick_size", 11)),
@@ -4154,9 +4201,7 @@ const minGap = this._axisTickLabelMinGap(axis, dim);
 const explicitAngle = this._axisTickLabelAngle(axis);
 const baseAngle = explicitAngle === null ? 0 : explicitAngle;
 const withBase = labels.map((label) => ({ ...label, angle: baseAngle, row: 0 }));
-let strategy = this._axisTickLabelStrategy(axis);
-if (strategy === "none") return [];
-if (strategy === "off") return [];
+let strategy = strategyValue;
 if (strategy === "auto") {
 if (!this._tickLabelsCollide(withBase, dim, fontSize, minGap)) return withBase;
 if (dim === "x" && axis.kind === "category" && labels.length <= 16) strategy = "rotate";
@@ -4170,10 +4215,26 @@ out = labels.map((label) => ({ ...label, angle, row: 0 }));
 } else if (strategy === "stagger" && dim === "x") {
 out = labels.map((label, i) => ({ ...label, angle: baseAngle, row: i % 2 }));
 }
-if (strategy === "hide" || this._tickLabelsCollide(out, dim, fontSize, minGap)) {
+if (this._tickLabelsCollide(out, dim, fontSize, minGap)) {
 out = this._downsampleTickLabels(out, dim, fontSize, minGap);
 }
 return out;
+}
+_xTickLabelTransform(axis, angle) {
+const value = Number(angle || 0);
+const side = axis && axis.side === "top" ? "top" : "bottom";
+if (value === 0) {
+return {
+transform: "translateX(-50%)",
+origin: side === "top" ? "bottom center" : "top center",
+};
+}
+const anchorAtEnd = (side === "bottom" && value < 0) || (side === "top" && value > 0);
+const verticalOrigin = side === "top" ? "bottom" : "top";
+return {
+transform: `${anchorAtEnd ? "translateX(-100%) " : ""}rotate(${value}deg)`,
+origin: `${verticalOrigin} ${anchorAtEnd ? "right" : "left"}`,
+};
 }
 _axisLabelCss(axis, dim, fallbackCss) {
 const rawPosition = axis && axis.label_position;
@@ -4243,6 +4304,10 @@ ctx.fillRect(p.x, p.y, p.w, p.h);
 }
 const xAxis = this._axis("x");
 const yAxis = this._axis("y");
+const extraXAxes = Object.values(this.axes).filter((axis) =>
+axis && axis.id !== "x" && String(axis.id || "").startsWith("x"));
+const extraYAxes = Object.values(this.axes).filter((axis) =>
+axis && axis.id !== "y" && String(axis.id || "").startsWith("y"));
 const hideX = this._axisTickLabelStrategy(xAxis) === "none";
 const hideY = this._axisTickLabelStrategy(yAxis) === "none";
 const xt = this._axisTicks(
@@ -4303,8 +4368,14 @@ const xHeight = Math.max(1, this._axisStyleNumber(xAxis, "axis_width", 1));
 if (frameSides.includes("top")) rule(xAxis, p.x, p.y, p.w, xHeight);
 if (frameSides.includes("bottom")) rule(xAxis, p.x, p.y + p.h - xHeight, p.w, xHeight);
 }
-for (const axis of Object.values(this.axes)) {
-if (!axis || axis.id === "y" || !String(axis.id || "").startsWith("y")) continue;
+for (const axis of extraXAxes) {
+if (this._axisTickLabelStrategy(axis) === "none") continue;
+const h = Math.max(1, this._axisStyleNumber(axis, "axis_width", 1));
+const y = axis.side === "top" ? p.y : p.y + p.h - h;
+rule(axis, p.x, y, p.w, h);
+}
+for (const axis of extraYAxes) {
+if (this._axisTickLabelStrategy(axis) === "none") continue;
 const w = Math.max(1, this._axisStyleNumber(axis, "axis_width", 1));
 const x = axis.side === "left" ? p.x : p.x + p.w - w;
 rule(axis, x, p.y, w, p.h);
@@ -4337,6 +4408,38 @@ const y = this._dataPx("y", value);
 if (!Number.isFinite(y) || y < p.y - 1 || y > p.y + p.h + 1) continue;
 const left = side === "right" ? edge - tick.inward : edge - tick.outward;
 rule(yAxis, left, y - tick.width / 2, tick.inward + tick.outward, tick.width, "tick_color");
+}
+}
+for (const axis of extraXAxes) {
+if (this._axisTickLabelStrategy(axis) === "none") continue;
+const ticks = this._axisTicks(
+axis.id,
+this._axisTickTarget(axis.id, Math.max(3, p.w / (axis.kind === "time" ? 90 : 80))),
+);
+const tick = tickParts(axis);
+const side = axis.side || "bottom";
+const edge = side === "top" ? p.y : p.y + p.h;
+for (const value of ticks.ticks) {
+const x = this._dataPx(axis.id, value);
+if (!Number.isFinite(x) || x < p.x - 1 || x > p.x + p.w + 1) continue;
+const top = side === "top" ? edge - tick.outward : edge - tick.inward;
+rule(axis, x - tick.width / 2, top, tick.width, tick.inward + tick.outward, "tick_color");
+}
+}
+for (const axis of extraYAxes) {
+if (this._axisTickLabelStrategy(axis) === "none") continue;
+const ticks = this._axisTicks(
+axis.id,
+this._axisTickTarget(axis.id, Math.max(3, p.h / 45)),
+);
+const tick = tickParts(axis);
+const side = axis.side || "right";
+const edge = side === "right" ? p.x + p.w : p.x;
+for (const value of ticks.ticks) {
+const y = this._dataPx(axis.id, value);
+if (!Number.isFinite(y) || y < p.y - 1 || y > p.y + p.h + 1) continue;
+const left = side === "right" ? edge - tick.inward : edge - tick.outward;
+rule(axis, left, y - tick.width / 2, tick.inward + tick.outward, tick.width, "tick_color");
 }
 }
 }
@@ -4383,13 +4486,48 @@ this._axisStyleNumber(xAxis, "tick_size", 11),
 );
 const rowOffset = Number(item.row || 0) * (Math.max(8, tickLabelSize) + 4);
 const top = xAxis.side === "top" ? p.y - 18 - rowOffset : p.y + p.h + 6 + rowOffset;
-const transform = `translateX(-50%) rotate(${Number(item.angle || 0)}deg)`;
-const origin = xAxis.side === "top" ? "bottom center" : "top center";
+const placement = this._xTickLabelTransform(xAxis, item.angle);
 label(
 item.text,
-`left:${item.pos}px;top:${top}px;transform:${transform};transform-origin:${origin};`,
+`left:${item.pos}px;top:${top}px;transform:${placement.transform};` +
+`transform-origin:${placement.origin};`,
 xAxis,
 );
+}
+for (const axis of extraXAxes) {
+const ticks = this._axisTicks(
+axis.id,
+this._axisTickTarget(axis.id, Math.max(3, p.w / (axis.kind === "time" ? 90 : 80))),
+);
+const labelCandidates = [];
+for (const value of (ticks.labels || ticks.ticks)) {
+const px = this._dataPx(axis.id, value);
+if (px < p.x - 1 || px > p.x + p.w + 1) continue;
+labelCandidates.push({ pos: px, text: this._axisTickText(axis, value, ticks.step) });
+}
+for (const item of this._layoutTickLabels(axis, "x", labelCandidates)) {
+const tickLabelSize = this._axisStyleNumber(
+axis,
+"tick_label_size",
+this._axisStyleNumber(axis, "tick_size", 11),
+);
+const rowOffset = Number(item.row || 0) * (Math.max(8, tickLabelSize) + 4);
+const top = axis.side === "top" ? p.y - 18 - rowOffset : p.y + p.h + 6 + rowOffset;
+const placement = this._xTickLabelTransform(axis, item.angle);
+label(
+item.text,
+`left:${item.pos}px;top:${top}px;transform:${placement.transform};` +
+`transform-origin:${placement.origin};`,
+axis,
+);
+}
+if (axis.label && this._axisTickLabelStrategy(axis) !== "none") {
+const top = axis.side === "top" ? p.y - 34 : p.y + p.h + 24;
+const fallbackCss =
+`left:${p.x + p.w / 2}px;top:${top}px;transform:translateX(-50%);font-weight:500;`;
+const placement = this._axisLabelCss(axis, "x", fallbackCss);
+label(axis.label, placement.css, axis, "label", placement.style);
+}
 }
 const yLabelCandidates = [];
 for (const v of (yt.labels || yt.ticks)) {
@@ -4405,8 +4543,7 @@ const css = yAxis.side === "right"
 : `right:${this.size.w - p.x + 8}px;top:${item.pos}px;transform:translateY(-50%) rotate(${angle}deg);transform-origin:right center;`;
 label(item.text, css, yAxis);
 }
-for (const axis of Object.values(this.axes)) {
-if (!axis || axis.id === "y" || !String(axis.id || "").startsWith("y")) continue;
+for (const axis of extraYAxes) {
 const ticks = this._axisTicks(axis.id, this._axisTickTarget(axis.id, Math.max(3, p.h / 45)));
 const labelCandidates = [];
 for (const v of (ticks.labels || ticks.ticks)) {
@@ -4422,7 +4559,7 @@ const css = axis.side === "left"
 : `left:${p.x + p.w + 8}px;top:${item.pos}px;transform:translateY(-50%) rotate(${angle}deg);transform-origin:left center;`;
 label(item.text, css, axis);
 }
-if (axis.label) {
+if (axis.label && this._axisTickLabelStrategy(axis) !== "none") {
 const fallbackCss = axis.side === "left"
 ? `left:10px;top:${p.y + p.h / 2}px;transform:rotate(-90deg) translateX(50%);transform-origin:left;font-weight:500;`
 : `left:${p.x + p.w + 40}px;top:${p.y + p.h / 2}px;transform:rotate(90deg) translateX(-50%);transform-origin:left;font-weight:500;`;
@@ -4430,13 +4567,13 @@ const placement = this._axisLabelCss(axis, "y", fallbackCss);
 label(axis.label, placement.css, axis, "label", placement.style);
 }
 }
-if (s.x_axis.label) {
+if (s.x_axis.label && !hideX) {
 const top = xAxis.side === "top" ? p.y - 34 : p.y + p.h + 24;
 const fallbackCss = `left:${p.x + p.w / 2}px;top:${top}px;transform:translateX(-50%);font-weight:500;`;
 const placement = this._axisLabelCss(xAxis, "x", fallbackCss);
 label(s.x_axis.label, placement.css, xAxis, "label", placement.style);
 }
-if (s.y_axis.label) {
+if (s.y_axis.label && !hideY) {
 const fallbackCss = yAxis.side === "right"
 ? `left:${p.x + p.w + 40}px;top:${p.y + p.h / 2}px;transform:rotate(90deg) translateX(-50%);transform-origin:left;font-weight:500;`
 : `left:10px;top:${p.y + p.h / 2}px;transform:rotate(-90deg) translateX(50%);transform-origin:left;font-weight:500;`;
@@ -4836,6 +4973,8 @@ this.gpuTraces = [];
 const XY_ANNOTATION_SHAPE_STYLE_KEYS = new Set([
 "color",
 "label_color",
+"label_opacity",
+"opacity",
 "width",
 "head_size",
 "head_style",
@@ -5219,7 +5358,13 @@ const d = document.createElement("div");
 d.textContent = text;
 const dx = Number.isFinite(Number(ann.dx)) ? Number(ann.dx) : 0;
 const dy = Number.isFinite(Number(ann.dy)) ? Number(ann.dy) : 0;
-const anchor = ann.anchor === "middle" ? "-50%" : ann.anchor === "end" ? "-100%" : "0px";
+const anchorName = ["start", "middle", "end"].includes(ann.anchor)
+? ann.anchor
+: ann.kind === "arrow" ||
+((ann.kind === "rule" || ann.kind === "band") && ann.axis === "x")
+? "middle"
+: "start";
+const anchor = anchorName === "middle" ? "-50%" : anchorName === "end" ? "-100%" : "0px";
 const rot = Number.isFinite(Number(style.rotation))
 ? ((Number(style.rotation) % 360) + 360) % 360
 : 0;
@@ -5238,7 +5383,7 @@ va === "center" || va === "middle" ? "-50%"
 : va === "bottom" ? (cw ? "-100%" : "0")
 : cw ? "0" : "-100%";
 const cross =
-ann.anchor === "middle" ? "-50%" : ann.anchor === "end" ? (cw ? "0" : "-100%") : cw ? "-100%" : "0";
+anchorName === "middle" ? "-50%" : anchorName === "end" ? (cw ? "0" : "-100%") : cw ? "-100%" : "0";
 transform = `rotate(${cw ? 90 : -90}deg) translate(${along},${cross})`;
 } else if (rot) {
 transform = `rotate(${-rot}deg) translate(${anchor},${vAnchor})`;
@@ -5251,12 +5396,22 @@ this._applySlot(d, "annotation_label");
 this._applyClass(d, ann.class_name);
 const labelStyle = {};
 for (const [key, value] of Object.entries(style)) {
+if (key === "opacity" && ann.kind === "text") {
+labelStyle[key] = value;
+continue;
+}
 if (XY_ANNOTATION_SHAPE_STYLE_KEYS.has(key)) continue;
 labelStyle[key] = value;
 }
 this._applyStyle(d, labelStyle);
 if (style && (style.label_color || style.color)) {
 d.style.color = this._annotationLabelPaint(style, this.theme.label);
+}
+if (style && style.label_opacity !== undefined) {
+const labelOpacity = Number(style.label_opacity);
+if (Number.isFinite(labelOpacity)) {
+d.style.opacity = String(Math.max(0, Math.min(1, labelOpacity)));
+}
 }
 this.labels.appendChild(d);
 const cs = getComputedStyle(d);
@@ -5489,8 +5644,16 @@ if (this.a11yLive.textContent !== announcement) this.a11yLive.textContent = anno
 }
 this.tooltip.style.display = "block";
 const tw = this.tooltip.offsetWidth;
-this.tooltip.style.left = Math.min(lx + 12, this.size.w - tw - 4) + "px";
-this.tooltip.style.top = ly + 12 + "px";
+const th = this.tooltip.offsetHeight;
+const edge = 4;
+const gap = 12;
+const maxLeft = Math.max(edge, this.size.w - tw - edge);
+const left = Math.max(edge, Math.min(lx + gap, maxLeft));
+const below = ly + gap;
+const above = ly - th - gap;
+const top = below + th <= this.size.h - edge ? below : Math.max(edge, above);
+this.tooltip.style.left = left + "px";
+this.tooltip.style.top = top + "px";
 },
 });
 Object.assign(ChartView.prototype, {
@@ -5607,12 +5770,12 @@ mode, sx: e.clientX, sy: e.clientY, d0,
 points: firstLassoPoint ? [firstLassoPoint] : null,
 previousLasso,
 };
-c.setPointerCapture(e.pointerId);
+try { c.setPointerCapture(e.pointerId); } catch (_err) {   }
 this.tooltip.style.display = "none";
 return;
 }
 drag = { px: e.clientX, py: e.clientY, view: { ...this.view }, moved: false };
-c.setPointerCapture(e.pointerId);
+try { c.setPointerCapture(e.pointerId); } catch (_err) {   }
 this.tooltip.style.display = "none";
 });
 this._listen(c, "pointermove", (e) => {
@@ -5642,10 +5805,13 @@ this._hover(e);
 });
 const end = (e) => {
 if (band) {
+if (band.mode === "select-lasso") this._updateBand(band, e);
 this.selRect.style.display = "none";
 this.selLasso.style.display = "none";
 const d1 = dataAt(e.clientX, e.clientY);
-const moved = Math.abs(e.clientX - band.sx) > 3 || Math.abs(e.clientY - band.sy) > 3;
+const moved = band.mode === "select-lasso"
+? band.points.length >= 3
+: Math.abs(e.clientX - band.sx) > 3 || Math.abs(e.clientY - band.sy) > 3;
 if (moved) {
 if (band.mode === "zoom") this._zoomToBox(band.d0, d1, true);
 else if (band.mode === "select-lasso") {
@@ -6261,6 +6427,7 @@ const canSelect = this._pickable
 && this._interactionFlag("select", true);
 let selectTrigger = null;
 let selectIndicator = null;
+let selectModeIcon = null;
 if (canSelect) {
 selectTrigger = mk("select", "Selection controls", () => {
 setSelectMenuOpen(!this._selectMenuOpen);
@@ -6269,11 +6436,17 @@ selectTrigger.dataset.xyModebarSelect = "";
 selectTrigger.dataset.xyModebarSelectTrigger = "";
 selectTrigger.setAttribute("aria-haspopup", "menu");
 selectTrigger.setAttribute("aria-expanded", "false");
+selectTrigger.replaceChildren();
+selectModeIcon = document.createElement("span");
+selectModeIcon.dataset.xyModebarSelectIcon = "";
+selectModeIcon.innerHTML = this._icon("select");
+selectTrigger.appendChild(selectModeIcon);
 selectIndicator = document.createElement("span");
 selectIndicator.dataset.xyModebarMenuIndicator = "";
 selectIndicator.innerHTML = this._icon("chevrondown");
 selectTrigger.appendChild(selectIndicator);
 this._selectMenuButton = selectTrigger;
+this._selectMenuIcon = selectModeIcon;
 }
 mk("pan", "Pan", () => this._setDragMode("pan"), "pan");
 const zoomMenu = document.createElement("div");
@@ -6611,6 +6784,18 @@ btn.setAttribute("aria-pressed", String(name === mode));
 }
 this._zoomMenuButton?.classList.toggle("xy-active", mode === "zoom");
 this._selectMenuButton?.classList.toggle("xy-active", mode.startsWith("select"));
+const selectionMode = {
+select: ["select", "Box Select"],
+"select-lasso": ["lasso", "Lasso Select"],
+"select-x": ["selectx", "X Range"],
+"select-y": ["selecty", "Y Range"],
+}[mode];
+if (selectionMode && this._selectMenuButton && this._selectMenuIcon) {
+const [iconName, label] = selectionMode;
+this._selectMenuIcon.innerHTML = this._icon(iconName);
+this._selectMenuButton.title = `Selection controls: ${label}`;
+this._selectMenuButton.setAttribute("aria-label", `Selection controls: ${label}`);
+}
 },
 _updateZoomMenuLabel() {
 if (!this._zoomMenuLabel || !this.view || !this.view0) return;
@@ -6971,24 +7156,25 @@ return svg('<path d="M10 3 V17 M3 10 H17"/><path d="M10 3 L8 5 M10 3 L12 5"/>' +
 '<path d="M10 17 L8 15 M10 17 L12 15"/><path d="M3 10 L5 8 M3 10 L5 12"/>' +
 '<path d="M17 10 L15 8 M17 10 L15 12"/>');
 case "zoom":
-return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
-'stroke-dasharray="3 2"/>');
+return svg('<path d="M7 3.5 H3.5 V7 M13 3.5 H16.5 V7 ' +
+'M3.5 13 V16.5 H7 M16.5 13 V16.5 H13"/>');
 case "select":
-return svg('<rect x="3.5" y="3.5" width="13" height="13" rx="1" ' +
-'stroke-dasharray="2.5 2"/><circle cx="7" cy="7" r="1" fill="currentColor" ' +
+return svg('<path d="M7 4 H4 V7 M13 4 H16 V7 M4 13 V16 H7 ' +
+'M16 13 V16 H13"/><circle cx="7" cy="8" r="1" fill="currentColor" ' +
 'stroke="none"/><circle cx="12.5" cy="9" r="1" fill="currentColor" stroke="none"/>' +
 '<circle cx="9.5" cy="13" r="1" fill="currentColor" stroke="none"/>');
 case "lasso":
-return svg('<path d="M4 6 C6 2 15 3 16 8 C17 13 11 17 6 14 C2 12 2 8 4 6 Z" ' +
-'stroke-dasharray="2.5 2"/><circle cx="6" cy="8" r="1" fill="currentColor" ' +
-'stroke="none"/><circle cx="12" cy="7" r="1" fill="currentColor" stroke="none"/>' +
-'<circle cx="10" cy="12" r="1" fill="currentColor" stroke="none"/>');
+return svg('<path d="M5 5.5 C7 3 13.5 3.5 15.5 7 C17 10 14 15.5 9 15.5 ' +
+'C4.5 15.5 2.5 11 4 7.5 Z"/><circle cx="5" cy="5.5" r="1" ' +
+'fill="currentColor" stroke="none"/><circle cx="15.5" cy="7" r="1" ' +
+'fill="currentColor" stroke="none"/><circle cx="9" cy="15.5" r="1" ' +
+'fill="currentColor" stroke="none"/>');
 case "selectx":
-return svg('<rect x="3" y="5" width="14" height="10" rx="1" stroke-dasharray="2.5 2"/>' +
-'<path d="M6 10 H14 M6 10 L8 8 M6 10 L8 12 M14 10 L12 8 M14 10 L12 12"/>');
+return svg('<path d="M5 4 V16 M15 4 V16 M7 10 H13 ' +
+'M7 10 L9 8 M7 10 L9 12 M13 10 L11 8 M13 10 L11 12"/>');
 case "selecty":
-return svg('<rect x="5" y="3" width="10" height="14" rx="1" stroke-dasharray="2.5 2"/>' +
-'<path d="M10 6 V14 M10 6 L8 8 M10 6 L12 8 M10 14 L8 12 M10 14 L12 12"/>');
+return svg('<path d="M4 5 H16 M4 15 H16 M10 7 V13 ' +
+'M10 7 L8 9 M10 7 L12 9 M10 13 L8 11 M10 13 L12 11"/>');
 case "chevrondown":
 return svg('<path d="M6 8 L10 12 L14 8"/>');
 case "collapse":
@@ -7282,6 +7468,13 @@ this._applyAppend(msg, buffers);
 } else if (msg.type === "pick_result") {
 if (msg.seq !== undefined && msg.seq !== this._pickSeq) return;
 if (!msg.row) { this.tooltip.style.display = "none"; return; }
+const local = this._lastRow;
+if (local && local.trace === msg.row.trace && local.index === msg.row.index) {
+for (const [key, value] of Object.entries(local)) {
+if (msg.row[key] === undefined) msg.row[key] = value;
+}
+}
+this._applySharedTooltipFields(msg.row);
 this._lastRow = msg.row;
 const xy = this._lastHoverXY;
 if (xy) this._renderTooltip(msg.row, xy.clientX, xy.clientY, {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,81 @@
+"""Shared helpers for the browser-probe tests.
+
+Plain functions (pytest puts this directory on ``sys.path``, so probe tests
+import them with ``from conftest import run_browser_probe``).
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _dump_dom(chromium: str, page: Path) -> str | None:
+    """One headless render pass; None on a chromium-level failure (retryable)."""
+    try:
+        proc = subprocess.run(
+            [
+                chromium,
+                "--headless=new",
+                "--no-sandbox",
+                "--disable-dev-shm-usage",
+                "--allow-file-access-from-files",
+                "--use-angle=swiftshader",
+                "--enable-unsafe-swiftshader",
+                "--hide-scrollbars",
+                "--window-size=640,480",
+                "--virtual-time-budget=8000",
+                "--dump-dom",
+                page.as_uri(),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    return proc.stdout if proc.returncode == 0 else None
+
+
+def run_browser_probe(
+    chromium: str,
+    document: str,
+    page: Path,
+    result_attribute: str,
+    *,
+    label: str,
+) -> dict:
+    """Render `document` headless and scrape one JSON probe result, with retries.
+
+    The probe script reports success by JSON-encoding its payload into
+    ``result_attribute`` on ``<body>`` and failure into
+    ``{result_attribute}-error``. Returns the parsed result payload. If Chromium
+    never returns a DOM the test is skipped as an environmental miss; once a
+    DOM is returned, probe errors and missing results fail the test.
+
+    Headless probes on shared runners have transient warm-up misses (virtual
+    time / GL init) that a relaunch clears; a genuine regression fails every
+    attempt with a *value* mismatch, which we surface — never retry away.
+    """
+    page.write_text(document, encoding="utf-8")
+    last: str | None = None
+    for _ in range(3):
+        dom = _dump_dom(chromium, page)
+        if dom is None:
+            continue
+        error = re.search(rf'{re.escape(result_attribute)}-error="([^"]*)"', dom)
+        if error:
+            last = f"probe error: {html.unescape(error.group(1))}"
+            continue
+        match = re.search(rf'{re.escape(result_attribute)}="([^"]*)"', dom)
+        if match:
+            return json.loads(html.unescape(match.group(1)))
+        last = "probe did not finish (no result attribute)"
+    if last:
+        pytest.fail(f"{label} could not run after retries: {last}")
+    pytest.skip("headless chromium unavailable/failed after retries")

--- a/tests/pyplot/test_reference_semantics.py
+++ b/tests/pyplot/test_reference_semantics.py
@@ -216,11 +216,11 @@ def _normalize_mask(mask: np.ndarray, size: int = 256) -> np.ndarray:
 
 @pytest.mark.parametrize("family", ["line", "bar", "image"])
 def test_reference_pngs_have_tolerant_perceptual_and_geometry_agreement(family: str) -> None:
-    # xy's static renderer has a documented 640x480 minimum canvas.  Render the
-    # reference at that same comparison canvas; figsize parity itself is not an
-    # exact contract at sub-minimum sizes.
+    # xy rasterizes its 320x240 logical canvas at 2x.  Render the Matplotlib
+    # reference at the same physical size and effective DPI so point-sized
+    # strokes, markers, and text remain comparable at 640x480.
     xyfig, xyax = xyplt.subplots(figsize=(4, 3), dpi=80)
-    mplfig, mplax = mplplt.subplots(figsize=(8, 6), dpi=80)
+    mplfig, mplax = mplplt.subplots(figsize=(4, 3), dpi=160)
     if family == "line":
         for ax in (xyax, mplax):
             ax.plot([0, 1, 2, 3], [0, 2, 1, 3], "o-", color="#2563eb", linewidth=2)
@@ -236,7 +236,7 @@ def test_reference_pngs_have_tolerant_perceptual_and_geometry_agreement(family: 
             ax.set_title("image")
     xybytes = xyfig._to_png()
     reference = BytesIO()
-    mplfig.savefig(reference, format="png", dpi=80)
+    mplfig.savefig(reference, format="png", dpi=160)
     xypixels, mplpixels = _png_pixels(xybytes), _png_pixels(reference.getvalue())
     assert xypixels.shape == mplpixels.shape == (480, 640, 4)
     xymask, mplmask = _foreground_mask(xypixels), _foreground_mask(mplpixels)

--- a/tests/reflex_adapter/test_assets.py
+++ b/tests/reflex_adapter/test_assets.py
@@ -80,6 +80,15 @@ def test_wrapper_sizes_static_and_live_charts_to_the_reflex_mount():
     assert "fitSpecToElement(data.spec)," in jsx
 
 
+def test_wrapper_discards_tailwind_scan_manifest_before_dom_props():
+    """The scan bridge must not become an unknown DOM attribute at runtime."""
+    jsx = (ADAPTER_ASSETS / "XYChart.jsx").read_text(encoding="utf-8")
+
+    assert "tailwindClassTokens: _tailwindClassTokens" in jsx
+    assert "void _tailwindClassTokens;" in jsx
+    assert "...divProps" in jsx
+
+
 def test_wrapper_mirrors_reflex_connection_options():
     """The shared-manager trick only works if our io() options match reflex's
     connect() (utils/state.js). These names are the coupling surface — if

--- a/tests/reflex_adapter/test_component.py
+++ b/tests/reflex_adapter/test_component.py
@@ -9,6 +9,8 @@ import pytest
 import reflex as rx
 import reflex_xy
 
+import xy
+
 
 class CompState(rx.State):
     last_row: dict = {}
@@ -66,6 +68,53 @@ def test_component_import_is_local_library(app_cwd):
     assert lib[0].startswith("$/public/external/"), "must never be an npm specifier"
 
 
+def test_static_chart_classes_are_visible_to_tailwind_source_scan(app_cwd):
+    """XYBF is opaque to Tailwind, so static chart classes need a JSX literal."""
+    static_chart = xy.chart(
+        xy.line(
+            [0, 1],
+            [1, 2],
+            class_name="stroke-[3px] transition-opacity",
+        ),
+        xy.vline(
+            0.5,
+            text="release",
+            class_name="[&>text]:font-semibold opacity-80",
+        ),
+        xy.legend(class_name="max-h-24 overflow-y-auto"),
+        xy.tooltip(class_name="max-w-64 break-words"),
+        xy.modebar(
+            class_name="rounded-lg shadow-sm",
+            button_class_name="hover:bg-slate-100 focus:ring-2",
+        ),
+        class_name="rounded-xl border border-slate-200",
+        class_names={
+            "title": "text-base font-semibold text-slate-900",
+            "selection": "fill-blue-500/10 stroke-blue-500",
+        },
+    )
+
+    rendered = str(reflex_xy.chart(static_chart, id="tailwind-chart"))
+    assert "tailwindClassTokens" in rendered
+    for class_string in (
+        "rounded-xl border border-slate-200",
+        "text-base font-semibold text-slate-900",
+        "fill-blue-500/10 stroke-blue-500",
+        "stroke-[3px] transition-opacity",
+        "[&>text]:font-semibold opacity-80",
+        "max-h-24 overflow-y-auto",
+        "max-w-64 break-words",
+        "rounded-lg shadow-sm",
+        "hover:bg-slate-100 focus:ring-2",
+    ):
+        assert class_string in rendered
+
+
+def test_live_chart_does_not_claim_runtime_classes_are_compile_time_known(app_cwd):
+    rendered = str(reflex_xy.chart("xyfig-runtime"))
+    assert "tailwindClassTokens" not in rendered
+
+
 def test_component_creation_does_not_touch_repo_root():
     """Outside an app cwd nothing has leaked assets/ into the repo."""
     repo_root = pathlib.Path(reflex_xy.__file__).resolve().parents[3]
@@ -74,3 +123,11 @@ def test_component_creation_does_not_touch_repo_root():
         "symlinks outside an app directory"
     )
     assert os.getcwd() != str(repo_root) or True
+
+
+def test_lasso_selection_summary_keeps_polygon_geometry():
+    source = (
+        pathlib.Path(__file__).parents[2] / "python/reflex-xy/reflex_xy/assets/XYChart.jsx"
+    ).read_text()
+    assert 'm.type === "select_polygon"' in source
+    assert 'lastSelect?.type === "select_polygon" ? lastSelect.points : null' in source

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -303,6 +303,27 @@ def test_semantic_annotations_and_markers_emit_expected_specs():
         xy.threshold(1.0, axis="z")
 
 
+def test_annotation_label_opacity_is_independent_from_geometry_opacity():
+    chart = xy.chart(
+        xy.x_band(
+            1.0,
+            2.0,
+            text="window",
+            opacity=0.12,
+            style={"label_opacity": 0.85},
+        )
+    )
+
+    spec, _ = chart.figure().build_payload()
+    style = spec["annotations"][0]["style"]
+
+    assert style["opacity"] == 0.12
+    assert style["label_opacity"] == 0.85
+
+    with pytest.raises(ValueError, match="label_opacity"):
+        xy.chart(xy.x_band(1.0, 2.0, text="window", style={"label_opacity": 1.1})).figure()
+
+
 def test_layered_tooltip_sources_keep_fields_tied_to_their_traces():
     data = FakeFrame(
         {
@@ -458,6 +479,26 @@ def test_component_style_tooltip_and_modebar_metadata_is_opt_in():
         },
     }
     assert spec["traces"][0]["style"]["class_name"] == "xy-mark-accounts"
+
+
+def test_figure_dom_class_strings_covers_every_class_carrying_surface():
+    """`Figure.dom_class_strings()` is the Tailwind scan inventory (see its
+    docstring): chart root, chrome slots, per-mark styles, annotation nodes."""
+    chart = xy.chart(
+        xy.line([0, 1], [1, 2], class_name="mark-node"),
+        xy.line([0, 1], [2, 3], class_name="mark-node"),  # dedupe, keep order
+        xy.vline(0.5, text="release", class_name="annotation-node"),
+        xy.legend(class_name="legend-node"),
+        class_name="root-node",
+        class_names={"title": "title-slot"},
+    )
+
+    class_strings = chart.figure().dom_class_strings()
+
+    for class_string in ("root-node", "title-slot", "legend-node", "mark-node", "annotation-node"):
+        assert class_string in class_strings, class_strings
+    assert len(class_strings) == len(set(class_strings)), class_strings
+    assert class_strings[0] == "root-node", class_strings
 
 
 def test_declarative_core_contract_for_layered_axis_chrome_and_interaction():
@@ -1711,6 +1752,58 @@ def test_dual_axis_component_payload_binds_traces_to_secondary_axis():
         xy.chart(
             xy.line(x=np.arange(3.0), y=np.arange(3.0), y_axis="y2"),
         ).figure()
+
+
+@pytest.mark.parametrize("axis_dim", ["x", "y"])
+@pytest.mark.parametrize(
+    "primary_is_category",
+    [True, False],
+    ids=["primary-category-named-linear", "primary-linear-named-category"],
+)
+def test_declarative_named_axis_category_state_is_scoped_per_axis_id(
+    axis_dim: str, primary_is_category: bool
+) -> None:
+    named_axis_id = f"{axis_dim}2"
+    axis_factory = xy.x_axis if axis_dim == "x" else xy.y_axis
+    side = "top" if axis_dim == "x" else "right"
+    category_values = ["Alpha", "Beta"]
+    numeric_values = [100.0, 200.0]
+    primary_values = category_values if primary_is_category else numeric_values
+    named_values = numeric_values if primary_is_category else category_values
+
+    def mark(values, *, named: bool = False):
+        props = (
+            {"x": values, "y": [1.0, 2.0]} if axis_dim == "x" else {"x": [1.0, 2.0], "y": values}
+        )
+        if named:
+            props[f"{axis_dim}_axis"] = named_axis_id
+        return xy.line(**props)
+
+    chart = xy.chart(
+        mark(primary_values),
+        mark(named_values, named=True),
+        axis_factory(type_="linear" if not primary_is_category else None),
+        axis_factory(
+            id=named_axis_id,
+            side=side,
+            type_="linear" if primary_is_category else None,
+        ),
+    )
+
+    fig = chart.figure()
+    spec, _ = fig.build_payload()
+    category_axis_id = axis_dim if primary_is_category else named_axis_id
+    linear_axis_id = named_axis_id if primary_is_category else axis_dim
+
+    assert fig._axis_categories == {category_axis_id: category_values}
+    assert spec["axes"][category_axis_id]["kind"] == "category"
+    assert spec["axes"][category_axis_id]["categories"] == category_values
+    assert spec["axes"][linear_axis_id]["kind"] == "linear"
+    assert "categories" not in spec["axes"][linear_axis_id]
+    assert [trace[f"{axis_dim}_axis"] for trace in spec["traces"]] == [
+        axis_dim,
+        named_axis_id,
+    ]
 
 
 def test_bad_child_type():

--- a/tests/test_declarative_colorbar.py
+++ b/tests/test_declarative_colorbar.py
@@ -1,0 +1,335 @@
+"""Declarative continuous-color marks drive built-in colorbar chrome."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import xy
+from conftest import run_browser_probe
+from xy.export import find_chromium
+
+
+def test_heatmap_colorbar_uses_compiled_scale_and_public_chrome_options() -> None:
+    chart = xy.heatmap_chart(
+        xy.heatmap(
+            [[-2.0, 0.0], [2.0, 4.0]],
+            name="temperature",
+            colormap="coolwarm",
+            domain=(-3.0, 5.0),
+        ),
+        xy.colorbar(
+            title="Temperature (°C)",
+            orientation="horizontal",
+            ticks=[-3, 0, 5],
+            class_name="scale",
+            style={"border-radius": 6},
+        ),
+    )
+
+    spec, _ = chart.figure().build_payload()
+
+    assert spec["colorbar"] == {
+        "domain": [-3.0, 5.0],
+        "colormap": "coolwarm",
+        "label": "Temperature (°C)",
+        "orientation": "horizontal",
+        "ticks": [-3.0, 0.0, 5.0],
+    }
+    assert spec["dom"]["class_names"]["colorbar"] == "scale"
+    assert spec["dom"]["styles"]["colorbar"] == {"border-radius": 6}
+
+
+def test_heatmap_colorbar_autoscales_and_uses_the_mark_name() -> None:
+    chart = xy.chart(
+        xy.heatmap([[0.25, 0.75], [1.25, 1.75]], name="intensity", colormap="purples"),
+        xy.colorbar(),
+    )
+
+    spec, _ = chart.figure().build_payload()
+
+    assert spec["colorbar"] == {
+        "domain": [0.25, 1.75],
+        "colormap": "purples",
+        "label": "intensity",
+        "orientation": "vertical",
+    }
+
+
+def test_continuous_scatter_colorbar_uses_color_column_not_trace_name() -> None:
+    data = {
+        "x": [0.0, 1.0, 2.0],
+        "y": [2.0, 3.0, 5.0],
+        "temperature": [12.0, 18.0, 31.0],
+    }
+    chart = xy.scatter_chart(
+        xy.scatter(
+            x="x",
+            y="y",
+            color="temperature",
+            data=data,
+            name="stations",
+            colormap="plasma",
+            color_domain=(10.0, 35.0),
+        ),
+        xy.colorbar(),
+    )
+
+    spec, _ = chart.figure().build_payload()
+
+    assert spec["colorbar"] == {
+        "domain": [10.0, 35.0],
+        "colormap": "plasma",
+        "label": "temperature",
+        "orientation": "vertical",
+    }
+
+
+@pytest.mark.parametrize(
+    "color",
+    ["#2563eb", ["low", "medium", "high"]],
+)
+def test_noncontinuous_scatter_does_not_invent_a_colorbar(color) -> None:
+    chart = xy.scatter_chart(
+        xy.scatter([0.0, 1.0, 2.0], [2.0, 3.0, 5.0], color=color),
+        xy.colorbar(),
+    )
+
+    spec, _ = chart.figure().build_payload()
+
+    assert "colorbar" not in spec
+
+
+def test_density_scatter_does_not_label_the_dropped_per_row_color_channel() -> None:
+    chart = xy.scatter_chart(
+        xy.scatter(
+            [0.0, 1.0, 2.0],
+            [2.0, 3.0, 5.0],
+            color=[10.0, 20.0, 30.0],
+            density=True,
+            colormap="plasma",
+        ),
+        xy.colorbar(),
+    )
+
+    spec, _ = chart.figure().build_payload()
+
+    assert spec["traces"][0]["tier"] == "density"
+    assert spec["traces"][0]["density"]["channels_dropped"] is True
+    assert "colorbar" not in spec
+
+
+def test_hexbin_and_contour_colorbars_use_compiled_domains() -> None:
+    x = np.array([-0.9, -0.8, -0.7, 0.1, 0.2, 0.3, 0.4])
+    y = np.array([-0.8, -0.7, -0.6, 0.1, 0.2, 0.3, 0.4])
+    hex_chart = xy.hexbin_chart(
+        xy.hexbin(x, y, gridsize=4, mincnt=1, colormap="magma"),
+        xy.colorbar(),
+    )
+    hex_fig = hex_chart.figure()
+    hex_spec, _ = hex_fig.build_payload()
+    hex_channel = hex_fig.traces[0].color_ch
+
+    assert hex_spec["colorbar"] == {
+        "domain": list(hex_channel.domain),
+        "colormap": "magma",
+        "label": "count",
+        "orientation": "vertical",
+    }
+
+    field = np.array(
+        [
+            [-2.0, -1.0, 0.0],
+            [-1.0, 0.0, 1.0],
+            [0.0, 1.0, 2.0],
+        ]
+    )
+    contour_chart = xy.contour_chart(
+        xy.contour(
+            field,
+            levels=[-1.5, -0.5, 0.5, 1.5],
+            filled=True,
+            name="elevation",
+            colormap="spectral",
+        ),
+        xy.colorbar(),
+    )
+    contour_spec, _ = contour_chart.figure().build_payload()
+
+    assert contour_spec["colorbar"] == {
+        "domain": [-1.5, 1.5],
+        "colormap": "spectral",
+        "label": "elevation",
+        "levels": 3,
+        "orientation": "vertical",
+    }
+
+
+def test_colorbar_uses_last_continuous_mark_and_show_false_removes_it() -> None:
+    chart = xy.chart(
+        xy.heatmap([[0.0, 1.0], [2.0, 3.0]], name="field", colormap="viridis"),
+        xy.scatter(
+            [0.0, 1.0],
+            [0.0, 1.0],
+            color=[100.0, 200.0],
+            name="quality",
+            colormap="plasma",
+        ),
+        xy.colorbar(),
+    )
+    hidden = xy.chart(
+        xy.heatmap([[0.0, 1.0], [2.0, 3.0]], colormap="viridis"),
+        xy.colorbar(show=False),
+    )
+
+    spec, _ = chart.figure().build_payload()
+    hidden_spec, _ = hidden.figure().build_payload()
+
+    assert spec["colorbar"] == {
+        "domain": [100.0, 200.0],
+        "colormap": "plasma",
+        "label": "quality",
+        "orientation": "vertical",
+    }
+    assert "colorbar" not in hidden_spec
+
+
+def test_colorbar_rejects_invalid_public_options() -> None:
+    with pytest.raises(ValueError, match="colorbar orientation"):
+        xy.colorbar(orientation="diagonal")
+    with pytest.raises(ValueError, match="colorbar orientation"):
+        xy.colorbar(orientation=["vertical"])
+    with pytest.raises(ValueError, match="colorbar ticks"):
+        xy.colorbar(ticks="0, 1")
+    with pytest.raises(ValueError, match="finite"):
+        xy.colorbar(ticks=[0.0, np.inf])
+
+
+@pytest.mark.parametrize(
+    ("node", "message"),
+    [
+        (xy.Colorbar(show="yes"), "colorbar show"),
+        (xy.Colorbar(title=42), "colorbar title"),
+        (xy.Colorbar(orientation="diagonal"), "colorbar orientation"),
+        (xy.Colorbar(ticks=[0.0, np.inf]), "colorbar tick"),
+        (xy.Colorbar(class_name=42), "colorbar class_name"),
+        (xy.Colorbar(style="color: red"), "colorbar style"),
+    ],
+)
+def test_direct_colorbar_instance_cannot_bypass_factory_validation(node, message) -> None:
+    chart = xy.heatmap_chart(
+        xy.heatmap([[0.0, 1.0], [2.0, 3.0]], colormap="viridis"),
+        node,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        chart.figure()
+
+
+def test_colorbar_uses_semantic_positional_fields_and_custom_render() -> None:
+    renderer = object()
+    node = xy.Colorbar(
+        True,
+        "Temperature",
+        "horizontal",
+        [0.0, 1.0],
+        "scale-class",
+        {"color": "red"},
+        renderer,
+    )
+
+    assert node.title == "Temperature"
+    assert node.orientation == "horizontal"
+    assert node.ticks == [0.0, 1.0]
+    assert node.class_name == "scale-class"
+    assert node.style == {"color": "red"}
+    assert node.render is renderer
+
+    custom = xy.heatmap_chart(
+        xy.heatmap([[0.0, 1.0], [2.0, 3.0]], colormap="viridis"),
+        node,
+    )
+    custom_spec, _ = custom.figure().build_payload()
+    assert "colorbar" not in custom_spec
+
+
+def test_declarative_colorbar_reaches_svg_export() -> None:
+    svg = xy.heatmap_chart(
+        xy.heatmap([[0.0, 0.5], [1.0, 1.5]], name="Intensity", colormap="purples"),
+        xy.colorbar(title="Intensity & confidence", ticks=[0.0, 1.5]),
+        width=520,
+        height=320,
+    ).to_svg()
+
+    assert '<linearGradient id="xy-colorbar-' in svg
+    assert "Intensity &amp; confidence" in svg
+    assert ">0<" in svg
+    assert ">1.5<" in svg
+
+
+def test_svg_explicit_colorbar_ticks_preserve_authored_precision() -> None:
+    svg = xy.heatmap_chart(
+        xy.heatmap([[0.0, 1.0], [2.0, 3.0]], colormap="viridis"),
+        xy.colorbar(ticks=[0.123, 2.987]),
+        width=520,
+        height=320,
+    ).to_svg()
+
+    assert ">0.123<" in svg
+    assert ">2.987<" in svg
+
+
+def _browser_colorbar_probe(chromium: str, document: str, page: Path) -> dict:
+    render_call = 'xy.renderStandalone(document.getElementById("chart"), spec, buf);'
+    assert render_call in document
+    probe = """
+  const view = xy.renderStandalone(document.getElementById("chart"), spec, buf);
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+    try {
+      const bar = document.querySelector('[data-xy-slot="colorbar_bar"]');
+      const title = document.querySelector('[data-xy-slot="colorbar_title"]');
+      const ticks = [...document.querySelectorAll('[data-xy-slot="colorbar_tick"]')];
+      document.body.setAttribute('data-xy-colorbar-probe', JSON.stringify({
+        exists: !!bar,
+        title: title && title.textContent,
+        tooltip: view._colorbar && view._colorbar.title,
+        gradient: bar && getComputedStyle(bar).backgroundImage,
+        tickLabels: ticks.map((tick) => tick.textContent),
+      }));
+    } catch (err) {
+      document.body.setAttribute(
+        'data-xy-colorbar-probe-error',
+        String((err && err.stack) || err)
+      );
+    }
+  }));
+"""
+    return run_browser_probe(
+        chromium,
+        document.replace(render_call, probe),
+        page,
+        "data-xy-colorbar-probe",
+        label="colorbar chrome probe",
+    )
+
+
+def test_declarative_colorbar_reaches_browser_chrome(tmp_path: Path) -> None:
+    chromium = find_chromium()
+    if chromium is None:
+        pytest.skip("Chromium unavailable")
+    chart = xy.heatmap_chart(
+        xy.heatmap([[0.0, 1.0], [2.0, 3.0]], name="Intensity", colormap="purples"),
+        xy.colorbar(ticks=[0.123, 2.987]),
+        width=480,
+        height=300,
+    )
+
+    result = _browser_colorbar_probe(chromium, chart.to_html(), tmp_path / "colorbar.html")
+
+    assert result["exists"] is True
+    assert result["title"] == "Intensity"
+    assert result["tooltip"] == "Intensity: 0 \u2013 3"
+    assert "linear-gradient" in result["gradient"]
+    assert result["tickLabels"] == ["0.123", "2.987"]

--- a/tests/test_facets.py
+++ b/tests/test_facets.py
@@ -249,6 +249,30 @@ def test_shared_categorical_axis_uses_union_category_order() -> None:
     assert specs[0]["x_axis"]["domain"] == specs[1]["x_axis"]["domain"]
 
 
+def test_shared_named_categorical_axis_uses_its_own_union_category_order() -> None:
+    data = {
+        "x": [1.0, 2.0, 3.0, 4.0],
+        "category": ["a", "b", "a", "c"],
+        "y": [1.0, 2.0, 3.0, 4.0],
+        "g": ["g1", "g1", "g2", "g2"],
+    }
+    grid = xy.facet_chart(
+        xy.line(x="x", y="y"),
+        xy.line(x="category", y="y", x_axis="x2"),
+        xy.x_axis(id="x2", side="top"),
+        by="g",
+        data=data,
+    ).figure()
+    specs = [fig.build_payload()[0] for fig in grid.figures]
+
+    assert all("categories" not in spec["axes"]["x"] for spec in specs)
+    assert [spec["axes"]["x2"]["categories"] for spec in specs] == [
+        ["a", "b", "c"],
+        ["a", "b", "c"],
+    ]
+    assert specs[0]["axes"]["x2"]["domain"] == specs[1]["axes"]["x2"]["domain"]
+
+
 # -- interaction linking ------------------------------------------------------
 
 

--- a/tests/test_legend_resize_regression.py
+++ b/tests/test_legend_resize_regression.py
@@ -1,14 +1,9 @@
-"""Behavioral regression: an explicit legend max-height survives a resize.
+"""Browser regressions for responsive legend and tooltip chrome.
 
-The client's responsive legend cap (`_resize`) re-applies an automatic
-`max-height` unless the author set one. The guard reads the chrome `styles`
-spec, which ships the author's *raw* key — and the Python API form is
-snake_case (`max_height`). A raw-key-only lookup missed that form, so on a
-responsive resize the automatic cap clobbered an explicit `max_height`
-(browser-verified: 50px became the plot height). The source-grep suites cannot
-see this — it only manifests in a live browser after a resize — so this test
-renders the standalone export in headless Chromium and asserts the computed
-`max-height` before *and* after a forced resize.
+The automatic legend bounds are low-priority, zero-specificity stylesheet defaults so an
+explicit component style survives resize. Narrow-chart probes additionally
+exercise long legend rows, edge tooltips, and the compact-layout origin; these
+failures only manifest after the browser computes real geometry.
 
 Skips (never fails) when no Chromium is available or the headless GL context
 can't come up, matching the repo's other browser probes.
@@ -16,15 +11,13 @@ can't come up, matching the repo's other browser probes.
 
 from __future__ import annotations
 
-import html as html_lib
-import json
-import re
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
 
 import pytest
+
+from conftest import run_browser_probe
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "python"))
@@ -79,60 +72,225 @@ _PROBE = """
 </script>
 """
 
+_OVERFLOW_PROBE = """
+<script>
+(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const raf = () => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+  try {
+    const view = window.__fcProbeView;
+    if (!view) throw new Error("no probe view captured");
+    const utilityStyle = document.createElement("style");
+    utilityStyle.textContent = `
+      @layer base, utilities;
+      @layer utilities {
+        .xy-probe-tooltip {
+          background: rgb(1 2 3);
+          color: rgb(250 251 252);
+          padding: 9px 11px;
+          border-radius: 13px;
+        }
+      }
+    `;
+    document.head.appendChild(utilityStyle);
+    const host = view.root.parentElement;
+    host.style.width = "320px";
+    host.style.height = "360px";
+    view.root.style.width = "320px";
+    view.root.style.height = "360px";
+    view.fluid = true;
+    view.fluidH = true;
+    view._resize(320, 360);
+    await raf();
 
-def _dump_dom(chromium: str, page: Path) -> str | None:
-    """One headless render pass; None on a chromium-level failure (retryable)."""
-    try:
-        proc = subprocess.run(
-            [
-                chromium,
-                "--headless=new",
-                "--no-sandbox",
-                "--disable-dev-shm-usage",
-                "--allow-file-access-from-files",
-                "--use-angle=swiftshader",
-                "--enable-unsafe-swiftshader",
-                "--hide-scrollbars",
-                "--window-size=640,480",
-                "--virtual-time-budget=8000",
-                "--dump-dom",
-                page.as_uri(),
-            ],
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
-    except subprocess.TimeoutExpired:
-        return None
-    return proc.stdout if proc.returncode == 0 else None
+    // A docs page can exceed the WebGL context budget. Exercise the same trace
+    // builder used during recovery and verify it retains the non-positional
+    // CPU channel views that rich tooltips need after the rebuild.
+    const sourceScatter = view.gpuTraces.find((g) => g.trace.id === 8);
+    const rebuiltScatter = {
+      trace: sourceScatter.trace,
+      xAxis: sourceScatter.xAxis,
+      yAxis: sourceScatter.yAxis,
+    };
+    view._buildScatterMark(rebuiltScatter, sourceScatter.trace, view._payload);
+    const colorCpuRetained = !!rebuiltScatter._cpu?.color;
+    const sizeCpuRetained = !!rebuiltScatter._cpu?.size;
+
+    const legend = document.querySelector('[data-xy-slot="legend"]');
+    if (!legend) throw new Error("legend never rendered");
+    view.canvas.focus();
+    view.canvas.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+    for (let i = 0; i < 100 && view.tooltip.style.display !== "block"; i++) {
+      await sleep(20);
+    }
+    await raf();
+    const tooltip = document.querySelector('[data-xy-slot="tooltip"]');
+    if (!tooltip || tooltip.style.display !== "block") {
+      throw new Error("keyboard tooltip never rendered");
+    }
+
+    const rootRect = view.root.getBoundingClientRect();
+    const legendRect = legend.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const tooltipStyle = getComputedStyle(tooltip);
+    const inside = (rect) =>
+      rect.left >= rootRect.left - 1 && rect.right <= rootRect.right + 1 &&
+      rect.top >= rootRect.top - 1 && rect.bottom <= rootRect.bottom + 1;
+    document.body.setAttribute("data-xy-chrome-overflow", JSON.stringify({
+      rootWidth: rootRect.width,
+      legendWithinRoot: inside(legendRect),
+      legendCenterError: Math.abs(
+        (legendRect.left + legendRect.right) / 2 -
+        (rootRect.left + view.plot.x + view.plot.w / 2)
+      ),
+      legendHasOverflow: legend.scrollWidth > legend.clientWidth || legend.scrollHeight > legend.clientHeight,
+      legendMaxWidth: getComputedStyle(legend).maxWidth,
+      canvasLeftError: Math.abs(
+        view.canvas.getBoundingClientRect().left - (rootRect.left + view.plot.x)
+      ),
+      canvasTopError: Math.abs(
+        view.canvas.getBoundingClientRect().top - (rootRect.top + view.plot.y)
+      ),
+      colorCpuRetained,
+      sizeCpuRetained,
+      tooltipWithinRoot: inside(tooltipRect),
+      tooltipWidth: tooltipRect.width,
+      tooltipText: tooltip.textContent,
+      tooltipBackground: tooltipStyle.backgroundColor,
+      tooltipColor: tooltipStyle.color,
+      tooltipPadding: tooltipStyle.padding,
+      tooltipRadius: tooltipStyle.borderRadius,
+    }));
+  } catch (err) {
+    document.body.setAttribute(
+      "data-xy-chrome-overflow-error",
+      String((err && err.stack) || err)
+    );
+  }
+})();
+</script>
+"""
+
+_AXIS_CATEGORY_PROBE = """
+<script>
+(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const raf = () => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+  try {
+    const view = window.__fcProbeView;
+    if (!view) throw new Error("no probe view captured");
+    let ticks = [];
+    for (let i = 0; i < 200; i++) {
+      ticks = [...document.querySelectorAll('[data-xy-label-kind="tick"]')];
+      if (
+        ticks.some((node) => node.dataset.xyAxis === "x") &&
+        ticks.some((node) => node.dataset.xyAxis === "x2")
+      ) break;
+      await sleep(25);
+    }
+    await raf();
+    ticks = [...document.querySelectorAll('[data-xy-label-kind="tick"]')];
+    const read = (axisId) => {
+      const axis = view.axes[axisId];
+      if (!axis) throw new Error(`missing ${axisId} axis`);
+      return {
+        kind: axis.kind,
+        categories: Array.from(axis.categories || []),
+        labels: ticks
+          .filter((node) => node.dataset.xyAxis === axisId)
+          .map((node) => node.textContent),
+      };
+    };
+    document.body.setAttribute(
+      "data-xy-axis-categories",
+      JSON.stringify({ x: read("x"), x2: read("x2") })
+    );
+  } catch (err) {
+    document.body.setAttribute(
+      "data-xy-axis-categories-error",
+      String((err && err.stack) || err)
+    );
+  }
+})();
+</script>
+"""
+
+_ANNOTATION_ALIGNMENT_PROBE = """
+<script>
+(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const raf = () => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+  try {
+    const view = window.__fcProbeView;
+    if (!view) throw new Error("no probe view captured");
+    let labels = [];
+    for (let i = 0; i < 200; i++) {
+      labels = [...document.querySelectorAll('[data-xy-slot="annotation_label"]')];
+      if (labels.length >= 2) break;
+      await sleep(25);
+    }
+    await raf();
+    const findLabel = (text) => labels.find((label) => label.textContent === text);
+    const band = findLabel("band-center");
+    const arrow = findLabel("arrow-center");
+    if (!band || !arrow) throw new Error("annotation labels never rendered");
+    const root = view.root.getBoundingClientRect();
+    const centerX = (element) => {
+      const rect = element.getBoundingClientRect();
+      return (rect.left + rect.right) / 2;
+    };
+    const bandExpected = root.left + (view._dataPxX(2) + view._dataPxX(4)) / 2;
+    const arrowExpected = root.left + (view._dataPxX(0) + view._dataPxX(2)) / 2;
+    document.body.setAttribute(
+      "data-xy-annotation-alignment",
+      JSON.stringify({
+        bandCenterError: Math.abs(centerX(band) - bandExpected),
+        arrowCenterError: Math.abs(centerX(arrow) - arrowExpected),
+        bandTransform: band.style.transform,
+        arrowTransform: arrow.style.transform,
+      })
+    );
+  } catch (err) {
+    document.body.setAttribute(
+      "data-xy-annotation-alignment-error",
+      String((err && err.stack) || err)
+    );
+  }
+})();
+</script>
+"""
 
 
-def _probe_maxheight(chromium: str, document: str, page: Path) -> dict | None:
-    """Render + probe with retries. Returns the parsed result payload, or None
-    if every attempt hit an environmental miss (no DOM / GL error / no result).
+def _probe_maxheight(chromium: str, document: str, page: Path) -> dict:
+    """Render + probe the legend max-height across a responsive resize."""
+    return run_browser_probe(
+        chromium, document, page, "data-xy-legend-maxheight", label="legend resize probe"
+    )
 
-    Headless probes on shared runners have transient warm-up misses (virtual
-    time / GL init) that a relaunch clears; a genuine regression fails every
-    attempt with a *value* mismatch, which we surface — never retry away.
-    """
-    page.write_text(document, encoding="utf-8")
-    last: str | None = None
-    for _ in range(3):
-        dom = _dump_dom(chromium, page)
-        if dom is None:
-            continue
-        error = re.search(r'data-xy-legend-maxheight-error="([^"]*)"', dom)
-        if error:
-            last = f"probe error: {html_lib.unescape(error.group(1))}"
-            continue
-        match = re.search(r'data-xy-legend-maxheight="([^"]*)"', dom)
-        if match:
-            return json.loads(html_lib.unescape(match.group(1)))
-        last = "probe did not finish (no result attribute)"
-    if last:
-        pytest.skip(f"legend resize probe could not run after retries: {last}")
-    pytest.skip("headless chromium unavailable/failed after retries")
-    return None  # unreachable; keeps type-checkers happy
+
+def _probe_overflow(chromium: str, document: str, page: Path) -> dict:
+    """Render the narrow chrome stress case and read its DOM bounds."""
+    return run_browser_probe(
+        chromium, document, page, "data-xy-chrome-overflow", label="chrome overflow probe"
+    )
+
+
+def _probe_axis_categories(chromium: str, document: str, page: Path) -> dict:
+    """Render mixed primary/named scales and read their normalized state + labels."""
+    return run_browser_probe(
+        chromium, document, page, "data-xy-axis-categories", label="axis category probe"
+    )
+
+
+def _probe_annotation_alignment(chromium: str, document: str, page: Path) -> dict:
+    """Render annotation labels and compare their DOM centers with geometry."""
+    return run_browser_probe(
+        chromium,
+        document,
+        page,
+        "data-xy-annotation-alignment",
+        label="annotation alignment probe",
+    )
 
 
 def test_snake_case_legend_max_height_survives_resize() -> None:
@@ -170,3 +328,218 @@ def test_snake_case_legend_max_height_survives_resize() -> None:
     assert payload["afterResize"] == "50px", (
         f"resize clobbered the explicit snake_case max_height: {payload}"
     )
+
+
+def test_long_legend_and_edge_tooltip_stay_inside_narrow_chart() -> None:
+    chromium = find_chromium()
+    if not chromium:
+        pytest.skip("no chromium available for the chrome overflow probe")
+
+    colors = (
+        "#2563eb",
+        "#7c3aed",
+        "#db2777",
+        "#ea580c",
+        "#0f766e",
+        "#0891b2",
+        "#4f46e5",
+        "#be123c",
+    )
+    children = [
+        xy.line(
+            [0, 1, 2],
+            [2 + index * 0.35, 4 + index * 0.2, 1.5 + index * 0.25],
+            name=f"Service {index + 1}: reconciliation and settlement pipeline",
+            color=color,
+        )
+        for index, color in enumerate(colors)
+    ]
+    data = {
+        "sample": [0, 1, 2],
+        "latency_ms": [8.0, 5.0, 1.0],
+        "service_tier": [
+            "edge",
+            "core",
+            "critical-payments-reconciliation-with-extra-long-label",
+        ],
+        "requests_per_minute": [1_200, 4_800, 12_400],
+    }
+    children.append(
+        xy.scatter(
+            x="sample",
+            y="latency_ms",
+            color="service_tier",
+            size="requests_per_minute",
+            data=data,
+            name="Interactive incident samples with resident tooltip fields",
+        )
+    )
+    chart = xy.chart(
+        *children,
+        xy.legend(loc="upper center", ncols=2, title="Long operational series"),
+        xy.tooltip(
+            fields=["sample", "latency_ms", "service_tier", "requests_per_minute"],
+            title="{service_tier}",
+            format={"latency_ms": ".1f", "requests_per_minute": ",.0f"},
+        ),
+        xy.interaction_config(
+            hover=True,
+            click=True,
+            crosshair=True,
+            select=True,
+            brush=True,
+            view_change=True,
+        ),
+        class_names={"tooltip": "xy-probe-tooltip"},
+        width="100%",
+        height=360,
+    )
+
+    document = chart.to_html()
+    render_call = next((call for call in _RENDER_CALLS if call in document), None)
+    assert render_call is not None
+    document = document.replace(
+        render_call,
+        render_call.replace(
+            "xy.renderStandalone(", "window.__fcProbeView = xy.renderStandalone(", 1
+        ),
+        1,
+    )
+    document = document.replace("</body>", _OVERFLOW_PROBE + "\n</body>", 1)
+
+    with tempfile.TemporaryDirectory() as td:
+        payload = _probe_overflow(chromium, document, Path(td) / "chrome_overflow.html")
+
+    assert payload["rootWidth"] == pytest.approx(320, abs=1), payload
+    assert payload["legendWithinRoot"] is True, payload
+    assert payload["legendCenterError"] <= 1, payload
+    assert payload["legendHasOverflow"] is True, payload
+    assert payload["legendMaxWidth"].endswith("px"), payload
+    assert payload["canvasLeftError"] <= 1, payload
+    assert payload["canvasTopError"] <= 1, payload
+    assert payload["colorCpuRetained"] is True, payload
+    assert payload["sizeCpuRetained"] is True, payload
+    assert payload["tooltipWithinRoot"] is True, payload
+    assert payload["tooltipWidth"] <= 312, payload
+    assert "critical-payments-reconciliation" in payload["tooltipText"], payload
+    assert payload["tooltipBackground"] == "rgb(1, 2, 3)", payload
+    assert payload["tooltipColor"] == "rgb(250, 251, 252)", payload
+    assert payload["tooltipPadding"] == "9px 11px", payload
+    assert payload["tooltipRadius"] == "13px", payload
+
+
+def test_midpoint_annotation_labels_are_visually_centered() -> None:
+    chromium = find_chromium()
+    if not chromium:
+        pytest.skip("no chromium available for the annotation alignment probe")
+
+    chart = xy.chart(
+        xy.line([0, 1, 2, 3, 4], [0, 1, 2, 3, 4]),
+        xy.x_band(2, 4, text="band-center"),
+        xy.arrow(0, 0, 2, 2, text="arrow-center"),
+        xy.x_axis(domain=(-0.5, 4.5)),
+        xy.y_axis(domain=(-0.5, 4.5)),
+        width=520,
+        height=320,
+    )
+
+    document = chart.to_html()
+    render_call = next((call for call in _RENDER_CALLS if call in document), None)
+    assert render_call is not None
+    document = document.replace(
+        render_call,
+        render_call.replace(
+            "xy.renderStandalone(", "window.__fcProbeView = xy.renderStandalone(", 1
+        ),
+        1,
+    )
+    document = document.replace("</body>", _ANNOTATION_ALIGNMENT_PROBE + "\n</body>", 1)
+
+    with tempfile.TemporaryDirectory() as td:
+        payload = _probe_annotation_alignment(
+            chromium,
+            document,
+            Path(td) / "annotation_alignment.html",
+        )
+
+    assert payload["bandCenterError"] <= 1, payload
+    assert payload["arrowCenterError"] <= 1, payload
+    assert "-50%" in payload["bandTransform"], payload
+    assert "-50%" in payload["arrowTransform"], payload
+
+
+@pytest.mark.parametrize(
+    "primary_is_category",
+    [True, False],
+    ids=["primary-category-named-linear", "primary-linear-named-category"],
+)
+def test_browser_named_axis_category_state_and_tick_chrome_are_independent(
+    primary_is_category: bool,
+) -> None:
+    chromium = find_chromium()
+    if not chromium:
+        pytest.skip("no chromium available for the named-axis category probe")
+
+    if primary_is_category:
+        chart = xy.chart(
+            xy.line(["Alpha", "Beta", "Gamma"], [1.0, 2.0, 3.0]),
+            xy.line([100.0, 200.0, 300.0], [3.0, 2.0, 1.0], x_axis="x2"),
+            xy.x_axis(tick_label_strategy="rotate"),
+            xy.x_axis(
+                id="x2",
+                side="top",
+                type_="linear",
+                tick_values=(100.0, 200.0, 300.0),
+                tick_labels=("N100", "N200", "N300"),
+                tick_label_strategy="rotate",
+            ),
+            width=560,
+            height=300,
+        )
+        expected = {
+            "x": {
+                "kind": "category",
+                "categories": ["Alpha", "Beta", "Gamma"],
+                "labels": ["Alpha", "Beta", "Gamma"],
+            },
+            "x2": {"kind": "linear", "categories": [], "labels": ["N100", "N200", "N300"]},
+        }
+    else:
+        chart = xy.chart(
+            xy.line([10.0, 20.0, 30.0], [1.0, 2.0, 3.0]),
+            xy.line(["Red", "Green", "Blue"], [3.0, 2.0, 1.0], x_axis="x2"),
+            xy.x_axis(
+                type_="linear",
+                tick_values=(10.0, 20.0, 30.0),
+                tick_labels=("P10", "P20", "P30"),
+                tick_label_strategy="rotate",
+            ),
+            xy.x_axis(id="x2", side="top", tick_label_strategy="rotate"),
+            width=560,
+            height=300,
+        )
+        expected = {
+            "x": {"kind": "linear", "categories": [], "labels": ["P10", "P20", "P30"]},
+            "x2": {
+                "kind": "category",
+                "categories": ["Red", "Green", "Blue"],
+                "labels": ["Red", "Green", "Blue"],
+            },
+        }
+
+    document = chart.to_html()
+    render_call = next((call for call in _RENDER_CALLS if call in document), None)
+    assert render_call is not None
+    document = document.replace(
+        render_call,
+        render_call.replace(
+            "xy.renderStandalone(", "window.__fcProbeView = xy.renderStandalone(", 1
+        ),
+        1,
+    )
+    document = document.replace("</body>", _AXIS_CATEGORY_PROBE + "\n</body>", 1)
+
+    with tempfile.TemporaryDirectory() as td:
+        payload = _probe_axis_categories(chromium, document, Path(td) / "axis_categories.html")
+
+    assert payload == expected

--- a/tests/test_png_export.py
+++ b/tests/test_png_export.py
@@ -10,6 +10,7 @@ import zlib
 
 import numpy as np
 
+import xy
 from xy import _png, _raster
 from xy._figure import Figure
 
@@ -96,6 +97,19 @@ def _decode_rgba(png: bytes) -> np.ndarray:
             destination += 4
         previous = row
     return np.frombuffer(decoded, dtype=np.uint8).reshape(height, width, 4)
+
+
+def _record_text(monkeypatch) -> list[tuple[float, float, int, float, str]]:
+    """Capture every native text command as (x, y, anchor_flags, size, text)."""
+    recorded: list[tuple[float, float, int, float, str]] = []
+    original_text = _raster._Cmd.text
+
+    def record_text(self, x, y, anchor, size, color, value):
+        recorded.append((float(x), float(y), int(anchor), float(size), str(value)))
+        return original_text(self, x, y, anchor, size, color, value)
+
+    monkeypatch.setattr(_raster._Cmd, "text", record_text)
+    return recorded
 
 
 def test_every_chart_kind_exports_valid_png() -> None:
@@ -252,6 +266,244 @@ def test_native_and_svg_share_layout() -> None:
     assert plot["w"] > 0 and plot["h"] > 0
     xt, _lab, _step = _svg.axis_ticks(spec["x_axis"], plot["w"], True)
     assert len(xt) >= 2  # shared tick math produces ticks both engines label
+
+
+def test_native_long_legend_is_clamped_and_ellipsized_inside_plot(monkeypatch) -> None:
+    from xy import _svg
+
+    names = [f"series-{index}-" + "very-long-operational-label-" * 2 for index in range(4)]
+    chart = xy.line_chart(
+        *(
+            xy.line([0.0, 1.0], [float(index), float(index + 1)], name=name)
+            for index, name in enumerate(names)
+        ),
+        xy.legend(
+            loc="upper right",
+            ncols=2,
+            title="Long operational series",
+            style={"background": "#ff00ff", "--xy-legend-frame-alpha": 1},
+        ),
+        width=320,
+        height=260,
+    )
+    spec, blob = chart.figure().build_payload()
+    _width, _height, _compact, plot = _svg.layout(spec)
+    recorded = _record_text(monkeypatch)
+    image = _raster.render_raster(spec, blob, scale=1)
+    rendered_text = [entry[4] for entry in recorded]
+
+    magenta = np.all(image[:, :, :3] == np.array([255, 0, 255], dtype=np.uint8), axis=2)
+    rows, columns = np.where(magenta)
+    assert len(columns) > 0
+    assert columns.min() >= int(plot["x"])
+    assert columns.max() <= int(plot["x"] + plot["w"])
+    assert rows.min() >= int(plot["y"])
+    assert rows.max() <= int(plot["y"] + plot["h"])
+    assert all(name not in rendered_text for name in names)
+    assert any(text.endswith("...") for text in rendered_text)
+
+
+def test_native_secondary_y_axis_scales_trace_and_renders_right_chrome() -> None:
+    from xy import _svg
+
+    chart = xy.chart(
+        xy.line([0.0, 1.0], [0.0, 1.0], color="#2563eb", width=3),
+        xy.line(
+            [0.0, 1.0],
+            [100.0, 200.0],
+            color="#dc2626",
+            width=3,
+            y_axis="y2",
+        ),
+        xy.y_axis(label="Primary"),
+        xy.y_axis(
+            id="y2",
+            label="Secondary",
+            side="right",
+            domain=(100.0, 200.0),
+            tick_values=(100.0, 150.0, 200.0),
+            style={
+                "axis_color": "#dc2626",
+                "axis_width": 2,
+                "tick_color": "#dc2626",
+                "tick_label_color": "#dc2626",
+                "label_color": "#dc2626",
+                "tick_length": 5,
+                "tick_width": 2,
+            },
+        ),
+        width=400,
+        height=240,
+    )
+    spec, blob = chart.figure().build_payload()
+    width, _height, _compact, plot = _svg.layout(spec)
+    image = _raster.render_raster(spec, blob, scale=1)
+
+    red = (
+        (image[:, :, 0] > 180)
+        & (image[:, :, 1] < 100)
+        & (image[:, :, 2] < 100)
+        & (image[:, :, 3] > 0)
+    )
+    x0, x1 = int(plot["x"]), int(plot["x"] + plot["w"])
+    y0, y1 = int(plot["y"]), int(plot["y"] + plot["h"])
+    assert int(red[y0 + 2 : y1 - 2, x0 + 2 : x1 - 2].sum()) > 20
+    assert int(red[y0:y1, x1 + 1 : width].sum()) > 20
+
+
+def test_native_secondary_x_axis_scales_trace_and_renders_top_chrome() -> None:
+    from xy import _svg
+
+    chart = xy.chart(
+        xy.line([0.0, 1.0], [0.0, 1.0], color="#2563eb", width=3),
+        xy.line(
+            [100.0, 200.0],
+            [0.2, 0.8],
+            color="#dc2626",
+            width=3,
+            x_axis="x2",
+        ),
+        xy.x_axis(label="Primary X"),
+        xy.x_axis(
+            id="x2",
+            label="Secondary X",
+            side="top",
+            domain=(100.0, 200.0),
+            tick_values=(100.0, 150.0, 200.0),
+            style={
+                "axis_color": "#dc2626",
+                "axis_width": 2,
+                "tick_color": "#dc2626",
+                "tick_label_color": "#dc2626",
+                "label_color": "#dc2626",
+                "tick_length": 5,
+                "tick_width": 2,
+            },
+        ),
+        width=400,
+        height=240,
+    )
+    spec, blob = chart.figure().build_payload()
+    _width, _height, _compact, plot = _svg.layout(spec)
+    image = _raster.render_raster(spec, blob, scale=1)
+
+    red = (
+        (image[:, :, 0] > 180)
+        & (image[:, :, 1] < 100)
+        & (image[:, :, 2] < 100)
+        & (image[:, :, 3] > 0)
+    )
+    x0, x1 = int(plot["x"]), int(plot["x"] + plot["w"])
+    y0, y1 = int(plot["y"]), int(plot["y"] + plot["h"])
+    assert int(red[y0 + 2 : y1 - 2, x0 + 2 : x1 - 2].sum()) > 20
+    assert int(red[:y0, x0:x1].sum()) > 20
+
+
+def test_native_mixed_primary_and_named_x_axis_kinds_render_independently(monkeypatch) -> None:
+    cases = (
+        (
+            xy.chart(
+                xy.line(["Primary Alpha", "Primary Beta", "Primary Gamma"], [1.0, 2.0, 3.0]),
+                xy.line([100.0, 200.0, 300.0], [3.0, 2.0, 1.0], x_axis="x2"),
+                xy.x_axis(tick_label_strategy="rotate"),
+                xy.x_axis(
+                    id="x2",
+                    side="top",
+                    type_="linear",
+                    tick_values=(100.0, 200.0, 300.0),
+                    tick_labels=("N100", "N200", "N300"),
+                    tick_label_strategy="rotate",
+                ),
+                width=560,
+                height=300,
+            ),
+            {"Primary Alpha", "Primary Gamma", "N100", "N300"},
+        ),
+        (
+            xy.chart(
+                xy.line([10.0, 20.0, 30.0], [1.0, 2.0, 3.0]),
+                xy.line(["Named Red", "Named Green", "Named Blue"], [3.0, 2.0, 1.0], x_axis="x2"),
+                xy.x_axis(
+                    type_="linear",
+                    tick_values=(10.0, 20.0, 30.0),
+                    tick_labels=("P10", "P20", "P30"),
+                    tick_label_strategy="rotate",
+                ),
+                xy.x_axis(id="x2", side="top", tick_label_strategy="rotate"),
+                width=560,
+                height=300,
+            ),
+            {"P10", "P30", "Named Red", "Named Blue"},
+        ),
+    )
+    recorded = _record_text(monkeypatch)
+    for chart, expected_labels in cases:
+        recorded.clear()
+        spec, blob = chart.figure().build_payload()
+        _raster.render_raster(spec, blob, scale=1)
+        assert expected_labels <= {entry[4] for entry in recorded}
+
+
+def test_native_named_axis_collision_and_title_placement_controls(monkeypatch) -> None:
+    from xy import _svg
+
+    values = list(range(30))
+    tick_labels = [f"very-long-native-label-{value}" for value in values]
+    chart = xy.chart(
+        xy.line(values, values, x_axis="x2"),
+        xy.x_axis(
+            id="x2",
+            side="top",
+            label="Native positioned title",
+            label_position="inside_end",
+            label_offset=6,
+            label_angle=90,
+            domain=(0.0, 29.0),
+            tick_values=values,
+            tick_labels=tick_labels,
+            tick_label_strategy="hide",
+        ),
+        width=400,
+        height=240,
+    )
+    spec, blob = chart.figure().build_payload()
+    _width, _height, _compact, plot = _svg.layout(spec)
+    recorded = _record_text(monkeypatch)
+    _raster.render_raster(spec, blob, scale=1)
+
+    visible_ticks = [entry for entry in recorded if entry[4] in tick_labels]
+    assert 0 < len(visible_ticks) < len(tick_labels)
+    title_x, title_y, title_anchor, _size, _text = next(
+        entry for entry in recorded if entry[4] == "Native positioned title"
+    )
+    assert title_x == plot["x"] + plot["w"]
+    assert plot["y"] < title_y < plot["y"] + plot["h"]
+    assert title_anchor == 2 | _raster._TEXT_ROT_CW
+
+
+def test_native_diagonal_tick_angle_keeps_all_labels_when_they_fit(monkeypatch) -> None:
+    # The native glyph protocol only rotates in quarter-turns, so a diagonal
+    # tick_label_angle falls back to horizontal strategy="hide" — which must
+    # only downsample on a real collision, not unconditionally.
+    tick_values = [0.0, 25.0, 50.0, 75.0, 100.0]
+    tick_labels = ["t0", "t25", "t50", "t75", "t100"]
+    chart = xy.chart(
+        xy.line([0.0, 100.0], [0.0, 1.0]),
+        xy.x_axis(
+            domain=(0.0, 100.0),
+            tick_values=tick_values,
+            tick_labels=tick_labels,
+            tick_label_angle=45,
+        ),
+        width=560,
+        height=300,
+    )
+    spec, blob = chart.figure().build_payload()
+    recorded = _record_text(monkeypatch)
+    _raster.render_raster(spec, blob, scale=1)
+
+    rendered = {entry[4] for entry in recorded}
+    assert set(tick_labels) <= rendered
 
 
 def test_native_smooth_stroke_matches_reference_polyline() -> None:

--- a/tests/test_static_client_security.py
+++ b/tests/test_static_client_security.py
@@ -459,6 +459,19 @@ def test_client_refreshes_and_destroys_density_sample_overlays() -> None:
         assert "view._applyDensitySample(g, d.sample, buffers);" in text
 
 
+def test_client_refreshes_theme_when_framework_theme_classes_change() -> None:
+    """Keep canvas paint synchronized with class-driven light/dark themes."""
+    required = (
+        "new MutationObserver(() => this.refreshTheme())",
+        'attributeFilter: ["class", "style"]',
+        "this._themeMutationObserver?.disconnect();",
+    )
+
+    for path, text in CLIENT_FILES:
+        for marker in required:
+            assert marker in text, f"{path} lost class-driven theme refresh {marker!r}"
+
+
 def test_client_lod_layer_stays_chart_agnostic_and_renderer_delegated() -> None:
     source_lod = (ROOT / "js/src/45_lod.js").read_text(encoding="utf-8")
     assert "trace.kind" not in source_lod

--- a/tests/test_static_client_security.py
+++ b/tests/test_static_client_security.py
@@ -33,7 +33,7 @@ THEME_FILES = (("js/src/20_theme.js", _read(ROOT / "js/src/20_theme.js")), _INDE
 
 
 def test_chrome_visual_defaults_are_a_defeatable_where_stylesheet() -> None:
-    """Themeable chrome styling lives in a zero-specificity :where() stylesheet
+    """Chrome styling lives in a layered, zero-specificity :where() stylesheet
     so user class_names / styles always win (the CSS+Tailwind contract).
     Every chrome slot's visual defaults + --chart-* token must be present, and
     the elements must carry only structural inline styles (no inline
@@ -68,6 +68,9 @@ def test_chrome_visual_defaults_are_a_defeatable_where_stylesheet() -> None:
         "--chart-badge-text",
     )
     for path, text in THEME_FILES:
+        assert "@layer base{" in text, (
+            f"{path} leaves XY defaults unlayered, which outranks Tailwind utilities"
+        )
         for rule in where_rules:
             assert rule in text, f"{path} missing defeatable chrome rule {rule!r}"
         for token in tokens:
@@ -113,11 +116,35 @@ def test_client_user_text_surfaces_use_text_nodes_not_html() -> None:
             'grip.innerHTML = this._icon("drag");',
             "b.innerHTML = this._icon(name);",
             'zoomIndicator.innerHTML = this._icon("chevrondown");',
+            'selectModeIcon.innerHTML = this._icon("select");',
             'selectIndicator.innerHTML = this._icon("chevrondown");',
             "icon.innerHTML = this._icon(name);",
             "icon.innerHTML = this._icon(name);",
             "icon.innerHTML = this._icon(name);",
+            "this._selectMenuIcon.innerHTML = this._icon(iconName);",
         ]
+
+
+def test_selection_mode_icons_are_crisp_and_the_trigger_tracks_active_mode() -> None:
+    """Selection glyphs avoid tiny dashed paths and expose the chosen gesture."""
+    required = (
+        'selectModeIcon.dataset.xyModebarSelectIcon = "";',
+        "this._selectMenuIcon.innerHTML = this._icon(iconName);",
+        'select: ["select", "Box Select"]',
+        '"select-lasso": ["lasso", "Lasso Select"]',
+        '"select-x": ["selectx", "X Range"]',
+        '"select-y": ["selecty", "Y Range"]',
+    )
+    for path, text in CLIENT_FILES:
+        for snippet in required:
+            assert snippet in text, f"{path} no longer reflects the active selection mode"
+        assert 'stroke-dasharray="2.5 2"' not in text, (
+            f"{path} restored fractional dashed selection glyphs that blur at toolbar size"
+        )
+
+    for path, text in THEME_FILES:
+        assert "min-width:42px" in text, f"{path} crowds the selection icon and chevron"
+        assert "[data-xy-modebar-select-icon]" in text, path
 
 
 def test_modebar_exports_are_local_and_exclude_interaction_chrome() -> None:
@@ -136,26 +163,34 @@ def test_modebar_exports_are_local_and_exclude_interaction_chrome() -> None:
             assert snippet in text, f"{path} missing toolbar export contract {snippet!r}"
 
 
-def test_client_respects_user_legend_max_height_style() -> None:
-    """The responsive legend cap must not overwrite explicit component styles.
+def test_pointer_capture_tolerates_synthetic_accessibility_clicks() -> None:
+    """Keyboard/automation focus clicks must not abort interaction setup.
 
-    _slotStyleValue canonicalizes the stored key, so a single canonical-name
-    guard honors snake_case (`max_height`, the Python API form), camelCase, and
-    kebab alike. A raw-key-only lookup let the snake_case form slip past the
-    guard, so the auto-cap clobbered it on resize (browser-verified 50px → plot
-    height)."""
-    required_guards = (
-        'this._slotStyleValue("legend", "max-height") == null',
-        # the canonical-name match inside _slotStyleValue is what makes the guard
-        # snake_case-aware — its removal would reintroduce the resize regression.
-        "if (this._stylePropertyName(key) === want) return style[key];",
-    )
-
+    Browsers can reject pointer capture for synthetic pointer events. Every
+    capture site therefore needs to degrade cleanly instead of surfacing an
+    uncaught ``InvalidStateError`` through the host framework.
+    """
     for path, text in CLIENT_FILES:
-        for guard in required_guards:
-            assert guard in text, f"{path} no longer preserves explicit legend max-height"
-        assert 'this._slotStyleValue("legend", "maxHeight")' not in text, (
-            f"{path} still uses the old raw-key double guard; _slotStyleValue now normalizes"
+        capture_lines = [
+            line.strip() for line in text.splitlines() if ".setPointerCapture(" in line
+        ]
+        assert len(capture_lines) == 4, f"{path} has an unexpected capture site"
+        assert all(line.startswith("try {") and "catch (_err)" in line for line in capture_lines), (
+            f"{path} leaves pointer capture unguarded for synthetic events"
+        )
+
+
+def test_exact_kernel_pick_preserves_shared_tooltip_fields() -> None:
+    """Exact pick replies must retain fields resident on sibling layers."""
+    required = (
+        '} else if (msg.type === "pick_result") {',
+        "this._applySharedTooltipFields(msg.row);",
+        "this._lastRow = msg.row;",
+    )
+    for path, text in CLIENT_FILES:
+        positions = [text.index(snippet) for snippet in required]
+        assert positions == sorted(positions), (
+            f"{path} no longer rehydrates a precise tooltip before rendering it"
         )
 
 
@@ -190,7 +225,7 @@ def test_client_numeric_styles_default_to_pixels_for_lengths() -> None:
 
 
 def test_client_selection_band_paint_is_a_defeatable_stylesheet_default() -> None:
-    """The box-select/zoom band must paint via the zero-specificity :where()
+    """The box-select/zoom band must paint via the layered :where()
     stylesheet (keyed on data-xy-band), never inline — otherwise a
     `class_names={"selection": …}` utility or `styles[selection]` would lose to
     the inline style, the one slot that breaks the "your styles always win"
@@ -575,7 +610,7 @@ def test_widget_bundle_is_valid_esm_not_leaking_marker_prose() -> None:
 
 def test_annotation_labels_and_cursor_stay_css_defeatable() -> None:
     """Annotation labels (DOM) and the interaction cursor must be overridable by
-    user CSS/Tailwind: the slot + font + cursor defaults live in the zero-
+    user CSS/Tailwind: the slot + font + cursor defaults live in the layered zero-
     specificity :where() stylesheet, never as inline styles that beat classes."""
     for path, text in CLIENT_FILES:
         assert '_applySlot(d, "annotation_label")' in text, (
@@ -589,6 +624,11 @@ def test_annotation_labels_and_cursor_stay_css_defeatable() -> None:
         "annotation label pins font inline; move it to the :where() stylesheet"
     )
     assert "if (style && (style.label_color || style.color)) {" in annotations
+    assert '"opacity",' in annotations
+    assert '"label_opacity",' in annotations
+    assert 'if (key === "opacity" && ann.kind === "text") {' in annotations
+    assert "if (style && style.label_opacity !== undefined) {" in annotations
+    assert "d.style.opacity = String(Math.max(0, Math.min(1, labelOpacity)));" in annotations
 
     # Cursor is attribute-driven, never inline (inline cursor beats cursor-* utils).
     chartview = _read(ROOT / "js/src/50_chartview.js")
@@ -678,7 +718,31 @@ def test_client_supports_edge_to_edge_sparklines() -> None:
     # padding override feeds _layout's margins
     assert "Array.isArray(this.spec.padding) ? this.spec.padding : null" in src
     assert "marginLeft = pad ? pad[3]" in src
-    # "none" returns an empty label set (previously returned all labels unlaid-out)
-    assert 'if (strategy === "none") return [];' in src
+    # "none" returns an empty label set even when the axis has only one tick.
+    assert 'if (strategyValue === "none" || strategyValue === "off") return [];' in src
+    assert "if (s.x_axis.label && !hideX)" in src
+    assert "if (s.y_axis.label && !hideY)" in src
     for path, text in CLIENT_FILES:
-        assert 'if (strategy === "none") return [];' in text, f"{path} lost none-hides-labels"
+        assert 'if (strategyValue === "none" || strategyValue === "off") return [];' in text, (
+            f"{path} lost none-hides-labels"
+        )
+
+
+def test_client_named_axes_handle_silent_gutters_and_reversed_ticks() -> None:
+    """Silent secondary chrome must not shrink the plot, and explicit ticks
+    remain valid when a named scale's range is reversed."""
+    required = (
+        'this._axisTickLabelStrategy(axis) !== "none"',
+        "const a = Math.min(lo, hi), b = Math.max(lo, hi);",
+        "v >= a && v <= b",
+    )
+    for path, text in CLIENT_FILES:
+        for marker in required:
+            assert marker in text, f"{path} lost named-axis range/layout guard {marker!r}"
+
+        label_layout = text.split("_layoutTickLabels(axis, dim, labels)", 1)[1].split(
+            "_axisLabelCss(axis, dim, fallbackCss)", 1
+        )[0]
+        assert label_layout.index("strategyValue") < label_layout.index("labels.length <= 1"), (
+            f"{path} lets a single label bypass tick_label_strategy='none'"
+        )

--- a/tests/test_svg_export.py
+++ b/tests/test_svg_export.py
@@ -99,6 +99,34 @@ def test_svg_styling_fidelity_markers() -> None:
     assert ">styled<" in svg
 
 
+def test_svg_transparent_gradient_stops_preserve_adjacent_hues() -> None:
+    fade = (
+        Figure()
+        .area(
+            [0.0, 1.0],
+            [1.0, 2.0],
+            color="#a78bfa",
+            fill="linear-gradient(currentColor, transparent)",
+        )
+        .to_svg()
+    )
+    assert 'stop-color="#a78bfa" stop-opacity="0"' in fade
+    assert 'stop-color="transparent"' not in fade
+
+    split = (
+        Figure()
+        .bar(
+            [0.0, 1.0],
+            [1.0, 2.0],
+            fill="linear-gradient(#ff0000, transparent 50%, #0000ff)",
+        )
+        .to_svg()
+    )
+    assert split.count('offset="50%"') == 2
+    assert 'offset="50%" stop-color="#ff0000" stop-opacity="0"' in split
+    assert 'offset="50%" stop-color="#0000ff" stop-opacity="0"' in split
+
+
 def test_svg_axes_chrome_and_hiding() -> None:
     fig = Figure(title="t", x_label="xx", y_label="yy")
     fig.line([0.0, 1.0], [0.0, 1.0], name="n")

--- a/tests/test_svg_export.py
+++ b/tests/test_svg_export.py
@@ -9,6 +9,7 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 import xy
 from xy._figure import Figure
@@ -112,6 +113,385 @@ def test_svg_axes_chrome_and_hiding() -> None:
     sparse = spark.to_svg()
     assert 'text-anchor="end"' not in sparse  # no y tick labels
     assert 'text-anchor="middle">' not in sparse  # no x tick labels / titles
+
+
+def test_svg_long_legend_is_clamped_and_ellipsized_inside_plot() -> None:
+    from xy import _svg
+
+    names = [f"series-{index}-" + "very-long-operational-label-" * 2 for index in range(4)]
+    chart = xy.line_chart(
+        *(
+            xy.line([0.0, 1.0], [float(index), float(index + 1)], name=name)
+            for index, name in enumerate(names)
+        ),
+        xy.legend(
+            loc="upper right",
+            ncols=2,
+            title="Long operational series",
+            style={"background": "#ff00ff", "--xy-legend-frame-alpha": 1},
+        ),
+        width=320,
+        height=260,
+    )
+    fig = chart.figure()
+    spec, _blob = fig.build_payload()
+    _width, _height, _compact, plot = _svg.layout(spec)
+    svg = fig.to_svg()
+    root = _parse(svg)
+
+    frame = next(node for node in root.iter() if node.get("fill") == "#ff00ff")
+    x, y = float(frame.get("x", "nan")), float(frame.get("y", "nan"))
+    width, height = float(frame.get("width", "nan")), float(frame.get("height", "nan"))
+    assert plot["x"] <= x <= x + width <= plot["x"] + plot["w"]
+    assert plot["y"] <= y <= y + height <= plot["y"] + plot["h"]
+    assert any(node.tag.endswith("clipPath") for node in root.iter())
+    assert all(name not in svg for name in names)
+    assert any((node.text or "").endswith("...") for node in root.iter())
+
+
+def test_svg_secondary_y_axis_scales_trace_and_renders_right_chrome() -> None:
+    from xy import _svg
+
+    chart = xy.chart(
+        xy.line([0.0, 1.0], [0.0, 1.0], color="#2563eb"),
+        xy.line([0.0, 1.0], [100.0, 200.0], color="#dc2626", y_axis="y2"),
+        xy.y_axis(label="Primary"),
+        xy.y_axis(
+            id="y2",
+            label="Secondary",
+            side="right",
+            domain=(100.0, 200.0),
+            tick_values=(100.0, 150.0, 200.0),
+            style={
+                "axis_color": "#dc2626",
+                "tick_color": "#dc2626",
+                "tick_label_color": "#dc2626",
+                "label_color": "#dc2626",
+                "tick_length": 5,
+            },
+        ),
+        width=400,
+        height=240,
+    )
+    fig = chart.figure()
+    spec, _blob = fig.build_payload()
+    _width, _height, _compact, plot = _svg.layout(spec)
+    root = _parse(fig.to_svg())
+
+    secondary_path = next(
+        node
+        for node in root.iter()
+        if node.tag.endswith("path") and node.get("stroke") == "#dc2626"
+    )
+    coords = [float(value) for value in re.findall(r"-?\d+(?:\.\d+)?", secondary_path.get("d", ""))]
+    ys = coords[1::2]
+    assert ys
+    assert all(plot["y"] <= value <= plot["y"] + plot["h"] for value in ys)
+
+    texts = {node.text for node in root.iter() if node.text}
+    assert {"100", "150", "200", "Secondary"} <= texts
+    right_edge = plot["x"] + plot["w"]
+    red_lines = [
+        node
+        for node in root.iter()
+        if node.tag.endswith("line") and node.get("stroke") == "#dc2626"
+    ]
+    assert any(
+        float(node.get("x1", "nan")) == right_edge and float(node.get("x2", "nan")) == right_edge
+        for node in red_lines
+    )
+    assert sum(float(node.get("x2", "0")) > right_edge for node in red_lines) >= 3
+
+
+def test_svg_short_chart_with_titled_legend_emits_no_empty_legend_box() -> None:
+    # A plot too short for even one legend row must not paint a floating
+    # frame/title-only box.
+    chart = xy.line_chart(
+        xy.line([0.0, 1.0], [0.0, 1.0], name="series-a"),
+        xy.legend(title="Legend title", style={"background": "#ff00ff"}),
+        width=400,
+        height=70,
+    )
+    svg = chart.to_svg()
+    assert "#ff00ff" not in svg
+    assert "Legend title" not in svg
+    assert "series-a" not in svg
+
+
+def test_svg_vertical_colorbar_clears_right_named_axis_chrome() -> None:
+    from xy import _svg
+
+    chart = xy.chart(
+        xy.heatmap([[0.0, 1.0], [2.0, 3.0]], name="field", colormap="viridis"),
+        xy.line([0.0, 1.0], [100.0, 200.0], y_axis="y2"),
+        xy.y_axis(id="y2", label="Secondary", side="right", domain=(100.0, 200.0)),
+        xy.colorbar(title="Field"),
+        width=560,
+        height=300,
+    )
+    fig = chart.figure()
+    spec, _blob = fig.build_payload()
+    _width, _height, _compact, plot = _svg.layout(spec)
+    root = _parse(fig.to_svg())
+
+    bar = next(
+        node for node in root.iter() if (node.get("fill") or "").startswith("url(#xy-colorbar-")
+    )
+    # The whole colorbar shifts right of the axis gutter, past the rotated
+    # secondary-axis title at plot-right+40.
+    assert float(bar.get("x", "nan")) > plot["x"] + plot["w"] + 40
+
+
+def test_svg_colorbar_clears_primary_right_axis_and_bottom_axis_chrome() -> None:
+    from xy import _svg
+
+    vertical = xy.heatmap_chart(
+        xy.heatmap([[0.0, 1.0], [2.0, 3.0]], colormap="viridis"),
+        xy.y_axis(label="Primary right", side="right"),
+        xy.colorbar(),
+        width=560,
+        height=320,
+    )
+    vertical_spec, _blob = vertical.figure().build_payload()
+    _width, _height, _compact, vertical_plot = _svg.layout(vertical_spec)
+    vertical_root = _parse(vertical.to_svg())
+    vertical_bar = next(
+        node
+        for node in vertical_root.iter()
+        if (node.get("fill") or "").startswith("url(#xy-colorbar-")
+    )
+    right_title = next(node for node in vertical_root.iter() if node.text == "Primary right")
+    assert float(vertical_bar.get("x", "nan")) > float(right_title.get("x", "nan"))
+    assert float(vertical_bar.get("x", "nan")) > vertical_plot["x"] + vertical_plot["w"] + 40
+
+    horizontal = xy.heatmap_chart(
+        xy.heatmap([[0.0, 1.0], [2.0, 3.0]], colormap="viridis"),
+        xy.x_axis(label="Bottom axis"),
+        xy.colorbar(orientation="horizontal", title="Intensity"),
+        width=560,
+        height=320,
+    )
+    horizontal_spec, _blob = horizontal.figure().build_payload()
+    _width, _height, _compact, horizontal_plot = _svg.layout(horizontal_spec)
+    horizontal_root = _parse(horizontal.to_svg())
+    horizontal_bar = next(
+        node
+        for node in horizontal_root.iter()
+        if (node.get("fill") or "").startswith("url(#xy-colorbar-")
+    )
+    bottom_title = next(node for node in horizontal_root.iter() if node.text == "Bottom axis")
+    assert float(horizontal_bar.get("y", "nan")) > float(bottom_title.get("y", "nan"))
+    assert float(horizontal_bar.get("y", "nan")) >= (
+        horizontal_plot["y"] + horizontal_plot["h"] + horizontal_plot["bottom_axis_room"]
+    )
+
+
+def test_svg_secondary_x_axis_scales_trace_and_renders_top_chrome() -> None:
+    from xy import _svg
+
+    chart = xy.chart(
+        xy.line([0.0, 1.0], [0.0, 1.0], color="#2563eb"),
+        xy.line([100.0, 200.0], [0.2, 0.8], color="#dc2626", x_axis="x2"),
+        xy.x_axis(label="Primary X"),
+        xy.x_axis(
+            id="x2",
+            label="Secondary X",
+            side="top",
+            domain=(100.0, 200.0),
+            tick_values=(100.0, 150.0, 200.0),
+            style={
+                "axis_color": "#dc2626",
+                "tick_color": "#dc2626",
+                "tick_label_color": "#dc2626",
+                "label_color": "#dc2626",
+                "tick_length": 5,
+            },
+        ),
+        width=400,
+        height=240,
+    )
+    fig = chart.figure()
+    spec, _blob = fig.build_payload()
+    _width, _height, _compact, plot = _svg.layout(spec)
+    root = _parse(fig.to_svg())
+
+    secondary_path = next(
+        node
+        for node in root.iter()
+        if node.tag.endswith("path") and node.get("stroke") == "#dc2626"
+    )
+    coords = [float(value) for value in re.findall(r"-?\d+(?:\.\d+)?", secondary_path.get("d", ""))]
+    xs = coords[0::2]
+    assert xs
+    assert all(plot["x"] <= value <= plot["x"] + plot["w"] for value in xs)
+
+    texts = {node.text for node in root.iter() if node.text}
+    assert {"100", "150", "200", "Secondary X"} <= texts
+    red_lines = [
+        node
+        for node in root.iter()
+        if node.tag.endswith("line") and node.get("stroke") == "#dc2626"
+    ]
+    assert any(
+        float(node.get("y1", "nan")) == plot["y"] and float(node.get("y2", "nan")) == plot["y"]
+        for node in red_lines
+    )
+    assert sum(float(node.get("y1", "inf")) < plot["y"] for node in red_lines) >= 3
+
+
+def test_svg_mixed_primary_and_named_x_axis_kinds_render_independently() -> None:
+    cases = (
+        (
+            xy.chart(
+                xy.line(["Primary Alpha", "Primary Beta", "Primary Gamma"], [1.0, 2.0, 3.0]),
+                xy.line([100.0, 200.0, 300.0], [3.0, 2.0, 1.0], x_axis="x2"),
+                xy.x_axis(tick_label_strategy="rotate"),
+                xy.x_axis(
+                    id="x2",
+                    side="top",
+                    type_="linear",
+                    tick_values=(100.0, 200.0, 300.0),
+                    tick_labels=("N100", "N200", "N300"),
+                    tick_label_strategy="rotate",
+                ),
+                width=560,
+                height=300,
+            ),
+            {"Primary Alpha", "Primary Beta", "Primary Gamma", "N100", "N200", "N300"},
+        ),
+        (
+            xy.chart(
+                xy.line([10.0, 20.0, 30.0], [1.0, 2.0, 3.0]),
+                xy.line(["Named Red", "Named Green", "Named Blue"], [3.0, 2.0, 1.0], x_axis="x2"),
+                xy.x_axis(
+                    type_="linear",
+                    tick_values=(10.0, 20.0, 30.0),
+                    tick_labels=("P10", "P20", "P30"),
+                    tick_label_strategy="rotate",
+                ),
+                xy.x_axis(id="x2", side="top", tick_label_strategy="rotate"),
+                width=560,
+                height=300,
+            ),
+            {"P10", "P20", "P30", "Named Red", "Named Green", "Named Blue"},
+        ),
+    )
+
+    for chart, expected_labels in cases:
+        root = _parse(chart.figure().to_svg())
+        rendered_labels = {node.text for node in root.iter() if node.text}
+        assert expected_labels <= rendered_labels
+
+
+@pytest.mark.parametrize(
+    ("side", "angle", "expected_anchor"),
+    [
+        ("bottom", -35, "end"),
+        ("bottom", 35, "start"),
+        ("top", 35, "end"),
+        ("top", -35, "start"),
+    ],
+)
+def test_svg_rotated_x_tick_labels_anchor_away_from_plot(
+    side: str,
+    angle: int,
+    expected_anchor: str,
+) -> None:
+    axis_id = "x" if side == "bottom" else "x2"
+    chart = xy.chart(
+        xy.line([0, 1], [0, 1], x_axis=axis_id),
+        xy.x_axis(
+            id=axis_id,
+            side=side,
+            tick_values=(0, 1),
+            tick_labels=("Long category alpha", "Long category beta"),
+            tick_label_strategy="rotate",
+            tick_label_angle=angle,
+        ),
+        width=480,
+        height=280,
+    )
+
+    root = _parse(chart.figure().to_svg())
+    labels = {
+        node.text: node
+        for node in root.iter()
+        if node.text in {"Long category alpha", "Long category beta"}
+    }
+    assert set(labels) == {"Long category alpha", "Long category beta"}
+    assert {node.get("text-anchor") for node in labels.values()} == {expected_anchor}
+    assert all(f"rotate({angle}" in node.get("transform", "") for node in labels.values())
+
+
+def test_static_named_axes_handle_reverse_silence_and_tick_count() -> None:
+    from xy import _svg
+
+    base = xy.chart(xy.line([0.0, 1.0], [0.0, 1.0]), width=400, height=240)
+    silent = xy.chart(
+        xy.line([0.0, 1.0], [0.0, 1.0]),
+        xy.x_axis(id="x2", side="top", tick_label_strategy="none"),
+        xy.y_axis(id="y2", side="right", tick_label_strategy="none"),
+        width=400,
+        height=240,
+    )
+    base_spec, _ = base.figure().build_payload()
+    silent_spec, _ = silent.figure().build_payload()
+    assert _svg.layout(silent_spec)[3] == _svg.layout(base_spec)[3]
+
+    chart = xy.chart(
+        xy.line([100.0, 150.0, 200.0], [0.0, 1.0, 2.0], x_axis="x2"),
+        xy.x_axis(
+            id="x2",
+            side="top",
+            domain=(100.0, 200.0),
+            reverse=True,
+            tick_values=(100.0, 150.0, 200.0),
+            tick_labels=("low", "middle", "high"),
+        ),
+        xy.y_axis(id="y2", side="right", domain=(0.0, 100.0), tick_count=2),
+        width=400,
+        height=240,
+    )
+    spec, _ = chart.figure().build_payload()
+    ticks, labels, _step = _svg.axis_ticks(spec["axes"]["x2"], 300, True)
+    assert ticks == labels == [100.0, 150.0, 200.0]
+    y_ticks, _y_labels, _y_step = _svg.axis_ticks(spec["axes"]["y2"], 180, False)
+    assert len(y_ticks) <= 3  # tick_count is a target and includes both endpoints
+    texts = {node.text for node in _parse(chart.to_svg()).iter() if node.text}
+    assert {"low", "middle", "high"} <= texts
+
+
+def test_svg_named_axis_collision_and_title_placement_controls() -> None:
+    values = list(range(30))
+    tick_labels = [f"very-long-secondary-label-{value}" for value in values]
+    chart = xy.chart(
+        xy.line(values, values, x_axis="x2"),
+        xy.x_axis(
+            id="x2",
+            side="top",
+            label="Secondary positioned title",
+            label_position="inside_end",
+            label_offset=6,
+            label_angle=47,
+            domain=(0.0, 29.0),
+            tick_values=values,
+            tick_labels=tick_labels,
+            tick_label_strategy="hide",
+        ),
+        width=400,
+        height=240,
+    )
+    spec, _ = chart.figure().build_payload()
+    _width, _height, _compact, plot = xy._svg.layout(spec)
+    root = _parse(chart.to_svg())
+
+    rendered_tick_labels = [node.text for node in root.iter() if node.text in tick_labels]
+    assert 0 < len(rendered_tick_labels) < len(tick_labels)
+    title = next(node for node in root.iter() if node.text == "Secondary positioned title")
+    assert float(title.get("x", "nan")) == plot["x"] + plot["w"]
+    assert plot["y"] < float(title.get("y", "nan")) < plot["y"] + plot["h"]
+    assert title.get("text-anchor") == "end"
+    assert title.get("transform", "").startswith("rotate(47 ")
 
 
 def test_svg_write_and_dimension_override(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -755,7 +755,7 @@ wheels = [
 
 [[package]]
 name = "xy"
-version = "0.1.0"
+version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },


### PR DESCRIPTION
# Complete XY styling, colorbar, and renderer parity

## Summary

This PR completes XY's public styling story and closes several browser/static-renderer gaps exposed by the new demos. It adds a comprehensive, live styling atlas; declarative continuous colorbars; named-axis parity across browser, SVG, and native PNG output; and more resilient chart chrome and interactions.

## What changed

### Styling documentation and live examples

- Added a complete styling gallery and component-variation guide covering every rendered mark family, all scatter symbols, axes, annotations, legends, tooltips, colorbars, facets, badges, interactions, and export boundaries.
- Made complete styling examples render as live previews instead of source-only snippets.
- Made styling demos responsive to light and dark mode, including chart surfaces, labels, legends, facets, annotations, and colorbars.
- Documented x/y axis tick, label, title, grid, and reference-line styling with public API examples.
- Clarified the boundary between built-in XY chrome and host-owned Reflex legends/tooltips.
- Added route-local heading links so copied anchors continue to work after client-side navigation.
- Removed internal implementation language and tightened unclear or misleading copy.

### Styling and Reflex/Tailwind integration

- Moved browser chrome defaults into a low-priority cascade layer with zero-specificity selectors, allowing Tailwind utilities, author CSS, and slot styles to override defaults without `!important`.
- Added responsive legend bounds and anchoring so long legends stay inside the plot after resize.
- Added tooltip wrapping, clamping, scrolling, and edge flipping for narrow charts.
- Exposed every static chart DOM class string through the Reflex adapter (sourced from a single `Figure.dom_class_strings()` inventory in core) so Tailwind can discover fixed-chart classes at compile time.
- Kept runtime state/`Var` class names host-owned and documented the required source or safelist pattern.
- Unified the docs app and repository-wide Ruff configuration and removed duplicate docs Ruff hooks.

### Declarative continuous colorbars

- Expanded `xy.colorbar()` to derive its domain, colormap, and default title from compatible continuous marks.
- Added validated `orientation` and explicit `ticks` options alongside the existing visibility, title, class, and style controls.
- Added browser, SVG, and native PNG support for vertical and horizontal colorbars.
- Matched browser colorbar tick-label formatting to the SVG/PNG `%g` output so explicit ticks read identically across all three renderers.
- Added layout clearance for named/right axes and bottom-axis chrome, and shifted the vertical colorbar clear of right-side named-axis labels and titles.
- Avoided misleading colorbars for constant or categorical colors, truecolor grids, and density scatter after its per-row color channel is dropped.

### Named axes and static-renderer parity

- Added independent scaling and chrome for named x/y axes in the browser, SVG export, and native PNG export.
- Added support for named-axis baselines, ticks, labels, titles, side placement, reverse ranges, collision strategies, and per-axis styling.
- Scoped categorical state to each axis ID and added shared named-category domains for facets.
- Bounded and ellipsized static legends so they do not escape small plots, and suppressed the legend frame entirely when no rows fit instead of drawing an empty box.
- Restricted tick-label downsampling to genuine collisions, so diagonal angles no longer drop labels that would fit.
- Fixed rotated x-axis tick anchoring: angled labels now anchor away from the plot instead of rotating over bars or marks.

### Interaction, tooltip, and annotation fixes

- Preserved shared tooltip fields after exact GPU/kernel picks and WebGL context recovery, and reused the already-computed local row so the exact-pick reply does not rescan sibling traces.
- Made synthetic accessibility clicks tolerant of unavailable pointer capture.
- Updated selection controls with clearer mode-specific icons and accessible labels.
- Separated annotation geometry opacity from DOM label opacity; `label_opacity` now controls annotation text explicitly.

## Test coverage

Added or expanded coverage for:

- Declarative colorbar inference, validation, precision, layout, and renderer output.
- Named and secondary axes across browser, SVG, and native PNG renderers.
- Rotated tick-label anchoring and collision behavior.
- Responsive legends, edge tooltips, annotation alignment, and shared tooltip fields.
- Facet category domains and per-axis categorical state.
- Reflex Tailwind class discovery and scan-only prop handling.
- Styling documentation completeness, live-preview compilation, dark-mode behavior, public DOM slots, mark families, and route-local anchors.

## Validation

- Repository-wide Ruff check: passed.
- Repository-wide Ruff format check: passed.
- Docs codespell check: passed.
- Full repository test suite: 1,834 passed, 66 skipped.
- Docs app test suite: 46 passed.
- Rebuilt the checked-in browser bundles from the updated JavaScript sources.
- No generated docs preview assets are included in the change.

## Compatibility

No breaking API changes; existing charts continue to work. One intentional **visual** behavior change: annotation geometry `opacity` no longer fades DOM labels (use `label_opacity` to fade label text) — documented in the changelog. Charts with saved SVG/PNG baselines that relied on the old opacity inheritance will render slightly differently. Otherwise the changes improve styling override precedence, responsive chrome, colorbar capabilities, and renderer consistency.
