### PR TITLE
Fix standalone density flicker on pan/zoom-out

### DIFF
--- a/js/src/50_chartview.js
+++ b/js/src/50_chartview.js
@@ -1825,7 +1825,12 @@ class ChartView {
 
   _drawDensitySample(g, x0, x1, y0, y1, opacityScale = 1) {
     const s = g && g.sampleOverlay;
-    if (!s || !s.n || !this._viewInside(s.win)) return;
+    // Draw the retained sample whenever it overlaps the view, not only when the
+    // view sits fully inside the sample window: a pan or zoom-out must keep the
+    // same "density + points" look instead of dropping the points the instant
+    // the view crosses the sample's home extent (the density grid stays, so the
+    // points have to as well). Off-screen points are clipped by the GPU.
+    if (!s || !s.n || !this._viewOverlaps(s.win)) return;
     this._drawPoints(
       s,
       this._map(s.xMeta, x0, x1, s.xAxis),

--- a/js/src/54_kernel.js
+++ b/js/src/54_kernel.js
@@ -90,15 +90,24 @@ Object.assign(ChartView.prototype, {
 
   _requestSampleRebin(g, view, seq) {
     if (!g._homeDensity) g._homeDensity = g.density;
-    // At (or beyond) the home view the full overview grid — binned from every
-    // source point kernel-side — beats any re-bin of the sample: restore it.
+    // The full overview grid — binned kernel-side from every source point at
+    // export — has enough resolution for any view that is not zoomed in
+    // *tighter* than the home extent. Re-binning the retained §28 sample only
+    // adds resolution once the user zooms in; doing it on a mere pan (or a
+    // zoom-out) would swap the full-data grid for a noisier sample-derived
+    // grid that normalizes against a different, much smaller maximum, so the
+    // density visibly jumps between the overview and the sample on the
+    // slightest drag. Gate on view *span*, not position: keep (and restore)
+    // the overview for pans and zoom-outs; only a real zoom-in re-bins.
     const v0 = this.view0;
-    const ex = Math.max(Math.abs(v0.x1 - v0.x0), 1e-300) * 1e-9;
-    const ey = Math.max(Math.abs(v0.y1 - v0.y0), 1e-300) * 1e-9;
-    const atHome =
-      Math.min(view.x0, view.x1) <= v0.x0 + ex && Math.max(view.x0, view.x1) >= v0.x1 - ex &&
-      Math.min(view.y0, view.y1) <= v0.y0 + ey && Math.max(view.y0, view.y1) >= v0.y1 - ey;
-    if (atHome) {
+    const homeSpanX = Math.max(Math.abs(v0.x1 - v0.x0), 1e-300);
+    const homeSpanY = Math.max(Math.abs(v0.y1 - v0.y0), 1e-300);
+    const viewSpanX = Math.abs(view.x1 - view.x0);
+    const viewSpanY = Math.abs(view.y1 - view.y0);
+    // 1e-6 slack absorbs float drift so a pan at home zoom never trips a re-bin.
+    const notZoomedIn =
+      viewSpanX >= homeSpanX * (1 - 1e-6) && viewSpanY >= homeSpanY * (1 - 1e-6);
+    if (notZoomedIn) {
       if (g.density !== g._homeDensity) {
         const hd = g._homeDensity;
         this._applySampleRebinGrid(g, {
@@ -399,6 +408,20 @@ Object.assign(ChartView.prototype, {
     const wx0 = Math.min(win.x0, win.x1), wx1 = Math.max(win.x0, win.x1);
     const wy0 = Math.min(win.y0, win.y1), wy1 = Math.max(win.y0, win.y1);
     return vx0 >= wx0 - ex && vx1 <= wx1 + ex && vy0 >= wy0 - ey && vy1 <= wy1 + ey;
+  },
+
+  // Does the current view overlap `win` at all (as opposed to sit fully inside
+  // it)? Used to keep the retained density sample on screen through pans and
+  // zoom-outs — the points are positioned in data space and the GPU clips the
+  // off-screen ones, so overlap is the right test, not containment.
+  _viewOverlaps(win) {
+    if (!win) return false;
+    const { x0, x1, y0, y1 } = this.view;
+    const vx0 = Math.min(x0, x1), vx1 = Math.max(x0, x1);
+    const vy0 = Math.min(y0, y1), vy1 = Math.max(y0, y1);
+    const wx0 = Math.min(win.x0, win.x1), wx1 = Math.max(win.x0, win.x1);
+    const wy0 = Math.min(win.y0, win.y1), wy1 = Math.max(win.y0, win.y1);
+    return vx0 <= wx1 && vx1 >= wx0 && vy0 <= wy1 && vy1 >= wy0;
   },
 
   _viewInsideRange(xRange, yRange) {

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -3215,7 +3215,7 @@ this._refreshReductionBadges();
 }
 _drawDensitySample(g, x0, x1, y0, y1, opacityScale = 1) {
 const s = g && g.sampleOverlay;
-if (!s || !s.n || !this._viewInside(s.win)) return;
+if (!s || !s.n || !this._viewOverlaps(s.win)) return;
 this._drawPoints(
 s,
 this._map(s.xMeta, x0, x1, s.xAxis),
@@ -7729,12 +7729,13 @@ for (const g of targets) this._requestSampleRebin(g, view, seq);
 _requestSampleRebin(g, view, seq) {
 if (!g._homeDensity) g._homeDensity = g.density;
 const v0 = this.view0;
-const ex = Math.max(Math.abs(v0.x1 - v0.x0), 1e-300) * 1e-9;
-const ey = Math.max(Math.abs(v0.y1 - v0.y0), 1e-300) * 1e-9;
-const atHome =
-Math.min(view.x0, view.x1) <= v0.x0 + ex && Math.max(view.x0, view.x1) >= v0.x1 - ex &&
-Math.min(view.y0, view.y1) <= v0.y0 + ey && Math.max(view.y0, view.y1) >= v0.y1 - ey;
-if (atHome) {
+const homeSpanX = Math.max(Math.abs(v0.x1 - v0.x0), 1e-300);
+const homeSpanY = Math.max(Math.abs(v0.y1 - v0.y0), 1e-300);
+const viewSpanX = Math.abs(view.x1 - view.x0);
+const viewSpanY = Math.abs(view.y1 - view.y0);
+const notZoomedIn =
+viewSpanX >= homeSpanX * (1 - 1e-6) && viewSpanY >= homeSpanY * (1 - 1e-6);
+if (notZoomedIn) {
 if (g.density !== g._homeDensity) {
 const hd = g._homeDensity;
 this._applySampleRebinGrid(g, {
@@ -7980,6 +7981,15 @@ const vy0 = Math.min(y0, y1), vy1 = Math.max(y0, y1);
 const wx0 = Math.min(win.x0, win.x1), wx1 = Math.max(win.x0, win.x1);
 const wy0 = Math.min(win.y0, win.y1), wy1 = Math.max(win.y0, win.y1);
 return vx0 >= wx0 - ex && vx1 <= wx1 + ex && vy0 >= wy0 - ey && vy1 <= wy1 + ey;
+},
+_viewOverlaps(win) {
+if (!win) return false;
+const { x0, x1, y0, y1 } = this.view;
+const vx0 = Math.min(x0, x1), vx1 = Math.max(x0, x1);
+const vy0 = Math.min(y0, y1), vy1 = Math.max(y0, y1);
+const wx0 = Math.min(win.x0, win.x1), wx1 = Math.max(win.x0, win.x1);
+const wy0 = Math.min(win.y0, win.y1), wy1 = Math.max(win.y0, win.y1);
+return vx0 <= wx1 && vx1 >= wx0 && vy0 <= wy1 && vy1 >= wy0;
 },
 _viewInsideRange(xRange, yRange) {
 if (!xRange || !yRange) return false;

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -3216,7 +3216,7 @@ this._refreshReductionBadges();
 }
 _drawDensitySample(g, x0, x1, y0, y1, opacityScale = 1) {
 const s = g && g.sampleOverlay;
-if (!s || !s.n || !this._viewInside(s.win)) return;
+if (!s || !s.n || !this._viewOverlaps(s.win)) return;
 this._drawPoints(
 s,
 this._map(s.xMeta, x0, x1, s.xAxis),
@@ -7730,12 +7730,13 @@ for (const g of targets) this._requestSampleRebin(g, view, seq);
 _requestSampleRebin(g, view, seq) {
 if (!g._homeDensity) g._homeDensity = g.density;
 const v0 = this.view0;
-const ex = Math.max(Math.abs(v0.x1 - v0.x0), 1e-300) * 1e-9;
-const ey = Math.max(Math.abs(v0.y1 - v0.y0), 1e-300) * 1e-9;
-const atHome =
-Math.min(view.x0, view.x1) <= v0.x0 + ex && Math.max(view.x0, view.x1) >= v0.x1 - ex &&
-Math.min(view.y0, view.y1) <= v0.y0 + ey && Math.max(view.y0, view.y1) >= v0.y1 - ey;
-if (atHome) {
+const homeSpanX = Math.max(Math.abs(v0.x1 - v0.x0), 1e-300);
+const homeSpanY = Math.max(Math.abs(v0.y1 - v0.y0), 1e-300);
+const viewSpanX = Math.abs(view.x1 - view.x0);
+const viewSpanY = Math.abs(view.y1 - view.y0);
+const notZoomedIn =
+viewSpanX >= homeSpanX * (1 - 1e-6) && viewSpanY >= homeSpanY * (1 - 1e-6);
+if (notZoomedIn) {
 if (g.density !== g._homeDensity) {
 const hd = g._homeDensity;
 this._applySampleRebinGrid(g, {
@@ -7981,6 +7982,15 @@ const vy0 = Math.min(y0, y1), vy1 = Math.max(y0, y1);
 const wx0 = Math.min(win.x0, win.x1), wx1 = Math.max(win.x0, win.x1);
 const wy0 = Math.min(win.y0, win.y1), wy1 = Math.max(win.y0, win.y1);
 return vx0 >= wx0 - ex && vx1 <= wx1 + ex && vy0 >= wy0 - ey && vy1 <= wy1 + ey;
+},
+_viewOverlaps(win) {
+if (!win) return false;
+const { x0, x1, y0, y1 } = this.view;
+const vx0 = Math.min(x0, x1), vx1 = Math.max(x0, x1);
+const vy0 = Math.min(y0, y1), vy1 = Math.max(y0, y1);
+const wx0 = Math.min(win.x0, win.x1), wx1 = Math.max(win.x0, win.x1);
+const wy0 = Math.min(win.y0, win.y1), wy1 = Math.max(win.y0, win.y1);
+return vx0 <= wx1 && vx1 >= wx0 && vy0 <= wy1 && vy1 >= wy0;
 },
 _viewInsideRange(xRange, yRange) {
 if (!xRange || !yRange) return false;

--- a/tests/test_density_pan_no_rebin.py
+++ b/tests/test_density_pan_no_rebin.py
@@ -1,0 +1,148 @@
+"""Standalone (kernel-less) density: panning must keep the full-data overview.
+
+A `to_html` density export ships the overview grid (binned kernel-side from
+every source point) plus the retained §28 sample. Without a kernel, only the
+sample can be re-binned in the browser. Re-binning it on a mere *pan* swaps the
+full-data grid for a noisier sample-derived grid normalized against a much
+smaller maximum, so the density visibly jumps (overview <-> sample) on the
+slightest drag. The re-bin must fire only on a genuine zoom-*in*, where it adds
+resolution the overview grid lacks; pans and zoom-outs keep the overview.
+
+This drives the real client in headless Chromium and inspects the decision made
+by `_requestSampleRebin`, using a sentinel object to distinguish "restored the
+overview" from "left the sample grid in place". The wall-clock re-bin worker is
+disabled (`_sampleRebinDisabled`) so no worker spawns to stall `--dump-dom`;
+the gate under test runs before that flag is consulted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import xy
+from conftest import run_browser_probe
+from xy.export import find_chromium
+
+_RENDER_CALL = 'xy.renderStandalone(document.getElementById("chart"), spec, buf);'
+
+_PROBE = """
+  const view = xy.renderStandalone(document.getElementById("chart"), spec, buf);
+  try {
+    view._drawNow();
+    view._raf = null;
+    // Never spawn the wall-clock re-bin worker under --virtual-time-budget
+    // --dump-dom; the pan/zoom gate under test runs before this flag is read.
+    view._sampleRebinDisabled = true;
+    const g = view.gpuTraces.find((t) => t.tier === "density");
+    const v0 = view.view0;
+    const sx = v0.x1 - v0.x0, sy = v0.y1 - v0.y0;
+    g._homeDensity = g.density;
+    // A sentinel stands in for a sample-rebinned grid; restoring the overview
+    // replaces it, leaving it in place means the re-bin path was taken.
+    const sentinel = { __sentinel: true };
+
+    // 1) Pan at home zoom (span unchanged, shifted 20%): keep the overview.
+    g.density = sentinel;
+    view._requestSampleRebin(
+      g,
+      { x0: v0.x0 + sx * 0.2, x1: v0.x1 + sx * 0.2,
+        y0: v0.y0 + sy * 0.2, y1: v0.y1 + sy * 0.2 },
+      view.seq,
+    );
+    const panRestoredOverview = g.density !== sentinel;
+    const panSpawnedWorker = !!view._rebinWorker;
+
+    // 2) Zoom in (span halved, centered): do NOT restore -> sample re-bin path.
+    g.density = sentinel;
+    const cx = (v0.x0 + v0.x1) / 2, cy = (v0.y0 + v0.y1) / 2;
+    view._requestSampleRebin(
+      g,
+      { x0: cx - sx * 0.25, x1: cx + sx * 0.25,
+        y0: cy - sy * 0.25, y1: cy + sy * 0.25 },
+      view.seq,
+    );
+    const zoomKeptSampleGrid = g.density === sentinel;
+
+    // 3) The retained sample overlay must keep drawing through a pan/zoom-out,
+    // not drop out the instant the view leaves its home window. Spy on the
+    // point draw for a zoomed-out view (span 2x, so the view is NOT inside the
+    // sample window) and for a view panned entirely off the data.
+    g.density = g._homeDensity;
+    let drewPoints = 0;
+    const realDrawPoints = view._drawPoints;
+    view._drawPoints = function () { drewPoints += 1; };
+    view.view = { x0: v0.x0 - sx * 0.5, x1: v0.x1 + sx * 0.5,
+                  y0: v0.y0 - sy * 0.5, y1: v0.y1 + sy * 0.5 };
+    view._drawDensitySample(g, view.view.x0, view.view.x1, view.view.y0, view.view.y1);
+    const sampleDrawnZoomedOut = drewPoints > 0;
+    drewPoints = 0;
+    view.view = { x0: v0.x1 + sx * 5, x1: v0.x1 + sx * 6,
+                  y0: v0.y1 + sy * 5, y1: v0.y1 + sy * 6 };
+    view._drawDensitySample(g, view.view.x0, view.view.x1, view.view.y0, view.view.y1);
+    const sampleSkippedOffData = drewPoints === 0;
+    view._drawPoints = realDrawPoints;
+
+    document.body.setAttribute("data-xy-rebin-probe", JSON.stringify({
+      hasDensity: !!g,
+      panRestoredOverview,
+      panSpawnedWorker,
+      zoomKeptSampleGrid,
+      sampleDrawnZoomedOut,
+      sampleSkippedOffData,
+    }));
+  } catch (err) {
+    document.body.setAttribute(
+      "data-xy-rebin-probe-error",
+      String((err && err.stack) || err),
+    );
+  }
+"""
+
+
+def _density_html() -> str:
+    rng = np.random.default_rng(0)
+    n = 60_000
+    x = rng.normal(0.0, 1.0, n)
+    y = rng.normal(0.0, 1.0, n)
+    # density=True forces the density tier (overview grid + retained sample)
+    # regardless of point count, so the export exercises the standalone re-bin
+    # path deterministically and cheaply.
+    chart = xy.scatter_chart(
+        xy.scatter(x, y, density=True),
+        xy.x_axis(),
+        xy.y_axis(),
+        width=480,
+        height=360,
+    )
+    html = chart.to_html()
+    assert _RENDER_CALL in html
+    return html
+
+
+def test_standalone_pan_keeps_overview_only_zoom_rebins(tmp_path: Path) -> None:
+    chromium = find_chromium()
+    if chromium is None:
+        pytest.skip("Chromium unavailable")
+
+    document = _density_html().replace(_RENDER_CALL, _PROBE)
+    result = run_browser_probe(
+        chromium,
+        document,
+        tmp_path / "density_pan.html",
+        "data-xy-rebin-probe",
+        label="density pan re-bin probe",
+    )
+
+    assert result["hasDensity"] is True
+    # A pan keeps (restores) the full-data overview and spawns no worker.
+    assert result["panRestoredOverview"] is True
+    assert result["panSpawnedWorker"] is False
+    # A genuine zoom-in still routes to the sample re-bin path.
+    assert result["zoomKeptSampleGrid"] is True
+    # The sample overlay travels with the view: it keeps drawing when zoomed out
+    # past its home window, and only drops when panned entirely off the data.
+    assert result["sampleDrawnZoomedOut"] is True
+    assert result["sampleSkippedOffData"] is True


### PR DESCRIPTION
## Problem

In a kernel-less `to_html` density export, the density visibly flickered on the slightest drag — swapping between the full-data overview grid and the retained sample. Two distinct causes:

1. **Color/brightness flip on pan.** `_requestSampleRebin` re-binned the sample whenever the view wasn't *exactly* at the home extent, so a pure pan swapped the full-data overview grid for a sample-derived grid normalized against a much smaller maximum. The two normalize differently, so the density jumped.

2. **Points vanishing on pan/zoom-out.** The retained sample overlay was gated by `_viewInside(s.win)`, so its individual points dropped out the instant the view left the sample's home window, while the density stayed — an inconsistent "density loses its grain" effect.

## Fix

1. Gate the re-bin on view **span**, not position: pans and zoom-outs keep (and restore) the full-data overview; only a genuine **zoom-in** re-bins, where the sample actually adds resolution the overview lacks.

2. Add `_viewOverlaps` and draw the sample whenever it **overlaps** the view. Points are positioned in data space and the GPU clips off-screen ones, so the "density + points" look now travels with the view and only drops when panned entirely off the data.

Scoped strictly to the standalone (no-kernel) path; the kernel `density_view` path is unchanged.

## Tests

Adds `tests/test_density_pan_no_rebin.py` — a headless-Chromium regression test asserting:

- a pan keeps the overview and spawns **no** re-bin worker,
- a zoom-in still routes to the sample re-bin path,
- the sample overlay persists through a zoom-out but drops when panned entirely off the data.

Render smoke + related suites pass; bundles regenerated via `node js/build.mjs`; ruff/format clean.