### PR TITLE
Add hard viewport bounds that clamp pan and zoom

### DIFF
--- a/examples/demo-advance.ipynb
+++ b/examples/demo-advance.ipynb
@@ -270,6 +270,33 @@
     ")\n",
     "chart"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "viewport-bounds-demo",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# PR verification: the initial viewport is smaller than the hard navigation bounds.\n",
+    "# Drag and wheel-zoom aggressively; neither axis should move beyond the red rules.\n",
+    "viewport_x = np.linspace(0, 100, 501)\n",
+    "viewport_y = np.sin(viewport_x / 7) + 0.15 * np.cos(viewport_x / 2)\n",
+    "\n",
+    "xy.line_chart(\n",
+    "    xy.line(viewport_x, viewport_y, name=\"signal\", color=\"#5477c4\", width=3),\n",
+    "    xy.vline(0, text=\"x min\", color=\"#ef4444\", width=2),\n",
+    "    xy.vline(100, text=\"x max\", color=\"#ef4444\", width=2),\n",
+    "    xy.hline(-1.25, text=\"y min\", color=\"#ef4444\", width=2),\n",
+    "    xy.hline(1.25, text=\"y max\", color=\"#ef4444\", width=2),\n",
+    "    xy.x_axis(label=\"x (hard bounds: 0 to 100)\", domain=(30, 60), bounds=(0, 100)),\n",
+    "    xy.y_axis(label=\"signal (hard bounds: -1.25 to 1.25)\", domain=(-0.6, 0.6), bounds=(-1.25, 1.25)),\n",
+    "    xy.legend(show=False),\n",
+    "    title=\"Hard viewport bounds — pan and zoom cannot cross the red limits\",\n",
+    "    width=1000,\n",
+    "    height=520,\n",
+    ")\n"
+   ]
   }
  ],
  "metadata": {

--- a/examples/demo-advance.ipynb
+++ b/examples/demo-advance.ipynb
@@ -290,12 +290,14 @@
     "    xy.hline(-1.25, text=\"y min\", color=\"#ef4444\", width=2),\n",
     "    xy.hline(1.25, text=\"y max\", color=\"#ef4444\", width=2),\n",
     "    xy.x_axis(label=\"x (hard bounds: 0 to 100)\", domain=(30, 60), bounds=(0, 100)),\n",
-    "    xy.y_axis(label=\"signal (hard bounds: -1.25 to 1.25)\", domain=(-0.6, 0.6), bounds=(-1.25, 1.25)),\n",
+    "    xy.y_axis(\n",
+    "        label=\"signal (hard bounds: -1.25 to 1.25)\", domain=(-0.6, 0.6), bounds=(-1.25, 1.25)\n",
+    "    ),\n",
     "    xy.legend(show=False),\n",
     "    title=\"Hard viewport bounds — pan and zoom cannot cross the red limits\",\n",
     "    width=1000,\n",
     "    height=520,\n",
-    ")\n"
+    ")"
    ]
   }
  ],

--- a/js/src/50_chartview.js
+++ b/js/src/50_chartview.js
@@ -213,10 +213,10 @@ class ChartView {
     this._armVisibilityResizeWatch();
     this._armDprWatch();
 
-    this.view0 = {
+    this.view0 = this._clampView({
       x0: spec.x_axis.range[0], x1: spec.x_axis.range[1],
       y0: spec.y_axis.range[0], y1: spec.y_axis.range[1],
-    };
+    });
     this.view = { ...this.view0 };
     this._initLinkedCharts();
 

--- a/js/src/53_interaction.js
+++ b/js/src/53_interaction.js
@@ -145,15 +145,12 @@ Object.assign(ChartView.prototype, {
         const cy0 = this._axisCoord(ya, y0), cy1 = this._axisCoord(ya, y1);
         const dx = ((e.clientX - drag.px) / this.plot.w) * (cx1 - cx0);
         const dy = ((e.clientY - drag.py) / this.plot.h) * (cy1 - cy0);
-        this.view = this._clampView({
+        this._setView({
           x0: this._axisValue(xa, cx0 - dx),
           x1: this._axisValue(xa, cx1 - dx),
           y0: this._axisValue(ya, cy0 + dy),
           y1: this._axisValue(ya, cy1 + dy),
-        });
-        this.draw();
-        this._scheduleViewRequest();
-        this._emitViewChange("pan");
+        }, { source: "pan" });
         return;
       }
       this._updateCrosshair(e);
@@ -1351,17 +1348,14 @@ Object.assign(ChartView.prototype, {
     if (![c0, c1, b0, b1].every(Number.isFinite) || b0 === b1) return [lo, hi];
     const reverse = c1 < c0;
     const boundLo = Math.min(b0, b1), boundHi = Math.max(b0, b1);
-    const boundSpan = boundHi - boundLo;
-    const span = Math.abs(c1 - c0);
-    let outLo, outHi;
-    if (span >= boundSpan) {
+    let outLo = Math.min(c0, c1), outHi = Math.max(c0, c1);
+    if (outHi - outLo >= boundHi - boundLo) {
       outLo = boundLo;
       outHi = boundHi;
     } else {
-      outLo = Math.min(c0, c1);
-      outHi = Math.max(c0, c1);
-      if (outLo < boundLo) { outHi += boundLo - outLo; outLo = boundLo; }
-      if (outHi > boundHi) { outLo -= outHi - boundHi; outHi = boundHi; }
+      const shift = Math.max(boundLo - outLo, Math.min(boundHi - outHi, 0));
+      outLo += shift;
+      outHi += shift;
     }
     const first = reverse ? outHi : outLo;
     const second = reverse ? outLo : outHi;

--- a/js/src/53_interaction.js
+++ b/js/src/53_interaction.js
@@ -145,12 +145,12 @@ Object.assign(ChartView.prototype, {
         const cy0 = this._axisCoord(ya, y0), cy1 = this._axisCoord(ya, y1);
         const dx = ((e.clientX - drag.px) / this.plot.w) * (cx1 - cx0);
         const dy = ((e.clientY - drag.py) / this.plot.h) * (cy1 - cy0);
-        this.view = {
+        this.view = this._clampView({
           x0: this._axisValue(xa, cx0 - dx),
           x1: this._axisValue(xa, cx1 - dx),
           y0: this._axisValue(ya, cy0 + dy),
           y1: this._axisValue(ya, cy1 + dy),
-        };
+        });
         this.draw();
         this._scheduleViewRequest();
         this._emitViewChange("pan");
@@ -1268,7 +1268,8 @@ Object.assign(ChartView.prototype, {
 
   _setView(next, opts = {}) {
     if (this._destroyed) return;
-    const target = { x0: next.x0, x1: next.x1, y0: next.y0, y1: next.y1 };
+    const target = this._clampView(
+      { x0: next.x0, x1: next.x1, y0: next.y0, y1: next.y1 });
     const animate = opts.animate === true && !this._prefersReducedMotion();
     const duration = opts.duration || 180;
     if (!animate || duration <= 0) {
@@ -1336,6 +1337,41 @@ Object.assign(ChartView.prototype, {
       }
     };
     this._animRaf = requestAnimationFrame(step);
+  },
+
+  // Keep a proposed viewport wholly inside each axis's optional hard bounds.
+  // Work in scale coordinates so log bounds clamp multiplicatively, while
+  // preserving the range direction used by reversed axes.
+  _clampAxisRange(axisId, lo, hi) {
+    const axis = this._axis(axisId);
+    if (!Array.isArray(axis.bounds) || axis.bounds.length !== 2) return [lo, hi];
+    const c0 = this._axisCoord(axis, lo), c1 = this._axisCoord(axis, hi);
+    const b0 = this._axisCoord(axis, axis.bounds[0]);
+    const b1 = this._axisCoord(axis, axis.bounds[1]);
+    if (![c0, c1, b0, b1].every(Number.isFinite) || b0 === b1) return [lo, hi];
+    const reverse = c1 < c0;
+    const boundLo = Math.min(b0, b1), boundHi = Math.max(b0, b1);
+    const boundSpan = boundHi - boundLo;
+    const span = Math.abs(c1 - c0);
+    let outLo, outHi;
+    if (span >= boundSpan) {
+      outLo = boundLo;
+      outHi = boundHi;
+    } else {
+      outLo = Math.min(c0, c1);
+      outHi = Math.max(c0, c1);
+      if (outLo < boundLo) { outHi += boundLo - outLo; outLo = boundLo; }
+      if (outHi > boundHi) { outLo -= outHi - boundHi; outHi = boundHi; }
+    }
+    const first = reverse ? outHi : outLo;
+    const second = reverse ? outLo : outHi;
+    return [this._axisValue(axis, first), this._axisValue(axis, second)];
+  },
+
+  _clampView(view) {
+    const x = this._clampAxisRange("x", view.x0, view.x1);
+    const y = this._clampAxisRange("y", view.y0, view.y1);
+    return { x0: x[0], x1: x[1], y0: y[0], y1: y[1] };
   },
 
   // Center-anchored zoom (f<1 in, f>1 out) — the modebar buttons; wheel is

--- a/python/xy/_figure.py
+++ b/python/xy/_figure.py
@@ -143,6 +143,7 @@ class Figure(AnnotationsMixin, PayloadMixin):
         label_angle: Optional[float] = None,
         type_: Optional[str] = None,
         domain: Optional[tuple[float, float]] = None,
+        bounds: Any = None,
         reverse: bool = False,
         format: Optional[str] = None,
         tick_count: Optional[int] = None,
@@ -163,6 +164,13 @@ class Figure(AnnotationsMixin, PayloadMixin):
             domain = self._finite_increasing_pair(domain, f"{axis_id} axis domain")
             if type_ == "log" and domain[0] <= 0:
                 raise ValueError(f"{axis_id} log axis domain must be positive")
+        if isinstance(bounds, str):
+            if bounds != "data":
+                raise ValueError(f"{axis_id} axis bounds must be an increasing pair or 'data'")
+        elif bounds is not None:
+            bounds = self._finite_increasing_pair(bounds, f"{axis_id} axis bounds")
+            if type_ == "log" and bounds[0] <= 0:
+                raise ValueError(f"{axis_id} log axis bounds must be positive")
         if side is None:
             side = "bottom" if axis_dim == "x" else ("right" if axis_id != "y" else "left")
         elif axis_dim == "x" and side not in {"top", "bottom"}:
@@ -188,6 +196,7 @@ class Figure(AnnotationsMixin, PayloadMixin):
             "label_angle": self._optional_finite_scalar(label_angle, f"{axis_id} axis label_angle"),
             "type": type_,
             "domain": domain,
+            "bounds": bounds,
             "reverse": self._bool_param(reverse, f"{axis_id} axis reverse"),
             "format": self._optional_text(format, f"{axis_id} axis format"),
             "tick_count": self._optional_positive_int(tick_count, f"{axis_id} axis tick_count"),
@@ -817,10 +826,10 @@ class Figure(AnnotationsMixin, PayloadMixin):
     def y_range(self) -> tuple[float, float]:
         return self._range("y")
 
-    def _range(self, axis_id: str) -> tuple[float, float]:
+    def _range(self, axis_id: str, *, use_domain: bool = True) -> tuple[float, float]:
         opts = self.axis_options.get(axis_id, {})
         fixed = opts.get("domain")
-        if fixed is not None:
+        if use_domain and fixed is not None:
             lo, hi = fixed
             return (hi, lo) if opts.get("reverse") else (lo, hi)
 
@@ -985,6 +994,13 @@ class Figure(AnnotationsMixin, PayloadMixin):
             spec["reverse"] = True
         if opts.get("domain") is not None:
             spec["domain"] = list(opts["domain"])
+        bounds = opts.get("bounds")
+        if bounds == "data":
+            # Resolve once on the Python side so the client receives concrete
+            # limits even when an independent explicit domain sets view0.
+            bounds = self._range(axis_id, use_domain=False)
+        if bounds is not None:
+            spec["bounds"] = sorted(bounds)
         if opts.get("format") is not None:
             spec["format"] = opts["format"]
         style = styles.compile_axis_style(opts.get("style"), f"{axis_id} axis style")

--- a/python/xy/components.py
+++ b/python/xy/components.py
@@ -36,7 +36,7 @@ import warnings
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from os import PathLike
-from typing import Any, Optional, TypeAlias, Union
+from typing import Any, Literal, Optional, TypeAlias, Union
 
 import numpy as np
 
@@ -198,6 +198,7 @@ class Axis(Component):
     label_angle: Optional[float] = None
     type_: Optional[str] = None  # "linear" | "time" | "log" (auto-detected if None)
     domain: Optional[tuple[float, float]] = None
+    bounds: Union[tuple[float, float], Literal["data"], None] = None
     reverse: bool = False
     format: Optional[str] = None
     tick_count: Optional[int] = None
@@ -1927,6 +1928,7 @@ def x_axis(
     label_angle: Optional[float] = None,
     type_: Optional[str] = None,
     domain: Optional[tuple[float, float]] = None,
+    bounds: Union[tuple[float, float], Literal["data"], None] = None,
     reverse: bool = False,
     format: Optional[str] = None,
     tick_count: Optional[int] = None,
@@ -1949,6 +1951,9 @@ def x_axis(
         label_angle: Label rotation in degrees.
         type_: Scale type, such as ``linear``, ``time``, or ``log``.
         domain: Explicit minimum and maximum scale values.
+        bounds: Hard navigation limits, or ``"data"`` to use the data range.
+            Pan and zoom are clamped within these limits; ``None`` leaves
+            navigation unrestricted.
         reverse: Whether to reverse the scale direction.
         format: Tick-label format string.
         tick_count: Requested number of ticks.
@@ -1980,6 +1985,7 @@ def x_axis(
         label_angle=_optional_finite_number(label_angle, "x_axis label_angle"),
         type_=type_,
         domain=_axis_domain(domain, "x_axis domain"),
+        bounds=_axis_bounds(bounds, "x_axis bounds"),
         reverse=_strict_bool(reverse, "x_axis reverse"),
         format=_optional_string(format, "x_axis format"),
         tick_count=_optional_positive_int(tick_count, "x_axis tick_count"),
@@ -2007,6 +2013,7 @@ def y_axis(
     label_angle: Optional[float] = None,
     type_: Optional[str] = None,
     domain: Optional[tuple[float, float]] = None,
+    bounds: Union[tuple[float, float], Literal["data"], None] = None,
     reverse: bool = False,
     format: Optional[str] = None,
     tick_count: Optional[int] = None,
@@ -2029,6 +2036,9 @@ def y_axis(
         label_angle: Label rotation in degrees.
         type_: Scale type, such as ``linear``, ``time``, or ``log``.
         domain: Explicit minimum and maximum scale values.
+        bounds: Hard navigation limits, or ``"data"`` to use the data range.
+            Pan and zoom are clamped within these limits; ``None`` leaves
+            navigation unrestricted.
         reverse: Whether to reverse the scale direction.
         format: Tick-label format string.
         tick_count: Requested number of ticks.
@@ -2060,6 +2070,7 @@ def y_axis(
         label_angle=_optional_finite_number(label_angle, "y_axis label_angle"),
         type_=type_,
         domain=_axis_domain(domain, "y_axis domain"),
+        bounds=_axis_bounds(bounds, "y_axis bounds"),
         reverse=_strict_bool(reverse, "y_axis reverse"),
         format=_optional_string(format, "y_axis format"),
         tick_count=_optional_positive_int(tick_count, "y_axis tick_count"),
@@ -2535,6 +2546,7 @@ class Chart(Component):
                 label_angle=axis.label_angle,
                 type_=axis.type_,
                 domain=axis.domain,
+                bounds=axis.bounds,
                 reverse=axis.reverse,
                 format=axis.format,
                 tick_count=axis.tick_count,
@@ -3457,6 +3469,16 @@ def _validate_axis_type(type_: Optional[str]) -> None:
 def _axis_domain(value: Any, label: str) -> Optional[tuple[float, float]]:
     if value is None:
         return None
+    return _validate.finite_increasing_pair(value, label)
+
+
+def _axis_bounds(value: Any, label: str) -> Union[tuple[float, float], Literal["data"], None]:
+    if value is None:
+        return value
+    if isinstance(value, str):
+        if value == "data":
+            return value
+        raise ValueError(f"{label} must be an increasing pair, 'data', or None")
     return _validate.finite_increasing_pair(value, label)
 
 

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -5926,15 +5926,12 @@ const cx0 = this._axisCoord(xa, x0), cx1 = this._axisCoord(xa, x1);
 const cy0 = this._axisCoord(ya, y0), cy1 = this._axisCoord(ya, y1);
 const dx = ((e.clientX - drag.px) / this.plot.w) * (cx1 - cx0);
 const dy = ((e.clientY - drag.py) / this.plot.h) * (cy1 - cy0);
-this.view = this._clampView({
+this._setView({
 x0: this._axisValue(xa, cx0 - dx),
 x1: this._axisValue(xa, cx1 - dx),
 y0: this._axisValue(ya, cy0 + dy),
 y1: this._axisValue(ya, cy1 + dy),
-});
-this.draw();
-this._scheduleViewRequest();
-this._emitViewChange("pan");
+}, { source: "pan" });
 return;
 }
 this._updateCrosshair(e);
@@ -7046,17 +7043,14 @@ const b1 = this._axisCoord(axis, axis.bounds[1]);
 if (![c0, c1, b0, b1].every(Number.isFinite) || b0 === b1) return [lo, hi];
 const reverse = c1 < c0;
 const boundLo = Math.min(b0, b1), boundHi = Math.max(b0, b1);
-const boundSpan = boundHi - boundLo;
-const span = Math.abs(c1 - c0);
-let outLo, outHi;
-if (span >= boundSpan) {
+let outLo = Math.min(c0, c1), outHi = Math.max(c0, c1);
+if (outHi - outLo >= boundHi - boundLo) {
 outLo = boundLo;
 outHi = boundHi;
 } else {
-outLo = Math.min(c0, c1);
-outHi = Math.max(c0, c1);
-if (outLo < boundLo) { outHi += boundLo - outLo; outLo = boundLo; }
-if (outHi > boundHi) { outLo -= outHi - boundHi; outHi = boundHi; }
+const shift = Math.max(boundLo - outLo, Math.min(boundHi - outHi, 0));
+outLo += shift;
+outHi += shift;
 }
 const first = reverse ? outHi : outLo;
 const second = reverse ? outLo : outHi;

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -1872,10 +1872,10 @@ this._ro.observe(this.root);
 }
 this._armVisibilityResizeWatch();
 this._armDprWatch();
-this.view0 = {
+this.view0 = this._clampView({
 x0: spec.x_axis.range[0], x1: spec.x_axis.range[1],
 y0: spec.y_axis.range[0], y1: spec.y_axis.range[1],
-};
+});
 this.view = { ...this.view0 };
 this._initLinkedCharts();
 this._themeWatch = window.matchMedia("(prefers-color-scheme: dark)");
@@ -5926,12 +5926,12 @@ const cx0 = this._axisCoord(xa, x0), cx1 = this._axisCoord(xa, x1);
 const cy0 = this._axisCoord(ya, y0), cy1 = this._axisCoord(ya, y1);
 const dx = ((e.clientX - drag.px) / this.plot.w) * (cx1 - cx0);
 const dy = ((e.clientY - drag.py) / this.plot.h) * (cy1 - cy0);
-this.view = {
+this.view = this._clampView({
 x0: this._axisValue(xa, cx0 - dx),
 x1: this._axisValue(xa, cx1 - dx),
 y0: this._axisValue(ya, cy0 + dy),
 y1: this._axisValue(ya, cy1 + dy),
-};
+});
 this.draw();
 this._scheduleViewRequest();
 this._emitViewChange("pan");
@@ -6969,7 +6969,8 @@ this._viewAnim = null;
 },
 _setView(next, opts = {}) {
 if (this._destroyed) return;
-const target = { x0: next.x0, x1: next.x1, y0: next.y0, y1: next.y1 };
+const target = this._clampView(
+{ x0: next.x0, x1: next.x1, y0: next.y0, y1: next.y1 });
 const animate = opts.animate === true && !this._prefersReducedMotion();
 const duration = opts.duration || 180;
 if (!animate || duration <= 0) {
@@ -7035,6 +7036,36 @@ this._emitViewChange(opts.source || "view", { broadcast: opts.broadcast });
 }
 };
 this._animRaf = requestAnimationFrame(step);
+},
+_clampAxisRange(axisId, lo, hi) {
+const axis = this._axis(axisId);
+if (!Array.isArray(axis.bounds) || axis.bounds.length !== 2) return [lo, hi];
+const c0 = this._axisCoord(axis, lo), c1 = this._axisCoord(axis, hi);
+const b0 = this._axisCoord(axis, axis.bounds[0]);
+const b1 = this._axisCoord(axis, axis.bounds[1]);
+if (![c0, c1, b0, b1].every(Number.isFinite) || b0 === b1) return [lo, hi];
+const reverse = c1 < c0;
+const boundLo = Math.min(b0, b1), boundHi = Math.max(b0, b1);
+const boundSpan = boundHi - boundLo;
+const span = Math.abs(c1 - c0);
+let outLo, outHi;
+if (span >= boundSpan) {
+outLo = boundLo;
+outHi = boundHi;
+} else {
+outLo = Math.min(c0, c1);
+outHi = Math.max(c0, c1);
+if (outLo < boundLo) { outHi += boundLo - outLo; outLo = boundLo; }
+if (outHi > boundHi) { outLo -= outHi - boundHi; outHi = boundHi; }
+}
+const first = reverse ? outHi : outLo;
+const second = reverse ? outLo : outHi;
+return [this._axisValue(axis, first), this._axisValue(axis, second)];
+},
+_clampView(view) {
+const x = this._clampAxisRange("x", view.x0, view.x1);
+const y = this._clampAxisRange("y", view.y0, view.y1);
+return { x0: x[0], x1: x[1], y0: y[0], y1: y[1] };
 },
 _zoomBy(f, animate = false) {
 const base = this._viewAnim ? this._viewAnim.target : this.view;

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -1873,10 +1873,10 @@ this._ro.observe(this.root);
 }
 this._armVisibilityResizeWatch();
 this._armDprWatch();
-this.view0 = {
+this.view0 = this._clampView({
 x0: spec.x_axis.range[0], x1: spec.x_axis.range[1],
 y0: spec.y_axis.range[0], y1: spec.y_axis.range[1],
-};
+});
 this.view = { ...this.view0 };
 this._initLinkedCharts();
 this._themeWatch = window.matchMedia("(prefers-color-scheme: dark)");
@@ -5927,12 +5927,12 @@ const cx0 = this._axisCoord(xa, x0), cx1 = this._axisCoord(xa, x1);
 const cy0 = this._axisCoord(ya, y0), cy1 = this._axisCoord(ya, y1);
 const dx = ((e.clientX - drag.px) / this.plot.w) * (cx1 - cx0);
 const dy = ((e.clientY - drag.py) / this.plot.h) * (cy1 - cy0);
-this.view = {
+this.view = this._clampView({
 x0: this._axisValue(xa, cx0 - dx),
 x1: this._axisValue(xa, cx1 - dx),
 y0: this._axisValue(ya, cy0 + dy),
 y1: this._axisValue(ya, cy1 + dy),
-};
+});
 this.draw();
 this._scheduleViewRequest();
 this._emitViewChange("pan");
@@ -6970,7 +6970,8 @@ this._viewAnim = null;
 },
 _setView(next, opts = {}) {
 if (this._destroyed) return;
-const target = { x0: next.x0, x1: next.x1, y0: next.y0, y1: next.y1 };
+const target = this._clampView(
+{ x0: next.x0, x1: next.x1, y0: next.y0, y1: next.y1 });
 const animate = opts.animate === true && !this._prefersReducedMotion();
 const duration = opts.duration || 180;
 if (!animate || duration <= 0) {
@@ -7036,6 +7037,36 @@ this._emitViewChange(opts.source || "view", { broadcast: opts.broadcast });
 }
 };
 this._animRaf = requestAnimationFrame(step);
+},
+_clampAxisRange(axisId, lo, hi) {
+const axis = this._axis(axisId);
+if (!Array.isArray(axis.bounds) || axis.bounds.length !== 2) return [lo, hi];
+const c0 = this._axisCoord(axis, lo), c1 = this._axisCoord(axis, hi);
+const b0 = this._axisCoord(axis, axis.bounds[0]);
+const b1 = this._axisCoord(axis, axis.bounds[1]);
+if (![c0, c1, b0, b1].every(Number.isFinite) || b0 === b1) return [lo, hi];
+const reverse = c1 < c0;
+const boundLo = Math.min(b0, b1), boundHi = Math.max(b0, b1);
+const boundSpan = boundHi - boundLo;
+const span = Math.abs(c1 - c0);
+let outLo, outHi;
+if (span >= boundSpan) {
+outLo = boundLo;
+outHi = boundHi;
+} else {
+outLo = Math.min(c0, c1);
+outHi = Math.max(c0, c1);
+if (outLo < boundLo) { outHi += boundLo - outLo; outLo = boundLo; }
+if (outHi > boundHi) { outLo -= outHi - boundHi; outHi = boundHi; }
+}
+const first = reverse ? outHi : outLo;
+const second = reverse ? outLo : outHi;
+return [this._axisValue(axis, first), this._axisValue(axis, second)];
+},
+_clampView(view) {
+const x = this._clampAxisRange("x", view.x0, view.x1);
+const y = this._clampAxisRange("y", view.y0, view.y1);
+return { x0: x[0], x1: x[1], y0: y[0], y1: y[1] };
 },
 _zoomBy(f, animate = false) {
 const base = this._viewAnim ? this._viewAnim.target : this.view;

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -5927,15 +5927,12 @@ const cx0 = this._axisCoord(xa, x0), cx1 = this._axisCoord(xa, x1);
 const cy0 = this._axisCoord(ya, y0), cy1 = this._axisCoord(ya, y1);
 const dx = ((e.clientX - drag.px) / this.plot.w) * (cx1 - cx0);
 const dy = ((e.clientY - drag.py) / this.plot.h) * (cy1 - cy0);
-this.view = this._clampView({
+this._setView({
 x0: this._axisValue(xa, cx0 - dx),
 x1: this._axisValue(xa, cx1 - dx),
 y0: this._axisValue(ya, cy0 + dy),
 y1: this._axisValue(ya, cy1 + dy),
-});
-this.draw();
-this._scheduleViewRequest();
-this._emitViewChange("pan");
+}, { source: "pan" });
 return;
 }
 this._updateCrosshair(e);
@@ -7047,17 +7044,14 @@ const b1 = this._axisCoord(axis, axis.bounds[1]);
 if (![c0, c1, b0, b1].every(Number.isFinite) || b0 === b1) return [lo, hi];
 const reverse = c1 < c0;
 const boundLo = Math.min(b0, b1), boundHi = Math.max(b0, b1);
-const boundSpan = boundHi - boundLo;
-const span = Math.abs(c1 - c0);
-let outLo, outHi;
-if (span >= boundSpan) {
+let outLo = Math.min(c0, c1), outHi = Math.max(c0, c1);
+if (outHi - outLo >= boundHi - boundLo) {
 outLo = boundLo;
 outHi = boundHi;
 } else {
-outLo = Math.min(c0, c1);
-outHi = Math.max(c0, c1);
-if (outLo < boundLo) { outHi += boundLo - outLo; outLo = boundLo; }
-if (outHi > boundHi) { outLo -= outHi - boundHi; outHi = boundHi; }
+const shift = Math.max(boundLo - outLo, Math.min(boundHi - outHi, 0));
+outLo += shift;
+outHi += shift;
 }
 const first = reverse ? outHi : outLo;
 const second = reverse ? outLo : outHi;

--- a/tests/test_viewport_bounds.py
+++ b/tests/test_viewport_bounds.py
@@ -1,5 +1,7 @@
 """Hard navigation-bound API and client-clamping contracts."""
 
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_viewport_bounds.py
+++ b/tests/test_viewport_bounds.py
@@ -1,0 +1,55 @@
+"""Hard navigation-bound API and client-clamping contracts."""
+
+from pathlib import Path
+
+import pytest
+
+import xy
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_explicit_axis_bounds_ship_separately_from_initial_domain() -> None:
+    chart = xy.bar_chart(
+        xy.bar(["A", "B", "C"], [10, 20, 30]),
+        xy.y_axis(domain=(5, 25), bounds=(0, 30)),
+    )
+
+    spec, _ = chart.figure().build_payload()
+
+    assert spec["y_axis"]["range"] == [5.0, 25.0]
+    assert spec["y_axis"]["domain"] == [5.0, 25.0]
+    assert spec["y_axis"]["bounds"] == [0.0, 30.0]
+    assert "bounds" not in spec["x_axis"]
+
+
+def test_data_bounds_resolve_independently_of_explicit_domain() -> None:
+    chart = xy.line_chart(
+        xy.line([10, 20, 30], [2, 4, 8]),
+        xy.x_axis(domain=(12, 18), bounds="data"),
+    )
+
+    spec, _ = chart.figure().build_payload()
+
+    assert spec["x_axis"]["range"] == [12.0, 18.0]
+    assert spec["x_axis"]["bounds"][0] < 10
+    assert spec["x_axis"]["bounds"][1] > 30
+
+
+@pytest.mark.parametrize("factory", [xy.x_axis, xy.y_axis])
+def test_axis_bounds_validation(factory) -> None:
+    with pytest.raises(ValueError, match="bounds"):
+        factory(bounds=(2, 1))
+    with pytest.raises(ValueError, match="bounds"):
+        factory(bounds="everything")
+    with pytest.raises(ValueError, match="positive"):
+        xy.line_chart(xy.line([1, 2], [1, 2]), factory(type_="log", bounds=(-1, 10))).figure()
+
+
+def test_client_clamps_pan_zoom_and_reversed_log_ranges() -> None:
+    source = (ROOT / "js/src/53_interaction.js").read_text(encoding="utf-8")
+
+    assert "_clampAxisRange(axisId, lo, hi)" in source
+    assert "const reverse = c1 < c0" in source
+    assert "const target = this._clampView(" in source
+    assert "this.view = this._clampView({" in source

--- a/tests/test_viewport_bounds.py
+++ b/tests/test_viewport_bounds.py
@@ -54,4 +54,4 @@ def test_client_clamps_pan_zoom_and_reversed_log_ranges() -> None:
     assert "_clampAxisRange(axisId, lo, hi)" in source
     assert "const reverse = c1 < c0" in source
     assert "const target = this._clampView(" in source
-    assert "this.view = this._clampView({" in source
+    assert '}, { source: "pan" });' in source


### PR DESCRIPTION
### Motivation
- Provide a way to keep interactive navigation (pan/zoom) inside meaningful data extents separate from the initial `domain` so users cannot pan/zoom the camera completely away from the chart.
- Keep exploratory interaction available while preventing empty/partially-visible charts and preserve existing semantics for reversed and log axes.

### Description
- Add a `bounds` field to `Axis` and expose `bounds=(lo, hi)` or `bounds="data"` on `xy.x_axis()` and `xy.y_axis()` so navigation limits are declaratively configurable.
- Validate `bounds` (including log-axis positivity) on the Python side and serialize `spec["bounds"]` separately from `domain`, resolving `"data"` to the data range at payload build time.
- Clamp the initial viewport, drag panning, wheel/box/button zooms, animated view transitions, and linked-view updates on the client by adding `_clampAxisRange` and `_clampView` helpers and integrating them where views are set/updated; clamping works in scale coordinates to preserve reversed and log semantics.
- Add `tests/test_viewport_bounds.py` covering payload serialization, `"data"` resolution, validation, and presence of client clamping hooks; regenerate the committed browser bundles so the shipped static client contains the clamp logic.

### Testing
- Ran unit tests: `PYTHONPATH=python python -m pytest tests/test_viewport_bounds.py tests/test_type_surface.py tests/test_figure.py -q` and `PYTHONPATH=python python -m pytest tests/test_viewport_bounds.py -q`, both succeeded (final run: 166 passed, 1 skipped; viewport-bounds tests passed).
- Ran formatting and lint checks: `ruff format --check` / `ruff check` on the modified files and fixed import ordering; all checks passed.
- Rebuilt the static client: `node js/build.mjs --check` and verified the generated bundles; check passed.
- Ran `git diff --check` to ensure no whitespace/check issues; no problems found.

------

Closes #82