### PR TITLE
Skip heavy CI for docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: ["main", "claude/**"]
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "spec/**"
   workflow_dispatch:
 
 # Multiple sessions push to two branches in bursts; without this the runner

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: ["main"]
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "spec/**"
   # `workflow_dispatch` allows CodSpeed to trigger backtest
   # performance analysis in order to generate initial data.
   workflow_dispatch:

--- a/scripts/verify_ci_workflow.py
+++ b/scripts/verify_ci_workflow.py
@@ -178,16 +178,32 @@ def _require_docs_spec_pr_paths_ignored(errors: list[str], text: str, workflow_l
         errors.append(f"{workflow_label} workflow missing pull_request trigger")
         return
 
-    trigger_lines = [lines[start]]
+    paths_ignore: list[str] | None = None
+    collecting_paths_ignore = False
     for line in lines[start + 1 :]:
         indent = len(line) - len(line.lstrip())
         if line.strip() and indent <= 2:
             break
-        trigger_lines.append(line)
-    trigger = "\n".join(trigger_lines)
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if indent == 4:
+            collecting_paths_ignore = bool(re.fullmatch(r"paths-ignore:\s*(?:#.*)?", stripped))
+            if collecting_paths_ignore:
+                paths_ignore = []
+            continue
+        if not collecting_paths_ignore or indent <= 4:
+            continue
+        item = re.fullmatch(r"-\s+(.+?)\s*", stripped)
+        if item is None or paths_ignore is None:
+            continue
+        value = re.sub(r"\s+#.*$", "", item.group(1)).strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        paths_ignore.append(value)
 
-    required = ("paths-ignore:", '- "docs/**"', '- "spec/**"')
-    missing = _missing_needles(trigger, required)
+    required = {"docs/**", "spec/**"}
+    missing = sorted(required - set(paths_ignore or []))
     if missing:
         errors.append(
             f"{workflow_label} pull_request trigger must skip docs/spec-only changes: {missing}"

--- a/scripts/verify_ci_workflow.py
+++ b/scripts/verify_ci_workflow.py
@@ -169,6 +169,31 @@ def _require_workflow_contains(
         errors.append(f"{workflow_label} workflow missing {description}: {missing}")
 
 
+def _require_docs_spec_pr_paths_ignored(errors: list[str], text: str, workflow_label: str) -> None:
+    """Require PR-only docs/spec changes to skip an expensive workflow."""
+    lines = text.splitlines()
+    try:
+        start = next(i for i, line in enumerate(lines) if line == "  pull_request:")
+    except StopIteration:
+        errors.append(f"{workflow_label} workflow missing pull_request trigger")
+        return
+
+    trigger_lines = [lines[start]]
+    for line in lines[start + 1 :]:
+        indent = len(line) - len(line.lstrip())
+        if line.strip() and indent <= 2:
+            break
+        trigger_lines.append(line)
+    trigger = "\n".join(trigger_lines)
+
+    required = ("paths-ignore:", '- "docs/**"', '- "spec/**"')
+    missing = _missing_needles(trigger, required)
+    if missing:
+        errors.append(
+            f"{workflow_label} pull_request trigger must skip docs/spec-only changes: {missing}"
+        )
+
+
 def validate_ci_workflow(path: Path = DEFAULT_CI_WORKFLOW) -> list[str]:
     try:
         text = path.read_text(encoding="utf-8")
@@ -177,6 +202,7 @@ def validate_ci_workflow(path: Path = DEFAULT_CI_WORKFLOW) -> list[str]:
 
     jobs = _job_blocks(text)
     errors: list[str] = []
+    _require_docs_spec_pr_paths_ignored(errors, text, "CI")
     missing_jobs = sorted(REQUIRED_CI_JOBS - set(jobs))
     if missing_jobs:
         errors.append(f"CI workflow missing required jobs: {missing_jobs}")
@@ -539,6 +565,7 @@ def validate_codspeed_workflow(path: Path = DEFAULT_CODSPEED_WORKFLOW) -> list[s
 
     jobs = _job_blocks(text)
     errors: list[str] = []
+    _require_docs_spec_pr_paths_ignored(errors, text, "CodSpeed")
     missing_jobs = sorted(REQUIRED_CODSPEED_JOBS - set(jobs))
     if missing_jobs:
         errors.append(f"CodSpeed workflow missing required jobs: {missing_jobs}")

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -57,43 +57,6 @@ def test_all_workflows_accept_current_gates() -> None:
     assert verify_ci_workflow.validate_all_workflows() == []
 
 
-def test_ci_workflow_rejects_running_for_spec_only_prs(tmp_path: Path) -> None:
-    workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
-    path = tmp_path / "ci.yml"
-    path.write_text(workflow.replace('      - "spec/**"\n', "", 1), encoding="utf-8")
-
-    errors = verify_ci_workflow.validate_ci_workflow(path)
-
-    assert any("CI pull_request trigger" in error and "spec/**" in error for error in errors)
-
-
-def test_codspeed_workflow_rejects_running_for_docs_only_prs(tmp_path: Path) -> None:
-    workflow = Path(".github/workflows/codspeed.yml").read_text(encoding="utf-8")
-    path = tmp_path / "codspeed.yml"
-    path.write_text(workflow.replace('      - "docs/**"\n', "", 1), encoding="utf-8")
-
-    errors = verify_ci_workflow.validate_codspeed_workflow(path)
-
-    assert any("CodSpeed pull_request trigger" in error and "docs/**" in error for error in errors)
-
-
-def test_ci_workflow_rejects_paths_ignore_text_hidden_in_a_comment(tmp_path: Path) -> None:
-    workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
-    path = tmp_path / "ci.yml"
-    path.write_text(
-        workflow.replace(
-            "    paths-ignore:\n",
-            "    paths:\n    # paths-ignore:\n",
-            1,
-        ),
-        encoding="utf-8",
-    )
-
-    errors = verify_ci_workflow.validate_ci_workflow(path)
-
-    assert any("CI pull_request trigger" in error for error in errors)
-
-
 def test_workflows_use_consistent_node24_action_pins() -> None:
     workflow_text = "\n".join(
         path.read_text(encoding="utf-8") for path in sorted(Path(".github/workflows").glob("*.yml"))

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -57,6 +57,26 @@ def test_all_workflows_accept_current_gates() -> None:
     assert verify_ci_workflow.validate_all_workflows() == []
 
 
+def test_ci_workflow_rejects_running_for_spec_only_prs(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+    path = tmp_path / "ci.yml"
+    path.write_text(workflow.replace('      - "spec/**"\n', "", 1), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_ci_workflow(path)
+
+    assert any("CI pull_request trigger" in error and "spec/**" in error for error in errors)
+
+
+def test_codspeed_workflow_rejects_running_for_docs_only_prs(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/codspeed.yml").read_text(encoding="utf-8")
+    path = tmp_path / "codspeed.yml"
+    path.write_text(workflow.replace('      - "docs/**"\n', "", 1), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_codspeed_workflow(path)
+
+    assert any("CodSpeed pull_request trigger" in error and "docs/**" in error for error in errors)
+
+
 def test_workflows_use_consistent_node24_action_pins() -> None:
     workflow_text = "\n".join(
         path.read_text(encoding="utf-8") for path in sorted(Path(".github/workflows").glob("*.yml"))

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -77,6 +77,23 @@ def test_codspeed_workflow_rejects_running_for_docs_only_prs(tmp_path: Path) -> 
     assert any("CodSpeed pull_request trigger" in error and "docs/**" in error for error in errors)
 
 
+def test_ci_workflow_rejects_paths_ignore_text_hidden_in_a_comment(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+    path = tmp_path / "ci.yml"
+    path.write_text(
+        workflow.replace(
+            "    paths-ignore:\n",
+            "    paths:\n    # paths-ignore:\n",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_ci_workflow(path)
+
+    assert any("CI pull_request trigger" in error for error in errors)
+
+
 def test_workflows_use_consistent_node24_action_pins() -> None:
     workflow_text = "\n".join(
         path.read_text(encoding="utf-8") for path in sorted(Path(".github/workflows").glob("*.yml"))


### PR DESCRIPTION
## Summary

- skip the full CI workflow when a pull request changes only files under `docs/**` and/or `spec/**`
- apply the same exclusion to CodSpeed benchmarks
- keep mixed code and documentation pull requests on the normal CI path
- enforce both path exclusions in the workflow verifier and its regression tests

## Why

Documentation and design-spec pull requests currently trigger the full Rust, Python, JavaScript, browser, wheel, and benchmark matrix even though they cannot affect those artifacts. This avoids that unnecessary runner load while leaving the dedicated Docs workflow available for documentation changes.

## Validation

- `python3 scripts/verify_ci_workflow.py`
- `.venv/bin/python -m pytest -q tests/test_verify_ci_workflow.py` (49 passed)
- `uvx ruff check scripts/verify_ci_workflow.py tests/test_verify_ci_workflow.py`
- `uvx ruff format --check scripts/verify_ci_workflow.py tests/test_verify_ci_workflow.py`
- YAML parsing for both edited workflows
- `git diff --check`

GitHub-managed default CodeQL is configured separately and is not changed by this PR.