### PR TITLE
Fix responsive chart resize flashing

### DIFF
--- a/js/src/50_chartview.js
+++ b/js/src/50_chartview.js
@@ -5,6 +5,7 @@
 const MARGIN = { l: 62, r: 14, t: 10, b: 42 };
 const COLORBAR_THICKNESS = 18;
 const COLORBAR_GAP = 24;
+const COMPACT_COLORBAR_GAP = 8;
 let XY_A11Y_ID = 0;
 const XY_SR_ONLY_STYLE =
   "position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;" +
@@ -191,6 +192,9 @@ class ChartView {
     this._progCache = new Map();
     this._bufSeq = 0;
     this._destroyed = false;
+    this._resizeRaf = null;
+    this._pendingResize = null;
+    this._resizeNeedsMeasure = false;
     this._hoverId = -1;
     this._hoverTarget = null;
     this._viewEventRaf = null;
@@ -262,7 +266,7 @@ class ChartView {
     if ((this.fluid || this.fluidH) && typeof ResizeObserver !== "undefined") {
       this._ro = new ResizeObserver((entries) => {
         const r = entries[entries.length - 1].contentRect;
-        if (r.width || r.height) this._resize(r.width, r.height);
+        if (r.width || r.height) this._queueResize(r.width, r.height);
       });
       this._ro.observe(this.root);
     }
@@ -303,13 +307,24 @@ class ChartView {
     // Explicit padding (spec.padding = [top,right,bottom,left]) overrides the
     // label-aware defaults — zero padding gives an edge-to-edge sparkline.
     const pad = Array.isArray(this.spec.padding) ? this.spec.padding : null;
-    const marginLeft = pad ? pad[3] : compact ? 46 : MARGIN.l;
     const colorbar = this.spec.colorbar;
     const verticalColorbar = colorbar && colorbar.orientation !== "horizontal";
     const horizontalColorbar = colorbar && colorbar.orientation === "horizontal";
-    const colorbarRightRoom = verticalColorbar ? 86 + (colorbar.label ? 18 : 0) : 0;
+    // Fluid charts have to remain useful inside dashboard columns. On compact
+    // widths, cap only oversized authored horizontal padding and collapse a
+    // vertical colorbar to its gradient; the full tick/title chrome returns
+    // automatically when the container widens again.
+    const responsivePad = this.fluid && compact && pad;
+    const marginLeft = pad ? (responsivePad ? Math.min(pad[3], 46) : pad[3]) : compact ? 46 : MARGIN.l;
+    this._compactVerticalColorbar = Boolean(this.fluid && compact && verticalColorbar);
+    const colorbarRightRoom = verticalColorbar
+      ? (this._compactVerticalColorbar
+        ? COMPACT_COLORBAR_GAP + COLORBAR_THICKNESS + 8
+        : 86 + (colorbar.label ? 18 : 0))
+      : 0;
     const colorbarBottomRoom = horizontalColorbar ? 38 + (colorbar.label ? 16 : 0) : 0;
-    const marginRight = (pad ? pad[1] : compact ? 8 : MARGIN.r) + colorbarRightRoom;
+    const baseRight = pad ? (responsivePad ? Math.min(pad[1], 8) : pad[1]) : compact ? 8 : MARGIN.r;
+    const marginRight = baseRight + colorbarRightRoom;
     const marginTop = pad ? pad[0] : compact ? 6 : MARGIN.t;
     const marginBottom = (pad ? pad[2] : compact ? 36 : MARGIN.b) + colorbarBottomRoom;
     const hasBottomAxis = Object.values(this.axes || {}).some((axis) =>
@@ -596,15 +611,34 @@ class ChartView {
 
   _syncContainerSize() {
     if (this._destroyed || !(this.fluid || this.fluidH) || !this.root) return;
-    const rect = this.root.getBoundingClientRect();
-    if (rect.width || rect.height) this._resize(rect.width, rect.height);
+    this._queueResize(null, null, true);
+  }
+
+  _queueResize(cssW = null, cssH = null, measure = false) {
+    if (this._destroyed) return;
+    if (cssW || cssH) this._pendingResize = { cssW, cssH };
+    if (measure) this._resizeNeedsMeasure = true;
+    if (this._resizeRaf) return;
+    this._resizeRaf = requestAnimationFrame(() => {
+      this._resizeRaf = null;
+      let pending = this._pendingResize;
+      this._pendingResize = null;
+      if (this._resizeNeedsMeasure && this.root) {
+        const rect = this.root.getBoundingClientRect();
+        if (rect.width || rect.height) pending = { cssW: rect.width, cssH: rect.height };
+      }
+      this._resizeNeedsMeasure = false;
+      if (pending && (pending.cssW || pending.cssH)) {
+        this._resize(pending.cssW, pending.cssH);
+      }
+    });
   }
 
   _armVisibilityResizeWatch() {
     if (!(this.fluid || this.fluidH)) return;
     const syncSoon = () => {
       if (this._destroyed) return;
-      requestAnimationFrame(() => this._syncContainerSize());
+      this._syncContainerSize();
     };
     this._listen(window, "resize", syncSoon);
     this._listen(window, "pageshow", syncSoon);
@@ -1072,7 +1106,12 @@ class ChartView {
     this._positionColorbar();
     this._fitModebar();
     this._pickDirty = true;
-    this.draw();
+    // Changing a canvas backing-store dimension clears it immediately. Resize
+    // work is already coalesced into one animation frame, so paint in that same
+    // frame instead of exposing cleared canvases until a second rAF callback.
+    if (this._raf) cancelAnimationFrame(this._raf);
+    this._raf = null;
+    this._drawNow();
     this._scheduleViewRequest();
   }
 
@@ -1499,14 +1538,24 @@ class ChartView {
   _positionColorbar() {
     if (!this._colorbar) return;
     const horizontal = this._colorbarHorizontal;
+    const compactVertical = !horizontal && this._compactVerticalColorbar;
+    const gap = compactVertical ? COMPACT_COLORBAR_GAP : COLORBAR_GAP;
     this._colorbar.style.left = (horizontal
       ? this.plot.x
-      : this.plot.x + this.plot.w + this._rightAxisRoom + COLORBAR_GAP) + "px";
+      : this.plot.x + this.plot.w + this._rightAxisRoom + gap) + "px";
     this._colorbar.style.top = (horizontal
       ? this.plot.y + this.plot.h + (this._bottomAxisRoom || 8)
       : this.plot.y) + "px";
-    this._colorbar.style.width = (horizontal ? this.plot.w : 66) + "px";
+    this._colorbar.style.width = (horizontal
+      ? this.plot.w
+      : compactVertical ? COLORBAR_THICKNESS : 66) + "px";
     this._colorbar.style.height = (horizontal ? 50 : Math.max(24, this.plot.h)) + "px";
+    this._colorbar.dataset.xyCompact = compactVertical ? "true" : "false";
+    for (const node of this._colorbar.querySelectorAll(
+      '[data-xy-slot="colorbar_tick"], [data-xy-slot="colorbar_title"]'
+    )) {
+      node.hidden = compactVertical;
+    }
   }
 
   _initGl(buffer) {
@@ -4092,6 +4141,10 @@ class ChartView {
     this._linkChannel = null;
     if (this._raf) cancelAnimationFrame(this._raf);
     this._raf = null;
+    if (this._resizeRaf) cancelAnimationFrame(this._resizeRaf);
+    this._resizeRaf = null;
+    this._pendingResize = null;
+    this._resizeNeedsMeasure = false;
     this._cancelViewAnimation();
     this._destroyGlResources();
     this.gl = null;

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -1713,6 +1713,7 @@ return null;
 const MARGIN = { l: 62, r: 14, t: 10, b: 42 };
 const COLORBAR_THICKNESS = 18;
 const COLORBAR_GAP = 24;
+const COMPACT_COLORBAR_GAP = 8;
 let XY_A11Y_ID = 0;
 const XY_SR_ONLY_STYLE =
 "position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;" +
@@ -1867,6 +1868,9 @@ this._glPrograms = [];
 this._progCache = new Map();
 this._bufSeq = 0;
 this._destroyed = false;
+this._resizeRaf = null;
+this._pendingResize = null;
+this._resizeNeedsMeasure = false;
 this._hoverId = -1;
 this._hoverTarget = null;
 this._viewEventRaf = null;
@@ -1915,7 +1919,7 @@ this._buildModebar(this.root);
 if ((this.fluid || this.fluidH) && typeof ResizeObserver !== "undefined") {
 this._ro = new ResizeObserver((entries) => {
 const r = entries[entries.length - 1].contentRect;
-if (r.width || r.height) this._resize(r.width, r.height);
+if (r.width || r.height) this._queueResize(r.width, r.height);
 });
 this._ro.observe(this.root);
 }
@@ -1945,13 +1949,20 @@ this.draw();
 _layout() {
 const compact = this.size.w < 520;
 const pad = Array.isArray(this.spec.padding) ? this.spec.padding : null;
-const marginLeft = pad ? pad[3] : compact ? 46 : MARGIN.l;
 const colorbar = this.spec.colorbar;
 const verticalColorbar = colorbar && colorbar.orientation !== "horizontal";
 const horizontalColorbar = colorbar && colorbar.orientation === "horizontal";
-const colorbarRightRoom = verticalColorbar ? 86 + (colorbar.label ? 18 : 0) : 0;
+const responsivePad = this.fluid && compact && pad;
+const marginLeft = pad ? (responsivePad ? Math.min(pad[3], 46) : pad[3]) : compact ? 46 : MARGIN.l;
+this._compactVerticalColorbar = Boolean(this.fluid && compact && verticalColorbar);
+const colorbarRightRoom = verticalColorbar
+? (this._compactVerticalColorbar
+? COMPACT_COLORBAR_GAP + COLORBAR_THICKNESS + 8
+: 86 + (colorbar.label ? 18 : 0))
+: 0;
 const colorbarBottomRoom = horizontalColorbar ? 38 + (colorbar.label ? 16 : 0) : 0;
-const marginRight = (pad ? pad[1] : compact ? 8 : MARGIN.r) + colorbarRightRoom;
+const baseRight = pad ? (responsivePad ? Math.min(pad[1], 8) : pad[1]) : compact ? 8 : MARGIN.r;
+const marginRight = baseRight + colorbarRightRoom;
 const marginTop = pad ? pad[0] : compact ? 6 : MARGIN.t;
 const marginBottom = (pad ? pad[2] : compact ? 36 : MARGIN.b) + colorbarBottomRoom;
 const hasBottomAxis = Object.values(this.axes || {}).some((axis) =>
@@ -2193,14 +2204,32 @@ return null;
 }
 _syncContainerSize() {
 if (this._destroyed || !(this.fluid || this.fluidH) || !this.root) return;
+this._queueResize(null, null, true);
+}
+_queueResize(cssW = null, cssH = null, measure = false) {
+if (this._destroyed) return;
+if (cssW || cssH) this._pendingResize = { cssW, cssH };
+if (measure) this._resizeNeedsMeasure = true;
+if (this._resizeRaf) return;
+this._resizeRaf = requestAnimationFrame(() => {
+this._resizeRaf = null;
+let pending = this._pendingResize;
+this._pendingResize = null;
+if (this._resizeNeedsMeasure && this.root) {
 const rect = this.root.getBoundingClientRect();
-if (rect.width || rect.height) this._resize(rect.width, rect.height);
+if (rect.width || rect.height) pending = { cssW: rect.width, cssH: rect.height };
+}
+this._resizeNeedsMeasure = false;
+if (pending && (pending.cssW || pending.cssH)) {
+this._resize(pending.cssW, pending.cssH);
+}
+});
 }
 _armVisibilityResizeWatch() {
 if (!(this.fluid || this.fluidH)) return;
 const syncSoon = () => {
 if (this._destroyed) return;
-requestAnimationFrame(() => this._syncContainerSize());
+this._syncContainerSize();
 };
 this._listen(window, "resize", syncSoon);
 this._listen(window, "pageshow", syncSoon);
@@ -2550,7 +2579,9 @@ this._positionReductionBadges();
 this._positionColorbar();
 this._fitModebar();
 this._pickDirty = true;
-this.draw();
+if (this._raf) cancelAnimationFrame(this._raf);
+this._raf = null;
+this._drawNow();
 this._scheduleViewRequest();
 }
 _buildDom(el) {
@@ -2924,14 +2955,24 @@ this._positionColorbar();
 _positionColorbar() {
 if (!this._colorbar) return;
 const horizontal = this._colorbarHorizontal;
+const compactVertical = !horizontal && this._compactVerticalColorbar;
+const gap = compactVertical ? COMPACT_COLORBAR_GAP : COLORBAR_GAP;
 this._colorbar.style.left = (horizontal
 ? this.plot.x
-: this.plot.x + this.plot.w + this._rightAxisRoom + COLORBAR_GAP) + "px";
+: this.plot.x + this.plot.w + this._rightAxisRoom + gap) + "px";
 this._colorbar.style.top = (horizontal
 ? this.plot.y + this.plot.h + (this._bottomAxisRoom || 8)
 : this.plot.y) + "px";
-this._colorbar.style.width = (horizontal ? this.plot.w : 66) + "px";
+this._colorbar.style.width = (horizontal
+? this.plot.w
+: compactVertical ? COLORBAR_THICKNESS : 66) + "px";
 this._colorbar.style.height = (horizontal ? 50 : Math.max(24, this.plot.h)) + "px";
+this._colorbar.dataset.xyCompact = compactVertical ? "true" : "false";
+for (const node of this._colorbar.querySelectorAll(
+'[data-xy-slot="colorbar_tick"], [data-xy-slot="colorbar_title"]'
+)) {
+node.hidden = compactVertical;
+}
 }
 _initGl(buffer) {
 const dpr = window.devicePixelRatio || 1;
@@ -5177,6 +5218,10 @@ this._linkChannel?.close?.();
 this._linkChannel = null;
 if (this._raf) cancelAnimationFrame(this._raf);
 this._raf = null;
+if (this._resizeRaf) cancelAnimationFrame(this._resizeRaf);
+this._resizeRaf = null;
+this._pendingResize = null;
+this._resizeNeedsMeasure = false;
 this._cancelViewAnimation();
 this._destroyGlResources();
 this.gl = null;

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -1714,6 +1714,7 @@ return null;
 const MARGIN = { l: 62, r: 14, t: 10, b: 42 };
 const COLORBAR_THICKNESS = 18;
 const COLORBAR_GAP = 24;
+const COMPACT_COLORBAR_GAP = 8;
 let XY_A11Y_ID = 0;
 const XY_SR_ONLY_STYLE =
 "position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;" +
@@ -1868,6 +1869,9 @@ this._glPrograms = [];
 this._progCache = new Map();
 this._bufSeq = 0;
 this._destroyed = false;
+this._resizeRaf = null;
+this._pendingResize = null;
+this._resizeNeedsMeasure = false;
 this._hoverId = -1;
 this._hoverTarget = null;
 this._viewEventRaf = null;
@@ -1916,7 +1920,7 @@ this._buildModebar(this.root);
 if ((this.fluid || this.fluidH) && typeof ResizeObserver !== "undefined") {
 this._ro = new ResizeObserver((entries) => {
 const r = entries[entries.length - 1].contentRect;
-if (r.width || r.height) this._resize(r.width, r.height);
+if (r.width || r.height) this._queueResize(r.width, r.height);
 });
 this._ro.observe(this.root);
 }
@@ -1946,13 +1950,20 @@ this.draw();
 _layout() {
 const compact = this.size.w < 520;
 const pad = Array.isArray(this.spec.padding) ? this.spec.padding : null;
-const marginLeft = pad ? pad[3] : compact ? 46 : MARGIN.l;
 const colorbar = this.spec.colorbar;
 const verticalColorbar = colorbar && colorbar.orientation !== "horizontal";
 const horizontalColorbar = colorbar && colorbar.orientation === "horizontal";
-const colorbarRightRoom = verticalColorbar ? 86 + (colorbar.label ? 18 : 0) : 0;
+const responsivePad = this.fluid && compact && pad;
+const marginLeft = pad ? (responsivePad ? Math.min(pad[3], 46) : pad[3]) : compact ? 46 : MARGIN.l;
+this._compactVerticalColorbar = Boolean(this.fluid && compact && verticalColorbar);
+const colorbarRightRoom = verticalColorbar
+? (this._compactVerticalColorbar
+? COMPACT_COLORBAR_GAP + COLORBAR_THICKNESS + 8
+: 86 + (colorbar.label ? 18 : 0))
+: 0;
 const colorbarBottomRoom = horizontalColorbar ? 38 + (colorbar.label ? 16 : 0) : 0;
-const marginRight = (pad ? pad[1] : compact ? 8 : MARGIN.r) + colorbarRightRoom;
+const baseRight = pad ? (responsivePad ? Math.min(pad[1], 8) : pad[1]) : compact ? 8 : MARGIN.r;
+const marginRight = baseRight + colorbarRightRoom;
 const marginTop = pad ? pad[0] : compact ? 6 : MARGIN.t;
 const marginBottom = (pad ? pad[2] : compact ? 36 : MARGIN.b) + colorbarBottomRoom;
 const hasBottomAxis = Object.values(this.axes || {}).some((axis) =>
@@ -2194,14 +2205,32 @@ return null;
 }
 _syncContainerSize() {
 if (this._destroyed || !(this.fluid || this.fluidH) || !this.root) return;
+this._queueResize(null, null, true);
+}
+_queueResize(cssW = null, cssH = null, measure = false) {
+if (this._destroyed) return;
+if (cssW || cssH) this._pendingResize = { cssW, cssH };
+if (measure) this._resizeNeedsMeasure = true;
+if (this._resizeRaf) return;
+this._resizeRaf = requestAnimationFrame(() => {
+this._resizeRaf = null;
+let pending = this._pendingResize;
+this._pendingResize = null;
+if (this._resizeNeedsMeasure && this.root) {
 const rect = this.root.getBoundingClientRect();
-if (rect.width || rect.height) this._resize(rect.width, rect.height);
+if (rect.width || rect.height) pending = { cssW: rect.width, cssH: rect.height };
+}
+this._resizeNeedsMeasure = false;
+if (pending && (pending.cssW || pending.cssH)) {
+this._resize(pending.cssW, pending.cssH);
+}
+});
 }
 _armVisibilityResizeWatch() {
 if (!(this.fluid || this.fluidH)) return;
 const syncSoon = () => {
 if (this._destroyed) return;
-requestAnimationFrame(() => this._syncContainerSize());
+this._syncContainerSize();
 };
 this._listen(window, "resize", syncSoon);
 this._listen(window, "pageshow", syncSoon);
@@ -2551,7 +2580,9 @@ this._positionReductionBadges();
 this._positionColorbar();
 this._fitModebar();
 this._pickDirty = true;
-this.draw();
+if (this._raf) cancelAnimationFrame(this._raf);
+this._raf = null;
+this._drawNow();
 this._scheduleViewRequest();
 }
 _buildDom(el) {
@@ -2925,14 +2956,24 @@ this._positionColorbar();
 _positionColorbar() {
 if (!this._colorbar) return;
 const horizontal = this._colorbarHorizontal;
+const compactVertical = !horizontal && this._compactVerticalColorbar;
+const gap = compactVertical ? COMPACT_COLORBAR_GAP : COLORBAR_GAP;
 this._colorbar.style.left = (horizontal
 ? this.plot.x
-: this.plot.x + this.plot.w + this._rightAxisRoom + COLORBAR_GAP) + "px";
+: this.plot.x + this.plot.w + this._rightAxisRoom + gap) + "px";
 this._colorbar.style.top = (horizontal
 ? this.plot.y + this.plot.h + (this._bottomAxisRoom || 8)
 : this.plot.y) + "px";
-this._colorbar.style.width = (horizontal ? this.plot.w : 66) + "px";
+this._colorbar.style.width = (horizontal
+? this.plot.w
+: compactVertical ? COLORBAR_THICKNESS : 66) + "px";
 this._colorbar.style.height = (horizontal ? 50 : Math.max(24, this.plot.h)) + "px";
+this._colorbar.dataset.xyCompact = compactVertical ? "true" : "false";
+for (const node of this._colorbar.querySelectorAll(
+'[data-xy-slot="colorbar_tick"], [data-xy-slot="colorbar_title"]'
+)) {
+node.hidden = compactVertical;
+}
 }
 _initGl(buffer) {
 const dpr = window.devicePixelRatio || 1;
@@ -5178,6 +5219,10 @@ this._linkChannel?.close?.();
 this._linkChannel = null;
 if (this._raf) cancelAnimationFrame(this._raf);
 this._raf = null;
+if (this._resizeRaf) cancelAnimationFrame(this._resizeRaf);
+this._resizeRaf = null;
+this._pendingResize = null;
+this._resizeNeedsMeasure = false;
 this._cancelViewAnimation();
 this._destroyGlResources();
 this.gl = null;

--- a/scripts/render_smoke_nonumpy.py
+++ b/scripts/render_smoke_nonumpy.py
@@ -1059,7 +1059,14 @@ try{{
       && v2.root.style.width==="100%" && v2.root.style.height==="100%")?1:0;
     holder.style.width="640px";
     holder.style.height="360px";
-    setTimeout(()=>{{try{{
+    setTimeout(async()=>{{try{{
+      // ResizeObserver now coalesces its work into requestAnimationFrame. A
+      // fixed delay can run before that frame under --virtual-time-budget, so
+      // poll the public result instead of assuming a particular task order.
+      const resizeDeadline=performance.now()+1000;
+      while((v2.size.w!==640 || v2.size.h!==360) && performance.now()<resizeDeadline){{
+        await new Promise((resolve)=>setTimeout(resolve,20));
+      }}
       const grew=(v2.size.w===640 && v2.size.h===360 && v2.canvas.width===v2.plot.w*v2.dpr
         && v2.canvas.height===v2.plot.h*v2.dpr && v2.chrome.width===640*v2.dpr
         && v2.chrome.height===360*v2.dpr)?1:0;

--- a/tests/test_legend_resize_regression.py
+++ b/tests/test_legend_resize_regression.py
@@ -288,6 +288,65 @@ _ANNOTATION_ALIGNMENT_PROBE = """
 </script>
 """
 
+_ATOMIC_RESIZE_PROBE = """
+<script>
+(() => {
+  try {
+    const view = window.__fcProbeView;
+    if (!view) throw new Error("no probe view captured");
+    if (!view.gl) throw new Error("no WebGL context");
+    if (view._raf) cancelAnimationFrame(view._raf);
+    view._raf = null;
+    view._drawNow();
+
+    const sampleCenterAlpha = () => {
+      const pixel = new Uint8Array(4);
+      view.gl.readPixels(
+        Math.floor(view.canvas.width / 2),
+        Math.floor(view.canvas.height / 2),
+        1, 1, view.gl.RGBA, view.gl.UNSIGNED_BYTE, pixel
+      );
+      return pixel[3];
+    };
+    const beforeAlpha = sampleCenterAlpha();
+
+    // _resize used to clear every backing store and defer replacement paint to
+    // another animation frame. Sampling immediately after it therefore caught
+    // the exact transparent frame users saw while dragging a narrow viewport.
+    view._resize(390, 500);
+    const afterResizeAlpha = sampleCenterAlpha();
+    const compactNodes = [...view._colorbar.querySelectorAll(
+      '[data-xy-slot="colorbar_tick"], [data-xy-slot="colorbar_title"]'
+    )];
+    const compactState = {
+      plotWidth: view.plot.w,
+      colorbarWidth: view._colorbar.getBoundingClientRect().width,
+      compact: view._colorbar.dataset.xyCompact,
+      hiddenChrome: compactNodes.filter((node) => node.hidden).length,
+      chromeCount: compactNodes.length,
+    };
+
+    view._resize(760, 500);
+    const restoredState = {
+      compact: view._colorbar.dataset.xyCompact,
+      hiddenChrome: compactNodes.filter((node) => node.hidden).length,
+    };
+    document.body.setAttribute("data-xy-atomic-resize", JSON.stringify({
+      beforeAlpha,
+      afterResizeAlpha,
+      compactState,
+      restoredState,
+    }));
+  } catch (err) {
+    document.body.setAttribute(
+      "data-xy-atomic-resize-error",
+      String((err && err.stack) || err)
+    );
+  }
+})();
+</script>
+"""
+
 
 def _probe_maxheight(chromium: str, document: str, page: Path) -> dict:
     """Render + probe the legend max-height across a responsive resize."""
@@ -318,6 +377,13 @@ def _probe_annotation_alignment(chromium: str, document: str, page: Path) -> dic
         page,
         "data-xy-annotation-alignment",
         label="annotation alignment probe",
+    )
+
+
+def _probe_atomic_resize(chromium: str, document: str, page: Path) -> dict:
+    """Resize a painted heatmap and inspect the immediate replacement frame."""
+    return run_browser_probe(
+        chromium, document, page, "data-xy-atomic-resize", label="atomic resize probe"
     )
 
 
@@ -356,6 +422,55 @@ def test_snake_case_legend_max_height_survives_resize() -> None:
     assert payload["afterResize"] == "50px", (
         f"resize clobbered the explicit snake_case max_height: {payload}"
     )
+
+
+def test_narrow_fluid_resize_stays_painted_and_preserves_plot_space() -> None:
+    chromium = find_chromium()
+    if not chromium:
+        pytest.skip("no chromium available for the resize regression probe")
+
+    chart = xy.heatmap_chart(
+        xy.heatmap(
+            [
+                [1.00, 0.72, 0.61, 0.55],
+                [1.00, 0.74, 0.64, 0.58],
+                [1.00, 0.69, 0.58, 0.51],
+                [1.00, 0.77, 0.67, 0.61],
+            ],
+            name="Retention",
+            colormap="viridis",
+            domain=(0, 1),
+        ),
+        xy.colorbar(title="Users retained", ticks=[0, 0.25, 0.5, 0.75, 1.0]),
+        width="100%",
+        height=500,
+        padding=[72, 106, 70, 92],
+    )
+
+    document = chart.to_html()
+    render_call = next((call for call in _RENDER_CALLS if call in document), None)
+    assert render_call is not None
+    document = document.replace(
+        render_call,
+        render_call.replace(
+            "xy.renderStandalone(", "window.__fcProbeView = xy.renderStandalone(", 1
+        ),
+        1,
+    )
+    document = document.replace("</body>", _ATOMIC_RESIZE_PROBE + "\n</body>", 1)
+
+    with tempfile.TemporaryDirectory() as td:
+        payload = _probe_atomic_resize(chromium, document, Path(td) / "atomic_resize.html")
+
+    assert payload["beforeAlpha"] > 0, payload
+    assert payload["afterResizeAlpha"] > 0, payload
+    assert payload["compactState"]["plotWidth"] >= 280, payload
+    assert payload["compactState"]["colorbarWidth"] == pytest.approx(18, abs=1), payload
+    assert payload["compactState"]["compact"] == "true", payload
+    assert payload["compactState"]["hiddenChrome"] == payload["compactState"]["chromeCount"], (
+        payload
+    )
+    assert payload["restoredState"] == {"compact": "false", "hiddenChrome": 0}, payload
 
 
 def test_long_legend_and_edge_tooltip_stay_inside_narrow_chart() -> None:

--- a/tests/test_static_client_security.py
+++ b/tests/test_static_client_security.py
@@ -404,6 +404,8 @@ def test_client_hardens_responsive_visibility_recovery() -> None:
         "new IntersectionObserver",
         "this._io?.disconnect();",
         "const compact = this.size.w < 520;",
+        "_queueResize(cssW = null, cssH = null, measure = false)",
+        'this._colorbar.dataset.xyCompact = compactVertical ? "true" : "false";',
     )
 
     for path, text in CLIENT_FILES:
@@ -761,7 +763,7 @@ def test_client_supports_edge_to_edge_sparklines() -> None:
     src = _CLIENT_SRC[1]
     # padding override feeds _layout's margins
     assert "Array.isArray(this.spec.padding) ? this.spec.padding : null" in src
-    assert "marginLeft = pad ? pad[3]" in src
+    assert "responsivePad ? Math.min(pad[3], 46) : pad[3]" in src
     # "none" returns an empty label set even when the axis has only one tick.
     assert 'if (strategyValue === "none" || strategyValue === "off") return [];' in src
     assert "if (s.x_axis.label && !hideX)" in src


### PR DESCRIPTION
## What

- coalesce `ResizeObserver` and visibility-driven resize work into one animation frame
- repaint WebGL and chrome canvases in the same frame that changes their backing-store dimensions
- keep narrow fluid plots readable by capping oversized horizontal padding and reducing vertical colorbars to their gradient until space returns
- add a real-Chromium regression that samples the canvas immediately after resize and verifies compact colorbar layout restores at wider widths

## Why

Changing a canvas `width` or `height` clears its backing store immediately. The responsive path then queued `draw()` for a later animation frame, leaving a transparent frame that appeared as a flash during continuous viewport resizing. At the same time, authored desktop padding plus full vertical-colorbar chrome could consume nearly all of a narrow fluid chart's plot area.

## Impact

The resize path now remains painted throughout the transition. The compact layout applies only to fluid charts below the existing 520px breakpoint; fixed-size charts and wider layouts retain their authored padding and full colorbar ticks/title.

## Checks

- `1982 passed, 66 skipped` (`pytest -q`)
- responsive/browser-security suite: `43 passed`
- targeted resize regression: `3 passed`
- `ruff check` and `ruff format --check`
- `node js/build.mjs --check`
- `git diff --check`

Closes #127