### PR TITLE
Fix FacetChart notebook display CSS isolation

### DIFF
--- a/python/xy/components.py
+++ b/python/xy/components.py
@@ -3384,7 +3384,18 @@ class FacetChart(Component):
         return self.to_html(path, custom_css=custom_css)
 
     def _repr_html_(self) -> str:
-        return self.to_html()
+        grid = self.figure()
+        return export.notebook_iframe(
+            grid.to_html(),
+            width=grid.width,
+            height=grid.grid_height + grid._title_height,
+        )
+
+    def _ipython_display_(self) -> None:
+        """Display the isolated facet document in notebook frontends."""
+        from IPython.display import display  # type: ignore[import-not-found]
+
+        display({"text/html": self._repr_html_()}, raw=True)
 
     def to_svg(self, path: Optional[str | PathLike[str]] = None) -> str:
         """A static SVG render of the facet grid (written to ``path`` if given)."""
@@ -4104,7 +4115,9 @@ def facet_chart(
         share_x: Whether panels share an x domain.
         share_y: Whether panels share a y domain.
         gap: Gap between panels in pixels.
-        **props: Additional shared chart properties.
+        **props: Additional shared chart properties. ``width`` is the total
+            grid width, while ``height`` is the height of each panel; the
+            composed height grows with the number of facet rows.
     """
     return FacetChart(
         children, by=by, cols=cols, share_x=share_x, share_y=share_y, gap=gap, **props

--- a/python/xy/facets.py
+++ b/python/xy/facets.py
@@ -204,12 +204,12 @@ class FacetGrid:
 <meta http-equiv="Content-Security-Policy" content="{export._STANDALONE_CSP}">
 <title>{title}</title>
 <style>
-html,body{{margin:0;width:100%;min-height:100%;font-family:system-ui,sans-serif;background:#fff;}}
-.xy-facet-title{{height:{self._TITLE_H}px;line-height:{self._TITLE_H}px;font:600 14px system-ui,sans-serif;margin:0;text-align:center;color:#1e293b;}}
-.xy-facet-grid{{display:grid;grid-template-columns:repeat({self.cols}, minmax(0, 1fr));gap:{self.gap}px;}}
-.xy-facet-panel{{min-width:0;}}
+.xy-facet-document{{margin:0;width:100%;min-height:100%;font-family:system-ui,sans-serif;background:#fff;}}
+.xy-facet-document .xy-facet-title{{height:{self._TITLE_H}px;line-height:{self._TITLE_H}px;font:600 14px system-ui,sans-serif;margin:0;text-align:center;color:#1e293b;}}
+.xy-facet-document .xy-facet-grid{{display:grid;grid-template-columns:repeat({self.cols}, minmax(0, 1fr));gap:{self.gap}px;}}
+.xy-facet-document .xy-facet-panel{{min-width:0;}}
 </style>
-{css}</head><body>
+{css}</head><body class="xy-facet-document">
 {heading}<div class="xy-facet-grid" id="xy-facet-grid"></div>
 <script>{js}</script>
 <script>

--- a/tests/test_facets.py
+++ b/tests/test_facets.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html as _html
 import re
 import struct
 
@@ -196,6 +197,50 @@ def test_facet_labels_and_grid_title_render_once() -> None:
     assert html.count("My grid") == 2
     # panel titles are the facet labels, not "grid · label" composites
     assert [fig.title for fig in grid.figures] == ["a", "b"]
+
+
+def test_facet_notebook_repr_isolates_standalone_document() -> None:
+    chart = xy.facet_chart(
+        xy.line(x="x", y="y"),
+        by="g",
+        data=_table(),
+        cols=1,
+        width=600,
+        height=200,
+        gap=10,
+        title="Notebook facets",
+    )
+
+    repr_html = chart._repr_html_()
+    document = _html.unescape(repr_html)
+
+    assert repr_html.startswith('<iframe class="xy-notebook-frame"')
+    assert 'sandbox="allow-scripts"' in repr_html
+    assert 'width="600" height="434"' in repr_html
+    assert "<!doctype html>" in document
+    assert '<body class="xy-facet-document">' in document
+    assert "html,body{" not in document
+    assert ".xy-facet-document .xy-facet-grid{" in document
+
+
+def test_facet_ipython_display_uses_isolated_repr(monkeypatch: pytest.MonkeyPatch) -> None:
+    import IPython.display
+
+    displayed: list[tuple[object, bool]] = []
+
+    def record(value: object, *, raw: bool = False) -> None:
+        displayed.append((value, raw))
+
+    monkeypatch.setattr(IPython.display, "display", record)
+    chart = xy.facet_chart(xy.line(x="x", y="y"), by="g", data=_table())
+
+    chart._ipython_display_()
+
+    assert len(displayed) == 1
+    payload, raw = displayed[0]
+    assert raw is True
+    assert isinstance(payload, dict)
+    assert payload["text/html"].startswith('<iframe class="xy-notebook-frame"')
 
 
 # -- PNG geometry -------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- FacetChart rendered a standalone HTML document via `_repr_html_` which injected document-level CSS into notebook pages and broke surrounding layout. 
- The facet `height` was documented ambiguously: it behaved as per-panel height while `width` was the total grid width, leading to unexpected composed heights. 
- A robust notebook display path should sandbox the facet document and provide an explicit IPython display path so frontends do not apply global styles.

### Description

- Change notebook representation to embed the standalone facet document in a sandboxed `srcdoc` iframe by returning `export.notebook_iframe(grid.to_html(), width=..., height=...)` from `FacetChart._repr_html_`. 
- Add an explicit `_ipython_display_` implementation that emits the isolated HTML payload using `display({...}, raw=True)` for rich display frontends. 
- Scope the facet standalone CSS beneath a root `.xy-facet-document` class and set the document `<body>` to that class so global selectors like `html,body{...}` no longer leak into host pages. 
- Clarify `facet_chart` docstring to state that `width` is the total grid width while `height` is the per-panel height, and add regression tests for the iframe wrapper, sandboxing, scoped CSS, and IPython display behavior in `tests/test_facets.py`.

### Testing

- Ran `PYTHONPATH=python pytest -q tests/test_facets.py`, which passed (`25 passed`).
- Ran `ruff check python/xy/components.py python/xy/facets.py tests/test_facets.py`, which passed with no issues. 
- Ran `git diff --check` to ensure no trailing/whitespace problems and verified working tree status.

------


Closes #90