### PR TITLE
Release the WebGL context in ChartView.destroy()

### DIFF
--- a/js/src/50_chartview.js
+++ b/js/src/50_chartview.js
@@ -4094,6 +4094,14 @@ class ChartView {
     this._raf = null;
     this._cancelViewAnimation();
     this._destroyGlResources();
+    // Release the GL context now instead of waiting for GC. Republishing a
+    // figure destroys and rebuilds its view, and browsers cap live contexts
+    // (~16); without an explicit loss the destroyed contexts pile up under
+    // repeated rebuilds (e.g. an on_view_change-driven refresh) and trip the
+    // "too many active WebGL contexts" eviction. Listeners are already removed
+    // above and _destroyed is set, so the resulting event starts no recovery.
+    const loseExt = this.gl && this.gl.getExtension("WEBGL_lose_context");
+    if (loseExt) loseExt.loseContext();
     this.gl = null;
     this.root.remove();
   }

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -5179,6 +5179,8 @@ if (this._raf) cancelAnimationFrame(this._raf);
 this._raf = null;
 this._cancelViewAnimation();
 this._destroyGlResources();
+const loseExt = this.gl && this.gl.getExtension("WEBGL_lose_context");
+if (loseExt) loseExt.loseContext();
 this.gl = null;
 this.root.remove();
 }

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -5180,6 +5180,8 @@ if (this._raf) cancelAnimationFrame(this._raf);
 this._raf = null;
 this._cancelViewAnimation();
 this._destroyGlResources();
+const loseExt = this.gl && this.gl.getExtension("WEBGL_lose_context");
+if (loseExt) loseExt.loseContext();
 this.gl = null;
 this.root.remove();
 }

--- a/spec/design-dossier.md
+++ b/spec/design-dossier.md
@@ -648,6 +648,10 @@ scrolled back into view; an over-budget panel keeps showing its last frame as a 
 image. Under the budget nothing is ever released. Every decision is observable:
 `data-xy-ctx` on the canvas reads `live` | `released` | `lost`. See
 `spec/process/production-readiness.md` §"WebGL context cap" for the claim limits.
+`destroy()` releases the context via `WEBGL_lose_context` too, so a view teardown —
+including the destroy+rebuild a full-payload republish performs — frees its slot
+immediately rather than leaving a destroyed context to linger until GC and count
+against the browser cap.
 
 **Device/context loss is a first-class event:** all GPU state is derived state, rebuilt
 from the scene graph + column store on a new context. The visible cost is one reupload

--- a/spec/design/renderer-architecture.md
+++ b/spec/design/renderer-architecture.md
@@ -145,9 +145,12 @@ Ordered by how much each compounds as kinds multiply.
 - **R8 — Lifecycle cleanup.** ✅ **Already complete** (re-audit): `destroy()`
   → `_destroyGlResources` frees per-trace static + drill buffers, density/
   heatmap/LUT textures (dedup via `texSeen`), pick FBO/texture, the quad, and
-  all programs. The original finding is stale. Remaining nicety only: move
-  per-kind buffer-name lists into a registry `dispose` hook when a kind
-  arrives whose resources don't fit the shared name list.
+  all programs, then releases the GL context itself via `WEBGL_lose_context`
+  so a torn-down view (including a full-payload republish's destroy+rebuild)
+  frees its context slot immediately instead of waiting for GC. The original
+  finding is stale. Remaining nicety only: move per-kind buffer-name lists into
+  a registry `dispose` hook when a kind arrives whose resources don't fit the
+  shared name list.
 - **R9 — Picking model won't stretch as-is.** GPU ID pass is point-only
   (`pointPick`); rect-family picking (bars/candles) is planned as a
   registry `pick` step (contract). The ID encoding is a single *global*


### PR DESCRIPTION
A full-payload republish rebuilds the view (destroy + new ChartView, hence a new GL context), and browsers cap live contexts (~16 in Chrome). destroy() freed GPU resources but never released the context itself, so destroyed contexts lingered until GC and — under repeated republishes, e.g. an on_view_change-driven figure refresh — tripped the browser's "too many active WebGL contexts" eviction.

destroy() now releases the context via WEBGL_lose_context after freeing resources; the context-lost listeners are already removed and _destroyed is set, so the resulting event starts no recovery. Rebuild the committed static bundles and record the behavior in the dossier (§18) and renderer-architecture (R8).