### PR TITLE
Handle static charts without DOM class inventories

### DIFF
--- a/python/reflex-xy/reflex_xy/component.py
+++ b/python/reflex-xy/reflex_xy/component.py
@@ -105,8 +105,14 @@ def _tailwind_class_manifest(figure: Any) -> str:
     The inventory itself is core-Figure knowledge and lives on
     :meth:`xy.Figure.dom_class_strings`; reading the built figure avoids a
     second payload compilation (which can be expensive for large charts).
+    Older xy releases do not expose that optional inventory; their static
+    payloads remain renderable, but cannot contribute classes to Tailwind's
+    source scan.
     """
-    return " ".join(figure.dom_class_strings())
+    dom_class_strings = getattr(figure, "dom_class_strings", None)
+    if not callable(dom_class_strings):
+        return ""
+    return " ".join(dom_class_strings())
 
 
 def chart(source: Any, **props: Any) -> Any:

--- a/tests/reflex_adapter/test_component.py
+++ b/tests/reflex_adapter/test_component.py
@@ -110,6 +110,20 @@ def test_static_chart_classes_are_visible_to_tailwind_source_scan(app_cwd):
         assert class_string in rendered
 
 
+def test_static_chart_without_class_inventory_still_compiles(app_cwd):
+    """Older core Figures predate the optional Tailwind class inventory."""
+    figure = xy.scatter_chart(xy.scatter([1, 2, 3], [3, 2, 1])).figure()
+
+    class LegacyFigure:
+        def build_payload(self):
+            return figure.build_payload()
+
+    rendered = str(reflex_xy.chart(LegacyFigure(), id="legacy-static-chart"))
+    assert 'id:"legacy-static-chart"' in rendered
+    assert "src:" in rendered
+    assert "tailwindClassTokens" not in rendered
+
+
 def test_live_chart_does_not_claim_runtime_classes_are_compile_time_known(app_cwd):
     rendered = str(reflex_xy.chart("xyfig-runtime"))
     assert "tailwindClassTokens" not in rendered


### PR DESCRIPTION
### Motivation
- Prevent Reflex page compilation from crashing when an installed `xy` core `Figure` does not expose the optional `dom_class_strings()` API so static-chart fallback remains usable.

### Description
- Feature-detect `Figure.dom_class_strings` in `python/reflex-xy/reflex_xy/component.py` and return an empty Tailwind manifest when the method is absent.
- Add `tests/reflex_adapter/test_component.py::test_static_chart_without_class_inventory_still_compiles` to cover legacy `Figure`-like objects that lack `dom_class_strings()`.

### Testing
- Ran `PYTHONPATH=python/reflex-xy:python python -m pytest -q tests/reflex_adapter/test_component.py`, which passed (`8 passed`).
- Ran `python -m ruff check` and `python -m ruff format --check` on the modified files with no failures.
- Attempting `PYTHONPATH=python/reflex-xy:python python -m pytest -q tests/reflex_adapter` could not collect the full adapter suite due to missing optional test dependencies (`uvicorn` and `hypothesis`).

------


Closes #81