### PR TITLE
Build native core during contributor setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,9 @@ Quick start:
 ```bash
 git clone https://github.com/reflex-dev/xy.git
 cd xy
-uv venv && uv pip install -e ".[dev]"
+make setup        # dev environment + native core (needs Rust)
 make check        # fast gate
-make check-full   # full production gate (needs Rust + Node 18+)
+make check-full   # full production gate (also needs Node 18+ and clippy)
 ```
 
 ## Check the active backend

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help:
 	@printf '%s\n' \
 		'xy developer shortcuts' \
 		'' \
-		'  make setup            create .venv and install .[dev]' \
+		'  make setup            create .venv, install .[dev], and build the native core' \
 		'  make setup-browser    install the pinned Playwright browser-test driver' \
 		'  make check            run the fast local verification gate' \
 		'  make check-full       run JS, Rust, and ABI gates too' \
@@ -46,6 +46,7 @@ help:
 setup:
 	uv venv
 	uv pip install -e ".[dev]"
+	cargo build --release
 
 setup-browser:
 	npm install

--- a/README.md
+++ b/README.md
@@ -213,8 +213,7 @@ Engineering references:
 ## Development
 
 ```bash
-uv venv
-uv pip install -e ".[dev]"
+make setup  # installs .[dev] and builds the required native core
 make check
 ```
 

--- a/docs/api-reference/contributing.md
+++ b/docs/api-reference/contributing.md
@@ -15,13 +15,14 @@ the engineering version contains the complete release and browser checklists.
 ~~~bash
 git clone https://github.com/reflex-dev/xy.git
 cd xy
-uv venv
-uv pip install -e ".[dev]"
+make setup
 make check
 ~~~
 
-Source development needs Python 3.11+, a Rust toolchain for the native core,
-and Node 18+ for bundle checks. Confirm the active compute backend explicitly:
+`make setup` installs the editable development package and builds the required
+native core. Source development needs Python 3.11+, a Rust toolchain for that
+core, and Node 18+ for bundle checks. Confirm the active compute backend
+explicitly:
 
 ~~~bash
 python -c "import xy.kernels as k; print(k.BACKEND)"

--- a/docs/engineering/contributing.md
+++ b/docs/engineering/contributing.md
@@ -16,12 +16,15 @@ the hard-won production invariants while the chart surface grows.
 
 ## Local Checks
 
-Install the dev environment:
+Install the dev environment and build the required native core:
 
 ```bash
-uv venv
-uv pip install -e ".[dev]"
+make setup
 ```
+
+`make setup` requires a Rust toolchain because it runs `cargo build --release`
+after installing the editable Python package. This leaves the checkout ready
+to import `xy.kernels` and run the fast gate.
 
 Run the fast local gate:
 

--- a/tests/test_verify_local.py
+++ b/tests/test_verify_local.py
@@ -470,6 +470,24 @@ def test_makefile_exposes_sdist_verification_shortcut() -> None:
     assert "make check-sdist" in makefile
 
 
+def test_contributor_setup_builds_native_core_and_docs_use_it() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    setup_recipe = makefile.split("setup:\n", 1)[1].split("\n\n", 1)[0]
+
+    assert "uv venv" in setup_recipe
+    assert 'uv pip install -e ".[dev]"' in setup_recipe
+    assert "cargo build --release" in setup_recipe
+
+    contributor_docs = (
+        (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8"),
+        (ENGINEERING_DOCS / "contributing.md").read_text(encoding="utf-8"),
+        (ROOT / "README.md").read_text(encoding="utf-8"),
+        (ROOT / "docs" / "api-reference" / "contributing.md").read_text(encoding="utf-8"),
+    )
+    for text in contributor_docs:
+        assert "make setup" in text
+
+
 def test_makefile_exposes_wheel_verification_shortcut() -> None:
     makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- build the required release native core as part of `make setup`
- route the contributor quick starts through `make setup` and document its Rust requirement
- add a regression test covering the setup recipe and contributor docs

## Root cause

The contributor quick start only created a virtual environment and installed the project editable. An editable install can complete without leaving `libxy_core` in one of the development loader paths, so the documented `make check` step then fails while importing `xy.kernels`.

`make setup` now runs `cargo build --release` explicitly, ensuring a source checkout is ready for the documented fast gate.

Closes #77.

## Validation

- clean setup with `XY_SKIP_CARGO=1` forced the editable-install path to omit the core; the explicit setup build then produced `target/release/libxy_core.dylib` and `xy.kernels.BACKEND == "native"`
- `.venv/bin/python -m pytest -q tests/test_verify_local.py` — 62 passed
- `make check-docs` — claim guardrails passed and 68 tests passed
- `git diff --check`

The broader `make check` run reached 1,843 passed and 66 skipped tests, with one unrelated local Chromium alignment failure in `test_midpoint_annotation_labels_are_visually_centered`; this patch does not change chart rendering or browser assets.