### PR TITLE
Fix density cache eviction and pan-past-data alignment bugs

### DIFF
--- a/examples/fastapi/live_drilldown.py
+++ b/examples/fastapi/live_drilldown.py
@@ -590,6 +590,16 @@ function overviewEdge(value, domain, cells) {{
   return Math.max(0, Math.min(cells, raw));
 }}
 
+// Inverse of overviewEdge: the data coordinate at a source-bin boundary. A
+// requested window can extend past the data domain, where overviewEdge clamps
+// the bin index; mapping that clamped index back gives the range the grid
+// actually covers, which is what the renderer must be told (see below).
+function overviewEdgeValue(bin, domain, cells) {{
+  const span = domain[1] - domain[0];
+  if (!Number.isFinite(span) || cells <= 0) return domain[0];
+  return domain[0] + (bin / cells) * span;
+}}
+
 function overviewSum(ii, stride, x0, x1, y0, y1) {{
   return (
     ii[y1 * stride + x1] -
@@ -619,6 +629,18 @@ function localDensityUpdate(msg) {{
   const visible = overviewSum(built.integral, built.stride, bx0, bx1, by0, by1);
   if (visible <= DIRECT_POINT_BUDGET * LOCAL_DENSITY_EXACT_FACTOR) return null;
   if (sourceW < 16 || sourceH < 16) return null;
+
+  // The grid's cells span the clamped source bins [bx0,bx1]x[by0,by1], which
+  // cover only the on-domain part of the requested window. Report the data
+  // range those bins actually represent — not the raw request. Reporting the
+  // request would stretch the fixed-extent texture across a wider window
+  // whenever the view reaches past the data, sliding the density off the
+  // point cloud (drilled points and the retained sample draw at true data
+  // coordinates, so any mismatch here shows up as an offset).
+  const gridX0 = overviewEdgeValue(bx0, density.x_range, width);
+  const gridX1 = overviewEdgeValue(bx1, density.x_range, width);
+  const gridY0 = overviewEdgeValue(by0, density.y_range, height);
+  const gridY1 = overviewEdgeValue(by1, density.y_range, height);
 
   const requestedW = Math.round(Number(msg.w) || width);
   const requestedH = Math.round(Number(msg.h) || height);
@@ -651,8 +673,8 @@ function localDensityUpdate(msg) {{
           w: outW,
           h: outH,
           max,
-          x_range: [loX, hiX],
-          y_range: [loY, hiY],
+          x_range: [gridX0, gridX1],
+          y_range: [gridY0, gridY1],
         }},
       }}],
     }},

--- a/js/src/45_lod.js
+++ b/js/src/45_lod.js
@@ -180,6 +180,19 @@ function lodHoldPendingDrill(view, g, d) {
   return estimatedVisible <= LOD_DIRECT_POINT_BUDGET * LOD_DRILL_EXIT_FACTOR;
 }
 
+// Every density object still reachable from the trace, so eviction never
+// deletes a texture that is about to be bound. Besides the active grid, the
+// previous grid, and the crossfade source, `_shownDensity` (what the tier last
+// drew — it becomes the next `_densitySwitchPrev`) and `_homeDensity` (the
+// standalone overview restore point) are live too. Missing `_shownDensity` here
+// let its texture be evicted while still referenced; the next crossfade bound
+// the freed handle → "bindTexture: attempt to use a deleted object", a dropped
+// density frame, and drilled points left stranded over a stale surface.
+function lodDensityPinned(g, d) {
+  return d === g.density || d === g.prevDensity || d === g._densitySwitchPrev ||
+    d === g._shownDensity || d === g._homeDensity;
+}
+
 function lodRememberDensity(view, g, d) {
   if (!d || !d.tex) return;
   d._stamp = ++view._densityStamp;
@@ -190,9 +203,7 @@ function lodRememberDensity(view, g, d) {
     let drop = -1;
     for (let i = 0; i < g.densityCache.length; i++) {
       const cand = g.densityCache[i];
-      if (cand === g.density) continue;
-      if (cand === g.prevDensity) continue;
-      if (cand === g._densitySwitchPrev) continue;
+      if (lodDensityPinned(g, cand)) continue;
       if (drop < 0) { drop = i; continue; }
       const dropArea = lodDensityArea(g.densityCache[drop]);
       const candArea = lodDensityArea(cand);
@@ -202,9 +213,7 @@ function lodRememberDensity(view, g, d) {
     }
     if (drop < 0) break;
     const old = g.densityCache.splice(drop, 1)[0];
-    if (old !== g.density && old !== g.prevDensity && old !== g._densitySwitchPrev) {
-      view.gl.deleteTexture(old.tex);
-    }
+    if (!lodDensityPinned(g, old)) view.gl.deleteTexture(old.tex);
   }
 }
 

--- a/js/src/50_chartview.js
+++ b/js/src/50_chartview.js
@@ -3019,8 +3019,15 @@ class ChartView {
   }
 
   _drawDensity(g, density, opacityScale = 1) {
-    opacityScale *= g._transitionOpacity ?? 1;
     const gl = this.gl;
+    const d = density || g.density;
+    // Structural guard: never bind a freed texture. Eviction pins every live
+    // density (lodDensityPinned), so this should not trigger — but a crossfade
+    // holds its source across frames, and binding a deleted handle is a hard
+    // WebGL error that aborts the draw, so treat an invalid texture as "nothing
+    // to draw" rather than risk it.
+    if (!d || !d.tex || !gl.isTexture(d.tex)) return;
+    opacityScale *= g._transitionOpacity ?? 1;
     const prog = this.densityProg;
     gl.useProgram(prog);
     const u = (n) => uniformOf(gl, prog, n);
@@ -3030,7 +3037,6 @@ class ChartView {
     gl.uniform4f(u("u_view"), vx0 ?? x0, vx1 ?? x1, vy0 ?? y0, vy1 ?? y1);
     gl.uniform1i(u("u_xmode"), this._axisMode(g.xAxis));
     gl.uniform1i(u("u_ymode"), this._axisMode(g.yAxis));
-    const d = density || g.density;
     gl.uniform4f(u("u_gridRange"), d.xRange[0], d.xRange[1], d.yRange[0], d.yRange[1]);
     gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * opacityScale);
     const constant = d.color;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,11 @@ dev = [
     # Decode oracle for the native JPEG/WebP encoders, never a runtime
     # dependency: the image-export tests importorskip it.
     "pillow>=10",
+    # The FastAPI drilldown example's live_drilldown module imports Starlette at
+    # load (its callback endpoint), never a runtime dependency of xy: the
+    # drilldown pan-alignment browser test importorskips it, so it lives in dev
+    # where CI exercises that test.
+    "starlette>=0.36",
 ]
 # Plotly comparison charts. Matplotlib is deliberately not a project extra:
 # benchmark jobs that compare against it install it explicitly as an external

--- a/python/xy/static/index.js
+++ b/python/xy/static/index.js
@@ -1470,6 +1470,10 @@ if (!Number.isFinite(baseVisible) || baseVisible <= 0) return false;
 const estimatedVisible = baseVisible * Math.max(1, pendingArea / drillArea);
 return estimatedVisible <= LOD_DIRECT_POINT_BUDGET * LOD_DRILL_EXIT_FACTOR;
 }
+function lodDensityPinned(g, d) {
+return d === g.density || d === g.prevDensity || d === g._densitySwitchPrev ||
+d === g._shownDensity || d === g._homeDensity;
+}
 function lodRememberDensity(view, g, d) {
 if (!d || !d.tex) return;
 d._stamp = ++view._densityStamp;
@@ -1480,9 +1484,7 @@ while (g.densityCache.length > maxCached) {
 let drop = -1;
 for (let i = 0; i < g.densityCache.length; i++) {
 const cand = g.densityCache[i];
-if (cand === g.density) continue;
-if (cand === g.prevDensity) continue;
-if (cand === g._densitySwitchPrev) continue;
+if (lodDensityPinned(g, cand)) continue;
 if (drop < 0) { drop = i; continue; }
 const dropArea = lodDensityArea(g.densityCache[drop]);
 const candArea = lodDensityArea(cand);
@@ -1492,9 +1494,7 @@ drop = i;
 }
 if (drop < 0) break;
 const old = g.densityCache.splice(drop, 1)[0];
-if (old !== g.density && old !== g.prevDensity && old !== g._densitySwitchPrev) {
-view.gl.deleteTexture(old.tex);
-}
+if (!lodDensityPinned(g, old)) view.gl.deleteTexture(old.tex);
 }
 }
 function lodApplyDrill(view, g, upd, buffers) {
@@ -4398,8 +4398,10 @@ gl.vertexAttrib1f(ATTR_SLOTS.a_dval, 0);
 gl.drawArrays(gl.POINTS, index, 1);
 }
 _drawDensity(g, density, opacityScale = 1) {
-opacityScale *= g._transitionOpacity ?? 1;
 const gl = this.gl;
+const d = density || g.density;
+if (!d || !d.tex || !gl.isTexture(d.tex)) return;
+opacityScale *= g._transitionOpacity ?? 1;
 const prog = this.densityProg;
 gl.useProgram(prog);
 const u = (n) => uniformOf(gl, prog, n);
@@ -4409,7 +4411,6 @@ const [vy0, vy1] = this._axisRange(g.yAxis);
 gl.uniform4f(u("u_view"), vx0 ?? x0, vx1 ?? x1, vy0 ?? y0, vy1 ?? y1);
 gl.uniform1i(u("u_xmode"), this._axisMode(g.xAxis));
 gl.uniform1i(u("u_ymode"), this._axisMode(g.yAxis));
-const d = density || g.density;
 gl.uniform4f(u("u_gridRange"), d.xRange[0], d.xRange[1], d.yRange[0], d.yRange[1]);
 gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * opacityScale);
 const constant = d.color;

--- a/python/xy/static/standalone.js
+++ b/python/xy/static/standalone.js
@@ -1471,6 +1471,10 @@ if (!Number.isFinite(baseVisible) || baseVisible <= 0) return false;
 const estimatedVisible = baseVisible * Math.max(1, pendingArea / drillArea);
 return estimatedVisible <= LOD_DIRECT_POINT_BUDGET * LOD_DRILL_EXIT_FACTOR;
 }
+function lodDensityPinned(g, d) {
+return d === g.density || d === g.prevDensity || d === g._densitySwitchPrev ||
+d === g._shownDensity || d === g._homeDensity;
+}
 function lodRememberDensity(view, g, d) {
 if (!d || !d.tex) return;
 d._stamp = ++view._densityStamp;
@@ -1481,9 +1485,7 @@ while (g.densityCache.length > maxCached) {
 let drop = -1;
 for (let i = 0; i < g.densityCache.length; i++) {
 const cand = g.densityCache[i];
-if (cand === g.density) continue;
-if (cand === g.prevDensity) continue;
-if (cand === g._densitySwitchPrev) continue;
+if (lodDensityPinned(g, cand)) continue;
 if (drop < 0) { drop = i; continue; }
 const dropArea = lodDensityArea(g.densityCache[drop]);
 const candArea = lodDensityArea(cand);
@@ -1493,9 +1495,7 @@ drop = i;
 }
 if (drop < 0) break;
 const old = g.densityCache.splice(drop, 1)[0];
-if (old !== g.density && old !== g.prevDensity && old !== g._densitySwitchPrev) {
-view.gl.deleteTexture(old.tex);
-}
+if (!lodDensityPinned(g, old)) view.gl.deleteTexture(old.tex);
 }
 }
 function lodApplyDrill(view, g, upd, buffers) {
@@ -4399,8 +4399,10 @@ gl.vertexAttrib1f(ATTR_SLOTS.a_dval, 0);
 gl.drawArrays(gl.POINTS, index, 1);
 }
 _drawDensity(g, density, opacityScale = 1) {
-opacityScale *= g._transitionOpacity ?? 1;
 const gl = this.gl;
+const d = density || g.density;
+if (!d || !d.tex || !gl.isTexture(d.tex)) return;
+opacityScale *= g._transitionOpacity ?? 1;
 const prog = this.densityProg;
 gl.useProgram(prog);
 const u = (n) => uniformOf(gl, prog, n);
@@ -4410,7 +4412,6 @@ const [vy0, vy1] = this._axisRange(g.yAxis);
 gl.uniform4f(u("u_view"), vx0 ?? x0, vx1 ?? x1, vy0 ?? y0, vy1 ?? y1);
 gl.uniform1i(u("u_xmode"), this._axisMode(g.xAxis));
 gl.uniform1i(u("u_ymode"), this._axisMode(g.yAxis));
-const d = density || g.density;
 gl.uniform4f(u("u_gridRange"), d.xRange[0], d.xRange[1], d.yRange[0], d.yRange[1]);
 gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * opacityScale);
 const constant = d.color;

--- a/spec/design/lod-architecture.md
+++ b/spec/design/lod-architecture.md
@@ -233,8 +233,19 @@ invariants so future kinds don't regress them:
 - **T6 — invalid requests do not mutate:** malformed viewport/screen requests
   fail before `enter_drill`, `exit_drill`, cache replacement, or buffer
   version changes. The previous representation remains the authority.
+- **T7 — cached textures outlive every live reference:** the multi-window
+  density cache (`densityCache`, capped LRU) may free an *evicted* grid's GPU
+  texture, but never one still reachable from the trace. `lodDensityPinned`
+  pins the active grid, the previous grid, the crossfade source
+  (`_densitySwitchPrev`), the last-drawn grid (`_shownDensity`, which becomes
+  the *next* crossfade source), and the standalone overview restore point
+  (`_homeDensity`). Freeing a still-referenced texture makes the next crossfade
+  bind a deleted handle — a hard WebGL error (`bindTexture: … deleted object`)
+  that drops the density frame and strands drilled points over a stale surface.
+  Every `_drawDensity` also skips a grid whose texture is not `gl.isTexture`, so
+  the invariant can never surface as a GL error even if a new reference is added.
 
-Any new tiered kind must state how it satisfies T1–T6 in its chart-kind
+Any new tiered kind must state how it satisfies T1–T7 in its chart-kind
 contract entry before it lands.
 
 ---

--- a/tests/test_density_texture_eviction.py
+++ b/tests/test_density_texture_eviction.py
@@ -1,0 +1,121 @@
+"""Density-cache eviction must never free a texture still referenced by the trace.
+
+The tiered density renderer keeps a small LRU of grid textures per trace and
+deletes the texture of any entry it evicts. Eviction pins the live references
+(active grid, previous grid, crossfade source) — but `_shownDensity`, the grid
+the tier last drew and the *next* crossfade source, was missing from that set.
+Its texture could be freed while still referenced; the following crossfade then
+bound the deleted handle ("bindTexture: attempt to use a deleted object"),
+aborting the density draw and stranding drilled points over a stale surface.
+
+This drives the real client in headless Chromium: it fills the cache past its
+cap with large-area grids while `_shownDensity` points at a small-area grid
+(the natural eviction target), then checks that grid's texture survived and that
+drawing it raises no GL error.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import xy
+from conftest import run_browser_probe
+from xy.export import find_chromium
+
+_RENDER_CALL = 'xy.renderStandalone(document.getElementById("chart"), spec, buf);'
+
+_PROBE = r"""
+  const view = xy.renderStandalone(document.getElementById("chart"), spec, buf);
+  try {
+    view._drawNow(); view._raf = null;
+    const gl = view.gl;
+    const g = view.gpuTraces.find((t) => t.tier === "density");
+    const GL_INVALID_OPERATION = 0x0502;
+
+    const mkTex = () => {
+      const t = gl.createTexture();
+      gl.bindTexture(gl.TEXTURE_2D, t);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.R8, 2, 2, 0, gl.RED, gl.UNSIGNED_BYTE,
+        new Uint8Array([1, 2, 3, 4]));
+      return t;
+    };
+    // Distinct grids that differ only in covered area (drives LRU's area rule).
+    const mkDensity = (side) => ({
+      w: 2, h: 2, max: 1, normMax: 1, grid: new Float32Array([1, 2, 3, 4]),
+      tex: mkTex(), lut: g.density.lut, colormap: "viridis",
+      xRange: [0, side], yRange: [0, side],
+    });
+
+    // A small-area grid becomes what the tier "last drew": in the cache, live
+    // via _shownDensity, but not the active/previous/crossfade grid.
+    const shown = mkDensity(0.02);
+    view._applySampleRebinGrid(g, shown, true);
+    g._shownDensity = shown;
+
+    // Fill well past the cap (8) with much larger grids so `shown` is the LRU
+    // eviction target on area. Without the pin its texture gets freed here.
+    for (let i = 0; i < 12; i++) view._applySampleRebinGrid(g, mkDensity(100 + i), true);
+
+    const shownTexAlive = gl.isTexture(shown.tex);
+    const inCache = (g.densityCache || []).includes(shown);
+
+    // Drawing the retained (crossfade-source) grid must not raise a GL error.
+    while (gl.getError() !== gl.NO_ERROR) { /* drain */ }
+    view._drawDensity(g, shown);
+    const drawError = gl.getError();
+
+    document.body.setAttribute("data-tex-probe", JSON.stringify({
+      hasDensity: !!g,
+      shownTexAlive,
+      inCache,
+      drawError,
+      invalidOp: drawError === GL_INVALID_OPERATION,
+    }));
+  } catch (err) {
+    document.body.setAttribute("data-tex-probe-error", String((err && err.stack) || err));
+  }
+"""
+
+
+def _density_html() -> str:
+    rng = np.random.default_rng(0)
+    n = 40_000
+    x = rng.normal(0.0, 1.0, n)
+    y = rng.normal(0.0, 1.0, n)
+    chart = xy.scatter_chart(
+        xy.scatter(x, y, density=True),
+        xy.x_axis(),
+        xy.y_axis(),
+        width=480,
+        height=360,
+    )
+    html = chart.to_html()
+    assert _RENDER_CALL in html
+    return html
+
+
+def test_density_cache_eviction_keeps_shown_texture(tmp_path: Path) -> None:
+    chromium = find_chromium()
+    if chromium is None:
+        pytest.skip("Chromium unavailable")
+
+    document = _density_html().replace(_RENDER_CALL, _PROBE)
+    result = run_browser_probe(
+        chromium,
+        document,
+        tmp_path / "tex_evict.html",
+        "data-tex-probe",
+        label="density texture eviction probe",
+    )
+
+    assert result["hasDensity"] is True
+    # The pin keeps `_shownDensity` in the cache and its texture alive through
+    # eviction; the pre-fix bug freed it (isTexture false) and left it evicted.
+    assert result["inCache"] is True
+    assert result["shownTexAlive"] is True
+    # Drawing the retained grid raises no "deleted object" error.
+    assert result["invalidOp"] is False, result
+    assert result["drawError"] == 0, result

--- a/tests/test_drilldown_pan_alignment.py
+++ b/tests/test_drilldown_pan_alignment.py
@@ -1,0 +1,139 @@
+"""FastAPI drilldown: a pan past the data must not offset the density surface.
+
+The drilldown export re-bins its density overview *in the browser* on pan/zoom
+(``localDensityUpdate`` in ``examples/fastapi/live_drilldown.py``) from a
+fixed-extent integral image. A requested window can reach past the data domain;
+the source-bin lookups clamp there, so the grid covers only the on-domain part
+of the window. If the update still reports the *requested* window as the grid's
+data range, the fixed-extent texture is stretched across the wider window and
+the density slides off the point cloud (drilled points and the retained §28
+sample draw at true data coordinates). This drives the real client in headless
+Chromium, pans well past the +x/+y data edge, and checks the reported density
+range stays within the data domain and its mass stays aligned with the data.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from conftest import run_browser_probe
+from xy.export import find_chromium
+
+FASTAPI_DIR = Path(__file__).resolve().parents[1] / "examples" / "fastapi"
+
+_ANCHOR = "window.xyLiveDrilldown = view;"
+
+_PROBE = r"""
+window.xyLiveDrilldown = view;
+(async () => {
+  try {
+    view._drawNow(); view._raf = null;
+    const g = view.gpuTraces.find((t) => t.tier === "density");
+    const ov = spec.traces.find((t) => t.kind === "scatter" && t.density).density;
+    const domX = ov.x_range, domY = ov.y_range;
+    const v0 = view.view0 || view.view;
+    const homeRange = { x: g.density.xRange.slice(), y: g.density.yRange.slice() };
+
+    // Density mass centroid in DATA coordinates, using the reported grid range.
+    const centroid = (d) => {
+      const { grid, w, h, xRange, yRange } = d;
+      let sx = 0, sy = 0, sw = 0;
+      for (let y = 0; y < h; y++) for (let x = 0; x < w; x++) {
+        const v = grid[y * w + x] || 0; if (v <= 0) continue;
+        sx += (xRange[0] + (x + 0.5) / w * (xRange[1] - xRange[0])) * v;
+        sy += (yRange[0] + (y + 0.5) / h * (yRange[1] - yRange[0])) * v;
+        sw += v;
+      }
+      return sw > 0 ? { x: sx / sw, y: sy / sw } : null;
+    };
+
+    // Pan well past the +x / +y data edge (span unchanged), so the requested
+    // window reaches beyond the domain and the source bins clamp.
+    const sx = v0.x1 - v0.x0, sy = v0.y1 - v0.y0;
+    const panned = { x0: v0.x0 + sx * 0.4, x1: v0.x1 + sx * 0.4,
+                     y0: v0.y0 + sy * 0.4, y1: v0.y1 + sy * 0.4 };
+    view.view = view._viewFrom(panned);
+    view._scheduleViewRequest(view.view, { delay: 0, seq: ++view.seq });
+    await new Promise((r) => setTimeout(r, 60));
+    view._drawNow(); view._raf = null;
+
+    const c = centroid(g.density);
+    document.body.setAttribute("data-drill-pan", JSON.stringify({
+      hasDensity: !!g,
+      domX, domY,
+      reqHiX: panned.x1, reqHiY: panned.y1,
+      homeRange,
+      pannedRange: { x: g.density.xRange.slice(), y: g.density.yRange.slice() },
+      centroid: c,
+    }));
+  } catch (err) {
+    document.body.setAttribute("data-drill-pan-error", String((err && err.stack) || err));
+  }
+})();
+"""
+
+
+def _drilldown_html() -> str:
+    # Enough points that a panned window still clears the browser-local re-bin
+    # budget (DIRECT_POINT_BUDGET * 4 = 800k visible); below it the pan falls to
+    # the server round-trip, which is unavailable under file:// and untested here.
+    os.environ["XY_LIVE_POINTS"] = "2000000"
+    sys.path.insert(0, str(FASTAPI_DIR))
+    import importlib
+
+    import live_drilldown
+
+    importlib.reload(live_drilldown)
+    html = live_drilldown.live_drilldown_html()
+    assert _ANCHOR in html
+    return html
+
+
+def test_drilldown_pan_past_data_keeps_density_aligned(tmp_path: Path) -> None:
+    chromium = find_chromium()
+    if chromium is None:
+        pytest.skip("Chromium unavailable")
+
+    document = _drilldown_html().replace(_ANCHOR, _PROBE, 1)
+    result = run_browser_probe(
+        chromium,
+        document,
+        tmp_path / "drilldown_pan.html",
+        "data-drill-pan",
+        label="drilldown pan alignment probe",
+    )
+
+    assert result["hasDensity"] is True
+    dom_x = result["domX"]
+    dom_y = result["domY"]
+    px = result["pannedRange"]["x"]
+    py = result["pannedRange"]["y"]
+
+    # The browser-local re-bin must have run (range changed from home), proving
+    # this exercised localDensityUpdate rather than silently no-op'ing.
+    assert px != result["homeRange"]["x"], "local density re-bin did not run on pan"
+
+    # The reported grid range must stay within the data domain: the overview
+    # integral only holds data inside the domain, so a range reaching past it
+    # (toward the requested window edge) is exactly the stretch bug.
+    span_x = dom_x[1] - dom_x[0]
+    span_y = dom_y[1] - dom_y[0]
+    eps_x = span_x * 1e-6
+    eps_y = span_y * 1e-6
+    assert px[1] <= dom_x[1] + eps_x, (px, dom_x)
+    assert py[1] <= dom_y[1] + eps_y, (py, dom_y)
+    # And it was genuinely clamped to the domain, not left at the request.
+    assert px[1] < result["reqHiX"] - eps_x, (px, result["reqHiX"])
+    assert py[1] < result["reqHiY"] - eps_y, (py, result["reqHiY"])
+
+    # The density mass stays aligned with the data (centered near the origin,
+    # not dragged toward the requested-but-empty window edge). The pre-fix
+    # stretch put the centroid past ~1.1 in x; the data centroid here is ~0.2.
+    c = result["centroid"]
+    assert c is not None
+    assert -1.0 < c["x"] < 1.0, c
+    assert -1.0 < c["y"] < 1.0, c

--- a/tests/test_drilldown_pan_alignment.py
+++ b/tests/test_drilldown_pan_alignment.py
@@ -97,6 +97,11 @@ def test_drilldown_pan_past_data_keeps_density_aligned(tmp_path: Path) -> None:
     chromium = find_chromium()
     if chromium is None:
         pytest.skip("Chromium unavailable")
+    # examples/fastapi/live_drilldown.py imports starlette at module load (the
+    # callback endpoint), but it is not a core test dependency. Skip cleanly
+    # where the fastapi example extra is not installed — same convention as
+    # tests/test_example_apps.py's importorskip for the fastapi app test.
+    pytest.importorskip("starlette")
 
     document = _drilldown_html().replace(_ANCHOR, _PROBE, 1)
     result = run_browser_probe(

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,19 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
 name = "anywidget"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -122,6 +135,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/ec/c8c19542f6389580e6281f87802849754b8910d29e0a7e36e32ac4e18811/hypothesis-6.156.4-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7338ee15ee84ef994ae3d1a2e71d25c82713bf5ec27f55442755ae15e38369b", size = 1071376, upload-time = "2026-07-08T21:54:54.003Z" },
     { url = "https://files.pythonhosted.org/packages/b5/10/57cc273baf0cfe722eaa903c72db7ca45e7df4cc0780f80cb5dfe50edbbf/hypothesis-6.156.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:539be6819696560c23ff6c0d0af4e7c1ea4936123f4433b511977a79adc371d5", size = 1121429, upload-time = "2026-07-08T21:55:17.323Z" },
     { url = "https://files.pythonhosted.org/packages/68/cf/4b31c31716980972f7b5dfd75fe11021e9b8b6dd09664cc5a82c8c03c2bc/hypothesis-6.156.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:b1717bc41d1a0683470f950c565ade33a52c28f600b1aa824d74f651a36e2c7b", size = 640761, upload-time = "2026-07-08T21:54:37.716Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -778,6 +800,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
 name = "traitlets"
 version = "5.15.1"
 source = { registry = "https://pypi.org/simple" }
@@ -861,6 +896,7 @@ dev = [
     { name = "pyarrow" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "starlette" },
     { name = "ty" },
 ]
 
@@ -875,6 +911,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-codspeed", marker = "extra == 'codspeed'", specifier = ">=5,<6" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.8" },
+    { name = "starlette", marker = "extra == 'dev'", specifier = ">=0.36" },
     { name = "ty", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev", "bench", "codspeed"]


### PR DESCRIPTION
## Summary

This PR fixes two critical bugs in the tiered density renderer:

1. **Density cache eviction freeing live textures**: The LRU cache eviction was not pinning `_shownDensity` (the grid last drawn, which becomes the next crossfade source), allowing its texture to be freed while still referenced. This caused WebGL errors when the next crossfade tried to bind the deleted handle, dropping the density frame and stranding drilled points over a stale surface.

2. **Drilldown pan-past-data misalignment**: When panning past the data domain, the browser-local density re-bin was reporting the *requested* window range instead of the *actual* clamped range that the grid covers. This stretched the fixed-extent texture across a wider window, sliding the density off the point cloud.

## Key Changes

- **`js/src/45_lod.js` and compiled outputs**: 
  - Added `lodDensityPinned()` helper to centralize the set of live density references: active grid, previous grid, crossfade source, last-drawn grid (`_shownDensity`), and standalone overview restore point (`_homeDensity`)
  - Updated eviction logic to use this helper, ensuring `_shownDensity` is never freed while still referenced
  - Added defensive check in `_drawDensity()` to skip grids with invalid textures (structural guard against deleted handles)

- **`examples/fastapi/live_drilldown.py`**:
  - Added `overviewEdgeValue()` function to map clamped source-bin indices back to data coordinates
  - Updated `localDensityUpdate()` to report the actual grid range (based on clamped bins) instead of the requested window range, preventing texture stretch when panning past the data domain

- **`spec/design/lod-architecture.md`**:
  - Added invariant T7 documenting the texture lifetime contract: cached textures must outlive every live reference, with `lodDensityPinned` as the authoritative pin set

- **Tests**:
  - `tests/test_density_texture_eviction.py`: Verifies that `_shownDensity` survives LRU eviction and its texture remains valid for drawing
  - `tests/test_drilldown_pan_alignment.py`: Verifies that panning past the data domain keeps the density grid range clamped to the domain and density mass aligned with the data

## Implementation Details

The fixes maintain the existing architecture while closing two reference-tracking gaps:

- The eviction pin set now includes all five density objects reachable from the trace, not just three. `_shownDensity` is critical because it persists across frames as the crossfade source.
- The drilldown re-bin now uses the clamped bin boundaries to compute the actual data range the grid covers, rather than the requested window. This ensures the renderer receives the correct range for the fixed-extent texture, preventing misalignment when the view extends past the data domain.
- The defensive texture check in `_drawDensity()` provides a safety net: even if a new code path accidentally creates a live reference outside the pin set, the draw will gracefully skip rather than crash with a hard WebGL error.

https://claude.ai/code/session_01V1YGm63EmTxJfgZYaV2rJr