### PR TITLE
Fix launch interactive probe for renamed standalone bootstrap

### DIFF
--- a/benchmarks/_launch_interactive.py
+++ b/benchmarks/_launch_interactive.py
@@ -92,10 +92,9 @@ function nonblank(gl) {
 
 def xy_probe_html(fig: Any) -> str:
     html = fig.to_html()
-    needle = 'xy.renderStandalone(document.getElementById("chart"), spec, bytes.buffer);'
+    needle = 'xy.renderStandalone(document.getElementById("chart"), spec, buf);'
     replacement = (
-        "window.__benchView=xy.renderStandalone("
-        'document.getElementById("chart"), spec, bytes.buffer);'
+        'window.__benchView=xy.renderStandalone(document.getElementById("chart"), spec, buf);'
     )
     if needle not in html:
         raise RuntimeError("xy standalone bootstrap changed")


### PR DESCRIPTION
## What

`benchmarks/bench_launch_scatter.py --interactive` injects a WebGL readback probe into xy's standalone HTML by string-replacing the exact `renderStandalone(...)` bootstrap call in `xy_probe_html`. The render client renamed the decoded-buffer variable (`bytes.buffer` → `buf`), so the needle stopped matching and the interactive lane died at runtime with:

```
RuntimeError: xy standalone bootstrap changed
```

This updates the needle (and its readback replacement) to match the shipped bootstrap.

## Why it wasn't caught

`bench_launch_scatter.py` isn't run in any CI lane — it's a manual, pinned-baseline launch artifact — and the static export lanes don't touch this code path. The drift only surfaces when actually driving the browser benchmark.

## Verification

- `xy_probe_html()` now injects successfully against the current `figure().to_html()` output (probe hook + `XY_BENCH` readback marker present).
- The interactive lane runs end-to-end again (verified locally under SwiftShader; both xy and Plotly arms render and read back non-blank frames).
- `ruff check` / `ruff format --check` clean; pre-commit hooks pass.

## Scope

One-line contract fix only. No behavior change to the measured numbers or the static lanes.