### PR TITLE
Type the render client: no implicit any, no implicit this

### DIFF
--- a/js/src/00_header.ts
+++ b/js/src/00_header.ts
@@ -37,7 +37,25 @@ const XY_FRAME_DEFAULT_LIMITS = Object.freeze({
   maxBufferBytes: 256 * 1024 * 1024,
 });
 
-export function xyByteSpan(value, label = "buffer") {
+/** Per-field caps on an inbound frame; callers may override any subset. */
+export interface FrameLimits {
+  maxFrameBytes?: number;
+  maxMetadataBytes?: number;
+  maxBuffers?: number;
+  maxBufferBytes?: number;
+}
+
+/** A decoded XYBF frame: the JSON metadata message plus zero-copy buffer
+ * spans into the caller's ArrayBuffer, and the envelope facts a caller may
+ * want to log or assert on. */
+export interface DecodedFrame {
+  message: any;
+  buffers: Uint8Array[];
+  version: number;
+  byteLength: number;
+}
+
+export function xyByteSpan(value: unknown, label = "buffer"): Uint8Array {
   if (value instanceof ArrayBuffer) return new Uint8Array(value);
   if (ArrayBuffer.isView(value)) {
     return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
@@ -45,7 +63,7 @@ export function xyByteSpan(value, label = "buffer") {
   throw new TypeError(`${label} must be an ArrayBuffer or ArrayBuffer view`);
 }
 
-export function bytesToSpan(b) {
+export function bytesToSpan(b: unknown): Uint8Array {
   const span = xyByteSpan(b, "chart payload");
   // anywidget/third-party callers may hand us an oddly-offset DataView. Keep
   // the normal aligned path zero-copy; preserve compatibility with one narrow
@@ -53,7 +71,7 @@ export function bytesToSpan(b) {
   return span.byteOffset % 4 === 0 ? span : new Uint8Array(span);
 }
 
-function xyFrameLimit(limits, name) {
+function xyFrameLimit(limits: FrameLimits | null, name: keyof FrameLimits): number {
   const fallback = XY_FRAME_DEFAULT_LIMITS[name];
   const value = limits && limits[name] != null ? limits[name] : fallback;
   if (!Number.isSafeInteger(value) || value <= 0) {
@@ -62,11 +80,11 @@ function xyFrameLimit(limits, name) {
   return value;
 }
 
-function xyAlign8(value) {
+function xyAlign8(value: number): number {
   return Math.ceil(value / XY_FRAME_ALIGNMENT) * XY_FRAME_ALIGNMENT;
 }
 
-function xyFrameU64(view, offset, label) {
+function xyFrameU64(view: DataView, offset: number, label: string): number {
   const value = view.getBigUint64(offset, true);
   if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
     throw new RangeError(`${label} exceeds JavaScript's safe integer range`);
@@ -74,7 +92,7 @@ function xyFrameU64(view, offset, label) {
   return Number(value);
 }
 
-function xyRequireZeroPadding(bytes, start, end, label) {
+function xyRequireZeroPadding(bytes: Uint8Array, start: number, end: number, label: string): void {
   if (end > bytes.byteLength) throw new RangeError(`truncated ${label} padding`);
   for (let i = start; i < end; i++) {
     if (bytes[i] !== 0) throw new RangeError(`non-zero ${label} padding`);
@@ -87,7 +105,7 @@ function xyRequireZeroPadding(bytes, start, end, label) {
  * not copied. Response.arrayBuffer() supplies an aligned base. Passing an
  * unaligned subview is rejected rather than silently slicing the whole frame.
  */
-export function decodeFrame(body, limits = null) {
+export function decodeFrame(body: unknown, limits: FrameLimits | null = null): DecodedFrame {
   const bytes = xyByteSpan(body, "frame body");
   const maxFrameBytes = xyFrameLimit(limits, "maxFrameBytes");
   const maxMetadataBytes = xyFrameLimit(limits, "maxMetadataBytes");

--- a/js/src/05_types.ts
+++ b/js/src/05_types.ts
@@ -1,0 +1,178 @@
+// Shared types for the render client.
+//
+// The client consumes a *data-less spec* plus raw f32 buffers (§29): the spec
+// is authored by the Python kernel (`python/xy/_figure.py` and friends) and
+// arrives as parsed JSON, so these declarations describe a wire contract, not
+// classes we construct. They are deliberately permissive where the wire is
+// permissive — optional members are optional here too, and open-ended maps
+// (per-axis styles, mark styles, per-kind trace extras) keep index signatures
+// rather than pretending to an exhaustive union that the kernel could widen at
+// any time. Tightening one of these is a real compatibility decision; make it
+// deliberately, alongside the Python side that emits it.
+//
+// Naming mirrors the wire: snake_case members are exactly the JSON keys.
+
+/** A JSON-ish value as it arrives from the kernel. */
+export type Json = string | number | boolean | null | Json[] | { [key: string]: Json };
+
+/** Style bags are open maps: the kernel may add keys the client ignores. */
+export type StyleBag = Record<string, any>;
+
+/** RGBA in 0..1, the form every GL uniform and colormap LUT expects. */
+export type Rgba = [number, number, number, number];
+
+/** One shipped column's metadata: f32 values are offset-encoded (§4/§16), so
+ * decoding is `value / scale + offset` in f64 on the CPU. */
+export interface ColumnMeta {
+  len: number;
+  offset: number;
+  scale?: number;
+  dtype?: string;
+  kind?: string;
+  categories?: string[];
+  [key: string]: any;
+}
+
+/** Axis descriptor (`spec.axes[id]`, plus the x/y shorthands). */
+export interface AxisSpec {
+  id?: string;
+  kind?: string;
+  side?: string;
+  label?: string;
+  range?: [number, number] | number[];
+  categories?: string[];
+  log?: boolean;
+  format?: string;
+  style?: StyleBag;
+  [key: string]: any;
+}
+
+/** A per-point channel encoding (color/size/stroke). `buf` indexes
+ * `spec.columns`; `mode` selects constant / continuous / categorical. */
+export interface ChannelSpec {
+  buf?: number;
+  mode?: string;
+  domain?: [number, number] | number[];
+  colormap?: string;
+  palette?: string[];
+  categories?: string[];
+  color?: string;
+  size?: number;
+  range?: number[];
+  [key: string]: any;
+}
+
+/** One trace as the kernel emits it. Chart-kind-specific members (density
+ * grids, hexbin deltas, mesh indices…) stay open — `MARK_KINDS` dispatches on
+ * `kind` and reads what its own renderer needs. */
+export interface TraceSpec {
+  id?: string | number;
+  kind: string;
+  name?: string;
+  tier?: string;
+  x?: number;
+  y?: number;
+  x_axis?: string;
+  y_axis?: string;
+  color?: ChannelSpec;
+  size?: ChannelSpec;
+  stroke?: ChannelSpec;
+  style?: StyleBag;
+  channels?: Record<string, ChannelSpec>;
+  [key: string]: any;
+}
+
+/** The first-paint spec (§29). */
+export interface ChartSpec {
+  protocol?: number;
+  title?: string;
+  columns: ColumnMeta[];
+  traces: TraceSpec[];
+  axes?: Record<string, AxisSpec>;
+  x_axis?: AxisSpec;
+  y_axis?: AxisSpec;
+  buffer_layout?: string;
+  interaction?: Record<string, any>;
+  mark_style?: Record<string, StyleBag>;
+  dom?: Record<string, any>;
+  padding?: number[];
+  show_legend?: boolean;
+  show_tooltip?: boolean;
+  [key: string]: any;
+}
+
+/** The kernel channel. `null` in standalone (`to_html`) pages, which is the
+ * signal to take every kernel-less path (§37). */
+export interface Comm {
+  send(msg: Record<string, any>): void;
+  onMessage?(cb: (content: any, buffers?: any) => void): () => void;
+  wantsViewChange?(): boolean;
+}
+
+/** Payload buffers: one blob (packed) or one span per column (split). */
+export type PayloadBuffers = Uint8Array | Uint8Array[];
+
+/** Tick generation result. `labels` may differ from `ticks` (log axes draw
+ * fewer labels than gridlines). */
+export interface TickResult {
+  ticks: number[];
+  labels?: number[];
+  step: number;
+  log?: boolean;
+  [key: string]: any;
+}
+
+/** Resolved canvas theme (§36): CSS tokens resolved to GL-ready RGBA. */
+export interface Theme {
+  bg: Rgba;
+  grid: Rgba;
+  axis: Rgba;
+  label: Rgba;
+  [key: string]: any;
+}
+
+/** Plot box in CSS pixels. */
+export interface PlotBox {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** A GPU-resident trace: the spec plus its uploaded buffers, decode metadata,
+ * and tier caches. Every member beyond `trace` is a rebuildable cache (§27),
+ * created lazily per mark kind, so this stays open by design. */
+export interface GpuTrace {
+  trace: TraceSpec;
+  tier?: string;
+  n?: number;
+  xAxis?: string;
+  yAxis?: string;
+  xMeta?: ColumnMeta;
+  yMeta?: ColumnMeta;
+  color?: Rgba;
+  drill?: any;
+  density?: any;
+  [key: string]: any;
+}
+
+/** A pick result: which trace and vertex the pointer is over. */
+export interface Hit {
+  trace: number;
+  index: number;
+  g?: GpuTrace;
+  [key: string]: any;
+}
+
+/** A tooltip/event row, denormalized to display values. */
+export type Row = Record<string, any>;
+
+/** One entry in `MARK_KINDS`: build uploads GPU state for a kind, draw renders
+ * it. The registry is the dispatch seam that keeps ChartView chart-agnostic. */
+export interface MarkKind {
+  build(view: any, g: GpuTrace, trace: TraceSpec, buffer: PayloadBuffers): void;
+  draw(view: any, g: GpuTrace, x0: number, x1: number, y0: number, y1: number): void;
+  retainCpu?: boolean;
+  pointPick?: boolean;
+  [key: string]: any;
+}

--- a/js/src/10_colormaps.ts
+++ b/js/src/10_colormaps.ts
@@ -3,7 +3,12 @@
 // interpolates a 256-texel LUT texture once per colormap.
 // ---------------------------------------------------------------------------
 
-const COLORMAP_STOPS = {
+/** One colormap as ordered RGB stops in 0..255. */
+type ColorStops = number[][];
+
+/** Compact RGB (0..255) stop lists; `buildLutData` interpolates them into the
+ * 256-texel LUT uploaded per colormap. A `_r` suffix reverses any entry. */
+const COLORMAP_STOPS: Record<string, ColorStops> = {
   binary: [[255, 255, 255], [0, 0, 0]],
   gray: [[0, 0, 0], [25, 25, 25], [51, 51, 51], [76, 76, 76], [102, 102, 102], [128, 128, 128], [153, 153, 153], [179, 179, 179], [204, 204, 204], [230, 230, 230], [255, 255, 255]],
   viridis: [[68, 1, 84], [72, 36, 117], [65, 68, 135], [53, 95, 141], [42, 120, 142], [33, 145, 140], [34, 168, 132], [68, 191, 112], [122, 209, 81], [189, 223, 38], [253, 231, 37]],
@@ -26,14 +31,14 @@ const COLORMAP_STOPS = {
   spectral: [[158, 1, 66], [212, 61, 79], [244, 109, 67], [253, 173, 96], [254, 224, 139], [255, 255, 190], [230, 245, 152], [170, 220, 164], [102, 194, 165], [51, 135, 188], [94, 79, 162]],
 };
 
-export function colormapStops(name) {
+export function colormapStops(name: string): ColorStops {
   const reversed = typeof name === "string" && name.endsWith("_r");
   const base = reversed ? name.slice(0, -2) : name;
   const stops = COLORMAP_STOPS[base] || COLORMAP_STOPS.viridis;
   return reversed ? [...stops].reverse() : stops;
 }
 
-export function buildLutData(name) {
+export function buildLutData(name: string): Uint8Array {
   const stops = colormapStops(name);
   const N = 256;
   const data = new Uint8Array(N * 4);

--- a/js/src/20_theme.ts
+++ b/js/src/20_theme.ts
@@ -1,8 +1,10 @@
+import type { Rgba, Theme } from "./05_types";
+
 // ---------------------------------------------------------------------------
 // Colors & theming (§36: chrome inherits CSS; marks read --chart-* tokens)
 // ---------------------------------------------------------------------------
 
-function resolveCssColor(host, expr) {
+function resolveCssColor(host: HTMLElement, expr: string): Rgba | null {
   const probe = document.createElement("span");
   probe.style.display = "none";
   probe.style.color = expr;
@@ -16,12 +18,12 @@ function resolveCssColor(host, expr) {
   return [r / 255, g / 255, b / 255, a];
 }
 
-function cssToken(el, name) {
+function cssToken(el: HTMLElement, name: string): string | null {
   const v = getComputedStyle(el).getPropertyValue(name).trim();
   return v || null;
 }
 
-export function hexColor(hex) {
+export function hexColor(hex: string): Rgba | null {
   const h = hex.replace("#", "");
   if (!/^(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(h)) {
     return null;
@@ -32,7 +34,7 @@ export function hexColor(hex) {
   return [((n >> 16) & 255) / 255, ((n >> 8) & 255) / 255, (n & 255) / 255, a];
 }
 
-export function parseColor(host, c, fallback) {
+export function parseColor(host: HTMLElement, c: unknown, fallback: Rgba): Rgba {
   if (!c) return fallback;
   if (typeof c !== "string") return fallback;
   const expr = c.trim();
@@ -48,10 +50,10 @@ export function parseColor(host, c, fallback) {
   return fallback;
 }
 
-export function readTheme(root) {
+export function readTheme(root: HTMLElement): Theme {
   const text = resolveCssColor(root, "currentColor") || [0.2, 0.2, 0.2, 1];
-  const withA = (c, a) => [c[0], c[1], c[2], a];
-  const tok = (name) => {
+  const withA = (c: Rgba, a: number): Rgba => [c[0], c[1], c[2], a];
+  const tok = (name: string): Rgba | null => {
     const v = cssToken(root, name);
     return v ? resolveCssColor(root, v) || null : null;
   };
@@ -63,7 +65,7 @@ export function readTheme(root) {
   };
 }
 
-export function cssColor([r, g, b, a]: any) {
+export function cssColor([r, g, b, a]: Rgba): string {
   return `rgba(${Math.round(r * 255)},${Math.round(g * 255)},${Math.round(b * 255)},${a})`;
 }
 
@@ -141,8 +143,8 @@ export const XY_CHROME_CSS = `
 
 // Inject XY_CHROME_CSS once per DOM root (document head or shadow root), so
 // multiple charts on one page share a single stylesheet.
-export function ensureChromeStylesheet(node) {
-  let root = node && node.getRootNode ? node.getRootNode() : document;
+export function ensureChromeStylesheet(node: Node | null): void {
+  let root: any = node && node.getRootNode ? node.getRootNode() : document;
   const isShadow = typeof ShadowRoot !== "undefined" && root instanceof ShadowRoot;
   if (!isShadow && !(root instanceof Document)) root = document; // detached subtree
   const scope = isShadow ? root : (root.head || document.head || root.documentElement);
@@ -154,9 +156,9 @@ export function ensureChromeStylesheet(node) {
   scope.appendChild(style);
 }
 
-export function safeCssPaint(host, expr, fallback = [0.5, 0.5, 0.5, 1]) {
+export function safeCssPaint(host: HTMLElement, expr: unknown, fallback: Rgba = [0.5, 0.5, 0.5, 1]): string {
   const parsed = parseColor(host, expr, fallback);
-  const color = Array.isArray(parsed) && parsed.length >= 4 && parsed.every(Number.isFinite)
+  const color: Rgba = Array.isArray(parsed) && parsed.length >= 4 && parsed.every(Number.isFinite)
     ? parsed
     : fallback;
   return cssColor(color);

--- a/js/src/30_ticks.ts
+++ b/js/src/30_ticks.ts
@@ -1,8 +1,10 @@
+import type { AxisSpec, TickResult } from "./05_types";
+
 // ---------------------------------------------------------------------------
 // Ticks (computed in f64 on the CPU — never through f32, §16)
 // ---------------------------------------------------------------------------
 
-function niceStep(rough) {
+function niceStep(rough: number): number {
   rough = Math.abs(rough);
   if (!Number.isFinite(rough) || rough <= 0) return 1;
   const mag = Math.pow(10, Math.floor(Math.log10(rough)));
@@ -12,7 +14,7 @@ function niceStep(rough) {
   return 10 * mag;
 }
 
-export function linearTicks(lo, hi, target = 6) {
+export function linearTicks(lo: number, hi: number, target = 6): TickResult {
   if (!Number.isFinite(lo) || !Number.isFinite(hi)) return { ticks: [], step: 1 };
   const a = Math.min(lo, hi);
   const b = Math.max(lo, hi);
@@ -26,7 +28,7 @@ export function linearTicks(lo, hi, target = 6) {
   return { ticks: out, step };
 }
 
-export function logTicks(lo, hi, target = 6) {
+export function logTicks(lo: number, hi: number, target = 6): TickResult {
   if (!Number.isFinite(lo) || !Number.isFinite(hi)) return { ticks: [], step: 1 };
   const a = Math.min(lo, hi);
   const b = Math.max(lo, hi);
@@ -52,7 +54,7 @@ export function logTicks(lo, hi, target = 6) {
   return { ticks: out, labels: labels.length ? labels : out, step: 1, log: true };
 }
 
-export function categoryTicks(lo, hi, categories, target = 6) {
+export function categoryTicks(lo: number, hi: number, categories: string[] | undefined, target = 6): TickResult {
   if (!categories || !categories.length) return { ticks: [], step: 1 };
   const start = Math.max(0, Math.ceil(Math.min(lo, hi)));
   const stop = Math.min(categories.length - 1, Math.floor(Math.max(lo, hi)));
@@ -73,7 +75,7 @@ const TIME_STEPS = [
   MS.d, 2 * MS.d, 7 * MS.d, 14 * MS.d,
 ];
 
-export function timeTicks(lo, hi, target = 6) {
+export function timeTicks(lo: number, hi: number, target = 6): TickResult {
   if (!Number.isFinite(lo) || !Number.isFinite(hi)) return { ticks: [], step: MS.d };
   const a = Math.min(lo, hi);
   const b = Math.max(lo, hi);
@@ -90,7 +92,7 @@ export function timeTicks(lo, hi, target = 6) {
   return { ticks: out, step };
 }
 
-function calendarTicks(lo, hi, rough) {
+function calendarTicks(lo: number, hi: number, rough: number): TickResult {
   const monthsRough = rough / (30 * MS.d);
   const monthSteps = [1, 2, 3, 6, 12, 24, 60, 120];
   let stepM = monthSteps[monthSteps.length - 1];
@@ -112,9 +114,9 @@ function calendarTicks(lo, hi, rough) {
   return { ticks: out, step: stepM * 30 * MS.d };
 }
 
-function fmtTime(ms, step) {
+function fmtTime(ms: number, step: number): string {
   const d = new Date(ms);
-  const pad = (n, w = 2) => String(n).padStart(w, "0");
+  const pad = (n: number, w = 2) => String(n).padStart(w, "0");
   if (step >= 28 * MS.d) {
     const mo = d.getUTCMonth();
     return mo === 0 ? String(d.getUTCFullYear())
@@ -126,7 +128,7 @@ function fmtTime(ms, step) {
   return `${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}.${pad(d.getUTCMilliseconds(), 3)}`;
 }
 
-export function fmtLinear(v, step) {
+export function fmtLinear(v: number, step: number): string {
   const av = Math.abs(v);
   if (av >= 1e6 || (av !== 0 && av < 1e-4)) return v.toExponential(1).replace("e+", "e");
   let dec = step ? Math.max(0, Math.ceil(-Math.log10(Math.abs(step)))) : 0;
@@ -137,7 +139,7 @@ export function fmtLinear(v, step) {
 // Match Python's default ``:g`` formatting used by the SVG/native colorbar
 // exporters. Explicit ticks are authored values, so their precision must not
 // be inferred from the unrelated automatic tick step for the whole domain.
-export function fmtGeneral(v, precision = 6) {
+export function fmtGeneral(v: number, precision = 6): string {
   const value = Number(v);
   if (!Number.isFinite(value)) return String(v);
   if (value === 0) return Object.is(value, -0) ? "-0" : "0";
@@ -155,12 +157,12 @@ export function fmtGeneral(v, precision = 6) {
   return text;
 }
 
-export function fmtCategory(v, categories) {
+export function fmtCategory(v: number, categories: string[] | undefined): string {
   const i = Math.round(v);
   return i >= 0 && i < categories.length ? String(categories[i]) : "";
 }
 
-export function fmtNumberSpec(v, format) {
+export function fmtNumberSpec(v: number, format: string): string {
   if (typeof format !== "string" || !Number.isFinite(Number(v))) return null;
   const percent = format.endsWith("%");
   const raw = percent ? format.slice(0, -1) : format;
@@ -177,11 +179,11 @@ export function fmtNumberSpec(v, format) {
   return percent ? `${text}%` : text;
 }
 
-function fmtTimeSpec(ms, format) {
+function fmtTimeSpec(ms: number, format: string): string {
   if (typeof format !== "string") return null;
   const d = new Date(ms);
   if (!Number.isFinite(d.getTime())) return null;
-  const pad = (n, w = 2) => String(n).padStart(w, "0");
+  const pad = (n: number, w = 2) => String(n).padStart(w, "0");
   const shortMonth = d.toLocaleString("en", { month: "short", timeZone: "UTC" });
   const longMonth = d.toLocaleString("en", { month: "long", timeZone: "UTC" });
   return format.replace(/%[YmdHMSbB]/g, (token) => {
@@ -199,7 +201,7 @@ function fmtTimeSpec(ms, format) {
   });
 }
 
-export function fmtAxis(axis, v, tickStep) {
+export function fmtAxis(axis: AxisSpec, v: number, tickStep?: number): string {
   if (axis && axis.kind === "category") return fmtCategory(v, axis.categories || []);
   if (axis && axis.kind === "time") return fmtTimeSpec(v, axis.format) || fmtTime(v, tickStep);
   const formatted = fmtNumberSpec(v, axis && axis.format);
@@ -209,9 +211,11 @@ export function fmtAxis(axis, v, tickStep) {
   return formatted || fmtLinear(v, tickStep);
 }
 
-export function fmtValue(v, kind?: any) {
+export function fmtValue(v: unknown, kind?: string): string {
   if (kind === "time_ms") {
-    const d = new Date(v);
+    // time_ms values arrive as epoch millis; a date string is equally valid to
+    // the Date constructor, so the cast admits both rather than narrowing.
+    const d = new Date(v as number | string);
     return d.toISOString().replace("T", " ").replace(".000Z", "Z");
   }
   if (typeof v === "string") return v;

--- a/js/src/40_gl.ts
+++ b/js/src/40_gl.ts
@@ -2,7 +2,25 @@
 // WebGL2 helpers
 // ---------------------------------------------------------------------------
 
-function compile(gl, type, src) {
+/** Any CPU-side coordinate source: a decoded column view of whatever dtype
+ * the wire shipped, or a plain array. */
+type NumericArray = Float32Array | Float64Array | Uint8Array | Uint32Array | number[];
+
+/** A linked program plus its uniform-location memo (renderer audit R1). */
+export interface XyProgram extends WebGLProgram {
+  _u: Record<string, WebGLUniformLocation | null>;
+}
+
+/** Densified monotone-cubic samples; `extra` mirrors an optional third
+ * channel (an area chart's baseline) resampled on the same knots. */
+export interface SmoothResample {
+  x: Float32Array;
+  y: Float32Array;
+  extra: Float32Array | null;
+  n: number;
+}
+
+function compile(gl: WebGL2RenderingContext, type: number, src: string): WebGLShader {
   const sh = gl.createShader(type);
   gl.shaderSource(sh, src);
   gl.compileShader(sh);
@@ -38,8 +56,8 @@ export const ATTR_SLOTS = {
   a_rgba: 12, a_style: 13, a_stroke: 14, a_radius: 15,
 };
 
-export function makeProgram(gl, vs, fs) {
-  const p = gl.createProgram();
+export function makeProgram(gl: WebGL2RenderingContext, vs: string, fs: string): XyProgram {
+  const p = gl.createProgram() as XyProgram;
   const vsh = compile(gl, gl.VERTEX_SHADER, vs);
   const fsh = compile(gl, gl.FRAGMENT_SHADER, fs);
   gl.attachShader(p, vsh);
@@ -64,7 +82,11 @@ export function makeProgram(gl, vs, fs) {
   return p;
 }
 
-export function uniformOf(gl, prog, name) {
+export function uniformOf(
+  gl: WebGL2RenderingContext,
+  prog: XyProgram,
+  name: string
+): WebGLUniformLocation | null {
   let loc = prog._u[name];
   if (loc === undefined) {
     loc = gl.getUniformLocation(prog, name);
@@ -870,7 +892,7 @@ void main() {
 // offset-encoded f32 columns (§4) is exact. Output is capped at `maxOut`
 // vertices; past that the polyline is sub-pixel dense and smoothing is a no-op.
 // ---------------------------------------------------------------------------
-function xyMonotoneTangents(x, y, n) {
+function xyMonotoneTangents(x: NumericArray, y: NumericArray, n: number): Float64Array {
   const d = new Float64Array(n - 1);
   const m = new Float64Array(n);
   for (let i = 0; i < n - 1; i++) {
@@ -894,7 +916,13 @@ function xyMonotoneTangents(x, y, n) {
   return m;
 }
 
-export function xySmoothResample(x, y, extra, n, maxOut) {
+export function xySmoothResample(
+  x: NumericArray,
+  y: NumericArray,
+  extra: NumericArray | null,
+  n: number,
+  maxOut: number
+): SmoothResample | null {
   if (n < 3) return null;
   const sub = Math.max(1, Math.min(16, Math.floor(maxOut / n)));
   if (sub <= 1) return null; // already pixel-dense; identity at pixel scale

--- a/js/src/45_lod.ts
+++ b/js/src/45_lod.ts
@@ -1,4 +1,6 @@
+import type { ChannelSpec, ColumnMeta, GpuTrace, PayloadBuffers, Rgba, StyleBag } from "./05_types";
 import { parseColor } from "./20_theme";
+import type { ChartView } from "./50_chartview";
 
 // ---------------------------------------------------------------------------
 
@@ -17,7 +19,75 @@ const LOD_DRILL_EXIT_FACTOR = 1.15;
 // and future chart kinds can intercept/override the mark renderer).
 // ---------------------------------------------------------------------------
 
-function lodFade(view, start, duration = 140) {
+/** A data-space rectangle: the window a drilled subset was cut from, or the
+ * view a pending kernel request was issued for. */
+interface LodWindow {
+  x0: number;
+  x1: number;
+  y0: number;
+  y1: number;
+}
+
+/** One cached aggregate: the decoded grid, its GL texture, and the data-space
+ * range it was binned over. Everything here is a rebuildable cache (§27) and
+ * the producers differ (first paint vs kernel update), so it stays open. */
+interface DensitySource {
+  w: number;
+  h: number;
+  max: number;
+  normMax?: number;
+  colormap?: string;
+  color?: Rgba | null;
+  xRange: number[];
+  yRange: number[];
+  grid: Float32Array;
+  tex: WebGLTexture;
+  [key: string]: any;
+}
+
+/** A kernel "points"-mode reply: the exact subset for the current view, with
+ * channels restored. Every `*.buf` member indexes `buffers`; per-kind channel
+ * extras stay open the way the rest of the wire does. */
+export interface LodDrillUpdate {
+  x: ColumnMeta;
+  y: ColumnMeta;
+  x_range: number[];
+  y_range: number[];
+  visible?: number;
+  drill_seq?: number;
+  style?: StyleBag;
+  color?: ChannelSpec;
+  size?: ChannelSpec;
+  stroke?: ChannelSpec;
+  channels?: Record<string, ChannelSpec>;
+  density_val?: ChannelSpec;
+  density_colormap?: string;
+  lod_blend?: number;
+  [key: string]: any;
+}
+
+/** The grid payload of a kernel "density"-mode reply. `enc === "log-u8"` means
+ * `buf` is quantized and needs `lodDecodeLogU8` before use. */
+interface LodDensityPayload {
+  buf: number;
+  w: number;
+  h: number;
+  max: number;
+  enc?: string;
+  colormap?: string;
+  color?: string;
+  x_range: number[];
+  y_range: number[];
+  sample?: any;
+  [key: string]: any;
+}
+
+interface LodDensityUpdate {
+  density: LodDensityPayload;
+  [key: string]: any;
+}
+
+function lodFade(view: ChartView, start: number | null | undefined, duration = 140) {
   if (start === undefined || start === null || duration <= 0 || view._prefersReducedMotion()) {
     return 1;
   }
@@ -29,7 +99,7 @@ function lodFade(view, start, duration = 140) {
 // to approximate counts so exposure normalization and re-encodes work
 // unchanged. The final texture is 8-bit log anyway, so the round-trip is
 // visually exact; decode is deterministic (no RNG/time).
-export function lodDecodeLogU8(buf, maxVal) {
+export function lodDecodeLogU8(buf: ArrayBuffer | ArrayBufferView, maxVal: number) {
   const u8 = buf instanceof ArrayBuffer ? new Uint8Array(buf) : new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
   const out = new Float32Array(u8.length);
   const denom = Math.log1p(Math.max(0, maxVal || 0));
@@ -41,13 +111,15 @@ export function lodDecodeLogU8(buf, maxVal) {
   return out;
 }
 
-export function lodCopyGrid(f32) {
+// Any numeric column view can back a grid (`_columnView` hands back the raw
+// dtype); only the f32 copy path allocates.
+export function lodCopyGrid(f32: Float32Array | Uint32Array | Uint8Array) {
   return f32.slice ? f32.slice() : new Float32Array(f32);
 }
 
 // Log tone-mapped grid upload (R8): stable perception across renormalization,
 // and the u_max swings between rebins compress logarithmically (§5/§F6).
-export function lodWriteGridTexture(gl, tex, f32, w, h, maxVal) {
+export function lodWriteGridTexture(gl: WebGL2RenderingContext, tex: WebGLTexture, f32: Float32Array | Uint8Array | Uint32Array, w: number, h: number, maxVal: number) {
   const data = new Uint8Array(f32.length);
   const denom = Math.log1p(Math.max(0, maxVal || 0));
   if (denom > 0) {
@@ -72,7 +144,7 @@ export function lodWriteGridTexture(gl, tex, f32, w, h, maxVal) {
 // Treat the color scale like exposure: brighten slowly on drill-in so a
 // smaller aggregate tile does not suddenly go hot, but recover faster when
 // the incoming tile needs more headroom to avoid clipping.
-function lodNormMax(g, nextMax) {
+function lodNormMax(g: GpuTrace, nextMax: number) {
   if (!Number.isFinite(nextMax) || nextMax <= 0) {
     g.densityNormMax = 0;
     return 0;
@@ -87,7 +159,7 @@ function lodNormMax(g, nextMax) {
   return norm;
 }
 
-function lodStartNormAnim(view, g, start, target) {
+function lodStartNormAnim(view: ChartView, g: GpuTrace, start: number, target: number) {
   if (!g.density || !g.density.grid || !Number.isFinite(target) || target <= 0) {
     g._densityNormAnim = null;
     return;
@@ -108,7 +180,7 @@ function lodStartNormAnim(view, g, start, target) {
   };
 }
 
-function lodStepNorm(view, g) {
+function lodStepNorm(view: ChartView, g: GpuTrace) {
   const anim = g._densityNormAnim;
   const d = g.density;
   if (!anim || !d || !d.grid || !d.tex) return;
@@ -133,16 +205,16 @@ function lodStepNorm(view, g) {
 
 // -- density-source cache (multi-window LOD cache, §10) ----------------------
 
-function lodDensityArea(d) {
+function lodDensityArea(d: DensitySource) {
   return Math.abs((d.xRange[1] - d.xRange[0]) * (d.yRange[1] - d.yRange[0]));
 }
 
-function lodWindowArea(win) {
+function lodWindowArea(win: LodWindow | null | undefined) {
   if (!win) return 0;
   return Math.abs((win.x1 - win.x0) * (win.y1 - win.y0));
 }
 
-function lodWindowCenterInside(win, view) {
+function lodWindowCenterInside(win: LodWindow | null | undefined, view: LodWindow | null | undefined) {
   if (!win || !view) return false;
   const cx = (view.x0 + view.x1) / 2;
   const cy = (view.y0 + view.y1) / 2;
@@ -154,7 +226,7 @@ function lodWindowCenterInside(win, view) {
   );
 }
 
-function lodDensityForView(view, g) {
+function lodDensityForView(view: ChartView, g: GpuTrace): DensitySource {
   const cache = g.densityCache || (g.density ? [g.density] : []);
   let best = null;
   let broadest = null;
@@ -167,7 +239,7 @@ function lodDensityForView(view, g) {
   return best || broadest || g.density;
 }
 
-function lodHoldPendingDrill(view, g, d) {
+function lodHoldPendingDrill(view: ChartView, g: GpuTrace, d: GpuTrace | null) {
   const pending = g._lodPendingView;
   if (!d || !pending || g._drillDying) return false;
   if (g._lodPendingSeq !== view.seq) return false;
@@ -190,12 +262,12 @@ function lodHoldPendingDrill(view, g, d) {
 // let its texture be evicted while still referenced; the next crossfade bound
 // the freed handle → "bindTexture: attempt to use a deleted object", a dropped
 // density frame, and drilled points left stranded over a stale surface.
-function lodDensityPinned(g, d) {
+function lodDensityPinned(g: GpuTrace, d: DensitySource) {
   return d === g.density || d === g.prevDensity || d === g._densitySwitchPrev ||
     d === g._shownDensity || d === g._homeDensity;
 }
 
-export function lodRememberDensity(view, g, d) {
+export function lodRememberDensity(view: ChartView, g: GpuTrace, d: DensitySource) {
   if (!d || !d.tex) return;
   d._stamp = ++view._densityStamp;
   if (!g.densityCache) g.densityCache = [];
@@ -224,7 +296,7 @@ export function lodRememberDensity(view, g, d) {
 // The kernel decided this view fits the direct budget and shipped real marks
 // (channels restored). Build/refresh a direct-shaped sibling on the tiered
 // trace; the tier draw uses it until the kernel switches back.
-export function lodApplyDrill(view, g, upd, buffers) {
+export function lodApplyDrill(view: ChartView, g: GpuTrace, upd: LodDrillUpdate, buffers: PayloadBuffers) {
   const gl = view.gl;
   const fresh = !g.drill; // transition INTO drill vs refresh of a live drill
   let d = g.drill;
@@ -286,7 +358,7 @@ export function lodApplyDrill(view, g, upd, buffers) {
     gl.bufferData(gl.ARRAY_BUFFER, view._asF32(buffers[upd.size.buf]), gl.STATIC_DRAW);
     d.sizeRange = upd.size.range_px;
   }
-  const styleChannel = (name) => upd.channels && upd.channels[name];
+  const styleChannel = (name: string) => upd.channels && upd.channels[name];
   const artistScalar = Number(d.trace.style && d.trace.style.artist_alpha);
   if (styleChannel("opacity") || styleChannel("artist_alpha") ||
       styleChannel("stroke_width") || styleChannel("symbol") || Number.isFinite(artistScalar)) {
@@ -297,7 +369,7 @@ export function lodApplyDrill(view, g, upd, buffers) {
       values[i * 4 + 2] = -1;
       values[i * 4 + 3] = -1;
     }
-    const copy = (name, component, scale = 1) => {
+    const copy = (name: string, component: number, scale = 1) => {
       const spec = styleChannel(name);
       if (!spec) return;
       const source = spec.dtype === "u8"
@@ -364,7 +436,7 @@ export function lodApplyDrill(view, g, upd, buffers) {
 // locally from the retained data-space brush (box or lasso). Exact for range
 // predicates — the same containment test the kernel runs (§34 Tier A) — so
 // the eventual kernel mask is a no-op overwrite, not a correction.
-function lodRestoreBrushMask(view, d, xs, ys) {
+function lodRestoreBrushMask(view: ChartView, d: GpuTrace, xs: Float32Array, ys: Float32Array) {
   const b = view._lastBrush;
   if (!b || !d.n) return;
   const ox = d.xMeta.offset, sx = d.xMeta.scale || 1;
@@ -392,7 +464,7 @@ function lodRestoreBrushMask(view, d, xs, ys) {
   view._applySelMask(d, mask);
 }
 
-export function lodDropDrill(view, g) {
+export function lodDropDrill(view: ChartView, g: GpuTrace) {
   const d = g.drill;
   if (!d) return;
   const gl = view.gl;
@@ -420,7 +492,7 @@ export function lodDropDrill(view, g) {
 // window at death: if it was, the kernel explicitly chose density FOR this
 // view (forced density / data change) and the revive path must not override
 // it; if it wasn't, a fast zoom back in may revive the still-exact subset.
-function lodMarkDrillDying(view, g) {
+function lodMarkDrillDying(view: ChartView, g: GpuTrace) {
   if (!g.drill) return;
   g._drillDying = true;
   g._drillDiedInsideWin = view._viewInside(g.drill.win);
@@ -429,7 +501,7 @@ function lodMarkDrillDying(view, g) {
   lodBeginDrillExitContinuous(view, g);
 }
 
-function lodDrillExitFade(view, g) {
+function lodDrillExitFade(view: ChartView, g: GpuTrace) {
   if (g._drillExitFadeStart === undefined || g._drillExitFadeStart === null) {
     g._drillExitFadeStart = view._now();
   }
@@ -452,12 +524,12 @@ const LOD_EXIT_FADE_MS = 120;
 // Exact inverse of smoothstep (s(t) = 3t^2 - 2t^3) via the trisection
 // identity — a linear approximation compounds visible error at the fade
 // ends when clocks hand off repeatedly under rapid zoom thrash.
-function lodFadeInvert(alpha) {
+function lodFadeInvert(alpha: number) {
   const a = Math.min(1, Math.max(0, alpha));
   return 0.5 - Math.sin(Math.asin(1 - 2 * a) / 3);
 }
 
-function lodDrillShownAlpha(view, g) {
+function lodDrillShownAlpha(view: ChartView, g: GpuTrace) {
   if (g._drillExitFadeStart != null) {
     return 1 - lodFade(view, g._drillExitFadeStart, LOD_EXIT_FADE_MS);
   }
@@ -472,7 +544,7 @@ function lodDrillShownAlpha(view, g) {
 }
 
 // Switch to the entry (fade-in) clock, seeded so it starts at the shown alpha.
-function lodEnterDrillContinuous(view, g) {
+function lodEnterDrillContinuous(view: ChartView, g: GpuTrace) {
   const alpha = lodDrillShownAlpha(view, g);
   g._drillShownAlpha = alpha;
   g._drillExitFadeStart = null;
@@ -481,7 +553,7 @@ function lodEnterDrillContinuous(view, g) {
 }
 
 // Switch to the exit (fade-out) clock, seeded the same way.
-function lodBeginDrillExitContinuous(view, g) {
+function lodBeginDrillExitContinuous(view: ChartView, g: GpuTrace) {
   if (g._drillExitFadeStart != null) return; // already exiting — keep its clock
   const alpha = lodDrillShownAlpha(view, g);
   g._drillShownAlpha = alpha;
@@ -494,11 +566,11 @@ function lodBeginDrillExitContinuous(view, g) {
 // Apply a kernel "density"-mode update: new grid texture with eased exposure
 // normalization, previous grid kept for the crossfade, source remembered in
 // the per-trace cache.
-export function lodApplyDensityUpdate(view, g, upd, buffers) {
+export function lodApplyDensityUpdate(view: ChartView, g: GpuTrace, upd: LodDensityUpdate, buffers: PayloadBuffers) {
   lodMarkDrillDying(view, g);
   const d = upd.density;
   const grid = d.enc === "log-u8"
-    ? lodDecodeLogU8(buffers[d.buf], d.max)
+    ? lodDecodeLogU8(buffers[d.buf] as Uint8Array, d.max)
     : lodCopyGrid(view._asF32(buffers[d.buf]));
   const normStart = lodNormMax(g, d.max);
   const normMax = view._prefersReducedMotion() ? d.max : normStart;
@@ -525,7 +597,7 @@ export function lodApplyDensityUpdate(view, g, upd, buffers) {
   lodRememberDensity(view, g, g.density);
 }
 
-function lodDrawDensityWithFade(view, g, density, opacityScale = 1) {
+function lodDrawDensityWithFade(view: ChartView, g: GpuTrace, density: DensitySource, opacityScale = 1) {
   if (density !== g._shownDensity) {
     // Reversing a crossfade mid-flight (rapid alternation across two cached
     // windows) swaps the roles with a mirrored clock so both textures keep
@@ -560,7 +632,7 @@ function lodDrawDensityWithFade(view, g, density, opacityScale = 1) {
 // window; aggregate + fading marks during transitions (drill-in entry fade,
 // dying drill exit fade); aggregate alone otherwise. Never blank, never a
 // hard cut (§5 smooth transitions).
-export function lodDrawDensityTier(view, g, x0, x1, y0, y1) {
+export function lodDrawDensityTier(view: ChartView, g: GpuTrace, x0: number, x1: number, y0: number, y1: number) {
   lodStepNorm(view, g);
   const d = g.drill;
   // Rapid zoom out→in revive: a dying drill whose window still covers the

--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -1,7 +1,19 @@
+import type {
+  AxisSpec,
+  ChartSpec,
+  ColumnMeta,
+  Comm,
+  GpuTrace,
+  PayloadBuffers,
+  Rgba,
+  StyleBag,
+  TraceSpec,
+} from "./05_types";
 import { PROTOCOL, xyByteSpan } from "./00_header";
 import { buildLutData, colormapStops } from "./10_colormaps";
 import { cssColor, ensureChromeStylesheet, hexColor, parseColor, readTheme, safeCssPaint } from "./20_theme";
 import { categoryTicks, fmtAxis, fmtGeneral, fmtLinear, fmtValue, linearTicks, logTicks, timeTicks } from "./30_ticks";
+import type { XyProgram } from "./40_gl";
 import { AREA_FS, AREA_VS, ATTR_SLOTS, BAR_VS, DENSITY_FS, GRID_VS, HEATMAP_FS, LINE_FS, LINE_VS, MESH_FS, MESH_VS, PICK_FS, PICK_VS, POINT_FS, POINT_SIMPLE_FS, POINT_SIMPLE_VS, POINT_VS, RECT_FS, RECT_VS, SEGMENT_FS, SEGMENT_VS, makeProgram, uniformOf, xySmoothResample } from "./40_gl";
 import { lodCopyGrid, lodDecodeLogU8, lodDrawDensityTier, lodRememberDensity, lodWriteGridTexture } from "./45_lod";
 import { markOf } from "./55_marks";
@@ -9,6 +21,31 @@ import { markOf } from "./55_marks";
 // ---------------------------------------------------------------------------
 // ChartView
 // ---------------------------------------------------------------------------
+
+/** A decoded column as `_columnView` returns it: the dtype follows the
+ * column's wire encoding, so every consumer accepts the union. */
+type ColumnView = Float32Array | Uint8Array | Uint32Array;
+
+/** An affine data->clip mapping as `_map` returns it: `[mul, add]`. Pan/zoom
+ * is a uniform update over these, never a buffer rewrite (§7). */
+type AxisMap = number[];
+
+/** A GL buffer tagged with its identity and element type, so a VAO built over
+ * a replaced buffer rebuilds instead of reading stale bytes. */
+interface XyBuffer extends WebGLBuffer {
+  _fcId?: number;
+  _fcType?: number;
+}
+
+/** The client-side view: one data-space range per axis, plus the x/y
+ * shorthands every draw path reads. */
+interface ViewState {
+  ranges: Record<string, number[]>;
+  x0: number;
+  x1: number;
+  y0: number;
+  y1: number;
+}
 
 // ChartView gains methods via prototype augmentation (51–57) and creates
 // instance fields ad hoc throughout its lifecycle; the merged index signature
@@ -80,14 +117,14 @@ const UNITLESS_STYLE_PROPS = new Set([
 // is safe: it only lowers the effective budget, releasing a few extra
 // off-screen contexts that revive on demand — it never evicts or blanks.
 const XY_CONTEXT_GOVERNOR = {
-  views: new Set(),
+  views: new Set<ChartView>(),
   seq: 1,
-  hiddenReleaseChannel: null,
-  hiddenReleaseQueue: [],
+  hiddenReleaseChannel: null as MessageChannel | null,
+  hiddenReleaseQueue: [] as ChartView[],
   // Cross-frame coordination (initialized lazily on first register()).
-  frameId: null,
-  channel: null,
-  foreign: null, // Map<frameId, liveCount> reported by other same-origin frames
+  frameId: null as string | null,
+  channel: null as BroadcastChannel | null,
+  foreign: null as Map<string, number> | null, // liveCount reported by other same-origin frames
   _announcedLive: -1,
   _crossFrameReady: false,
   _rebalanceScheduled: false,
@@ -97,11 +134,11 @@ const XY_CONTEXT_GOVERNOR = {
     // does not push chart contexts into browser-side eviction.
     return Number.isFinite(v) && v >= 1 ? Math.floor(v) : 12;
   },
-  register(view) {
+  register(view: ChartView) {
     this._initCrossFrame();
     this.views.add(view);
   },
-  unregister(view) {
+  unregister(view: ChartView) {
     view._ctxPendingReservation = false;
     this.views.delete(view);
     this._announceLive();
@@ -110,7 +147,7 @@ const XY_CONTEXT_GOVERNOR = {
   // least-recently-visible off-screen views until the requester fits the
   // budget. If every live view is visible, overflow is allowed — the browser
   // may LRU-evict, and eviction recovery rebuilds on re-entry.
-  reserve(requester) {
+  reserve(requester: ChartView) {
     const live = [];
     let pending = 0;
     for (const view of this.views) {
@@ -142,7 +179,7 @@ const XY_CONTEXT_GOVERNOR = {
       if (view._releaseContext()) over -= 1;
     }
   },
-  acquired(requester) {
+  acquired(requester: ChartView) {
     requester._ctxPendingReservation = false;
     // A context just came live. Shed our own off-screen views if that pushed
     // the shared budget over, then tell peer frames the new count so theirs
@@ -150,7 +187,7 @@ const XY_CONTEXT_GOVERNOR = {
     this._rebalance();
     this._announceLive();
   },
-  cancel(requester) {
+  cancel(requester: ChartView) {
     requester._ctxPendingReservation = false;
   },
   // --- Cross-frame budget sharing over BroadcastChannel (§18) ---------------
@@ -168,7 +205,7 @@ const XY_CONTEXT_GOVERNOR = {
     try {
       this.frameId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
       this.channel = new BroadcastChannel("xy-webgl-context-governor");
-      this.channel.onmessage = (event) => this._onForeignMessage(event.data);
+      this.channel.onmessage = (event: MessageEvent) => this._onForeignMessage(event.data);
       // Announce arrival so already-open frames re-advertise their counts, and
       // drop our contribution from theirs when we go away.
       this._post({ t: "hello", id: this.frameId });
@@ -196,14 +233,14 @@ const XY_CONTEXT_GOVERNOR = {
       this.channel = null; // sandboxed context: stay per-document
     }
   },
-  _post(msg) {
+  _post(msg: any) {
     try {
       if (this.channel) this.channel.postMessage(msg);
     } catch (_err) {
       /* channel closed mid-teardown */
     }
   },
-  _onForeignMessage(msg) {
+  _onForeignMessage(msg: any) {
     if (!msg || !this.foreign || msg.id === this.frameId) return;
     if (msg.t === "live") {
       this.foreign.set(msg.id, msg.n | 0);
@@ -315,7 +352,7 @@ const XY_CONTEXT_GOVERNOR = {
 // arrive asynchronously, but big dashboards create every chart synchronously —
 // the estimate lets reserve() prefer below-the-fold charts immediately. The
 // 25% margin matches the observer's rootMargin (recovery hysteresis).
-function xyInitiallyVisible(el) {
+function xyInitiallyVisible(el: HTMLElement) {
   if (typeof window === "undefined" || !el.getBoundingClientRect) return true;
   const rect = el.getBoundingClientRect();
   if (!rect.width && !rect.height) return false; // hidden boot slot: recoverable
@@ -327,7 +364,7 @@ function xyInitiallyVisible(el) {
 }
 
 export class ChartView {
-  constructor(el, spec, buffer, comm) {
+  constructor(el: HTMLElement, spec: ChartSpec, buffer: PayloadBuffers, comm: Comm | null) {
     if (spec.protocol !== PROTOCOL) {
       el.textContent =
         `xy: protocol mismatch (client speaks ${PROTOCOL}, kernel sent ${spec.protocol}). ` +
@@ -422,7 +459,7 @@ export class ChartView {
       // fallback behind for browsers without WebGL2; recovery attempts catch
       // the same error themselves and therefore never replace their canvas.
       XY_CONTEXT_GOVERNOR.unregister(this);
-      if (String(err && err.message || err) === "webgl2 unavailable") {
+      if (String(err && (err as Error).message || err) === "webgl2 unavailable") {
         this.root.textContent = "xy: WebGL2 unavailable in this browser.";
       }
       throw err;
@@ -471,7 +508,7 @@ export class ChartView {
       }
     }
 
-    this._unsubscribeComm = comm ? comm.onMessage((msg, buffers) => this._onKernelMsg(msg, buffers)) : null;
+    this._unsubscribeComm = comm ? comm.onMessage((msg: any, buffers: PayloadBuffers) => this._onKernelMsg(msg, buffers)) : null;
     if (this._startEntranceAnimation) this._startEntranceAnimation();
     else this.draw();
   }
@@ -531,7 +568,7 @@ export class ChartView {
     };
   }
 
-  _normalizeAxes(spec) {
+  _normalizeAxes(spec: ChartSpec) {
     const axes = { ...(spec.axes || {}) };
     if (spec.x_axis) axes.x = spec.x_axis;
     if (spec.y_axis) axes.y = spec.y_axis;
@@ -541,16 +578,16 @@ export class ChartView {
     return axes;
   }
 
-  _axis(axisId) {
+  _axis(axisId: string) {
     const id = axisId || "x";
     return this.axes[id] || (String(id).startsWith("y") ? this.axes.y : this.axes.x) || {};
   }
 
-  _axisDim(axisId) {
+  _axisDim(axisId: string) {
     return String(axisId || "x").startsWith("y") ? "y" : "x";
   }
 
-  _axisMode(axisId) {
+  _axisMode(axisId: string) {
     return this._axis(axisId).scale === "log" ? 1 : 0;
   }
 
@@ -558,7 +595,7 @@ export class ChartView {
     return Object.keys(this.axes || {});
   }
 
-  _copyView(view) {
+  _copyView(view: any): ViewState {
     const ranges: any = {};
     for (const axisId of this._axisIds()) {
       const range = view?.ranges?.[axisId] || this._axis(axisId).range || [0, 1];
@@ -569,7 +606,7 @@ export class ChartView {
     return { ranges, x0: x[0], x1: x[1], y0: y[0], y1: y[1] };
   }
 
-  _viewFrom(next, base = this.view) {
+  _viewFrom(next: any, base = this.view): ViewState {
     const ranges = {};
     for (const axisId of this._axisIds()) {
       const source = next?.ranges?.[axisId]
@@ -578,12 +615,12 @@ export class ChartView {
         || base?.ranges?.[axisId]
         || this._axis(axisId).range
         || [0, 1];
-      ranges[axisId] = [Number(source[0]), Number(source[1])];
+      (ranges as Record<string, number[]>)[axisId] = [Number(source[0]), Number(source[1])];
     }
     return this._copyView({ ranges });
   }
 
-  _axisPolicy(name) {
+  _axisPolicy(name: string) {
     const configured = this.interaction?.[name];
     if (!Array.isArray(configured) || !configured.length) return this._axisIds();
     const declared = new Set(this._axisIds());
@@ -602,7 +639,7 @@ export class ChartView {
   // mutation keeps its window inside its home extents. Cursor-anchored zoom
   // is a scaling plus a translation, so without containment a zoom-in/out
   // chain at two cursor positions is an exact pan of the "locked" axis.
-  _axisContained(axisId) {
+  _axisContained(axisId: string) {
     if (!this._interactionFlag("navigation", true)) return false;
     if (!this._interactionFlag("zoom", true)) return false;
     if (!this._axisPolicy("zoom_axes").includes(axisId)) return false;
@@ -610,7 +647,7 @@ export class ChartView {
     return !this._axisPolicy("pan_axes").includes(axisId);
   }
 
-  _resolveDefaultDragAction() {
+  _resolveDefaultDragAction(): string {
     const requested = typeof this.interaction?.default_drag_action === "string"
       ? this.interaction.default_drag_action : "auto";
     const canNavigate = this._interactionFlag("navigation", true);
@@ -633,7 +670,7 @@ export class ChartView {
     return requested === "none" ? "none" : this._resolveDefaultDragActionFallback();
   }
 
-  _resolveDefaultDragActionFallback() {
+  _resolveDefaultDragActionFallback(): string {
     const saved = this.interaction.default_drag_action;
     this.interaction.default_drag_action = "auto";
     const resolved = this._resolveDefaultDragAction();
@@ -641,19 +678,19 @@ export class ChartView {
     return resolved;
   }
 
-  _axisCoord(axis, value) {
+  _axisCoord(axis: AxisSpec, value: number) {
     const v = Number(value);
     if (!Number.isFinite(v)) return NaN;
     if (axis && axis.scale === "log") return v > 0 ? Math.log10(v) : NaN;
     return v;
   }
 
-  _axisValue(axis, coord) {
+  _axisValue(axis: AxisSpec, coord: number) {
     if (axis && axis.scale === "log") return Math.pow(10, coord);
     return coord;
   }
 
-  _axisRange(axisId, view = this.view) {
+  _axisRange(axisId: string, view = this.view) {
     const mapped = view?.ranges?.[axisId];
     if (Array.isArray(mapped)) return [mapped[0], mapped[1]];
     if (axisId === "x" && view) return [view.x0, view.x1];
@@ -663,12 +700,12 @@ export class ChartView {
     return [Number(r[0]), Number(r[1])];
   }
 
-  _axisTicks(axisId, target): any {
+  _axisTicks(axisId: string, target: number): any {
     const axis = this._axis(axisId);
     const [lo, hi] = this._axisRange(axisId);
     if (Array.isArray(axis.tick_values)) {
       const a = Math.min(lo, hi), b = Math.max(lo, hi);
-      const ticks = axis.tick_values.map(Number).filter((v) => Number.isFinite(v) && v >= a && v <= b);
+      const ticks = axis.tick_values.map(Number).filter((v: number) => Number.isFinite(v) && v >= a && v <= b);
       return { ticks, labels: ticks, step: ticks.length > 1 ? Math.abs(ticks[1] - ticks[0]) : 1 };
     }
     if (axis.kind === "time") return timeTicks(lo, hi, target);
@@ -677,15 +714,15 @@ export class ChartView {
     return linearTicks(lo, hi, target);
   }
 
-  _axisTickText(axis, value, step) {
+  _axisTickText(axis: AxisSpec, value: number, step: number) {
     if (Array.isArray(axis.tick_values) && Array.isArray(axis.tick_labels)) {
-      const index = axis.tick_values.findIndex((candidate) => Number(candidate) === Number(value));
+      const index = axis.tick_values.findIndex((candidate: unknown) => Number(candidate) === Number(value));
       if (index >= 0 && index < axis.tick_labels.length) return String(axis.tick_labels[index]);
     }
     return fmtAxis(axis, value, step);
   }
 
-  _axisTickTarget(axisId, fallback) {
+  _axisTickTarget(axisId: string, fallback: number) {
     const axis = this._axis(axisId);
     const requested = Number(axis && axis.tick_count);
     if (Number.isFinite(requested) && requested > 0) {
@@ -694,7 +731,7 @@ export class ChartView {
     return fallback;
   }
 
-  _dataPx(axisId, value) {
+  _dataPx(axisId: string, value: number) {
     const dim = this._axisDim(axisId);
     const axis = this._axis(axisId);
     const [lo, hi] = this._axisRange(axisId);
@@ -706,13 +743,21 @@ export class ChartView {
     return this.plot.y + (1 - (c - c0) / (c1 - c0)) * this.plot.h;
   }
 
-  _listen(target, type, handler, options?: any) {
-    target.addEventListener(type, handler, options);
+  _listen<E extends Event = Event>(
+    target: EventTarget,
+    type: string,
+    handler: (event: E) => void,
+    options?: AddEventListenerOptions | boolean
+  ) {
+    // The DOM signature is invariant in its event type; the generic keeps
+    // call sites precise (PointerEvent, WheelEvent, …) and the cast is the
+    // one place that admits the widening the DOM API requires.
+    target.addEventListener(type, handler as EventListener, options);
     this._listeners.push({ target, type, handler, options });
     return handler;
   }
 
-  _interactionFlag(name, fallback = false) {
+  _interactionFlag(name: string, fallback = false) {
     const value = this.interaction && this.interaction[name];
     return value === undefined ? fallback : value === true;
   }
@@ -730,7 +775,7 @@ export class ChartView {
     };
   }
 
-  _dispatchChartEvent(name, detail) {
+  _dispatchChartEvent(name: string, detail: any) {
     if (!this.root || typeof CustomEvent !== "function") return;
     this.root.dispatchEvent(new CustomEvent(`xy:${name}`, {
       detail,
@@ -777,7 +822,7 @@ export class ChartView {
     if (!group || typeof BroadcastChannel !== "function") return;
     this._linkAxes = this._axisPolicy("link_axes");
     this._linkChannel = new BroadcastChannel(`xy:${group}`);
-    this._linkChannel.onmessage = (event) => {
+    this._linkChannel.onmessage = (event: MessageEvent) => {
       const msg = event.data || {};
       if (msg.source === this._linkedSource) return;
       if (this._interactionFlag("link_select") && msg.selection) {
@@ -787,7 +832,7 @@ export class ChartView {
         if (selection.clear) {
           this._clearSelection({ broadcast: false, dispatch: false });
         } else if (selection.polygon) {
-          this._stateSelection = { polygon: selection.polygon.map((point) => [...point]) };
+          this._stateSelection = { polygon: selection.polygon.map((point: number[]) => [...point]) };
           this._selectLocalPolygon(selection.polygon, { dispatch: false });
         } else if (selection.range) {
           const { x0, x1, y0, y1 } = selection.range;
@@ -820,23 +865,23 @@ export class ChartView {
     };
   }
 
-  _broadcastLinkedView(detail) {
+  _broadcastLinkedView(detail: any) {
     if (!this._linkChannel) return;
-    const axes = (detail.axes || []).filter((axisId) => this._linkAxes.includes(axisId));
+    const axes = (detail.axes || []).filter((axisId: string) => this._linkAxes.includes(axisId));
     if (!axes.length) return;
-    const ranges = Object.fromEntries(axes.map((axisId) => [axisId, detail.ranges[axisId]]));
+    const ranges = Object.fromEntries(axes.map((axisId: string) => [axisId, detail.ranges[axisId]]));
     this._linkChannel.postMessage({
       source: this._linkedSource,
       view: { ...detail, axes, ranges },
     });
   }
 
-  _broadcastLinkedSelection(selection) {
+  _broadcastLinkedSelection(selection: any) {
     if (!this._linkChannel || !this._interactionFlag("link_select")) return;
     this._linkChannel.postMessage({ source: this._linkedSource, selection });
   }
 
-  setView(ranges, opts: any = {}) {
+  setView(ranges: any, opts: any = {}) {
     return this._setView({ ranges }, {
       animate: opts.animate === true,
       source: "programmatic",
@@ -850,14 +895,14 @@ export class ChartView {
     return this._resetView(opts.animate !== false, "reset");
   }
 
-  _applyClass(el, className) {
+  _applyClass(el: HTMLElement, className: string) {
     if (typeof className !== "string") return;
     for (const token of className.split(/\s+/).filter(Boolean)) {
       try { el.classList.add(token); } catch (_) { /* Ignore invalid CSS class tokens. */ }
     }
   }
 
-  _stylePropertyName(key) {
+  _stylePropertyName(key: string) {
     if (key.startsWith("--")) return key;
     // Accept snake_case (the Python API form, e.g. `font_size`), camelCase
     // (React-style `fontSize`), and kebab-case interchangeably, normalizing all
@@ -866,17 +911,17 @@ export class ChartView {
     // the spec, so without it a validated `font_size` reached
     // setProperty("font_size", …) and the browser silently dropped it. It also
     // lets the unitless-property check below see the real (kebab) name.
-    return key.replace(/_/g, "-").replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+    return key.replace(/_/g, "-").replace(/[A-Z]/g, (match: string) => `-${match.toLowerCase()}`);
   }
 
-  _stylePropertyValue(property, value) {
+  _stylePropertyValue(property: string, value: any) {
     if (typeof value !== "number") return String(value);
     if (!Number.isFinite(value)) return null;
     if (property.startsWith("--") || UNITLESS_STYLE_PROPS.has(property)) return String(value);
     return `${value}px`;
   }
 
-  _applyStyle(el, style) {
+  _applyStyle(el: HTMLElement, style: StyleBag) {
     if (!style || typeof style !== "object" || Array.isArray(style)) return;
     for (const [key, value] of Object.entries(style)) {
       if (typeof key !== "string") continue;
@@ -887,7 +932,7 @@ export class ChartView {
     }
   }
 
-  _applySlot(el, slot) {
+  _applySlot(el: HTMLElement, slot: string) {
     if (el && el.dataset) el.dataset.xySlot = slot;
     const dom = this.spec.dom;
     if (!dom || typeof dom !== "object") return;
@@ -901,7 +946,7 @@ export class ChartView {
     }
   }
 
-  _slotStyleValue(slot, property) {
+  _slotStyleValue(slot: string, property: string) {
     const styles = this.spec.dom?.styles;
     const style = styles && typeof styles === "object" ? styles[slot] : null;
     if (!style || typeof style !== "object" || Array.isArray(style)) return null;
@@ -923,7 +968,7 @@ export class ChartView {
     this._queueResize(null, null, true);
   }
 
-  _queueResize(cssW = null, cssH = null, measure = false) {
+  _queueResize(cssW: number | null = null, cssH: number | null = null, measure = false) {
     if (this._destroyed) return;
     if (cssW || cssH) this._pendingResize = { cssW, cssH };
     if (measure) this._resizeNeedsMeasure = true;
@@ -962,20 +1007,20 @@ export class ChartView {
     }
   }
 
-  _markStateValue(state, property, fallback = null) {
+  _markStateValue(state: string, property: string, fallback: any = null) {
     const styles = this.markStyle && typeof this.markStyle === "object" ? this.markStyle[state] : null;
     if (!styles || typeof styles !== "object" || Array.isArray(styles)) return fallback;
     if (Object.prototype.hasOwnProperty.call(styles, property)) return styles[property];
     return fallback;
   }
 
-  _markStateNumber(state, property, fallback) {
+  _markStateNumber(state: string, property: string, fallback: number) {
     const value = this._markStateValue(state, property, fallback);
     if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
     return value;
   }
 
-  _markStatePaint(state, property, fallback) {
+  _markStatePaint(state: string, property: string, fallback: string) {
     const value = this._markStateValue(state, property, fallback);
     return typeof value === "string" ? value : fallback;
   }
@@ -1003,7 +1048,7 @@ export class ChartView {
   // spec + payload, then a fresh view request re-syncs live tiers (kernel
   // updates written into now-dead buffers are gone until it answers).
   _initContextLossRecovery() {
-    this._listen(this.canvas, "webglcontextlost", (e) => {
+    this._listen(this.canvas, "webglcontextlost", (e: Event) => {
       e.preventDefault();
       if (this._destroyed) return;
       const governedRelease = this.canvas.dataset.xyCtx === "released";
@@ -1118,8 +1163,8 @@ export class ChartView {
         const transient =
           !this.gl ||
           this.gl.isContextLost() ||
-          String(err && err.message || err).includes("shader compile: null") ||
-          String(err && err.message || err).startsWith("WebGL error ");
+          String(err && (err as Error).message || err).includes("shader compile: null") ||
+          String(err && (err as Error).message || err).startsWith("WebGL error ");
         if (transient) {
           this._contextRecoveryError = null;
           this._scheduleContextRecovery();
@@ -1285,7 +1330,7 @@ export class ChartView {
     this._rebuildEvictedContext();
   }
 
-  _assertContextFrameReady(stage) {
+  _assertContextFrameReady(stage: string) {
     if (!this.gl) {
       throw new Error(`context lost during ${stage} draw`);
     }
@@ -1426,7 +1471,7 @@ export class ChartView {
   // FBO realloc is deferred to the next actual pick (_renderPick checks dims).
   // The view request re-decimates/re-bins at the new pixel size (§28), so a
   // bigger chart gains real detail, not just stretched pixels.
-  _resize(cssW, cssH) {
+  _resize(cssW: number, cssH: number) {
     const w = this.fluid && cssW ? Math.max(120, Math.round(cssW)) : this.size.w;
     const h = this.fluidH && cssH ? Math.max(120, Math.round(cssH)) : this.size.h;
     // Browser zoom changes devicePixelRatio with no container resize (R7);
@@ -1471,7 +1516,7 @@ export class ChartView {
     this._scheduleViewRequest();
   }
 
-  _buildDom(el) {
+  _buildDom(el: HTMLElement) {
     const s = this.spec;
     const root = document.createElement("div");
     root.className = "xy";
@@ -1569,13 +1614,13 @@ export class ChartView {
     this._buildReductionBadges(root);
   }
 
-  _a11yAxisSummary(axisId, name) {
+  _a11yAxisSummary(axisId: string, name: string) {
     const axis = this._axis(axisId);
     const label = axis.label ? `${name} axis (${axis.label})` : `${name} axis`;
     if (axis.kind === "category") {
       const categories = Array.isArray(axis.categories) ? axis.categories : [];
       if (!categories.length) return `${label} uses categories.`;
-      const shown = categories.slice(0, 6).map((value) => String(value));
+      const shown = categories.slice(0, 6).map((value: number) => String(value));
       const remaining = categories.length - shown.length;
       const suffix = remaining > 0 ? `, and ${remaining} more` : "";
       return `${label} has ${categories.length} categories: ${shown.join(", ")}${suffix}.`;
@@ -1589,7 +1634,7 @@ export class ChartView {
     const traces = Array.isArray(this.spec.traces) ? this.spec.traces : [];
     const parts = [this.spec.title ? `${this.spec.title}.` : "Interactive chart."];
     parts.push(`${traces.length} data series.`);
-    const names = traces.map((trace) => trace && trace.name).filter(Boolean).slice(0, 6);
+    const names = traces.map((trace: TraceSpec | null) => trace && trace.name).filter(Boolean).slice(0, 6);
     if (names.length) parts.push(`Series: ${names.join(", ")}.`);
     const x = this._a11yAxisSummary("x", "X");
     const y = this._a11yAxisSummary("y", "Y");
@@ -1607,7 +1652,7 @@ export class ChartView {
     this.canvas.setAttribute("aria-label", `Plot area.${instruction}`);
   }
 
-  _compactInt(value) {
+  _compactInt(value: number) {
     const n = Number(value);
     if (!Number.isFinite(n)) return "0";
     return Math.round(n).toLocaleString();
@@ -1657,9 +1702,9 @@ export class ChartView {
     this._positionReductionBadges();
   }
 
-  _buildReductionBadges(root) {
+  _buildReductionBadges(root: HTMLElement) {
     const items = this._reductionBadgeItems();
-    const hasDensityTrace = (this.spec.traces || []).some((t) => t.tier === "density");
+    const hasDensityTrace = (this.spec.traces || []).some((t: TraceSpec) => t.tier === "density");
     if (!items.length && !hasDensityTrace) return;
     const box = document.createElement("div");
     box.style.cssText =
@@ -1671,7 +1716,7 @@ export class ChartView {
     this._refreshReductionBadges();
   }
 
-  _buildLegend(root) {
+  _buildLegend(root: HTMLElement) {
     const s = this.spec;
     this._legends = [];
     const items = [];
@@ -1680,7 +1725,7 @@ export class ChartView {
         if (t.tier === "density") {
           items.push({ swatch: "gradient", cmap: t.density.colormap, name: t.name || "density" });
         } else if (t.color && t.color.mode === "categorical") {
-          t.color.categories.forEach((cat, i) =>
+          t.color.categories.forEach((cat: string, i: number) =>
             items.push({ swatch: t.color.palette[i], name: cat, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, style: t.style || {} }));
         } else if (t.color && t.color.mode === "continuous") {
           items.push({ swatch: "gradient", cmap: t.color.colormap, name: t.name || "value" });
@@ -1697,7 +1742,7 @@ export class ChartView {
     // Manually added Legend artists ship explicit items + their own loc, so a
     // second legend (e.g. one per line group) renders as its own box.
     for (const extra of s.extra_legends || []) {
-      const mapped = (extra.items || []).map((it) => ({
+      const mapped = (extra.items || []).map((it: any) => ({
         swatch: it.style && it.style.color,
         name: it.name,
         symbol: it.kind === "scatter" ? (it.style?.symbol || "circle") : null,
@@ -1708,7 +1753,7 @@ export class ChartView {
     }
   }
 
-  _legendBox(root, items, options) {
+  _legendBox(root: HTMLElement, items: any[], options: any) {
     const lg = document.createElement("div");
     const loc = options.loc || "upper right";
     const ncols = Math.max(1, Number(options.ncols) || 1);
@@ -1746,7 +1791,7 @@ export class ChartView {
         svg.setAttribute("width", "18");
         svg.setAttribute("height", "14");
         const path = document.createElementNS(ns, "path");
-        const paths = {
+        const paths: Record<string, string> = {
           square: "M4.5 2.5h9v9h-9z", diamond: "M9 2l5 5-5 5-5-5z",
           thin_diamond: "M9 2l3 5-3 5-3-5z",
           triangle: "M9 2l-5 10h10z", triangle_down: "M9 12L4 2h10z",
@@ -1803,7 +1848,7 @@ export class ChartView {
     return lg;
   }
 
-  _positionLegend(lg, loc) {
+  _positionLegend(lg: HTMLElement, loc: string) {
     if (!lg) return;
     // Responsive anchors flow through private custom properties consumed by a
     // zero-specificity rule. Author classes or component styles can still set
@@ -1824,7 +1869,7 @@ export class ChartView {
     lg.style.setProperty("--xy-legend-transform", `translate(${tx},${ty})`);
   }
 
-  _buildColorbar(root) {
+  _buildColorbar(root: HTMLElement) {
     const cb = this.spec.colorbar;
     if (!cb) return;
     const box = document.createElement("div");
@@ -1914,7 +1959,7 @@ export class ChartView {
     }
   }
 
-  _initGl(buffer) {
+  _initGl(buffer: PayloadBuffers) {
     const dpr = window.devicePixelRatio || 1;
     this.dpr = dpr;
     this.canvas.width = this.plot.w * dpr;
@@ -1961,7 +2006,7 @@ export class ChartView {
     gl.vertexAttribDivisor(ATTR_SLOTS.a_corner, 0);
     gl.bindVertexArray(null);
 
-    this.gpuTraces = this.spec.traces.map((t) => this._buildTrace(buffer, t));
+    this.gpuTraces = this.spec.traces.map((t: TraceSpec) => this._buildTrace(buffer, t));
     this._updatePickable();
   }
 
@@ -1971,12 +2016,12 @@ export class ChartView {
   // trigger tracks the capability instead of freezing at construction time.
   _updatePickable() {
     this._pickable = this.gpuTraces.some(
-      (t) => markOf(t.trace.kind).pointPick && (t.tier !== "density" || t.drill));
+      (t: GpuTrace) => markOf(t.trace.kind).pointPick && (t.tier !== "density" || t.drill));
     if (this._pickable && !this.pickFbo) this._initPickTarget();
     this._syncModebarSelect?.();
   }
 
-  _prog(key, vs, fs) {
+  _prog(key: string, vs: string, fs: string) {
     let p = this._progCache.get(key);
     if (!p) {
       p = makeProgram(this.gl, vs, fs);
@@ -1997,7 +2042,7 @@ export class ChartView {
   get densityProg() { return this._prog("density", GRID_VS, DENSITY_FS); }
   get heatmapProg() { return this._prog("heatmap", GRID_VS, HEATMAP_FS); }
 
-  _lut(name) {
+  _lut(name: string) {
     if (this._lutCache.has(name)) return this._lutCache.get(name);
     const gl = this.gl;
     const tex = gl.createTexture();
@@ -2011,7 +2056,7 @@ export class ChartView {
     return tex;
   }
 
-  _paletteLut(palette) {
+  _paletteLut(palette: string[]) {
     // Cached by palette identity: categorical drill updates request this per
     // zoom step, and an uncached texture per call is a steady GL leak.
     const key = "pal:" + palette.join(",");
@@ -2036,7 +2081,7 @@ export class ChartView {
     return tex;
   }
 
-  _buildTrace(buffer, t) {
+  _buildTrace(buffer: PayloadBuffers, t: TraceSpec) {
     const gl = this.gl;
     const g: any = {
       trace: t,
@@ -2088,7 +2133,7 @@ export class ChartView {
   // Shared (x,y) geometry setup for xy-shaped marks (scatter, line, area, …).
   // A mark whose geometry isn't a plain x/y pair (bars/candles have their own
   // vertex layout) skips this and uploads its own buffers in build().
-  _buildXY(g, t, buffer) {
+  _buildXY(g: GpuTrace, t: TraceSpec, buffer: PayloadBuffers) {
     const x = this._columnView(buffer, this.spec.columns[t.x]);
     const y = this._columnView(buffer, this.spec.columns[t.y]);
     g.xMeta = { ...this.spec.columns[t.x] };
@@ -2099,8 +2144,8 @@ export class ChartView {
     g.yBuf = this._upload(y);
   }
 
-  _buildInstanceStyleChannels(g, t, buffer, widthName) {
-    const channel = (name) => t.channels && t.channels[name];
+  _buildInstanceStyleChannels(g: GpuTrace, t: TraceSpec, buffer: PayloadBuffers, widthName: string) {
+    const channel = (name: string) => t.channels && t.channels[name];
     const artistScalar = Number(t.style && t.style.artist_alpha);
     const hasStyle = channel("opacity") || channel("artist_alpha") ||
       channel(widthName) || channel("symbol") || Number.isFinite(artistScalar);
@@ -2112,7 +2157,7 @@ export class ChartView {
         values[i * 4 + 2] = -1;
         values[i * 4 + 3] = -1;
       }
-      const copy = (name, component, scale = 1) => {
+      const copy = (name: string, component: number, scale = 1) => {
         const spec = channel(name);
         if (!spec) return;
         const source = this._columnView(buffer, this.spec.columns[spec.buf]);
@@ -2140,7 +2185,7 @@ export class ChartView {
     }
   }
 
-  _buildScatterMark(g, t, buffer) {
+  _buildScatterMark(g: GpuTrace, t: TraceSpec, buffer: PayloadBuffers) {
     this._buildXY(g, t, buffer);
     g.colorMode = 0;
     g.color = parseColor(this.root, t.color && t.color.color, [0.3, 0.47, 0.66, 1]);
@@ -2174,9 +2219,9 @@ export class ChartView {
 
   // Point symbol + stroke (scatter). An omitted stroke color means "face":
   // use each point's resolved LUT/palette color, never a generic trace color.
-  _pointMarkStyle(g, t) {
+  _pointMarkStyle(g: GpuTrace, t: TraceSpec) {
     const s = t.style || {};
-    g.symbol = { circle: 0, square: 1, diamond: 2, triangle: 3, cross: 4, hexagon: 5, pentagon: 6, star: 7, triangle_down: 8, triangle_left: 9, triangle_right: 10, x: 11, point: 12, pixel: 13, thin_diamond: 14, plus_line: 15, x_line: 16 }[s.symbol] || 0;
+    g.symbol = ({ circle: 0, square: 1, diamond: 2, triangle: 3, cross: 4, hexagon: 5, pentagon: 6, star: 7, triangle_down: 8, triangle_left: 9, triangle_right: 10, x: 11, point: 12, pixel: 13, thin_diamond: 14, plus_line: 15, x_line: 16 } as Record<string, number>)[s.symbol] || 0;
     g.pointStrokeWidth = Number(s.stroke_width) || 0;
     g.pointStrokeFace = !s.stroke && (!t.stroke || t.stroke.mode === "match_fill");
     g.pointStroke = s.stroke
@@ -2184,7 +2229,7 @@ export class ChartView {
       : null;
   }
 
-  _sampleTraceSpec(parentTrace, sample) {
+  _sampleTraceSpec(parentTrace: TraceSpec, sample: any) {
     return {
       id: parentTrace.id,
       kind: "scatter",
@@ -2202,7 +2247,7 @@ export class ChartView {
     };
   }
 
-  _buildDensitySample(parentTrace, sample, buffer) {
+  _buildDensitySample(parentTrace: TraceSpec, sample: any, buffer: PayloadBuffers) {
     if (!sample || !sample.x || !sample.y || sample.x.col === undefined || sample.y.col === undefined) {
       return null;
     }
@@ -2222,7 +2267,7 @@ export class ChartView {
     return g;
   }
 
-  _destroyDensitySample(g) {
+  _destroyDensitySample(g: GpuTrace) {
     const s = g && g.sampleOverlay;
     if (!s || !this.gl) return;
     for (const b of [s.xBuf, s.yBuf, s.cBuf, s.rgbaBuf, s.sBuf, s.styleBuf,
@@ -2232,7 +2277,7 @@ export class ChartView {
     g.sampleOverlay = null;
   }
 
-  _applyDensitySample(g, sample, buffers) {
+  _applyDensitySample(g: GpuTrace, sample: any, buffers: PayloadBuffers) {
     this._destroyDensitySample(g);
     if (!sample || !sample.x || !sample.y || sample.x.buf === undefined || sample.y.buf === undefined) {
       this._refreshReductionBadges();
@@ -2302,7 +2347,7 @@ export class ChartView {
       gl.bufferData(gl.ARRAY_BUFFER, this._asF32(buffers[sample.size.buf]), gl.STATIC_DRAW);
       s.sizeRange = sample.size.range_px;
     }
-    const channel = (name) => sample.channels && sample.channels[name];
+    const channel = (name: string) => sample.channels && sample.channels[name];
     const artistScalar = Number(trace.style && trace.style.artist_alpha);
     if (channel("opacity") || channel("artist_alpha") || channel("stroke_width") ||
         channel("symbol") || Number.isFinite(artistScalar)) {
@@ -2313,7 +2358,7 @@ export class ChartView {
         values[i * 4 + 2] = -1;
         values[i * 4 + 3] = -1;
       }
-      const copy = (name, component, scale = 1) => {
+      const copy = (name: string, component: number, scale = 1) => {
         const spec = channel(name);
         if (!spec) return;
         const source = spec.dtype === "u8"
@@ -2336,7 +2381,7 @@ export class ChartView {
     this._refreshReductionBadges();
   }
 
-  _drawDensitySample(g, x0, x1, y0, y1, opacityScale = 1) {
+  _drawDensitySample(g: GpuTrace, x0: number, x1: number, y0: number, y1: number, opacityScale = 1) {
     const s = g && g.sampleOverlay;
     // Draw the retained sample whenever it overlaps the view, not only when the
     // view sits fully inside the sample window: a pan or zoom-out must keep the
@@ -2358,11 +2403,11 @@ export class ChartView {
   // one-liner `linear-gradient(currentColor, transparent)` follows the palette
   // and theme. Colors are premultiplied here and interpolated premultiplied in
   // the shader, so fades to transparent keep their hue.
-  _resolveMarkFill(style, markColor) {
+  _resolveMarkFill(style: StyleBag, markColor: Rgba) {
     const fill = style && style.fill;
     if (!fill || !Array.isArray(fill.stops) || fill.stops.length < 2) return null;
     const mode = fill.space === "plot" ? 2 : 1;
-    const dir = { down: 0, up: 1, left: 2, right: 3 }[fill.dir] ?? 0;
+    const dir = ({ down: 0, up: 1, left: 2, right: 3 } as Record<string, number>)[fill.dir] ?? 0;
     const count = Math.min(fill.stops.length, 8);
     const pos = new Float32Array(8);
     const colors = new Float32Array(32);
@@ -2381,9 +2426,9 @@ export class ChartView {
     return { mode, dir, count, pos, colors };
   }
 
-  _setGradientUniforms(prog, grad) {
+  _setGradientUniforms(prog: XyProgram, grad: any) {
     const gl = this.gl;
-    const u = (n) => uniformOf(gl, prog, n);
+    const u = (n: string) => uniformOf(gl, prog, n);
     if (!grad) {
       gl.uniform1i(u("u_gradMode"), 0);
       return;
@@ -2395,20 +2440,20 @@ export class ChartView {
     gl.uniform4fv(u("u_gradColor"), grad.colors);
   }
 
-  _fillOpacity(style, fallback = 1) {
+  _fillOpacity(style: StyleBag, fallback = 1) {
     return Number(style.opacity ?? fallback) * Number(style.fill_opacity ?? 1);
   }
 
-  _strokeOpacity(style, fallback = 1) {
+  _strokeOpacity(style: StyleBag, fallback = 1) {
     return Number(style.opacity ?? fallback) * Number(style.stroke_opacity ?? 1);
   }
 
   // Rect-family styling uniforms (rounded corners, stroke, gradient). Radius
   // and stroke width are CSS px -> device px; the stroke color ships
   // premultiplied to match the shader's blend space.
-  _setRectStyleUniforms(prog, g) {
+  _setRectStyleUniforms(prog: XyProgram, g: GpuTrace) {
     const gl = this.gl;
-    const u = (n) => uniformOf(gl, prog, n);
+    const u = (n: string) => uniformOf(gl, prog, n);
     gl.uniform2f(u("u_res"), this.canvas.width, this.canvas.height);
     const cr = g.cornerRadius || [0, 0];
     gl.uniform2f(u("u_radius"), cr[0] * this.dpr, cr[1] * this.dpr);
@@ -2426,14 +2471,14 @@ export class ChartView {
   // stroke, gradient. `corner_radius` is a scalar (all corners) or a
   // [tip, base] pair in mark space — (6, 0) rounds only the value end. A
   // stroke width with no stroke color borders in the mark color at full alpha.
-  _rectMarkStyleGpu(g, t) {
+  _rectMarkStyleGpu(g: GpuTrace, t: TraceSpec) {
     const s = t.style || {};
     const cr = s.corner_radius;
     g.cornerRadius = Array.isArray(cr)
       ? [Number(cr[0]) || 0, Number(cr[1]) || 0]
       : [Number(cr) || 0, Number(cr) || 0];
     g.strokeWidth = Number(s.stroke_width) || 0;
-    const opaque = [g.color[0], g.color[1], g.color[2], 1];
+    const opaque: Rgba = [g.color[0], g.color[1], g.color[2], 1];
     g.strokeColor = s.stroke ? parseColor(this.root, s.stroke, opaque) : opaque;
     g.grad = this._resolveMarkFill(s, g.color);
   }
@@ -2441,7 +2486,7 @@ export class ChartView {
   // curve:"smooth" resample for the polyline marks. Returns null unless the
   // trace opted in and the data qualifies; hover keeps reading the original
   // `_cpu` columns either way (`_nearestCpuIndex` limits to the source length).
-  _smoothArrays(t, x, y, base, n) {
+  _smoothArrays(t: TraceSpec, x: ColumnView, y: ColumnView, base: ColumnView | null, n: number) {
     if (!t.style || t.style.curve !== "smooth") return null;
     return xySmoothResample(x, y, base || null, n, 32768);
   }
@@ -2450,7 +2495,7 @@ export class ChartView {
   // its drawn corner vertices. Runs after smoothing/decimation so canonical
   // inputs stay compact — both the initial build and every LOD tier swap must
   // apply it before upload. Returns null when the trace isn't stepped.
-  _stepArrays(t, x, y, n) {
+  _stepArrays(t: TraceSpec, x: ColumnView, y: ColumnView, n: number) {
     const where = t.style && t.style.step;
     if (!where || n < 2) return null;
     const perGap = where === "mid" ? 3 : 2;
@@ -2477,7 +2522,7 @@ export class ChartView {
     return { x: sx, y: sy, n: m };
   }
 
-  _buildLineMark(g, t, buffer) {
+  _buildLineMark(g: GpuTrace, t: TraceSpec, buffer: PayloadBuffers) {
     const x = this._columnView(buffer, this.spec.columns[t.x]);
     const y = this._columnView(buffer, this.spec.columns[t.y]);
     g.xMeta = { ...this.spec.columns[t.x] };
@@ -2498,7 +2543,7 @@ export class ChartView {
     g.color = parseColor(this.root, t.style && t.style.color, [0.3, 0.47, 0.66, 1]);
   }
 
-  _buildSegmentMark(g, t, buffer) {
+  _buildSegmentMark(g: GpuTrace, t: TraceSpec, buffer: PayloadBuffers) {
     const x0 = this._columnView(buffer, this.spec.columns[t.x0]);
     const x1 = this._columnView(buffer, this.spec.columns[t.x1]);
     const y0 = this._columnView(buffer, this.spec.columns[t.y0]);
@@ -2531,7 +2576,7 @@ export class ChartView {
     g._cpu = { x: x0, y: y1, xMeta: g.x0Meta, yMeta: g.y1Meta };
   }
 
-  _buildMeshMark(g, t, buffer) {
+  _buildMeshMark(g: GpuTrace, t: TraceSpec, buffer: PayloadBuffers) {
     for (const name of ["x0", "x1", "x2", "y0", "y1", "y2"]) {
       const values = this._columnView(buffer, this.spec.columns[t[name]]);
       g[name + "Meta"] = { ...this.spec.columns[t[name]] };
@@ -2564,7 +2609,7 @@ export class ChartView {
   // encoded space: stored = (value - offset) * scale, so a data-space delta
   // scales by meta.scale and the center columns' metas serve every vertex.
   // The ring must match HEX_RING in python/xy/_svg.py.
-  _buildHexbinMark(g, t, buffer) {
+  _buildHexbinMark(g: GpuTrace, t: TraceSpec, buffer: PayloadBuffers) {
     const cx = this._columnView(buffer, this.spec.columns[t.x]);
     const cy = this._columnView(buffer, this.spec.columns[t.y]);
     const xMeta = { ...this.spec.columns[t.x] };
@@ -2612,7 +2657,7 @@ export class ChartView {
     g.meshStroke = parseColor(this.root, style.stroke || "transparent", [0, 0, 0, 0]);
   }
 
-  _buildAreaMark(g, t, buffer) {
+  _buildAreaMark(g: GpuTrace, t: TraceSpec, buffer: PayloadBuffers) {
     const x = this._columnView(buffer, this.spec.columns[t.x]);
     const y = this._columnView(buffer, this.spec.columns[t.y]);
     const base = this._columnView(buffer, this.spec.columns[t.base]);
@@ -2633,7 +2678,7 @@ export class ChartView {
     g.grad = this._resolveMarkFill(t.style, g.color);
   }
 
-  _buildRectMark(g, t, buffer) {
+  _buildRectMark(g: GpuTrace, t: TraceSpec, buffer: PayloadBuffers) {
     const x0 = this._columnView(buffer, this.spec.columns[t.x0]);
     const x1 = this._columnView(buffer, this.spec.columns[t.x1]);
     const y0 = this._columnView(buffer, this.spec.columns[t.y0]);
@@ -2669,7 +2714,7 @@ export class ChartView {
     this._rectMarkStyleGpu(g, t);
   }
 
-  _buildBarMark(g, t, buffer) {
+  _buildBarMark(g: GpuTrace, t: TraceSpec, buffer: PayloadBuffers) {
     const b = t.bar;
     if (!b) return this._buildRectMark(g, t, buffer);
     const pos = this._columnView(buffer, this.spec.columns[b.pos]);
@@ -2721,11 +2766,11 @@ export class ChartView {
     this._rectMarkStyleGpu(g, t);
   }
 
-  _buildHeatmapMark(g, t, buffer) {
+  _buildHeatmapMark(g: GpuTrace, t: TraceSpec, buffer: PayloadBuffers) {
     const h = t.heatmap;
     const truecolor = Array.isArray(h.rgba_bufs);
     const grid = truecolor
-      ? h.rgba_bufs.map((index) => this._columnView(buffer, this.spec.columns[index]))
+      ? h.rgba_bufs.map((index: number) => this._columnView(buffer, this.spec.columns[index]))
       : this._columnView(buffer, this.spec.columns[h.buf]);
     g.heatmap = {
       w: h.w,
@@ -2740,7 +2785,7 @@ export class ChartView {
     if (!truecolor) g._cpuHeatmap = { grid };
   }
 
-  _uploadRgbaGrid(channels, w, h) {
+  _uploadRgbaGrid(channels: any, w: number, h: number) {
     const gl = this.gl;
     const tex = gl.createTexture();
     const data = new Uint8Array(w * h * 4);
@@ -2758,14 +2803,14 @@ export class ChartView {
     return tex;
   }
 
-  _uploadGrid(f32, w, h, maxVal) {
+  _uploadGrid(f32: ColumnView, w: number, h: number, maxVal: number) {
     const gl = this.gl;
     const tex = gl.createTexture();
     lodWriteGridTexture(gl, tex, f32, w, h, maxVal);
     return tex;
   }
 
-  _uploadHeatmapGrid(f32, w, h) {
+  _uploadHeatmapGrid(f32: ColumnView, w: number, h: number) {
     const gl = this.gl;
     const tex = gl.createTexture();
     const data = new Uint8Array(f32.length);
@@ -2791,7 +2836,7 @@ export class ChartView {
   // lifecycle live in 45_lod.js — chart-agnostic so future tiered kinds
   // (heatmap, histogram) reuse them instead of copy-pasting.
 
-  _columnView(buffer, meta) {
+  _columnView(buffer: PayloadBuffers, meta: ColumnMeta) {
     // Packed layout: one blob, columns addressed by global byte_offset.
     // Split layout (§29 first paint): `buffer` is a list of per-column
     // buffers and the column entry carries `buf`, its list index. A
@@ -2822,7 +2867,7 @@ export class ChartView {
     return new Float32Array(span.buffer, absoluteOffset, length);
   }
 
-  _upload(view) {
+  _upload(view: ArrayBufferView) {
     const gl = this.gl;
     const buf = gl.createBuffer();
     // Identity tag for VAO config signatures: a replaced buffer (data update,
@@ -2845,7 +2890,7 @@ export class ChartView {
   // and because VAOs isolate attribute-enable state per draw, the old
   // "disable every leftover attrib" loops (and their per-frame
   // gl.getParameter(MAX_VERTEX_ATTRIBS) driver round-trip) go away entirely.
-  _bindVao(g, key, parts, setup) {
+  _bindVao(g: GpuTrace, key: string, parts: any[], setup: () => void) {
     const gl = this.gl;
     if (!g._vaos) g._vaos = new Map();
     const sig = parts.join("|");
@@ -2862,7 +2907,7 @@ export class ChartView {
     }
   }
 
-  _deleteVaos(g) {
+  _deleteVaos(g: GpuTrace) {
     if (!g || !g._vaos) return;
     const gl = this.gl;
     if (gl) for (const { vao } of g._vaos.values()) gl.deleteVertexArray(vao);
@@ -2871,7 +2916,7 @@ export class ChartView {
 
   // Enable slot + pointer into `buf` — only ever called inside a _bindVao
   // setup closure, so the state lands in that VAO, not global state.
-  _vaoAttr(slot, buf, byteOffset, divisor, size = 1, normalized = false) {
+  _vaoAttr(slot: number, buf: XyBuffer, byteOffset: number, divisor: number, size = 1, normalized = false) {
     const gl = this.gl;
     gl.bindBuffer(gl.ARRAY_BUFFER, buf);
     gl.enableVertexAttribArray(slot);
@@ -2905,7 +2950,7 @@ export class ChartView {
 
   // -- drawing --------------------------------------------------------------
 
-  _map(meta, lo, hi, axisId = null) {
+  _map(meta: ColumnMeta, lo: number, hi: number, axisId: string | null = null) {
     if (!axisId) {
       const mul = 2 / ((hi - lo) * meta.scale);
       const add = ((meta.offset - lo) / (hi - lo)) * 2 - 1;
@@ -2920,7 +2965,7 @@ export class ChartView {
     return [mul, add];
   }
 
-  _mapConst(value, lo, hi, axisId = null) {
+  _mapConst(value: number, lo: number, hi: number, axisId: string | null = null) {
     if (!axisId) return ((value - lo) / (hi - lo)) * 2 - 1;
     const axis = this._axis(axisId);
     const c = this._axisCoord(axis, value);
@@ -2930,7 +2975,7 @@ export class ChartView {
     return ((c - c0) / (c1 - c0)) * 2 - 1;
   }
 
-  _edgePadForValue(value, lo, hi, pixels) {
+  _edgePadForValue(value: number, lo: number, hi: number, pixels: number) {
     if (!Number.isFinite(value) || !Number.isFinite(lo) || !Number.isFinite(hi) || hi === lo) return 0;
     const span = Math.abs(hi - lo);
     const eps = span * 1e-10 + 1e-12;
@@ -2941,9 +2986,9 @@ export class ChartView {
     return 0;
   }
 
-  _setAxisUniforms(prog, prefix, meta, axisId) {
+  _setAxisUniforms(prog: XyProgram, prefix: string, meta: ColumnMeta, axisId: string) {
     const gl = this.gl;
-    const u = (n) => uniformOf(gl, prog, n);
+    const u = (n: string) => uniformOf(gl, prog, n);
     gl.uniform2f(u(`${prefix}meta`), meta && Number.isFinite(meta.offset) ? meta.offset : 0, meta && meta.scale ? meta.scale : 1);
     gl.uniform1i(u(`${prefix}mode`), this._axisMode(axisId));
   }
@@ -2983,7 +3028,7 @@ export class ChartView {
     gl.clearColor(0, 0, 0, 0);
     gl.clear(gl.COLOR_BUFFER_BIT);
 
-    const drawTrace = (g) => {
+    const drawTrace = (g: GpuTrace) => {
       if (g.tier === "density") {
         // Tier frame (drill/fades/cache) lives in 45_lod.js — chart-agnostic.
         const [gx0, gx1] = this._axisRange(g.xAxis);
@@ -3017,14 +3062,14 @@ export class ChartView {
   }
 
 
-  _canDrawSimplePoints(g) {
+  _canDrawSimplePoints(g: GpuTrace) {
     return g.colorMode === 0 && g.sizeMode === 0 && !g.selActive &&
       !g.rgbaBuf && !g.styleBuf && !g.strokeBuf &&
       (g.symbol || 0) === 0 && (g.pointStrokeWidth || 0) <= 0 &&
       Math.max(g.lodBlendShown ?? 0, g.lodBlend ?? 0) <= 0.001;
   }
 
-  _drawPoints(g, xm, ym, opacityScale = 1) {
+  _drawPoints(g: GpuTrace, xm: number[], ym: number[], opacityScale = 1) {
     opacityScale *= g._transitionOpacity ?? 1;
     const animationScale = g._transitionScale ?? 1;
     if (this._canDrawSimplePoints(g)) {
@@ -3034,7 +3079,7 @@ export class ChartView {
     const gl = this.gl;
     const prog = this.pointProg;
     gl.useProgram(prog);
-    const u = (n) => uniformOf(gl, prog, n);
+    const u = (n: string) => uniformOf(gl, prog, n);
     gl.uniform2f(u("u_xmap"), xm[0], xm[1]);
     gl.uniform2f(u("u_ymap"), ym[0], ym[1]);
     this._setAxisUniforms(prog, "u_x", g.xMeta, g.xAxis);
@@ -3052,7 +3097,7 @@ export class ChartView {
     gl.uniform1f(u("u_selectedOpacity"), this._markStateNumber("selected", "opacity", 1));
     gl.uniform1f(u("u_unselectedOpacity"), this._markStateNumber("unselected", "opacity", 0.12));
     // Optional selected/unselected recolor (§34): .a=1 tints, .a=0 keeps native.
-    const stateColor = (loc, expr) => {
+    const stateColor = (loc: WebGLUniformLocation | null, expr: string) => {
       const c = expr ? parseColor(this.root, expr, [0, 0, 0, 1]) : null;
       gl.uniform4f(loc, c ? c[0] : 0, c ? c[1] : 0, c ? c[2] : 0, c ? 1 : 0);
     };
@@ -3151,11 +3196,11 @@ export class ChartView {
     gl.drawArrays(gl.POINTS, 0, g.n);
   }
 
-  _drawSimplePoints(g, xm, ym, opacityScale = 1) {
+  _drawSimplePoints(g: GpuTrace, xm: number[], ym: number[], opacityScale = 1) {
     const gl = this.gl;
     const prog = this.pointSimpleProg;
     gl.useProgram(prog);
-    const u = (n) => uniformOf(gl, prog, n);
+    const u = (n: string) => uniformOf(gl, prog, n);
     gl.uniform2f(u("u_xmap"), xm[0], xm[1]);
     gl.uniform2f(u("u_ymap"), ym[0], ym[1]);
     this._setAxisUniforms(prog, "u_x", g.xMeta, g.xAxis);
@@ -3203,11 +3248,11 @@ export class ChartView {
     );
   }
 
-  _drawHoverPoint(g, index, xm, ym) {
+  _drawHoverPoint(g: GpuTrace, index: number, xm: number[], ym: number[]) {
     const gl = this.gl;
     const prog = this.pointProg;
     gl.useProgram(prog);
-    const u = (n) => uniformOf(gl, prog, n);
+    const u = (n: string) => uniformOf(gl, prog, n);
     gl.uniform2f(u("u_xmap"), xm[0], xm[1]);
     gl.uniform2f(u("u_ymap"), ym[0], ym[1]);
     this._setAxisUniforms(prog, "u_x", g.xMeta, g.xAxis);
@@ -3243,7 +3288,7 @@ export class ChartView {
     gl.drawArrays(gl.POINTS, index, 1);
   }
 
-  _drawDensity(g, density, opacityScale = 1) {
+  _drawDensity(g: GpuTrace, density: any, opacityScale = 1) {
     const gl = this.gl;
     const d = density || g.density;
     // Structural guard: never bind a freed texture. Eviction pins every live
@@ -3255,7 +3300,7 @@ export class ChartView {
     opacityScale *= g._transitionOpacity ?? 1;
     const prog = this.densityProg;
     gl.useProgram(prog);
-    const u = (n) => uniformOf(gl, prog, n);
+    const u = (n: string) => uniformOf(gl, prog, n);
     const { x0, x1, y0, y1 } = this.view;
     const [vx0, vx1] = this._axisRange(g.xAxis);
     const [vy0, vy1] = this._axisRange(g.yAxis);
@@ -3277,13 +3322,13 @@ export class ChartView {
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
   }
 
-  _drawHeatmap(g) {
+  _drawHeatmap(g: GpuTrace) {
     const h = g.heatmap;
     if (!h) return;
     const gl = this.gl;
     const prog = this.heatmapProg;
     gl.useProgram(prog);
-    const u = (n) => uniformOf(gl, prog, n);
+    const u = (n: string) => uniformOf(gl, prog, n);
     const { x0, x1, y0, y1 } = this.view;
     const [vx0, vx1] = this._axisRange(g.xAxis);
     const [vy0, vy1] = this._axisRange(g.yAxis);
@@ -3317,11 +3362,11 @@ export class ChartView {
     gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
   }
 
-  _drawLine(g, xm, ym, color = null, width = null, opacity = null) {
+  _drawLine(g: GpuTrace, xm: number[], ym: number[], color: Rgba | null = null, width: number | null = null, opacity: number | null = null) {
     if (g.n < 2) return;
     const gl = this.gl;
     gl.useProgram(this.lineProg);
-    const u = (n) => uniformOf(gl, this.lineProg, n);
+    const u = (n: string) => uniformOf(gl, this.lineProg, n);
     gl.uniform2f(u("u_xmap"), xm[0], xm[1]);
     gl.uniform2f(u("u_ymap"), ym[0], ym[1]);
     this._setAxisUniforms(this.lineProg, "u_x", g.xMeta, g.xAxis);
@@ -3365,12 +3410,12 @@ export class ChartView {
     gl.drawArraysInstanced(gl.TRIANGLE_STRIP, 0, 4, segments);
   }
 
-  _drawSegments(g, xm, ym) {
+  _drawSegments(g: GpuTrace, xm: number[], ym: number[]) {
     if (g.n < 1) return;
     const gl = this.gl;
     const prog = this.segmentProg;
     gl.useProgram(prog);
-    const u = (n) => uniformOf(gl, prog, n);
+    const u = (n: string) => uniformOf(gl, prog, n);
     gl.uniform2f(u("u_xmap"), xm[0], xm[1]);
     gl.uniform2f(u("u_ymap"), ym[0], ym[1]);
     this._setAxisUniforms(prog, "u_x0", g.x0Meta, g.xAxis);
@@ -3420,9 +3465,9 @@ export class ChartView {
     gl.drawArraysInstanced(gl.TRIANGLE_STRIP, 0, 4, count);
   }
 
-  _segmentDash(g, prog) {
+  _segmentDash(g: GpuTrace, prog: XyProgram) {
     const gl = this.gl;
-    const u = (n) => uniformOf(gl, prog, n);
+    const u = (n: string) => uniformOf(gl, prog, n);
     const dash = g.trace.style && g.trace.style.dash;
     const cpu = g._segmentCpu;
     if (!dash || !dash.length || !cpu) {
@@ -3436,11 +3481,11 @@ export class ChartView {
       ? g._segmentDashDirections : (g._segmentDashDirections = new Float32Array(n));
     const k0 = new Array(n), k1 = new Array(n), lengths = new Float32Array(n);
     const adjacency = new Map();
-    const add = (key, index) => {
+    const add = (key: string, index: number) => {
       const edges = adjacency.get(key);
       if (edges) edges.push(index); else adjacency.set(key, [index]);
     };
-    const key = (x, y) => `${Math.round(x * 1000)},${Math.round(y * 1000)}`;
+    const key = (x: number, y: number) => `${Math.round(x * 1000)},${Math.round(y * 1000)}`;
     const dpr = this.dpr;
     for (let i = 0; i < n; i++) {
       const x0 = this._dataPx(g.xAxis, this._decodeValue(cpu.x0, g.x0Meta, i));
@@ -3452,10 +3497,10 @@ export class ChartView {
       add(k0[i], i); add(k1[i], i);
     }
     const visited = new Uint8Array(n);
-    const walk = (start) => {
+    const walk = (start: number) => {
       let current = start, accumulated = 0;
       while (true) {
-        const edge = (adjacency.get(current) || []).find((index) => !visited[index]);
+        const edge = (adjacency.get(current) || []).find((index: number) => !visited[index]);
         if (edge === undefined) break;
         visited[edge] = 1;
         if (k0[edge] === current) {
@@ -3472,7 +3517,7 @@ export class ChartView {
     };
     for (const [node, edges] of adjacency) if (edges.length === 1) walk(node);
     for (let i = 0; i < n; i++) if (!visited[i]) walk(k0[i]);
-    const upload = (buffer, values) => {
+    const upload = (buffer: WebGLBuffer | null, values: ArrayBufferView) => {
       if (!buffer) return this._upload(values);
       gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
       gl.bufferData(gl.ARRAY_BUFFER, values, gl.DYNAMIC_DRAW);
@@ -3493,12 +3538,12 @@ export class ChartView {
     return true;
   }
 
-  _drawMesh(g, xm, ym) {
+  _drawMesh(g: GpuTrace, xm: number[], ym: number[]) {
     if (g.n < 1) return;
     const gl = this.gl;
     const prog = this.meshProg;
     gl.useProgram(prog);
-    const u = (n) => uniformOf(gl, prog, n);
+    const u = (n: string) => uniformOf(gl, prog, n);
     gl.uniform2f(u("u_xmap"), xm[0], xm[1]);
     gl.uniform2f(u("u_ymap"), ym[0], ym[1]);
     for (const name of ["x0", "x1", "x2"]) this._setAxisUniforms(prog, "u_" + name, g[name + "Meta"], g.xAxis);
@@ -3523,7 +3568,7 @@ export class ChartView {
       g.styleBuf ? g.styleBuf._fcId : 0, g.strokeBuf ? g.strokeBuf._fcId : 0);
     this._bindVao(g, "mesh", parts, () => {
       for (const name of ["x0", "x1", "x2", "y0", "y1", "y2"]) {
-        this._vaoAttr(ATTR_SLOTS["a" + name], g[name + "Buf"], 0, 1);
+        this._vaoAttr(ATTR_SLOTS[("a" + name) as keyof typeof ATTR_SLOTS], g[name + "Buf"], 0, 1);
       }
       if (g.cBuf) this._vaoAttr(ATTR_SLOTS.a_cval, g.cBuf, 0, 1);
       if (g.rgbaBuf) this._vaoAttr(ATTR_SLOTS.a_rgba, g.rgbaBuf, 0, 1, 4, true);
@@ -3541,9 +3586,9 @@ export class ChartView {
   // screen-space arc length (device px) for the current view, upload it, and
   // set the dash-pattern uniforms. Returns false (u_dashCount=0) for solid
   // lines. Cost is O(vertices) per draw, dashed traces only.
-  _lineDash(g) {
+  _lineDash(g: GpuTrace) {
     const gl = this.gl;
-    const u = (n) => uniformOf(gl, this.lineProg, n);
+    const u = (n: string) => uniformOf(gl, this.lineProg, n);
     const dash = g.trace.style && g.trace.style.dash;
     if (!dash || !dash.length || !g._dashX) {
       gl.uniform1i(u("u_dashCount"), 0);
@@ -3585,12 +3630,12 @@ export class ChartView {
     return true;
   }
 
-  _drawArea(g, xm, ym, bm) {
+  _drawArea(g: GpuTrace, xm: number[], ym: number[], bm: number[]) {
     if (g.n < 2) return;
     const gl = this.gl;
     const prog = this.areaProg;
     gl.useProgram(prog);
-    const u = (n) => uniformOf(gl, prog, n);
+    const u = (n: string) => uniformOf(gl, prog, n);
     gl.uniform2f(u("u_xmap"), xm[0], xm[1]);
     gl.uniform2f(u("u_ymap"), ym[0], ym[1]);
     gl.uniform2f(u("u_bmap"), bm[0], bm[1]);
@@ -3616,12 +3661,12 @@ export class ChartView {
     gl.drawArraysInstanced(gl.TRIANGLE_STRIP, 0, 4, count);
   }
 
-  _drawRects(g, x0, x1, y0, y1, edgePad = [0, 0, 0, 0]) {
+  _drawRects(g: GpuTrace, x0: AxisMap, x1: AxisMap, y0: AxisMap, y1: AxisMap, edgePad = [0, 0, 0, 0]) {
     if (!g.n) return;
     const gl = this.gl;
     const prog = this.rectProg;
     gl.useProgram(prog);
-    const u = (n) => uniformOf(gl, prog, n);
+    const u = (n: string) => uniformOf(gl, prog, n);
     gl.uniform2f(u("u_x0map"), x0[0], x0[1]);
     gl.uniform2f(u("u_x1map"), x1[0], x1[1]);
     gl.uniform2f(u("u_y0map"), y0[0], y0[1]);
@@ -3675,12 +3720,12 @@ export class ChartView {
     gl.drawArraysInstanced(gl.TRIANGLE_STRIP, 0, 4, g.n);
   }
 
-  _drawBars(g, pmap, v1map, v0map, v0Const, v0EdgePad = 0) {
+  _drawBars(g: GpuTrace, pmap: number[], v1map: number[], v0map: number[], v0Const: number, v0EdgePad = 0) {
     if (!g.n) return;
     const gl = this.gl;
     const prog = this.barProg;
     gl.useProgram(prog);
-    const u = (n) => uniformOf(gl, prog, n);
+    const u = (n: string) => uniformOf(gl, prog, n);
     gl.uniform2f(u("u_pmap"), pmap[0], pmap[1]);
     gl.uniform2f(u("u_v1map"), v1map[0], v1map[1]);
     gl.uniform2f(u("u_v0map"), v0map ? v0map[0] : 1, v0map ? v0map[1] : 0);
@@ -3761,35 +3806,35 @@ export class ChartView {
     gl.drawArraysInstanced(gl.TRIANGLE_STRIP, 0, 4, g.n);
   }
 
-  _dataPxX(value) {
+  _dataPxX(value: number) {
     return this._dataPx("x", value);
   }
 
-  _dataPxY(value) {
+  _dataPxY(value: number) {
     return this._dataPx("y", value);
   }
 
-  _styleNumber(style, key, fallback) {
+  _styleNumber(style: StyleBag, key: string, fallback: any) {
     if (!style || typeof style !== "object") return fallback;
     const value = Number(style[key]);
     return Number.isFinite(value) ? value : fallback;
   }
 
-  _axisStyleNumber(axis, key, fallback) {
+  _axisStyleNumber(axis: AxisSpec, key: string, fallback: number) {
     return this._styleNumber(axis && axis.style, key, fallback);
   }
 
-  _axisStylePaint(axis, key, fallback) {
+  _axisStylePaint(axis: AxisSpec, key: string, fallback: any) {
     const style = axis && typeof axis.style === "object" ? axis.style : null;
     return safeCssPaint(this.root, style && style[key], fallback);
   }
 
-  _axisStyleValue(axis, key) {
+  _axisStyleValue(axis: AxisSpec, key: string) {
     const style = axis && typeof axis.style === "object" ? axis.style : null;
     return style && Object.prototype.hasOwnProperty.call(style, key) ? style[key] : undefined;
   }
 
-  _axisGridDash(axis) {
+  _axisGridDash(axis: AxisSpec) {
     const value = String(this._axisStyleValue(axis, "grid_dash") || "solid");
     if (value === "dashed") return [6, 4];
     if (value === "dotted") return [1, 3];
@@ -3797,12 +3842,12 @@ export class ChartView {
     return [];
   }
 
-  _axisTickLabelStrategy(axis) {
+  _axisTickLabelStrategy(axis: AxisSpec) {
     const value = String((axis && axis.tick_label_strategy) || "auto").replace(/-/g, "_");
     return ["auto", "hide", "rotate", "stagger", "none", "off"].includes(value) ? value : "auto";
   }
 
-  _axisTickLabelAnchor(axis) {
+  _axisTickLabelAnchor(axis: AxisSpec) {
     const raw = axis && axis.tick_label_anchor !== undefined
       ? axis.tick_label_anchor
       : this._axisStyleValue(axis, "tick_label_anchor");
@@ -3814,22 +3859,22 @@ export class ChartView {
     return null; // unset/unknown: the caller picks its dimension's default
   }
 
-  _axisTickLabelAngle(axis) {
+  _axisTickLabelAngle(axis: AxisSpec) {
     const angle = Number(axis ? axis.tick_label_angle : undefined);
     return Number.isFinite(angle) ? angle : null;
   }
 
-  _axisTickLabelMinGap(axis, dim) {
+  _axisTickLabelMinGap(axis: AxisSpec, dim: "x" | "y") {
     const gap = Number(axis ? axis.tick_label_min_gap : undefined);
     return Number.isFinite(gap) && gap >= 0 ? gap : (dim === "x" ? 8 : 4);
   }
 
-  _estimateTickLabel(text, fontSize) {
+  _estimateTickLabel(text: string, fontSize: number) {
     const s = String(text || "");
     return { w: Math.max(fontSize * 0.7, s.length * fontSize * 0.62), h: fontSize * 1.2 };
   }
 
-  _tickLabelExtent(label, dim, fontSize) {
+  _tickLabelExtent(label: any, dim: "x" | "y", fontSize: number) {
     const size = this._estimateTickLabel(label.text, fontSize);
     const angle = Math.abs(Number(label.angle || 0)) * Math.PI / 180;
     return dim === "y"
@@ -3837,7 +3882,7 @@ export class ChartView {
       : Math.abs(Math.cos(angle)) * size.w + Math.abs(Math.sin(angle)) * size.h;
   }
 
-  _tickLabelsCollide(labels, dim, fontSize, minGap, anchor = "center") {
+  _tickLabelsCollide(labels: any[], dim: "x" | "y", fontSize: number, minGap: number, anchor = "center") {
     const rows = new Map();
     for (const label of labels) {
       const row = Number(label.row || 0);
@@ -3845,7 +3890,7 @@ export class ChartView {
       rows.get(row).push(label);
     }
     for (const rowLabels of rows.values()) {
-      rowLabels.sort((a, b) => a.pos - b.pos);
+      rowLabels.sort((a: any, b: any) => a.pos - b.pos);
       if (dim === "x" && anchor !== "center") {
         // Edge-anchored labels all run the same direction from their tick.
         // Rotated ones are parallel lines: they clear each other when the
@@ -3877,21 +3922,21 @@ export class ChartView {
     return false;
   }
 
-  _downsampleTickLabels(labels, dim, fontSize, minGap, anchor = "center") {
+  _downsampleTickLabels(labels: any[], dim: "x" | "y", fontSize: number, minGap: number, anchor = "center") {
     if (labels.length <= 1) return labels;
     for (let stride = 2; stride <= labels.length; stride++) {
-      const out = labels.filter((_, i) => i % stride === 0);
+      const out = labels.filter((_: any, i: number) => i % stride === 0);
       if (!this._tickLabelsCollide(out, dim, fontSize, minGap, anchor)) return out;
     }
     return labels.slice(0, 1);
   }
 
-  _layoutTickLabels(axis, dim, labels) {
+  _layoutTickLabels(axis: AxisSpec, dim: "x" | "y", labels: any[]) {
     const strategyValue = this._axisTickLabelStrategy(axis);
     if (strategyValue === "none" || strategyValue === "off") return [];
     if (labels.length <= 1) {
       const angle = this._axisTickLabelAngle(axis);
-      return labels.map((label) => ({ ...label, angle: angle === null ? 0 : angle, row: 0 }));
+      return labels.map((label: any) => ({ ...label, angle: angle === null ? 0 : angle, row: 0 }));
     }
     const fontSize = Math.max(
       8,
@@ -3904,7 +3949,7 @@ export class ChartView {
     const anchor = dim === "x" ? (this._axisTickLabelAnchor(axis) ?? "center") : "center";
     const explicitAngle = this._axisTickLabelAngle(axis);
     const baseAngle = explicitAngle === null ? 0 : explicitAngle;
-    const withBase = labels.map((label) => ({ ...label, angle: baseAngle, row: 0 }));
+    const withBase = labels.map((label: any) => ({ ...label, angle: baseAngle, row: 0 }));
     let strategy = strategyValue;
     if (strategy === "auto") {
       if (!this._tickLabelsCollide(withBase, dim, fontSize, minGap, anchor)) return withBase;
@@ -3916,9 +3961,9 @@ export class ChartView {
     let out = withBase;
     if (strategy === "rotate" && dim === "x") {
       const angle = explicitAngle === null ? (axis.side === "top" ? 35 : -35) : explicitAngle;
-      out = labels.map((label) => ({ ...label, angle, row: 0 }));
+      out = labels.map((label: any) => ({ ...label, angle, row: 0 }));
     } else if (strategy === "stagger" && dim === "x") {
-      out = labels.map((label, i) => ({ ...label, angle: baseAngle, row: i % 2 }));
+      out = labels.map((label: any, i: number) => ({ ...label, angle: baseAngle, row: i % 2 }));
     }
 
     // Strategies handle collisions; a non-colliding label set stays intact
@@ -3929,7 +3974,7 @@ export class ChartView {
     return out;
   }
 
-  _xTickLabelTransform(axis, angle) {
+  _xTickLabelTransform(axis: AxisSpec, angle: number) {
     const value = Number(angle || 0);
     const side = axis && axis.side === "top" ? "top" : "bottom";
     // An explicit anchor (mpl `ha`) pins that edge as the transform origin,
@@ -3959,7 +4004,7 @@ export class ChartView {
     };
   }
 
-  _axisLabelCss(axis, dim, fallbackCss) {
+  _axisLabelCss(axis: AxisSpec, dim: "x" | "y", fallbackCss: string) {
     const rawPosition = axis && axis.label_position;
     const hasPosition = rawPosition !== undefined && rawPosition !== null;
     const hasOffset = axis && Number.isFinite(Number(axis.label_offset));
@@ -4053,8 +4098,8 @@ export class ChartView {
       this._axisTickTarget("x", Math.max(3, p.w / (xAxis.kind === "time" ? 90 : 80))),
     );
     const yt = this._axisTicks("y", this._axisTickTarget("y", Math.max(3, p.h / 45)));
-    const xEdge = (px) => Math.min(p.x + p.w - 0.5, Math.max(p.x + 0.5, Math.round(px) + 0.5));
-    const yEdge = (py) => Math.min(p.y + p.h - 0.5, Math.max(p.y + 0.5, Math.round(py) + 0.5));
+    const xEdge = (px: number) => Math.min(p.x + p.w - 0.5, Math.max(p.x + 0.5, Math.round(px) + 0.5));
+    const yEdge = (py: number) => Math.min(p.y + p.h - 0.5, Math.max(p.y + 0.5, Math.round(py) + 0.5));
 
     ctx.strokeStyle = this._axisStylePaint(xAxis, "grid_color", this.theme.grid);
     ctx.lineWidth = Math.max(0.5, this._axisStyleNumber(xAxis, "grid_width", 1));
@@ -4099,7 +4144,7 @@ export class ChartView {
     // the chrome canvas, behind the data). Rebuilt with the labels; static
     // between throttled zoom frames since the plot rect doesn't move on zoom.
     if (updateLabels) {
-      const rule = (styleAxis, left, top, w, h, colorKey = "axis_color") => {
+      const rule = (styleAxis: AxisSpec, left: number, top: number, w: number, h: number, colorKey = "axis_color") => {
         const d = document.createElement("div");
         d.style.cssText =
           `position:absolute;left:${left}px;top:${top}px;width:${w}px;height:${h}px;` +
@@ -4133,7 +4178,7 @@ export class ChartView {
         rule(axis, x, p.y, w, p.h);
       }
 
-      const tickParts = (axis) => {
+      const tickParts = (axis: AxisSpec) => {
         const length = Math.max(0, this._axisStyleNumber(axis, "tick_length", 0));
         const width = Math.max(0.5, this._axisStyleNumber(axis, "tick_width", 1));
         const direction = String(this._axisStyleValue(axis, "tick_direction") || "out");
@@ -4197,7 +4242,7 @@ export class ChartView {
       }
     }
 
-    const label = (text, css, axis, kind = "tick", extraStyle = null) => {
+    const label = (text: string, css: string, axis: AxisSpec, kind = "tick", extraStyle: StyleBag | null = null) => {
       if (!updateLabels) return;
       const d = document.createElement("div");
       d.textContent = text;
@@ -4297,7 +4342,7 @@ export class ChartView {
     // the transform origin, so a rotated label pivots about the point at the
     // tick. Unset defaults to the tick-side edge — mpl `ha`: "end" left of
     // the plot, "start" right of it — reproducing the classic layout.
-    const yLabelCss = (axis, onRight, item) => {
+    const yLabelCss = (axis: AxisSpec, onRight: boolean, item: any) => {
       const pin = onRight ? p.x + p.w + 8 : p.x - 8;
       const anchor = this._axisTickLabelAnchor(axis) ?? (onRight ? "start" : "end");
       const shift = anchor === "end" ? "-100%" : anchor === "start" ? "0%" : "-50%";
@@ -4349,8 +4394,8 @@ export class ChartView {
     // Data transitions stay pickable: the pick shader follows the same
     // interpolated positions as the visible point shader. View and LOD
     // handoffs still suppress hit-testing while their mapping changes.
-    const activeStart = (v) => v !== undefined && v !== null;
-    return !!this._viewAnim || this.gpuTraces.some((g) =>
+    const activeStart = (v: any) => v !== undefined && v !== null;
+    return !!this._viewAnim || this.gpuTraces.some((g: GpuTrace) =>
       activeStart(g._densityFadeStart) ||
       activeStart(g._densitySwitchFadeStart) ||
       activeStart(g._drillFadeStart) ||
@@ -4373,7 +4418,7 @@ export class ChartView {
     const { x0, x1, y0, y1 } = this.view;
     const prog = this.pickProg;
     gl.useProgram(prog);
-    const u = (n) => uniformOf(gl, prog, n);
+    const u = (n: string) => uniformOf(gl, prog, n);
     gl.uniform1f(u("u_dpr"), this.dpr);
     // Global pick-id space: trace ranges are [pickBase, pickBase + n), bases
     // start at 1 so the all-zero clear stays the background sentinel.
@@ -4434,7 +4479,7 @@ export class ChartView {
     this._pickDirty = false;
   }
 
-  _pickAt(cssX, cssY) {
+  _pickAt(cssX: number, cssY: number) {
     if (
       !this._pickable ||
       this._glLost ||
@@ -4464,18 +4509,18 @@ export class ChartView {
     const id = buf[0] + buf[1] * 0x100 + buf[2] * 0x10000 + buf[3] * 0x1000000;
     if (id === 0) return null;
     const g = this.gpuTraces.find(
-      (t) => t.pickBase > 0 && id >= t.pickBase && id < t.pickBase + t.pickCount
+      (t: TraceSpec) => t.pickBase > 0 && id >= t.pickBase && id < t.pickBase + t.pickCount
     );
     if (!g) return null;
     return { trace: g.trace.id, index: id - g.pickBase, g };
   }
 
-  _decodeValue(values, meta, index) {
+  _decodeValue(values: any, meta: ColumnMeta, index: number) {
     if (!values || !meta || index < 0 || index >= values.length) return NaN;
     return values[index] / (meta.scale || 1) + meta.offset;
   }
 
-  _dataFromCanvas(cssX, cssY, xAxisId = "x", yAxisId = "y") {
+  _dataFromCanvas(cssX: number, cssY: number, xAxisId = "x", yAxisId = "y") {
     const [x0, x1] = this._axisRange(xAxisId);
     const [y0, y1] = this._axisRange(yAxisId);
     const xAxis = this._axis(xAxisId);
@@ -4491,7 +4536,7 @@ export class ChartView {
     ];
   }
 
-  _nearestCpuIndex(g, dataX) {
+  _nearestCpuIndex(g: GpuTrace, dataX: number) {
     const cpu = g && g._cpu;
     if (!cpu || !cpu.x || !cpu.x.length) return -1;
     const xMeta = cpu.xMeta || g.xMeta;
@@ -4516,7 +4561,7 @@ export class ChartView {
     return best;
   }
 
-  _hoverAt(cssX, cssY) {
+  _hoverAt(cssX: number, cssY: number) {
     const maxPx = 12;
     let best = null;
     for (const g of this.gpuTraces) {
@@ -4560,7 +4605,7 @@ export class ChartView {
     return best;
   }
 
-  _barHover(g, dataX, dataY) {
+  _barHover(g: GpuTrace, dataX: number, dataY: number) {
     const cpu = g._cpu;
     const horizontal = g.orientation === 1;
     const limit = Math.min(cpu.x.length, cpu.y.length, g.n || cpu.x.length);
@@ -4583,7 +4628,7 @@ export class ChartView {
     return null;
   }
 
-  _rectHover(g, dataX, dataY) {
+  _rectHover(g: GpuTrace, dataX: number, dataY: number) {
     const r = g._cpuRect;
     const limit = Math.min(r.x0.length, r.x1.length, r.y0.length, r.y1.length, g.n || r.x0.length);
     for (let i = 0; i < limit; i++) {
@@ -4601,7 +4646,7 @@ export class ChartView {
     return null;
   }
 
-  _heatmapHover(g, dataX, dataY) {
+  _heatmapHover(g: GpuTrace, dataX: number, dataY: number) {
     const h = g.heatmap;
     if (!h || !g._cpuHeatmap) return null;
     const [x0, x1] = h.xRange;
@@ -4662,7 +4707,7 @@ export class ChartView {
     this.draw(true);
   }
 
-  _hover(e) {
+  _hover(e: PointerEvent) {
     // Pointer exploration supersedes any positional prefix retained for
     // keyboard readouts and their asynchronous exact-value replies.
     this._a11yKeyboardReadout = null;
@@ -4712,7 +4757,7 @@ export class ChartView {
 
 
 
-  _asF32(b) {
+  _asF32(b: any) {
     if (b instanceof ArrayBuffer) return new Float32Array(b);
     if (b.byteOffset % 4 === 0) {
       return new Float32Array(b.buffer, b.byteOffset, Math.floor(b.byteLength / 4));
@@ -4720,12 +4765,12 @@ export class ChartView {
     return new Float32Array(b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength));
   }
 
-  _asU8(b) {
+  _asU8(b: any) {
     if (b instanceof ArrayBuffer) return new Uint8Array(b);
     return new Uint8Array(b.buffer, b.byteOffset, b.byteLength);
   }
 
-  _asU32(b) {
+  _asU32(b: any) {
     if (b instanceof ArrayBuffer) return new Uint32Array(b);
     if (b.byteOffset % 4 === 0) {
       return new Uint32Array(b.buffer, b.byteOffset, Math.floor(b.byteLength / 4));
@@ -4826,7 +4871,7 @@ export class ChartView {
     this.root.remove();
   }
 
-  _deleteBuffers(obj, names) {
+  _deleteBuffers(obj: any, names: string[]) {
     const gl = this.gl;
     if (!gl || !obj) return;
     const seen = new Set();
@@ -4840,7 +4885,7 @@ export class ChartView {
     }
   }
 
-  _destroyTraceResources(g, texSeen) {
+  _destroyTraceResources(g: GpuTrace, texSeen: Set<WebGLTexture>) {
     if (!g) return;
     this._destroyDensitySample(g);
     this._deleteVaos(g);

--- a/js/src/51_annotations.ts
+++ b/js/src/51_annotations.ts
@@ -1,3 +1,4 @@
+import type { Rgba, StyleBag } from "./05_types";
 import { safeCssPaint } from "./20_theme";
 import { ChartView } from "./50_chartview";
 
@@ -5,6 +6,28 @@ import { ChartView } from "./50_chartview";
 // in _drawChrome; this part owns the 2D-canvas overlay — markers, arrows,
 // shape fills, and collision-nudged labels. Split out of 50_chartview.js;
 // augments the prototype so `this.*` is unchanged.
+
+/** One `spec.annotations` entry. `kind` dispatches and the per-kind members
+ * (endpoints, span bounds, symbol…) stay open the way the rest of the wire
+ * does. */
+interface AnnotationSpec {
+  kind?: string;
+  style?: StyleBag;
+  [key: string]: any;
+}
+
+/** A point (or a unit tangent) in canvas px, y-down. */
+type Point2 = number[];
+
+/** A resolved arrow path: gap-trimmed endpoints, the optional quadratic
+ * control point, and the unit tangents INTO p0/p1 (head/tail orientation). */
+interface ArrowGeometry {
+  p0: Point2;
+  p1: Point2;
+  control: Point2 | null;
+  dir0: Point2;
+  dir1: Point2;
+}
 
 // Annotation style keys consumed by the canvas shape (shaft/head/marker
 // geometry and paint) — never forwarded to the DOM label as CSS.
@@ -48,10 +71,10 @@ const XY_ANNOTATION_SHAPE_STYLE_KEYS = new Set([
 // ("left,right,up,down" px, y-down) is the start label's extents rectangle
 // around the shifted start: the start trims to where the departure tangent
 // exits it — matplotlib's text-patch clipping.
-function xyLabelClearExit(style, tangent) {
+function xyLabelClearExit(style: StyleBag, tangent: Point2): number {
   if (typeof style.label_clear !== "string") return 0;
   const parts = style.label_clear.split(",").map(Number);
-  if (parts.length !== 4 || parts.some((p) => !Number.isFinite(p) || p < 0)) return 0;
+  if (parts.length !== 4 || parts.some((p: number) => !Number.isFinite(p) || p < 0)) return 0;
   const [left, right, up, down] = parts;
   const [tx, ty] = tangent;
   const exitX = tx > 1e-9 ? right / tx : tx < -1e-9 ? left / -tx : Infinity;
@@ -60,8 +83,10 @@ function xyLabelClearExit(style, tangent) {
   return Number.isFinite(exit) ? exit : 0;
 }
 
-function xyArrowGeometry(x0, y0, x1, y1, style) {
-  const num = (v) => (Number.isFinite(Number(v)) ? Number(v) : null);
+function xyArrowGeometry(
+  x0: number, y0: number, x1: number, y1: number, style: StyleBag,
+): ArrowGeometry {
+  const num = (v: unknown) => (Number.isFinite(Number(v)) ? Number(v) : null);
   if (typeof style.start_offset === "string") {
     const offset = style.start_offset.split(",").map(Number);
     if (offset.length === 2 && offset.every(Number.isFinite)) {
@@ -90,7 +115,7 @@ function xyArrowGeometry(x0, y0, x1, y1, style) {
     cx = (x0 + x1) / 2 + curve * dy;
     cy = (y0 + y1) / 2 - curve * dx;
   }
-  const toward = (px, py, qx, qy) => {
+  const toward = (px: number, py: number, qx: number, qy: number): Point2 => {
     const d = Math.hypot(qx - px, qy - py) || 1;
     return [(qx - px) / d, (qy - py) / d];
   };
@@ -109,7 +134,7 @@ function xyArrowGeometry(x0, y0, x1, y1, style) {
 }
 
 // The shaft as a point list (quadratic Bézier sampled when curved).
-function xyArrowShaftPoints(geom, samples = 24) {
+function xyArrowShaftPoints(geom: ArrowGeometry, samples = 24): Point2[] {
   const [x0, y0] = geom.p0;
   const [x1, y1] = geom.p1;
   if (!geom.control) return [[x0, y0], [x1, y1]];
@@ -125,7 +150,7 @@ function xyArrowShaftPoints(geom, samples = 24) {
 
 // The polyline with `trim` px of arclength removed from its end (a tapered
 // shaft ends at the head BASE — a full-length shaft would swallow the head).
-function xyTrimPolylineEnd(points, trim) {
+function xyTrimPolylineEnd(points: Point2[], trim: number): Point2[] {
   if (!(trim > 0) || points.length < 2) return points;
   const out = points.slice();
   let remaining = trim;
@@ -146,7 +171,7 @@ function xyTrimPolylineEnd(points, trim) {
 
 // The shaft as a filled polygon whose width interpolates from w0 to w1
 // (matplotlib's fancy/simple/wedge arrowstyles are filled tapered shafts).
-function xyTaperPolygon(points, w0, w1) {
+function xyTaperPolygon(points: Point2[], w0: number, w1: number): Point2[] {
   const left = [];
   const right = [];
   const count = points.length;
@@ -165,19 +190,22 @@ function xyTaperPolygon(points, w0, w1) {
 }
 
 Object.assign(ChartView.prototype, {
-  _annotationPaint(style, fallback) {
+  _annotationPaint(style: StyleBag, fallback: Rgba) {
     return safeCssPaint(this.root, style && style.color, fallback);
   },
 
-  _annotationLabelPaint(style, fallback) {
+  _annotationLabelPaint(style: StyleBag, fallback: Rgba) {
     return safeCssPaint(this.root, style && (style.label_color || style.color), fallback);
   },
 
-  _annotationStrokePaint(style, fallback) {
+  _annotationStrokePaint(style: StyleBag, fallback: Rgba) {
     return safeCssPaint(this.root, style && style.stroke_color, fallback);
   },
 
-  _drawAnnotationMarker(ctx, x, y, style, ann) {
+  _drawAnnotationMarker(
+    ctx: CanvasRenderingContext2D, x: number, y: number,
+    style: StyleBag, ann: AnnotationSpec,
+  ) {
     if (!Number.isFinite(x) || !Number.isFinite(y)) return;
     const r = Math.max(1, this._styleNumber(style, "size", Number(ann.size) || 8) / 2);
     const symbol = ["circle", "square", "diamond", "cross"].includes(ann.symbol) ? ann.symbol : "circle";
@@ -213,7 +241,10 @@ Object.assign(ChartView.prototype, {
     ctx.restore();
   },
 
-  _drawArrowLine(ctx, x0, y0, x1, y1, style) {
+  _drawArrowLine(
+    ctx: CanvasRenderingContext2D,
+    x0: number, y0: number, x1: number, y1: number, style: StyleBag,
+  ) {
     if (![x0, y0, x1, y1].every(Number.isFinite)) return;
     const geom = xyArrowGeometry(x0, y0, x1, y1, style);
     ctx.save();
@@ -257,7 +288,10 @@ Object.assign(ChartView.prototype, {
   // One arrow endpoint decoration. dir is the unit tangent INTO the point;
   // styles mirror matplotlib arrowstyles: "triangle" (filled, "-|>"/fancy),
   // "v" (open stroke, "->"), "bar" ("|-|" caps), "none".
-  _drawArrowEnd(ctx, point, dir, endStyle, head) {
+  _drawArrowEnd(
+    ctx: CanvasRenderingContext2D, point: Point2, dir: Point2,
+    endStyle: string, head: number,
+  ) {
     if (endStyle === "none") return;
     const [px, py] = point;
     const angle = Math.atan2(dir[1], dir[0]);
@@ -268,7 +302,7 @@ Object.assign(ChartView.prototype, {
       ctx.stroke();
       return;
     }
-    const wing = (side) => [
+    const wing = (side: number): Point2 => [
       px - head * Math.cos(angle - side * Math.PI / 6),
       py - head * Math.sin(angle - side * Math.PI / 6),
     ];
@@ -288,7 +322,7 @@ Object.assign(ChartView.prototype, {
     ctx.fill();
   },
 
-  _drawAnnotationShapes(ctx) {
+  _drawAnnotationShapes(ctx: CanvasRenderingContext2D) {
     const annotations = Array.isArray(this.spec.annotations) ? this.spec.annotations : [];
     if (!annotations.length) return;
     const p = this.plot;
@@ -369,7 +403,7 @@ Object.assign(ChartView.prototype, {
     ctx.restore();
   },
 
-  _drawAnnotationLabels(updateLabels) {
+  _drawAnnotationLabels(updateLabels: boolean) {
     if (!updateLabels) return;
     const annotations = Array.isArray(this.spec.annotations) ? this.spec.annotations : [];
     if (!annotations.length) return;
@@ -510,7 +544,7 @@ Object.assign(ChartView.prototype, {
       // rule stroke / arrow / marker alpha (exporter semantics), not a label
       // dimmer; only text/callout labels own their opacity.
       const opacityIsShape = ann.kind !== "text" && ann.kind !== "callout";
-      const labelStyle = {};
+      const labelStyle: StyleBag = {};
       for (const [key, value] of Object.entries(style)) {
         if (key === "opacity" && ann.kind === "text") {
           labelStyle[key] = value;
@@ -538,7 +572,7 @@ Object.assign(ChartView.prototype, {
       // its text edge, not its box edge — shift the translate by the leading
       // padding+border on each anchored side (a no-op for plain labels).
       const cs = getComputedStyle(d);
-      const edge = (pad, border) => (parseFloat(pad) || 0) + (parseFloat(border) || 0);
+      const edge = (pad: string, border: string) => (parseFloat(pad) || 0) + (parseFloat(border) || 0);
       const padL = edge(cs.paddingLeft, cs.borderLeftWidth);
       const padR = edge(cs.paddingRight, cs.borderRightWidth);
       const padT = edge(cs.paddingTop, cs.borderTopWidth);
@@ -591,4 +625,4 @@ Object.assign(ChartView.prototype, {
       }
     }
   },
-});
+} as ThisType<ChartView> & Record<string, unknown>);

--- a/js/src/52_tooltip.ts
+++ b/js/src/52_tooltip.ts
@@ -1,3 +1,4 @@
+import type { GpuTrace, Hit, Row } from "./05_types";
 import { fmtCategory, fmtNumberSpec, fmtValue } from "./30_ticks";
 import { ChartView } from "./50_chartview";
 
@@ -5,8 +6,16 @@ import { ChartView } from "./50_chartview";
 // row, denormalize units, and compose the tooltip lines/DOM. Split out of
 // 50_chartview.js; augments the prototype so `this.*` is unchanged.
 
+/** One `spec.tooltip.sources[field]` entry: the trace and channel a shared
+ * tooltip field reads from when the hovered trace doesn't carry it. */
+interface TooltipSource {
+  trace: number;
+  channel: string;
+  [key: string]: any;
+}
+
 Object.assign(ChartView.prototype, {
-  _showTooltip(hit, clientX, clientY) {
+  _showTooltip(hit: Hit, clientX: number, clientY: number) {
     const row = this._localRow(hit);
     this._lastRow = row;
     this._setTooltipAnchor(hit, row, clientX, clientY);
@@ -40,7 +49,7 @@ Object.assign(ChartView.prototype, {
     }
   },
 
-  _localRow(hit) {
+  _localRow(hit: Hit) {
     // Approximate readout from the resident f32 (used in standalone export and
     // as the instant value before the kernel's exact reply, §37). Only present
     // when CPU copies were retained (renderStandalone); the widget path replaces
@@ -106,7 +115,7 @@ Object.assign(ChartView.prototype, {
     return row;
   },
 
-  _sourceDisplayValue(g, channel, value, kind) {
+  _sourceDisplayValue(g: GpuTrace, channel: string, value: number, kind: string | undefined) {
     const axis = channel === "x" ? this._axis(g && g.xAxis) : this._axis(g && g.yAxis);
     if (channel === "x" && axis.kind === "category") {
       return [fmtCategory(value, axis.categories || []), undefined];
@@ -117,7 +126,7 @@ Object.assign(ChartView.prototype, {
     return [value, kind];
   },
 
-  _sourceValue(g, source, index) {
+  _sourceValue(g: GpuTrace, source: TooltipSource, index: number) {
     if (!g || index < 0) return [undefined, undefined];
     const channel = source.channel;
     if (channel === "x" || channel === "y") {
@@ -147,14 +156,14 @@ Object.assign(ChartView.prototype, {
     return [undefined, undefined];
   },
 
-  _applySharedTooltipFields(row) {
+  _applySharedTooltipFields(row: Row) {
     const sources = this.spec.tooltip && this.spec.tooltip.sources;
     if (!sources || typeof sources !== "object" || row.x === undefined) return;
     for (const [field, entries] of Object.entries(sources)) {
       if (!Array.isArray(entries) || row[field] !== undefined) continue;
       const source = entries.find((entry) => entry.trace === row.trace) || entries[0];
       if (!source || !Number.isFinite(Number(source.trace))) continue;
-      const g = this.gpuTraces.find((trace) => trace.trace.id === source.trace);
+      const g = this.gpuTraces.find((trace: GpuTrace) => trace.trace.id === source.trace);
       if (!g) continue;
       let idx = Number.isInteger(row.index) && source.trace === row.trace ? row.index : -1;
       if (
@@ -170,7 +179,7 @@ Object.assign(ChartView.prototype, {
     }
   },
 
-  _denormalizeUnit(value, domain) {
+  _denormalizeUnit(value: unknown, domain: number[] | undefined) {
     const v = Number(value);
     if (!Number.isFinite(v)) return v;
     if (!Array.isArray(domain) || domain.length < 2) return v;
@@ -180,7 +189,7 @@ Object.assign(ChartView.prototype, {
     return lo + v * (hi - lo);
   },
 
-  _defaultTooltipLines(row) {
+  _defaultTooltipLines(row: Row) {
     const lines = [];
     if (row.x !== undefined) lines.push(`x: ${fmtValue(row.x, row.x_kind)}`);
     if (row.y !== undefined) lines.push(`y: ${fmtValue(row.y, row.y_kind)}`);
@@ -191,26 +200,26 @@ Object.assign(ChartView.prototype, {
     return lines;
   },
 
-  _tooltipLookup(row, field) {
+  _tooltipLookup(row: Row, field: string) {
     const aliases = (this.spec.tooltip && this.spec.tooltip.aliases) || {};
     const key = row[field] !== undefined ? field : aliases[field];
     if (!key || row[key] === undefined) return [undefined, undefined];
     return [row[key], row[`${key}_kind`]];
   },
 
-  _formatTooltipValue(value, kind, format) {
+  _formatTooltipValue(value: any, kind: string | undefined, format: string) {
     const formatted = fmtNumberSpec(value, format);
     if (formatted !== null) return formatted;
     return fmtValue(value, kind);
   },
 
-  _tooltipLines(row) {
+  _tooltipLines(row: Row) {
     const tooltip = this.spec.tooltip || {};
     if (!tooltip.title && !Array.isArray(tooltip.fields)) return this._defaultTooltipLines(row);
     const formats = tooltip.format || {};
     const lines = [];
     if (typeof tooltip.title === "string") {
-      const title = tooltip.title.replace(/\{([^}]+)\}/g, (_, field) => {
+      const title = tooltip.title.replace(/\{([^}]+)\}/g, (_: string, field: string) => {
         const [value, kind] = this._tooltipLookup(row, field);
         return value === undefined ? "" : this._formatTooltipValue(value, kind, formats[field]);
       });
@@ -228,7 +237,7 @@ Object.assign(ChartView.prototype, {
   },
 
   // Anchor in data space so view changes carry the tooltip with its point.
-  _setTooltipAnchor(hit, row, clientX, clientY) {
+  _setTooltipAnchor(hit: Hit, row: Row, clientX: number, clientY: number) {
     const g = hit.g;
     if (!g) { this._tooltipAnchor = null; return; }
     const xAxis = g.xAxis || "x";
@@ -277,7 +286,7 @@ Object.assign(ChartView.prototype, {
     this._placeTooltip(pos.lx, pos.ly);
   },
 
-  _placeTooltip(lx, ly) {
+  _placeTooltip(lx: number, ly: number) {
     const tw = this.tooltip.offsetWidth;
     const th = this.tooltip.offsetHeight;
     const edge = 4;
@@ -291,7 +300,7 @@ Object.assign(ChartView.prototype, {
     this.tooltip.style.top = top + "px";
   },
 
-  _renderTooltip(row, clientX, clientY, options: any = {}) {
+  _renderTooltip(row: Row, clientX: number, clientY: number, options: any = {}) {
     if (!row || this.spec.show_tooltip === false) {
       this._hideTooltip();
       return;
@@ -301,7 +310,7 @@ Object.assign(ChartView.prototype, {
       // Text nodes, not innerHTML: category labels are user data and must never
       // be parsed as markup (a category named "<img onerror=…>" is just a label).
       this.tooltip.textContent = "";
-      lines.forEach((ln, i) => {
+      lines.forEach((ln: string, i: number) => {
         if (i) this.tooltip.appendChild(document.createElement("br"));
         this.tooltip.appendChild(document.createTextNode(ln));
       });
@@ -326,4 +335,4 @@ Object.assign(ChartView.prototype, {
       this._placeTooltip(clientX - rect.left, clientY - rect.top);
     }
   },
-});
+} as ThisType<ChartView> & Record<string, unknown>);

--- a/js/src/53_interaction.ts
+++ b/js/src/53_interaction.ts
@@ -1,17 +1,95 @@
 import { XY_CHROME_CSS } from "./20_theme";
 import { ChartView } from "./50_chartview";
 import { markOf } from "./55_marks";
+import type { GpuTrace } from "./05_types";
 
 // ChartView interaction: pointer/drag/wheel wiring, crosshair, box + lasso
 // selection, the modebar, and the animated view (pan/zoom) state machine.
 // Split out of 50_chartview.js; augments the prototype so `this.*` is
 // unchanged. Method bodies reference kernel-comm helpers (54) at call time.
 
+/** One lasso vertex: client coordinates for the drag hit-test, plus the
+ * data-space anchor the finished polygon is actually sent in. */
+interface LassoPoint {
+  x: number;
+  y: number;
+  data: number[];
+}
+
+/** In-flight drag of one vertex handle on the editable lasso overlay.
+ * `original` restores the vertex if the gesture is cancelled. */
+interface LassoHandleDrag {
+  index: number;
+  pointerId: number;
+  original: number[];
+  handle: SVGElement;
+}
+
+/** In-flight rubber-band gesture: box zoom, box/axis select, or lasso select.
+ * `points` is lasso-only; `previousLasso` restores a replaced polygon when the
+ * new gesture turns out not to have moved. */
+interface BandState {
+  mode: string;
+  sx: number;
+  sy: number;
+  d0: number[];
+  points: LassoPoint[] | null;
+  previousLasso: number[][] | null;
+}
+
+/** In-flight pan drag: the view it started from, the axes it may move, and the
+ * union of axes it has actually changed (the "end" event's payload). */
+interface DragState {
+  px: number;
+  py: number;
+  view: any;
+  moved: boolean;
+  interactionId: number;
+  axes: string[];
+  changedAxes: string[];
+}
+
+/** In-flight modebar reposition drag off the grip. */
+interface ModebarDragState {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  dx: number;
+  dy: number;
+  moved: boolean;
+}
+
+/** A view write: per-axis `[lo, hi]` ranges keyed by axis id. Stays open — the
+ * view object's full shape is owned by 50_chartview. */
+interface ViewInput {
+  ranges?: Record<string, number[]>;
+  [key: string]: any;
+}
+
+/** Options bag threaded through the durable-state writers (view changes,
+ * selection, history): provenance, animation, and the dispatch/broadcast
+ * opt-outs that linked and history-driven applies use. */
+interface InteractionOpts {
+  source?: string;
+  interactionId?: number;
+  history?: boolean;
+  animate?: boolean;
+  duration?: number;
+  phase?: string;
+  broadcast?: boolean;
+  dispatch?: boolean;
+  anchors?: Record<string, number>;
+  axes?: string[];
+  request?: boolean;
+  requestDelay?: number;
+  requestMaxWait?: number;
+}
+
 Object.assign(ChartView.prototype, {
   _initInteraction() {
     const c = this.canvas;
-    let drag = null;
-    let band = null;
+    let drag: DragState | null = null;
+    let band: BandState | null = null;
 
     // Rubber-band overlay for box-select (§34) — DOM, above the canvas.
     // border/background come from the stylesheet (--chart-selection*).
@@ -31,9 +109,9 @@ Object.assign(ChartView.prototype, {
     this.selLasso.appendChild(this.selLassoHandles);
     this.root.appendChild(this.selLasso);
     this._lassoPolygon = null;
-    let lassoHandleDrag = null;
+    let lassoHandleDrag: LassoHandleDrag | null = null;
 
-    const moveLassoHandle = (e) => {
+    const moveLassoHandle = (e: PointerEvent) => {
       if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId
           || !this._lassoPolygon) return;
       const rect = c.getBoundingClientRect();
@@ -44,8 +122,8 @@ Object.assign(ChartView.prototype, {
       e.preventDefault();
       e.stopPropagation();
     };
-    this._listen(this.selLasso, "pointerdown", (e) => {
-      const handle = e.target.closest?.("[data-xy-selection-lasso-handle]");
+    this._listen(this.selLasso, "pointerdown", (e: PointerEvent) => {
+      const handle = (e.target as Element).closest?.("[data-xy-selection-lasso-handle]") as SVGElement;
       if (!handle || !this._lassoPolygon) return;
       const index = Number(handle.dataset.xySelectionLassoHandle);
       if (!Number.isInteger(index) || !this._lassoPolygon[index]) return;
@@ -62,7 +140,7 @@ Object.assign(ChartView.prototype, {
       e.stopPropagation();
     });
     this._listen(this.selLasso, "pointermove", moveLassoHandle);
-    this._listen(this.selLasso, "pointerup", (e) => {
+    this._listen(this.selLasso, "pointerup", (e: PointerEvent) => {
       if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId) return;
       moveLassoHandle(e);
       const handle = lassoHandleDrag.handle;
@@ -70,7 +148,7 @@ Object.assign(ChartView.prototype, {
       delete handle.dataset.xyActive;
       if (this._lassoPolygon) this._sendSelectPolygon(this._lassoPolygon);
     });
-    this._listen(this.selLasso, "pointercancel", (e) => {
+    this._listen(this.selLasso, "pointercancel", (e: PointerEvent) => {
       if (!lassoHandleDrag || e.pointerId !== lassoHandleDrag.pointerId) return;
       if (this._lassoPolygon) {
         this._lassoPolygon[lassoHandleDrag.index] = lassoHandleDrag.original;
@@ -94,11 +172,11 @@ Object.assign(ChartView.prototype, {
       this.root.appendChild(this.crosshairY);
     }
 
-    const dataAt = (clientX, clientY) => {
+    const dataAt = (clientX: number, clientY: number) => {
       const r = c.getBoundingClientRect();
       return this._dataFromCanvas(clientX - r.left, clientY - r.top);
     };
-    const lassoPointAt = (clientX, clientY) => {
+    const lassoPointAt = (clientX: number, clientY: number): LassoPoint => {
       const r = c.getBoundingClientRect();
       const cssX = Math.max(0, Math.min(r.width, clientX - r.left));
       const cssY = Math.max(0, Math.min(r.height, clientY - r.top));
@@ -109,7 +187,7 @@ Object.assign(ChartView.prototype, {
       };
     };
 
-    this._listen(c, "pointerdown", (e) => {
+    this._listen(c, "pointerdown", (e: PointerEvent) => {
       this._cancelViewAnimation();
       const canPan = this._interactionFlag("pan", true);
       const canZoom = this._interactionFlag("zoom", true);
@@ -124,7 +202,7 @@ Object.assign(ChartView.prototype, {
         : this.dragMode === "zoom" && canNavigate && canZoom && canBoxZoom ? "zoom" : null;
       if (mode) {
         const previousLasso = mode.startsWith("select") && this._lassoPolygon
-          ? this._lassoPolygon.map((point) => [...point])
+          ? this._lassoPolygon.map((point: number[]) => [...point])
           : null;
         if (mode.startsWith("select")) this._clearLassoOverlay();
         const firstLassoPoint = mode === "select-lasso" ? lassoPointAt(e.clientX, e.clientY) : null;
@@ -158,7 +236,7 @@ Object.assign(ChartView.prototype, {
         this._hideTooltip();
       }
     });
-    this._listen(c, "pointermove", (e) => {
+    this._listen(c, "pointermove", (e: PointerEvent) => {
       if (band) { this._updateBand(band, e); return; }
       if (drag) {
         drag.moved = true;
@@ -191,7 +269,7 @@ Object.assign(ChartView.prototype, {
       this._updateCrosshair(e);
       this._hover(e);
     });
-    const end = (e) => {
+    const end = (e: PointerEvent) => {
       if (band) {
         // Pointermove is not guaranteed to run at the pointer-up coordinate.
         // Capture that final vertex before deciding whether the gesture moved;
@@ -214,7 +292,7 @@ Object.assign(ChartView.prototype, {
           } else if (band.mode === "select-lasso") {
             if (band.points.length >= 3) {
               const editable = this._simplifyLassoPoints(band.points);
-              this._sendSelectPolygon(editable.map((point) => point.data));
+              this._sendSelectPolygon(editable.map((point: LassoPoint) => point.data));
             } else if (band.previousLasso) {
               this._lassoPolygon = band.previousLasso;
               this._renderLassoSelection();
@@ -269,14 +347,14 @@ Object.assign(ChartView.prototype, {
     // prefix — keyboard traversal also stores an XY for exact replies, but
     // its readout must survive mouse movement elsewhere; Escape owns it),
     // any pointerover whose target left the chart root runs the same exit.
-    this._listen(document, "pointerover", (e) => {
+    this._listen(document, "pointerover", (e: PointerEvent) => {
       if (!this._lastHoverXY || this._a11yKeyboardReadout) return;
-      if (this.root.contains(e.target)) return;
+      if (this.root.contains(e.target as Node)) return;
       this._pointerHoverExit();
     });
-    this._listen(c, "click", (e) => this._click(e));
+    this._listen(c, "click", (e: MouseEvent) => this._click(e));
 
-    this._listen(c, "wheel", (e) => {
+    this._listen(c, "wheel", (e: WheelEvent) => {
       if (!this._interactionFlag("navigation", true)) return;
       if (!this._interactionFlag("zoom", true)) return;
       if (!this._interactionFlag("wheel_zoom", true)) return;
@@ -293,7 +371,7 @@ Object.assign(ChartView.prototype, {
       if (!this._interactionFlag("double_click_reset", true)) return;
       this._resetView(true, "reset");
     });
-    this._listen(c, "keydown", (e) => {
+    this._listen(c, "keydown", (e: KeyboardEvent) => {
       if (e.key === "Escape" && (band || drag)) {
         this.selRect.style.display = "none";
         this.selLasso.style.display = "none";
@@ -303,7 +381,7 @@ Object.assign(ChartView.prototype, {
         e.stopImmediatePropagation();
       }
     });
-    this._listen(c, "keydown", (e) => this._onA11yKey(e));
+    this._listen(c, "keydown", (e: KeyboardEvent) => this._onA11yKey(e));
   },
 
   // Shared exit path for canvas pointerleave and the document-level missed-
@@ -326,13 +404,13 @@ Object.assign(ChartView.prototype, {
   },
 
   _a11yPointGroups() {
-    return (this.gpuTraces || []).filter((g) =>
+    return (this.gpuTraces || []).filter((g: GpuTrace) =>
       markOf(g.trace.kind).pointPick && g.tier !== "density" && g._cpu &&
       g._cpu.x && g._cpu.y && Math.min(g._cpu.x.length, g._cpu.y.length) > 0);
   },
 
-  _onA11yKey(e) {
-    const direction = { ArrowRight: 1, ArrowDown: 1, ArrowLeft: -1, ArrowUp: -1 }[e.key];
+  _onA11yKey(e: KeyboardEvent) {
+    const direction = ({ ArrowRight: 1, ArrowDown: 1, ArrowLeft: -1, ArrowUp: -1 } as Record<string, number>)[e.key];
     const activate = e.key === "Enter" || e.key === " ";
     if (direction === undefined && e.key !== "Home" && e.key !== "End" && e.key !== "Escape"
         && !activate) {
@@ -395,7 +473,7 @@ Object.assign(ChartView.prototype, {
     // density handoff, or animated tier frame.
     if (this._interactionTransitionActive()) return;
     const groups = this._a11yPointGroups();
-    const total = groups.reduce((sum, g) => sum + Math.min(g._cpu.x.length, g._cpu.y.length), 0);
+    const total = groups.reduce((sum: number, g: GpuTrace) => sum + Math.min(g._cpu.x.length, g._cpu.y.length), 0);
     if (!total) return;
     // Traversal intentionally follows trace/series data order, not visual x
     // order: sorting would change source-row identity and make streamed appends
@@ -431,7 +509,7 @@ Object.assign(ChartView.prototype, {
     this._drawKeepPick();
   },
 
-  _updateCrosshair(e) {
+  _updateCrosshair(e: PointerEvent) {
     if (!this.crosshairX || !this.crosshairY) return;
     const rect = this.canvas.getBoundingClientRect();
     const rootRect = this.root.getBoundingClientRect();
@@ -458,7 +536,7 @@ Object.assign(ChartView.prototype, {
     if (this.crosshairY) this.crosshairY.style.display = "none";
   },
 
-  _click(e) {
+  _click(e: MouseEvent) {
     if (this._ignoreNextClick) {
       this._ignoreNextClick = false;
       return;
@@ -499,7 +577,7 @@ Object.assign(ChartView.prototype, {
     }
   },
 
-  _updateBand(band, e) {
+  _updateBand(band: BandState, e: PointerEvent) {
     const rect = this.canvas.getBoundingClientRect();
     const rootRect = this.root.getBoundingClientRect();
     if (band.mode === "select-lasso") {
@@ -512,7 +590,7 @@ Object.assign(ChartView.prototype, {
           && Math.hypot(clientX - previous.x, clientY - previous.y) >= 3) {
         band.points.push({ x: clientX, y: clientY, data: this._dataFromCanvas(cssX, cssY) });
       }
-      const points = band.points.map((point) => [
+      const points = band.points.map((point: LassoPoint) => [
         Math.max(this.plot.x, Math.min(this.plot.x + this.plot.w, point.x - rootRect.left)),
         Math.max(this.plot.y, Math.min(this.plot.y + this.plot.h, point.y - rootRect.top)),
       ]);
@@ -521,7 +599,7 @@ Object.assign(ChartView.prototype, {
       this.selLasso.setAttribute("width", String(this.root.clientWidth));
       this.selLasso.setAttribute("height", String(this.root.clientHeight));
       this.selLassoPath.setAttribute(
-        "d", points.map((point, i) => `${i ? "L" : "M"}${point[0]} ${point[1]}`).join(" ") + " Z"
+        "d", points.map((point: number[], i: number) => `${i ? "L" : "M"}${point[0]} ${point[1]}`).join(" ") + " Z"
       );
       return;
     }
@@ -550,15 +628,15 @@ Object.assign(ChartView.prototype, {
     void rect;
   },
 
-  _simplifyLassoPoints(points, tolerance = 6, maxPoints = 16) {
-    const source = points.filter((point) => point && Number.isFinite(point.x) && Number.isFinite(point.y));
+  _simplifyLassoPoints(points: LassoPoint[], tolerance = 6, maxPoints = 16) {
+    const source = points.filter((point: LassoPoint) => point && Number.isFinite(point.x) && Number.isFinite(point.y));
     if (source.length > 3) {
       const first = source[0], last = source[source.length - 1];
       if (Math.hypot(first.x - last.x, first.y - last.y) <= tolerance) source.pop();
     }
     if (source.length <= 3) return source.slice();
 
-    const distanceToSegmentSq = (point, start, end) => {
+    const distanceToSegmentSq = (point: LassoPoint, start: LassoPoint, end: LassoPoint) => {
       const dx = end.x - start.x, dy = end.y - start.y;
       if (dx === 0 && dy === 0) {
         return (point.x - start.x) ** 2 + (point.y - start.y) ** 2;
@@ -569,7 +647,7 @@ Object.assign(ChartView.prototype, {
       const x = start.x + t * dx, y = start.y + t * dy;
       return (point.x - x) ** 2 + (point.y - y) ** 2;
     };
-    const simplifyAt = (currentTolerance) => {
+    const simplifyAt = (currentTolerance: number) => {
       const keep = new Uint8Array(source.length);
       keep[0] = 1;
       keep[source.length - 1] = 1;
@@ -590,7 +668,7 @@ Object.assign(ChartView.prototype, {
           stack.push([start, furthest], [furthest, end]);
         }
       }
-      return source.filter((_point, index) => keep[index]);
+      return source.filter((_point: LassoPoint, index: number) => keep[index]);
     };
     let simplified = simplifyAt(tolerance);
     if (simplified.length < 3) {
@@ -677,7 +755,7 @@ Object.assign(ChartView.prototype, {
     });
   },
 
-  _sendSelect(d0, d1, opts: any = {}) {
+  _sendSelect(d0: number[], d1: number[], opts: InteractionOpts = {}) {
     this._clearLassoOverlay();
     const x0 = Math.min(d0[0], d1[0]), x1 = Math.max(d0[0], d1[0]);
     const y0 = Math.min(d0[1], d1[1]), y1 = Math.max(d0[1], d1[1]);
@@ -703,7 +781,7 @@ Object.assign(ChartView.prototype, {
     }
   },
 
-  _sendSelectPolygon(points, opts: any = {}) {
+  _sendSelectPolygon(points: number[][], opts: InteractionOpts = {}) {
     if (!Array.isArray(points) || points.length < 3) return;
     const polygon = points.map((point) => [point[0], point[1]]);
     if (!polygon.every((point) => point.every(Number.isFinite))) return;
@@ -728,12 +806,12 @@ Object.assign(ChartView.prototype, {
     }
   },
 
-  _selectLocalPolygon(points, opts: any = {}) {
-    const xs = points.map((point) => point[0]);
-    const ys = points.map((point) => point[1]);
+  _selectLocalPolygon(points: number[][], opts: InteractionOpts = {}) {
+    const xs = points.map((point: number[]) => point[0]);
+    const ys = points.map((point: number[]) => point[1]);
     const minX = Math.min(...xs), maxX = Math.max(...xs);
     const minY = Math.min(...ys), maxY = Math.max(...ys);
-    const inside = (x, y) => {
+    const inside = (x: number, y: number) => {
       let hit = false;
       for (let i = 0, j = points.length - 1; i < points.length; j = i++) {
         const [xi, yi] = points[i], [xj, yj] = points[j];
@@ -774,7 +852,7 @@ Object.assign(ChartView.prototype, {
   },
 
   // Standalone selection (no kernel): mask the retained CPU f32 columns (§37).
-  _selectLocal(x0, x1, y0, y1, opts: any = {}) {
+  _selectLocal(x0: number, x1: number, y0: number, y1: number, opts: InteractionOpts = {}) {
     let total = 0;
     for (const g of this.gpuTraces) {
       // _cpu only exists where the standalone entry retained copies (retainCpu).
@@ -804,7 +882,7 @@ Object.assign(ChartView.prototype, {
     }
   },
 
-  _applySelMask(g, maskF32) {
+  _applySelMask(g: GpuTrace, maskF32: Float32Array) {
     const gl = this.gl;
     if (!g.selBuf) g.selBuf = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, g.selBuf);
@@ -812,7 +890,7 @@ Object.assign(ChartView.prototype, {
     g.selActive = true;
   },
 
-  _clearSelection(opts: any = {}) {
+  _clearSelection(opts: InteractionOpts = {}) {
     this._clearLassoOverlay();
     // Clearing a durable selection is itself a durable-state change; linked
     // applies (dispatch: false) and no-op clears push nothing.
@@ -840,7 +918,7 @@ Object.assign(ChartView.prototype, {
     }
   },
 
-  _clampModebar(left, top) {
+  _clampModebar(left?: number, top?: number) {
     const bar = this._modebar;
     if (!bar || !this.root) return;
     const currentLeft = left ?? (Number.parseFloat(bar.style.left) || 0);
@@ -851,7 +929,7 @@ Object.assign(ChartView.prototype, {
     bar.style.top = `${Math.max(0, Math.min(maxTop, currentTop))}px`;
   },
 
-  _buildModebar(root) {
+  _buildModebar(root: HTMLElement) {
     if (this.spec.show_modebar === false) return;
     const bar = document.createElement("div");
     // The modebar is chrome, so keep it out of the way until the chart is
@@ -870,7 +948,7 @@ Object.assign(ChartView.prototype, {
     let setSelectMenuOpen: any = () => {};
     let setExportMenuOpen: any = () => {};
 
-    const setVisible = (visible) => {
+    const setVisible = (visible: boolean) => {
       const show = visible || this._modebarDragging || bar.contains(document.activeElement);
       bar.style.opacity = show ? "1" : "0";
       bar.style.pointerEvents = show ? "auto" : "none";
@@ -883,8 +961,8 @@ Object.assign(ChartView.prototype, {
       setExportMenuOpen(false);
     });
     this._listen(bar, "focusin", () => setVisible(true));
-    this._listen(bar, "focusout", (e) => {
-      if (!bar.contains(e.relatedTarget) && !root.matches(":hover")) setVisible(false);
+    this._listen(bar, "focusout", (e: FocusEvent) => {
+      if (!bar.contains(e.relatedTarget as Node) && !root.matches(":hover")) setVisible(false);
     });
 
     // One combined grip/menu control avoids a second, visually redundant dots
@@ -905,9 +983,9 @@ Object.assign(ChartView.prototype, {
     bar.appendChild(grip);
 
     const DRAG_THRESHOLD_PX = 6;
-    let modebarDrag = null;
+    let modebarDrag: ModebarDragState | null = null;
     let suppressGripClickUntil = 0;
-    this._listen(grip, "pointerdown", (e) => {
+    this._listen(grip, "pointerdown", (e: PointerEvent) => {
       if (e.pointerType === "mouse" && e.button !== 0) return;
       e.stopPropagation();
       const barRect = bar.getBoundingClientRect();
@@ -922,7 +1000,7 @@ Object.assign(ChartView.prototype, {
       try { grip.setPointerCapture(e.pointerId); } catch (_err) { /* synthetic event */ }
       setVisible(true);
     });
-    this._listen(grip, "pointermove", (e) => {
+    this._listen(grip, "pointermove", (e: PointerEvent) => {
       if (!modebarDrag || e.pointerId !== modebarDrag.pointerId) return;
       const distance = Math.hypot(e.clientX - modebarDrag.startX, e.clientY - modebarDrag.startY);
       if (!modebarDrag.moved) {
@@ -940,7 +1018,7 @@ Object.assign(ChartView.prototype, {
       const top = e.clientY - rootRect.top - modebarDrag.dy;
       this._clampModebar(left, top);
     });
-    const endModebarDrag = (e) => {
+    const endModebarDrag = (e: PointerEvent) => {
       if (!modebarDrag || e.pointerId !== modebarDrag.pointerId) return;
       const moved = modebarDrag.moved;
       const cancelled = e.type === "pointercancel";
@@ -954,7 +1032,7 @@ Object.assign(ChartView.prototype, {
     };
     this._listen(grip, "pointerup", endModebarDrag);
     this._listen(grip, "pointercancel", endModebarDrag);
-    this._listen(grip, "click", (e) => {
+    this._listen(grip, "click", (e: MouseEvent) => {
       e.stopPropagation();
       if (performance.now() <= suppressGripClickUntil) {
         suppressGripClickUntil = 0;
@@ -963,7 +1041,7 @@ Object.assign(ChartView.prototype, {
       setExportMenuOpen(!this._exportMenuOpen);
     });
 
-    const mk = (name, title, onClick, toggles?: any) => {
+    const mk = (name: string, title: string, onClick: () => void, toggles?: string) => {
       const b = document.createElement("button");
       b.type = "button";
       b.title = title;
@@ -975,8 +1053,8 @@ Object.assign(ChartView.prototype, {
       b.style.cssText =
         "display:flex;align-items:center;justify-content:center;pointer-events:auto;";
       this._applySlot(b, "modebar_button");
-      this._listen(b, "pointerdown", (e) => e.stopPropagation());
-      this._listen(b, "click", (e) => { e.stopPropagation(); onClick(); });
+      this._listen(b, "pointerdown", (e: PointerEvent) => e.stopPropagation());
+      this._listen(b, "click", (e: MouseEvent) => { e.stopPropagation(); onClick(); });
       bar.appendChild(b);
       if (toggles) this._modeBtns[toggles] = b;
       return b;
@@ -1064,8 +1142,8 @@ Object.assign(ChartView.prototype, {
         "position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
       bar.appendChild(zoomMenu);
     }
-    const zoomMenuItems = [];
-    const mkZoomItem = (name, label, onClick, toggles?: any, separator = false) => {
+    const zoomMenuItems: HTMLButtonElement[] = [];
+    const mkZoomItem = (name: string, label: string, onClick: () => void, toggles?: string, separator = false) => {
       const button = document.createElement("button");
       button.type = "button";
       button.tabIndex = -1;
@@ -1082,8 +1160,8 @@ Object.assign(ChartView.prototype, {
       const text = document.createElement("span");
       text.textContent = label;
       button.appendChild(text);
-      this._listen(button, "pointerdown", (e) => e.stopPropagation());
-      this._listen(button, "click", (e) => {
+      this._listen(button, "pointerdown", (e: PointerEvent) => e.stopPropagation());
+      this._listen(button, "click", (e: MouseEvent) => {
         e.stopPropagation();
         setZoomMenuOpen(false, true);
         onClick();
@@ -1119,8 +1197,8 @@ Object.assign(ChartView.prototype, {
     selectMenu.style.cssText =
       "position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
     bar.appendChild(selectMenu);
-    const selectMenuItems = [];
-    const mkSelectItem = (name, label, mode) => {
+    const selectMenuItems: HTMLButtonElement[] = [];
+    const mkSelectItem = (name: string, label: string, mode: string) => {
       const button = document.createElement("button");
       button.type = "button";
       button.tabIndex = -1;
@@ -1136,8 +1214,8 @@ Object.assign(ChartView.prototype, {
       const text = document.createElement("span");
       text.textContent = label;
       button.appendChild(text);
-      this._listen(button, "pointerdown", (e) => e.stopPropagation());
-      this._listen(button, "click", (e) => {
+      this._listen(button, "pointerdown", (e: PointerEvent) => e.stopPropagation());
+      this._listen(button, "click", (e: MouseEvent) => {
         e.stopPropagation();
         setSelectMenuOpen(false, true);
         this._setDragMode(mode);
@@ -1161,8 +1239,8 @@ Object.assign(ChartView.prototype, {
     exportMenu.style.cssText =
       "position:absolute;display:none;flex-direction:column;z-index:7;pointer-events:auto;";
     bar.appendChild(exportMenu);
-    const exportMenuItems = [];
-    const mkExportItem = (name, label, onClick, separator = false) => {
+    const exportMenuItems: HTMLButtonElement[] = [];
+    const mkExportItem = (name: string, label: string, onClick: () => unknown, separator = false) => {
       const button = document.createElement("button");
       button.type = "button";
       button.tabIndex = -1;
@@ -1179,8 +1257,8 @@ Object.assign(ChartView.prototype, {
       const text = document.createElement("span");
       text.textContent = label;
       button.appendChild(text);
-      this._listen(button, "pointerdown", (e) => e.stopPropagation());
-      this._listen(button, "click", (e) => {
+      this._listen(button, "pointerdown", (e: PointerEvent) => e.stopPropagation());
+      this._listen(button, "click", (e: MouseEvent) => {
         e.stopPropagation();
         setExportMenuOpen(false, true);
         Promise.resolve(onClick()).catch((error) => console.error(`xy: ${label} failed`, error));
@@ -1194,7 +1272,7 @@ Object.assign(ChartView.prototype, {
     // subset renders here — pdf/html entries are Python-side formats and are
     // skipped. No config keeps the historical png/svg/csv menu; an explicit
     // empty list hides the download items entirely.
-    const EXPORT_ITEMS = {
+    const EXPORT_ITEMS: Record<string, [string, () => unknown]> = {
       png: ["Export PNG", () => this._exportRaster("png")],
       jpeg: ["Export JPEG", () => this._exportRaster("jpeg")],
       webp: ["Export WebP", () => this._exportRaster("webp")],
@@ -1210,7 +1288,7 @@ Object.assign(ChartView.prototype, {
     }
 
     if (zoomTrigger) {
-      setZoomMenuOpen = (open, restoreFocus = false) => {
+      setZoomMenuOpen = (open: boolean, restoreFocus = false) => {
         const show = Boolean(open);
         if (show) {
           setSelectMenuOpen(false);
@@ -1243,7 +1321,7 @@ Object.assign(ChartView.prototype, {
         zoomMenu.style.visibility = "visible";
       };
     }
-    setSelectMenuOpen = (open, restoreFocus = false) => {
+    setSelectMenuOpen = (open: boolean, restoreFocus = false) => {
       if (!selectTrigger) return;
       const show = Boolean(open);
       if (show) {
@@ -1276,7 +1354,7 @@ Object.assign(ChartView.prototype, {
       selectMenu.style.top = `${Math.max(-rootTop, Math.min(maxTop, preferredTop))}px`;
       selectMenu.style.visibility = "visible";
     };
-    setExportMenuOpen = (open, restoreFocus = false) => {
+    setExportMenuOpen = (open: boolean, restoreFocus = false) => {
       // export_config(formats=[]) leaves nothing to show: the grip stays a
       // pure drag handle rather than opening an empty menu.
       const show = Boolean(open) && exportMenuItems.length > 0;
@@ -1327,13 +1405,13 @@ Object.assign(ChartView.prototype, {
       selectTrigger.style.display = on ? "flex" : "none";
     };
     this._syncModebarSelect();
-    this._listen(document, "pointerdown", (e) => {
-      if (this._zoomMenuOpen && !bar.contains(e.target)) setZoomMenuOpen(false);
-      if (this._selectMenuOpen && !bar.contains(e.target)) setSelectMenuOpen(false);
-      if (this._exportMenuOpen && !bar.contains(e.target)) setExportMenuOpen(false);
+    this._listen(document, "pointerdown", (e: PointerEvent) => {
+      if (this._zoomMenuOpen && !bar.contains(e.target as Node)) setZoomMenuOpen(false);
+      if (this._selectMenuOpen && !bar.contains(e.target as Node)) setSelectMenuOpen(false);
+      if (this._exportMenuOpen && !bar.contains(e.target as Node)) setExportMenuOpen(false);
     });
     if (zoomTrigger) {
-      this._listen(zoomTrigger, "keydown", (e) => {
+      this._listen(zoomTrigger, "keydown", (e: KeyboardEvent) => {
         if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
         e.preventDefault();
         e.stopPropagation();
@@ -1341,7 +1419,7 @@ Object.assign(ChartView.prototype, {
         const index = e.key === "ArrowDown" ? 0 : zoomMenuItems.length - 1;
         zoomMenuItems[index].focus();
       });
-      this._listen(zoomMenu, "keydown", (e) => {
+      this._listen(zoomMenu, "keydown", (e: KeyboardEvent) => {
         if (e.key === "Escape") {
           e.preventDefault();
           e.stopPropagation();
@@ -1350,7 +1428,7 @@ Object.assign(ChartView.prototype, {
         }
         if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(e.key)) return;
         e.preventDefault();
-        const current = zoomMenuItems.indexOf(document.activeElement);
+        const current = zoomMenuItems.indexOf(document.activeElement as HTMLButtonElement);
         let next = e.key === "Home" ? 0 : e.key === "End" ? zoomMenuItems.length - 1 : current;
         if (e.key === "ArrowDown") next = (current + 1) % zoomMenuItems.length;
         if (e.key === "ArrowUp") next = (current - 1 + zoomMenuItems.length) % zoomMenuItems.length;
@@ -1358,7 +1436,7 @@ Object.assign(ChartView.prototype, {
       });
     }
     if (selectTrigger) {
-      this._listen(selectTrigger, "keydown", (e) => {
+      this._listen(selectTrigger, "keydown", (e: KeyboardEvent) => {
         if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
         e.preventDefault();
         e.stopPropagation();
@@ -1366,7 +1444,7 @@ Object.assign(ChartView.prototype, {
         const index = e.key === "ArrowDown" ? 0 : selectMenuItems.length - 1;
         selectMenuItems[index].focus();
       });
-      this._listen(selectMenu, "keydown", (e) => {
+      this._listen(selectMenu, "keydown", (e: KeyboardEvent) => {
         if (e.key === "Escape") {
           e.preventDefault();
           e.stopPropagation();
@@ -1375,7 +1453,7 @@ Object.assign(ChartView.prototype, {
         }
         if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(e.key)) return;
         e.preventDefault();
-        const current = selectMenuItems.indexOf(document.activeElement);
+        const current = selectMenuItems.indexOf(document.activeElement as HTMLButtonElement);
         let next = e.key === "Home" ? 0 : e.key === "End" ? selectMenuItems.length - 1 : current;
         if (e.key === "ArrowDown") next = (current + 1) % selectMenuItems.length;
         if (e.key === "ArrowUp") {
@@ -1384,7 +1462,7 @@ Object.assign(ChartView.prototype, {
         selectMenuItems[next].focus();
       });
     }
-    this._listen(grip, "keydown", (e) => {
+    this._listen(grip, "keydown", (e: KeyboardEvent) => {
       if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
       // export_config(formats=[]) (or a PDF/HTML-only list) leaves no
       // client-side items: nothing to open or focus.
@@ -1395,7 +1473,7 @@ Object.assign(ChartView.prototype, {
       const index = e.key === "ArrowDown" ? 0 : exportMenuItems.length - 1;
       exportMenuItems[index].focus();
     });
-    this._listen(exportMenu, "keydown", (e) => {
+    this._listen(exportMenu, "keydown", (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.preventDefault();
         e.stopPropagation();
@@ -1404,7 +1482,7 @@ Object.assign(ChartView.prototype, {
       }
       if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(e.key)) return;
       e.preventDefault();
-      const current = exportMenuItems.indexOf(document.activeElement);
+      const current = exportMenuItems.indexOf(document.activeElement as HTMLButtonElement);
       let next = e.key === "Home" ? 0 : e.key === "End" ? exportMenuItems.length - 1 : current;
       if (e.key === "ArrowDown") next = (current + 1) % exportMenuItems.length;
       if (e.key === "ArrowUp") {
@@ -1442,7 +1520,7 @@ Object.assign(ChartView.prototype, {
     this._clampModebar();
   },
 
-  _setDragMode(mode) {
+  _setDragMode(mode: string) {
     this.dragMode = mode;
     // Cursor telegraphs the gesture (grab for pan, crosshair for box-zoom) but
     // lives in the defeatable :where([data-xy-slot="canvas"]) stylesheet keyed on
@@ -1456,12 +1534,12 @@ Object.assign(ChartView.prototype, {
     }
     this._zoomMenuButton?.classList.toggle("xy-active", mode === "zoom");
     this._selectMenuButton?.classList.toggle("xy-active", mode.startsWith("select"));
-    const selectionMode = {
+    const selectionMode = ({
       select: ["select", "Box Select"],
       "select-lasso": ["lasso", "Lasso Select"],
       "select-x": ["selectx", "X Range"],
       "select-y": ["selecty", "Y Range"],
-    }[mode];
+    } as Record<string, [string, string]>)[mode];
     if (selectionMode && this._selectMenuButton && this._selectMenuIcon) {
       const [iconName, label] = selectionMode;
       this._selectMenuIcon.innerHTML = this._icon(iconName);
@@ -1470,7 +1548,7 @@ Object.assign(ChartView.prototype, {
     }
   },
 
-  _actionLabel(action, axes) {
+  _actionLabel(action: string, axes: Iterable<string>) {
     const ids = Array.isArray(axes) ? axes : [...axes || []];
     if (!ids.length) return action;
     return `${action} on ${ids.join(" and ")} ${ids.length === 1 ? "axis" : "axes"}`;
@@ -1478,7 +1556,7 @@ Object.assign(ChartView.prototype, {
 
   _updateZoomMenuLabel() {
     if (!this._zoomMenuLabel || !this.view || !this.view0) return;
-    const axisPercent = (axisId, lo, hi, homeLo, homeHi) => {
+    const axisPercent = (axisId: string, lo: number, hi: number, homeLo: number, homeHi: number) => {
       const axis = this._axis(axisId);
       const span = Math.abs(this._axisCoord(axis, hi) - this._axisCoord(axis, lo));
       const homeSpan = Math.abs(
@@ -1517,7 +1595,7 @@ Object.assign(ChartView.prototype, {
     this._viewAnim = null;
   },
 
-  _setView(next, opts: any = {}) {
+  _setView(next: ViewInput, opts: InteractionOpts = {}) {
     if (this._destroyed) return [];
     const target = this._clampView(this._viewFrom(next), { anchors: opts.anchors });
     const changedAxes = this._axisIds().filter((axisId) => {
@@ -1591,22 +1669,22 @@ Object.assign(ChartView.prototype, {
       interactionId: opts.interactionId,
       broadcast: opts.broadcast,
     };
-    const lerp = (a, b, t) => a + (b - a) * t;
-    const span = (v) => Math.max(
+    const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+    const span = (v: ViewInput) => Math.max(
       ...this._axisIds().map((axisId) => {
         const [lo, hi] = this._axisRange(axisId, v);
         return Math.abs(hi - lo);
       }),
       1e-12,
     );
-    const closeEnough = (a, b) => {
+    const closeEnough = (a: ViewInput, b: ViewInput) => {
       const tol = span(b) * 1e-4;
       return Math.max(...this._axisIds().flatMap((axisId) => {
         const ar = this._axisRange(axisId, a), br = this._axisRange(axisId, b);
         return [Math.abs(ar[0] - br[0]), Math.abs(ar[1] - br[1])];
       })) <= tol;
     };
-    const step = (nowFrame) => {
+    const step = (nowFrame: number) => {
       if (this._destroyed) { this._animRaf = null; return; }
       const anim = this._viewAnim;
       if (!anim) { this._animRaf = null; return; }
@@ -1614,7 +1692,7 @@ Object.assign(ChartView.prototype, {
       anim.last = nowFrame;
       const k = 1 - Math.exp(-dt / anim.tau);
       const t = closeEnough(this.view, anim.target) ? 1 : k;
-      const ranges = {};
+      const ranges: Record<string, number[]> = {};
       for (const axisId of this._axisIds()) {
         const current = this._axisRange(axisId), targetRange = this._axisRange(axisId, anim.target);
         ranges[axisId] = [
@@ -1647,7 +1725,7 @@ Object.assign(ChartView.prototype, {
   // Keep a proposed viewport wholly inside each axis's optional hard bounds.
   // Work in scale coordinates so log bounds clamp multiplicatively, while
   // preserving the range direction used by reversed axes.
-  _zoomLimitForAxis(axisId) {
+  _zoomLimitForAxis(axisId: string) {
     if (!this._axisPolicy("zoom_axes").includes(axisId)) return [null, null];
     const configured = this.interaction?.zoom_limits;
     if (configured && typeof configured === "object" && !Array.isArray(configured)) {
@@ -1657,7 +1735,7 @@ Object.assign(ChartView.prototype, {
     return [1, null];
   },
 
-  _clampAxisRange(axisId, lo, hi, anchorFrac = 0.5) {
+  _clampAxisRange(axisId: string, lo: number, hi: number, anchorFrac = 0.5) {
     const axis = this._axis(axisId);
     let c0 = this._axisCoord(axis, lo), c1 = this._axisCoord(axis, hi);
     if (![c0, c1].every(Number.isFinite) || c0 === c1) return this._axisRange(axisId, this.view0);
@@ -1716,9 +1794,9 @@ Object.assign(ChartView.prototype, {
     return [this._axisValue(axis, first), this._axisValue(axis, second)];
   },
 
-  _clampView(view, opts: any = {}) {
+  _clampView(view: ViewInput, opts: InteractionOpts = {}) {
     const candidate = this._viewFrom(view, this.view0);
-    const ranges = {};
+    const ranges: Record<string, number[]> = {};
     for (const axisId of this._axisIds()) {
       const [lo, hi] = this._axisRange(axisId, candidate);
       ranges[axisId] = this._clampAxisRange(axisId, lo, hi, opts.anchors?.[axisId] ?? 0.5);
@@ -1732,7 +1810,7 @@ Object.assign(ChartView.prototype, {
     return new Set(this._axisPolicy("zoom_axes"));
   },
 
-  _zoomBy(f, animate = false, source = f < 1 ? "zoom_in" : "zoom_out") {
+  _zoomBy(f: number, animate = false, source = f < 1 ? "zoom_in" : "zoom_out") {
     const base = this._viewAnim ? this._viewAnim.target : this.view;
     const axes = this._zoomAxes();
     const ranges = Object.fromEntries(
@@ -1751,7 +1829,7 @@ Object.assign(ChartView.prototype, {
     });
   },
 
-  _zoomAxisRange(axisId, lo, hi, f, anchorFrac) {
+  _zoomAxisRange(axisId: string, lo: number, hi: number, f: number, anchorFrac: number) {
     const axis = this._axis(axisId);
     const c0 = this._axisCoord(axis, lo);
     const c1 = this._axisCoord(axis, hi);
@@ -1791,17 +1869,17 @@ Object.assign(ChartView.prototype, {
     ];
   },
 
-  _zoomAt(f, fx, fy, animate = false, duration = 120, opts: any = {}) {
+  _zoomAt(f: number, fx: number, fy: number, animate = false, duration = 120, opts: InteractionOpts = {}) {
     const base = this._viewAnim ? this._viewAnim.target : this.view;
     // An axis-band gesture scopes the zoom to the hovered axis (§6 of
     // view-state.md); the policy still filters, never grants.
     const axes = Array.isArray(opts.axes)
-      ? new Set(opts.axes.filter((axisId) => this._zoomAxes().has(axisId)))
+      ? new Set(opts.axes.filter((axisId: string) => this._zoomAxes().has(axisId)))
       : this._zoomAxes();
     const ranges = Object.fromEntries(
       this._axisIds().map((axisId) => [axisId, [...this._axisRange(axisId, base)]])
     );
-    const anchors = {};
+    const anchors: Record<string, number> = {};
     for (const axisId of axes) {
       const anchor = this._axisDim(axisId) === "x" ? fx : fy;
       const [lo, hi] = ranges[axisId];
@@ -1819,7 +1897,7 @@ Object.assign(ChartView.prototype, {
     });
   },
 
-  _queueWheelZoom(factor, fx, fy, axesScope = null) {
+  _queueWheelZoom(factor: number, fx: number, fy: number, axesScope: string[] | null = null) {
     if (!Number.isFinite(factor) || factor <= 0) return;
     // A queued delta keeps the gesture open: kill the pending end timer here,
     // not in the rAF. Otherwise a wheel event landing just before the 90 ms
@@ -1893,9 +1971,9 @@ Object.assign(ChartView.prototype, {
 
   // Box-zoom: fit the view to the dragged data rectangle (§16 precision floor;
   // ignore degenerate drags that would collapse a span below f32 resolution).
-  _zoomToBox(d0, d1, animate = false, opts: any = {}) {
+  _zoomToBox(d0: number[], d1: number[], animate = false, opts: InteractionOpts = {}) {
     const axes = this._zoomAxes();
-    const fractions = {};
+    const fractions: Record<string, number[]> = {};
     for (const dim of ["x", "y"]) {
       const primary = this._axis(dim);
       const [lo, hi] = this._axisRange(dim);
@@ -1908,7 +1986,7 @@ Object.assign(ChartView.prototype, {
     const ranges = Object.fromEntries(
       this._axisIds().map((axisId) => [axisId, [...this._axisRange(axisId)]])
     );
-    const anchors = {};
+    const anchors: Record<string, number> = {};
     for (const axisId of axes) {
       const axis = this._axis(axisId);
       const [lo, hi] = ranges[axisId];
@@ -1934,7 +2012,7 @@ Object.assign(ChartView.prototype, {
     });
   },
 
-  _resetView(animate = true, source = "reset", axesOverride = null) {
+  _resetView(animate = true, source = "reset", axesOverride: string[] | null = null) {
     const ranges = Object.fromEntries(
       this._axisIds().map((axisId) => [axisId, [...this._axisRange(axisId)]])
     );
@@ -1957,7 +2035,7 @@ Object.assign(ChartView.prototype, {
     return config && typeof config === "object" ? config : {};
   },
 
-  _exportFilename(extension) {
+  _exportFilename(extension: string) {
     const configured = this._exportConfig().filename;
     if (typeof configured === "string" && configured) return `${configured}.${extension}`;
     const title = String(this.spec.title || "xy-chart")
@@ -1968,7 +2046,7 @@ Object.assign(ChartView.prototype, {
     return `${title}.${extension}`;
   },
 
-  _downloadExport(blob, filename) {
+  _downloadExport(blob: Blob, filename: string) {
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
@@ -2039,7 +2117,7 @@ Object.assign(ChartView.prototype, {
       '[data-xy-slot="modebar"],[data-xy-slot="tooltip"],' +
       '[data-xy-slot="selection"],[data-xy-selection-lasso-overlay],' +
       '[data-xy-slot="crosshair_x"],[data-xy-slot="crosshair_y"]'
-    ).forEach((node) => node.remove());
+    ).forEach((node: Element) => node.remove());
     const stylesheet = document.createElement("style");
     stylesheet.textContent = XY_CHROME_CSS;
     clone.prepend(stylesheet);
@@ -2061,12 +2139,12 @@ Object.assign(ChartView.prototype, {
     return this._exportRaster("png");
   },
 
-  _exportRaster(format) {
+  _exportRaster(format: string) {
     const svg = this._exportSvgMarkup();
     const sourceUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
     const image = new Image();
     const config = this._exportConfig();
-    const mime = { png: "image/png", jpeg: "image/jpeg", webp: "image/webp" }[format];
+    const mime = ({ png: "image/png", jpeg: "image/jpeg", webp: "image/webp" } as Record<string, string>)[format];
     if (!mime) return Promise.reject(new Error(`unsupported raster export ${format}`));
     return new Promise<void>((resolve, reject) => {
       image.onload = () => {
@@ -2121,7 +2199,7 @@ Object.assign(ChartView.prototype, {
   _exportCsvText() {
     const columns = ["trace", "name", "kind", "index", "x", "y", "x0", "x1", "y0", "y1", "value"];
     const rows = [columns];
-    const clean = (value) => Number.isFinite(value) ? value : "";
+    const clean = (value: number) => Number.isFinite(value) ? value : "";
     for (const g of this.gpuTraces || []) {
       const trace = g.trace || {};
       const prefix = [trace.id ?? "", trace.name ?? "", trace.kind ?? ""];
@@ -2159,7 +2237,7 @@ Object.assign(ChartView.prototype, {
           "", "", "", "", ""]);
       }
     }
-    const quote = (value) => {
+    const quote = (value: unknown) => {
       const text = String(value ?? "");
       const escaped = text.split('"').join('""');
       return text.includes(",") || text.includes('"') || text.includes("\r") || text.includes("\n")
@@ -2176,9 +2254,9 @@ Object.assign(ChartView.prototype, {
     );
   },
 
-  _icon(name) {
+  _icon(name: string) {
     // Inline stroke SVGs (currentColor) — no external assets (§33 no supply chain).
-    const svg = (body) =>
+    const svg = (body: string) =>
       `<svg width="15" height="15" viewBox="0 0 20 20" fill="none" ` +
       `stroke="currentColor" stroke-width="1.6" stroke-linecap="round" ` +
       `stroke-linejoin="round">${body}</svg>`;
@@ -2252,4 +2330,4 @@ Object.assign(ChartView.prototype, {
         return svg("");
     }
   },
-});
+} as ThisType<ChartView> & Record<string, unknown>);

--- a/js/src/54_kernel.ts
+++ b/js/src/54_kernel.ts
@@ -1,4 +1,5 @@
 import { bytesToSpan } from "./00_header";
+import type { GpuTrace, TraceSpec } from "./05_types";
 import { lodApplyDensityUpdate, lodApplyDrill, lodDropDrill, lodRememberDensity } from "./45_lod";
 import { xyCreateRebinWorker } from "./46_worker";
 import { ChartView } from "./50_chartview";
@@ -8,8 +9,74 @@ import { ChartView } from "./50_chartview";
 // (§16). Split out of 50_chartview.js; augments the prototype so `this.*`
 // is unchanged.
 
+/** An inbound kernel message. `type` dispatches; the rest is wire data the
+ * kernel may widen at any time (§29), so it stays open — each branch below
+ * reads only the members its own message kind carries. */
+interface KernelMessage {
+  type: string;
+  [key: string]: any;
+}
+
+/** One per-trace entry of a `tier_update` / `density_update` / `selection`
+ * reply. Members are per-message-kind, so this stays as open as the wire. */
+interface TraceUpdate {
+  id: number;
+  [key: string]: any;
+}
+
+/** The comm's binary side-channel: one blob per `*.buf` index. The concrete
+ * view type depends on the transport (widget comm vs websocket), and every
+ * consumer re-wraps it (`_asF32`/`_asU32`/`bytesToSpan`). */
+type WireBuffers = any[];
+
+/** A resolved view as `_copyView` emits it: per-axis ranges (§9.2) plus the
+ * x/y shorthands every single-axis path reads. */
+interface ViewState {
+  ranges: Record<string, number[]>;
+  x0: number;
+  x1: number;
+  y0: number;
+  y1: number;
+}
+
+/** A data-space rectangle: a drilled window, or a view being tested against
+ * one. */
+interface DataWindow {
+  x0: number;
+  x1: number;
+  y0: number;
+  y1: number;
+}
+
+/** A density grid plus its uploaded texture — the 45_lod density cache shape.
+ * Every member is a rebuildable cache (§27), so per-producer extras stay. */
+interface DensityGrid {
+  w: number;
+  h: number;
+  max: number;
+  normMax?: number;
+  grid: Float32Array;
+  tex: WebGLTexture;
+  [key: string]: any;
+}
+
+/** A "grid" reply from the bundled re-bin worker (46_worker). */
+interface RebinResult {
+  type: string;
+  seq: number;
+  trace: string | number;
+  w: number;
+  h: number;
+  max: number;
+  x0: number;
+  x1: number;
+  y0: number;
+  y1: number;
+  grid: ArrayBuffer;
+}
+
 Object.assign(ChartView.prototype, {
-  _scheduleViewRequest(viewOverride = this.view, opts: any = {}) {
+  _scheduleViewRequest(this: ChartView, viewOverride: ViewState = this.view, opts: any = {}) {
     if (this._destroyed || this._glLost) return;
     if (!this.comm) {
       // Kernel-less (standalone HTML): density traces refine via the bundled
@@ -17,8 +84,8 @@ Object.assign(ChartView.prototype, {
       this._scheduleSampleRebin(viewOverride, opts);
       return;
     }
-    const needsDecimated = this.spec.traces.some((t) => t.tier === "decimated");
-    const needsDensity = this.gpuTraces.some((g) => g.tier === "density");
+    const needsDecimated = this.spec.traces.some((t: TraceSpec) => t.tier === "decimated");
+    const needsDensity = this.gpuTraces.some((g: GpuTrace) => g.tier === "density");
     if (!needsDecimated && !needsDensity) return;
     const seq = opts.seq ?? ++this.seq;
     const view = this._copyView(viewOverride);
@@ -80,10 +147,10 @@ Object.assign(ChartView.prototype, {
   // Standalone (kernel-less) density refinement. Debounced like the kernel
   // request path, then the retained §28 sample re-bins in the bundled worker —
   // off the main thread — and applies like a density_update.
-  _scheduleSampleRebin(viewOverride = this.view, opts: any = {}) {
+  _scheduleSampleRebin(this: ChartView, viewOverride: ViewState = this.view, opts: any = {}) {
     if (this._destroyed || this._glLost || this._sampleRebinDisabled) return;
     const targets = (this.gpuTraces || []).filter(
-      (g) => g.tier === "density" && g.sampleOverlay && g.sampleOverlay._cpu
+      (g: GpuTrace) => g.tier === "density" && g.sampleOverlay && g.sampleOverlay._cpu
     );
     if (!targets.length) return;
     const seq = opts.seq ?? ++this.seq;
@@ -95,7 +162,7 @@ Object.assign(ChartView.prototype, {
     }, opts.delay ?? 120);
   },
 
-  _requestSampleRebin(g, view, seq) {
+  _requestSampleRebin(g: GpuTrace, view: ViewState, seq: number) {
     if (!g._homeDensity) g._homeDensity = g.density;
     // The full overview grid — binned kernel-side from every source point at
     // export — has enough resolution for any view that is not zoomed in
@@ -135,7 +202,7 @@ Object.assign(ChartView.prototype, {
         this._sampleRebinDisabled = true; // no worker: stretched overview stays
         return;
       }
-      this._rebinWorker.onmessage = (e) => this._onRebinResult(e.data);
+      this._rebinWorker.onmessage = (e: MessageEvent) => this._onRebinResult(e.data);
       this._rebinInit = new Set();
     }
     if (!this._rebinInit.has(g.trace.id)) {
@@ -163,9 +230,9 @@ Object.assign(ChartView.prototype, {
     });
   },
 
-  _onRebinResult(msg) {
+  _onRebinResult(msg: RebinResult) {
     if (this._destroyed || this._glLost || !msg || msg.type !== "grid" || msg.seq !== this.seq) return;
-    const g = this.gpuTraces.find((t) => t.trace.id === msg.trace && t.tier === "density");
+    const g = this.gpuTraces.find((t: GpuTrace) => t.trace.id === msg.trace && t.tier === "density");
     if (!g) return;
     const grid = new Float32Array(msg.grid);
     this._applySampleRebinGrid(g, {
@@ -181,7 +248,7 @@ Object.assign(ChartView.prototype, {
   // Swap the density grid/texture only — unlike lodApplyDensityUpdate this
   // leaves the retained sample overlay alone (it is the re-bin source and the
   // deep-zoom point overlay). Texture lifetime stays with the LOD cache.
-  _applySampleRebinGrid(g, density, rebinned) {
+  _applySampleRebinGrid(g: GpuTrace, density: DensityGrid, rebinned: boolean) {
     g.prevDensity = g.density;
     g._densityFadeStart = this._now();
     g.densityNormMax = density.normMax || density.max;
@@ -198,7 +265,7 @@ Object.assign(ChartView.prototype, {
   // changed. Only those GPU traces rebuild; everything else keeps its state.
   // Tiered traces then refine to the *current* window through the normal
   // stale-while-revalidate request path (§17).
-  _applyAppend(msg, buffers) {
+  _applyAppend(msg: KernelMessage, buffers: WireBuffers) {
     const spec = msg.spec;
     const blobRaw = buffers && buffers[0];
     if (!spec || !blobRaw || !spec.traces) return;
@@ -209,7 +276,7 @@ Object.assign(ChartView.prototype, {
     // - zoomed with the right edge pinned to the old live edge: slide the
     //   window forward at constant width (tail-follow).
     // - zoomed anywhere else: the user is inspecting history; don't move them.
-    const spanEps = (lo, hi) => Math.max(Math.abs(hi - lo), 1e-300) * 1e-9;
+    const spanEps = (lo: number, hi: number) => Math.max(Math.abs(hi - lo), 1e-300) * 1e-9;
     const ex = spanEps(this.view0.x0, this.view0.x1);
     const ey = spanEps(this.view0.y0, this.view0.y1);
     const atHome =
@@ -227,7 +294,7 @@ Object.assign(ChartView.prototype, {
       const w = this.view.x1 - this.view.x0;
       nextView = { ...this.view, x1: nextHome.x1, x0: nextHome.x1 - w };
     }
-    const animated = !!spec.animation || spec.traces.some((trace) => !!trace.animation);
+    const animated = !!spec.animation || spec.traces.some((trace: TraceSpec) => !!trace.animation);
     if (animated && !this._glLost && this.gl && this.updatePayload(spec, blob)) {
       // updatePayload owns previous/next GPU lifetime and matching. Preserve
       // append's follow policy instead of always animating to the new home
@@ -258,8 +325,8 @@ Object.assign(ChartView.prototype, {
     if (this._glLost || !this.gl) return;
     const texSeen = new Set();
     for (const id of msg.affected || []) {
-      const i = this.gpuTraces.findIndex((g) => g.trace.id === id);
-      const ts = spec.traces.find((t) => t.id === id);
+      const i = this.gpuTraces.findIndex((g: GpuTrace) => g.trace.id === id);
+      const ts = spec.traces.find((t: TraceSpec) => t.id === id);
       if (i < 0 || !ts) continue;
       this._destroyTraceResources(this.gpuTraces[i], texSeen);
       this.gpuTraces[i] = this._buildTrace(blob, ts);
@@ -269,14 +336,14 @@ Object.assign(ChartView.prototype, {
     this.draw();
   },
 
-  _onKernelMsg(msg, buffers) {
+  _onKernelMsg(msg: KernelMessage, buffers: WireBuffers) {
     if (this._destroyed) return;
     if (!msg) return;
     if (this._glLost && msg.type !== "append" && msg.type !== "pick_result") return;
     if (msg.type === "tier_update") {
       if (msg.seq !== this.seq) return;
       for (const upd of msg.traces) {
-        const g = this.gpuTraces.find((t) => t.trace.id === upd.id);
+        const g = this.gpuTraces.find((t: GpuTrace) => t.trace.id === upd.id);
         if (!g) continue;
         const gl = this.gl;
         const xArr = this._asF32(buffers[upd.x.buf]);
@@ -310,12 +377,12 @@ Object.assign(ChartView.prototype, {
     } else if (msg.type === "density_update") {
       if (msg.seq !== undefined && msg.seq !== this.seq) return;
       const densityTraces = msg.traces || [];
-      const pendingTraceIds = new Set(densityTraces.map((upd) => Number(upd.id)));
+      const pendingTraceIds = new Set(densityTraces.map((upd: TraceUpdate) => Number(upd.id)));
       if (pendingTraceIds.size === 0 && msg.trace !== undefined) {
         pendingTraceIds.add(Number(msg.trace));
       }
       const clearAllPending = pendingTraceIds.size === 0 && msg.stale;
-      const clearPending = (g) => {
+      const clearPending = (g: GpuTrace) => {
         if (msg.seq !== undefined && g._lodPendingSeq !== msg.seq) return;
         g._lodPendingView = null;
         g._lodPendingSeq = null;
@@ -329,7 +396,7 @@ Object.assign(ChartView.prototype, {
         }
       }
       for (const upd of densityTraces) {
-        const g = this.gpuTraces.find((t) => t.trace.id === upd.id && t.tier === "density");
+        const g = this.gpuTraces.find((t: GpuTrace) => t.trace.id === upd.id && t.tier === "density");
         if (!g) continue;
         clearPending(g);
         if (upd.mode === "points") { this._applyDrill(g, upd, buffers); continue; }
@@ -421,7 +488,7 @@ Object.assign(ChartView.prototype, {
 
   // Shared mask application for kernel "selection" replies and pushed
   // "selection_rows" messages — both carry the same per-trace index buffers.
-  _applySelectionBuffers(msg, buffers) {
+  _applySelectionBuffers(msg: KernelMessage, buffers: WireBuffers) {
     if (!msg.traces || !msg.traces.length) {
       for (const g of this.gpuTraces) {
         g.selActive = false;
@@ -430,7 +497,7 @@ Object.assign(ChartView.prototype, {
       return;
     }
     for (const upd of msg.traces) {
-      const g = this.gpuTraces.find((t) => t.trace.id === upd.id);
+      const g = this.gpuTraces.find((t: GpuTrace) => t.trace.id === upd.id);
       if (!g) continue;
       // Aggregate density has no per-point marks, but a drilled view does —
       // the kernel's indices are in the drilled subset's space (§17).
@@ -453,18 +520,18 @@ Object.assign(ChartView.prototype, {
   // Drill lifecycle, exit fades, and the density-source cache live in
   // 45_lod.js (chart-agnostic). These delegates keep the ChartView API
   // stable for tests and callers.
-  _applyDrill(g, upd, buffers) {
+  _applyDrill(g: GpuTrace, upd: any, buffers: WireBuffers) {
     lodApplyDrill(this, g, upd, buffers);
   },
 
-  _dropDrill(g) {
+  _dropDrill(g: GpuTrace) {
     lodDropDrill(this, g);
   },
 
   // Is the current view fully covered by a drilled window? A tiny epsilon
   // absorbs f32 round-trip slop so we don't flip to the overview at the exact
   // window edge right after drilling in.
-  _viewInside(win) {
+  _viewInside(win: DataWindow) {
     if (!win) return false;
     const { x0, x1, y0, y1 } = this.view;
     const ex = Math.abs(x1 - x0) * 1e-4, ey = Math.abs(y1 - y0) * 1e-4;
@@ -479,7 +546,7 @@ Object.assign(ChartView.prototype, {
   // it)? Used to keep the retained density sample on screen through pans and
   // zoom-outs — the points are positioned in data space and the GPU clips the
   // off-screen ones, so overlap is the right test, not containment.
-  _viewOverlaps(win) {
+  _viewOverlaps(win: DataWindow) {
     if (!win) return false;
     const { x0, x1, y0, y1 } = this.view;
     const vx0 = Math.min(x0, x1), vx1 = Math.max(x0, x1);
@@ -489,8 +556,8 @@ Object.assign(ChartView.prototype, {
     return vx0 <= wx1 && vx1 >= wx0 && vy0 <= wy1 && vy1 >= wy0;
   },
 
-  _viewInsideRange(xRange, yRange) {
+  _viewInsideRange(xRange: number[], yRange: number[]) {
     if (!xRange || !yRange) return false;
     return this._viewInside({ x0: xRange[0], x1: xRange[1], y0: yRange[0], y1: yRange[1] });
   },
-});
+} as ThisType<ChartView> & Record<string, unknown>);

--- a/js/src/55_marks.ts
+++ b/js/src/55_marks.ts
@@ -1,3 +1,5 @@
+import type { GpuTrace, MarkKind, PayloadBuffers, Rgba, TraceSpec } from "./05_types";
+import type { ChartView } from "./50_chartview";
 import { parseColor } from "./20_theme";
 
 // ---------------------------------------------------------------------------
@@ -33,7 +35,22 @@ import { parseColor } from "./20_theme";
 //   refreshColor — re-resolve CSS-expressed constant colors on theme change
 //                  (§36 live re-resolution); each kind knows where its
 //                  constant color lives in the spec.
-const RECT_MARK = {
+
+// The registry's own narrowing of `MarkKind`: `view` is always the ChartView
+// doing the dispatch. Every renderer below reads its window off the gpu
+// record's axes, so the (x0,x1,y0,y1) draw args stay optional here — the
+// dispatch site passes them for marks that do read them.
+type MarkBuild = (view: ChartView, g: GpuTrace, t: TraceSpec, buffer: PayloadBuffers) => void;
+type MarkDraw = (view: ChartView, g: GpuTrace, x0?: number, x1?: number, y0?: number, y1?: number) => void;
+type MarkRefreshColor = (view: ChartView, g: GpuTrace) => void;
+
+interface Mark extends MarkKind {
+  build: MarkBuild;
+  draw: MarkDraw;
+  refreshColor?: MarkRefreshColor;
+}
+
+const RECT_MARK: Mark = {
   build: (view, g, t, buffer) => view._buildRectMark(g, t, buffer),
   draw: (view, g) => {
     const [x0, x1] = view._axisRange(g.xAxis);
@@ -51,13 +68,13 @@ const RECT_MARK = {
     );
   },
   refreshColor: (view, g) => {
-    if (!g.colorMode) g.color = parseColor(view.root, g.trace.style.color, g.color);
+    if (!g.colorMode) g.color = parseColor(view.root, g.trace.style.color, g.color as Rgba);
     // stroke + gradient stops are CSS-expressed too — re-resolve with the theme.
     view._rectMarkStyleGpu(g, g.trace);
   },
 };
 
-const BAR_MARK = {
+const BAR_MARK: Mark = {
   build: (view, g, t, buffer) => view._buildBarMark(g, t, buffer),
   draw: (view, g) => {
     if (!g.trace.bar) {
@@ -88,13 +105,13 @@ const BAR_MARK = {
     view._drawBars(g, pmap, v1map, v0map, v0Const, v0EdgePad);
   },
   refreshColor: (view, g) => {
-    if (!g.colorMode) g.color = parseColor(view.root, g.trace.style.color, g.color);
+    if (!g.colorMode) g.color = parseColor(view.root, g.trace.style.color, g.color as Rgba);
     // stroke + gradient stops are CSS-expressed too — re-resolve with the theme.
     view._rectMarkStyleGpu(g, g.trace);
   },
 };
 
-const SEGMENT_MARK = {
+const SEGMENT_MARK: Mark = {
   build: (view, g, t, buffer) => view._buildSegmentMark(g, t, buffer),
   draw: (view, g) => {
     const [x0, x1] = view._axisRange(g.xAxis);
@@ -106,11 +123,11 @@ const SEGMENT_MARK = {
     );
   },
   refreshColor: (view, g) => {
-    if (!g.colorMode) g.color = parseColor(view.root, g.trace.style.color, g.color);
+    if (!g.colorMode) g.color = parseColor(view.root, g.trace.style.color, g.color as Rgba);
   },
 };
 
-const AREA_MARK = {
+const AREA_MARK: Mark = {
   build: (view, g, t, buffer) => view._buildAreaMark(g, t, buffer),
   draw: (view, g) => {
     const [x0, x1] = view._axisRange(g.xAxis);
@@ -135,13 +152,13 @@ const AREA_MARK = {
     }
   },
   refreshColor: (view, g) => {
-    g.color = parseColor(view.root, g.trace.style.color, g.color);
+    g.color = parseColor(view.root, g.trace.style.color, g.color as Rgba);
     g.lineColor = parseColor(view.root, g.trace.style.line_color || g.trace.style.color, g.lineColor || g.color);
     g.grad = view._resolveMarkFill(g.trace.style, g.color);
   },
 };
 
-const MESH_MARK = {
+const MESH_MARK: Mark = {
   build: (view, g, t, buffer) => view._buildMeshMark(g, t, buffer),
   draw: (view, g) => {
     const [x0, x1] = view._axisRange(g.xAxis);
@@ -149,7 +166,7 @@ const MESH_MARK = {
     view._drawMesh(g, view._map(g.x0Meta, x0, x1, g.xAxis), view._map(g.y0Meta, y0, y1, g.yAxis));
   },
   refreshColor: (view, g) => {
-    if (g.colorMode === 0 && g.trace.color) g.color = parseColor(view.root, g.trace.color.color, g.color);
+    if (g.colorMode === 0 && g.trace.color) g.color = parseColor(view.root, g.trace.color.color, g.color as Rgba);
     const style = g.trace.style || {};
     g.meshStroke = parseColor(view.root, style.stroke || "transparent", [0, 0, 0, 0]);
   },
@@ -175,7 +192,7 @@ export const MARK_KINDS = {
       view._drawMesh(g, view._map(g.x0Meta, x0, x1, g.xAxis), view._map(g.y0Meta, y0, y1, g.yAxis));
     },
     refreshColor: (view, g) => {
-      if (g.colorMode === 0 && g.trace.color) g.color = parseColor(view.root, g.trace.color.color, g.color);
+      if (g.colorMode === 0 && g.trace.color) g.color = parseColor(view.root, g.trace.color.color, g.color as Rgba);
       const style = g.trace.style || {};
       g.meshStroke = parseColor(view.root, style.stroke || "transparent", [0, 0, 0, 0]);
     },
@@ -197,7 +214,7 @@ export const MARK_KINDS = {
     retainCpu: true,
     refreshColor: (view, g) => {
       if (g.colorMode === 0 && g.trace.color) {
-        g.color = parseColor(view.root, g.trace.color.color, g.color);
+        g.color = parseColor(view.root, g.trace.color.color, g.color as Rgba);
       }
       view._pointMarkStyle(g, g.trace);
     },
@@ -210,13 +227,13 @@ export const MARK_KINDS = {
       view._drawLine(g, view._map(g.xMeta, x0, x1, g.xAxis), view._map(g.yMeta, y0, y1, g.yAxis));
     },
     refreshColor: (view, g) => {
-      g.color = parseColor(view.root, g.trace.style.color, g.color);
+      g.color = parseColor(view.root, g.trace.style.color, g.color as Rgba);
     },
   },
   area: AREA_MARK,
-};
+} satisfies Record<string, Mark>;
 
 // Registry lookup with the scatter fallback every dispatch site shares.
-export function markOf(kind) {
-  return MARK_KINDS[kind] || MARK_KINDS.scatter;
+export function markOf(kind: string): Mark {
+  return (MARK_KINDS as Record<string, Mark>)[kind] || MARK_KINDS.scatter;
 }

--- a/js/src/56_animation.ts
+++ b/js/src/56_animation.ts
@@ -1,11 +1,12 @@
 import { PROTOCOL } from "./00_header";
 import { ChartView } from "./50_chartview";
+import type { ChartSpec, ColumnMeta, GpuTrace, PayloadBuffers, TraceSpec } from "./05_types";
 
 // Declarative data animation: one browser clock, bounded previous/next GPU
 // state, no Python round-trips per frame. Full scene refreshes call
 // updatePayload(); rapid updates cancel/coalesce latest-wins.
 
-const XY_EASINGS = {
+const XY_EASINGS: Record<string, number[]> = {
   linear: [0, 0, 1, 1],
   ease: [0.25, 0.1, 0.25, 1],
   "ease-in": [0.42, 0, 1, 1],
@@ -13,14 +14,71 @@ const XY_EASINGS = {
   "ease-in-out": [0.42, 0, 0.58, 1],
 };
 
-function xyCubicBezierProgress(value, points) {
+/** `easing: {type: "spring", ...}` — a duration-independent spring policy. */
+interface SpringEasing {
+  type?: string;
+  stiffness?: number;
+  damping?: number;
+  mass?: number;
+}
+
+/** `easing`: a named curve, four explicit bezier control points, or a spring. */
+type Easing = string | number[] | SpringEasing;
+
+/** The figure-level `animation` block merged with a trace's own override, as
+ * `_resolvedAnimation` returns it. Open like the rest of the wire: the kernel
+ * may ship keys this client ignores. */
+interface AnimationConfig {
+  _present?: boolean;
+  enabled?: boolean;
+  enter?: string;
+  update?: string;
+  easing?: Easing;
+  delay?: number;
+  duration?: number;
+  match?: string;
+  interpolate?: string[];
+  [key: string]: any;
+}
+
+/** One trace's in-flight transition, resolved once at the start of a run. */
+interface AnimationRecord {
+  g: GpuTrace;
+  config: AnimationConfig;
+  phase: string;
+  delay: number;
+  duration: number;
+}
+
+/** Old→new index pairing for one trace (`g._transitionMatch`). `fallback`
+ * records the §28 reason whenever the requested strategy was not honored. */
+interface TransitionMatch {
+  strategy: string;
+  pairs: [number, number][];
+  fallback: string | null;
+}
+
+/** The CPU-side bar cache (`g._cpuBar`) bar interpolation reads back. */
+interface BarCpu {
+  pos: Float32Array;
+  value1: Float32Array;
+  value0: Float32Array | null;
+  value0Const?: number;
+  posMeta: ColumnMeta;
+  value1Meta: ColumnMeta;
+  value0Meta: ColumnMeta | null;
+  width: number;
+  [key: string]: any;
+}
+
+function xyCubicBezierProgress(value: number, points: number[]) {
   const x1 = Number(points[0]), y1 = Number(points[1]);
   const x2 = Number(points[2]), y2 = Number(points[3]);
-  const sample = (t, a, b) => {
+  const sample = (t: number, a: number, b: number) => {
     const u = 1 - t;
     return 3 * u * u * t * a + 3 * u * t * t * b + t * t * t;
   };
-  const slope = (t, a, b) => {
+  const slope = (t: number, a: number, b: number) => {
     const u = 1 - t;
     return 3 * u * u * a + 6 * u * t * (b - a) + 3 * t * t * (1 - b);
   };
@@ -38,7 +96,7 @@ function xyCubicBezierProgress(value, points) {
   return sample(t, y1, y2);
 }
 
-function xySpringProgress(value, policy) {
+function xySpringProgress(value: number, policy: SpringEasing) {
   const stiffness = Math.max(1e-6, Number(policy.stiffness) || 170);
   const damping = Math.max(1e-6, Number(policy.damping) || 26);
   const mass = Math.max(1e-6, Number(policy.mass) || 1);
@@ -48,7 +106,7 @@ function xySpringProgress(value, policy) {
   // sampled response by its value at the endpoint so progress reaches 1
   // continuously instead of snapping from a nearly-settled value on the last
   // frame.
-  const response = (progress) => {
+  const response = (progress: number) => {
     const time = progress * 6 / w0;
     if (zeta < 1) {
       const wd = w0 * Math.sqrt(1 - zeta * zeta);
@@ -62,16 +120,16 @@ function xySpringProgress(value, policy) {
   return Math.max(0, Math.min(1.15, result));
 }
 
-function xyAnimationEase(value, easing) {
+function xyAnimationEase(value: number, easing: Easing) {
   if (easing && typeof easing === "object" && !Array.isArray(easing) && easing.type === "spring") {
     return xySpringProgress(value, easing);
   }
-  const points = Array.isArray(easing) ? easing : XY_EASINGS[easing] || XY_EASINGS["ease-out"];
+  const points = Array.isArray(easing) ? easing : XY_EASINGS[easing as string] || XY_EASINGS["ease-out"];
   return xyCubicBezierProgress(value, points);
 }
 
 Object.assign(ChartView.prototype, {
-  _resolvedAnimation(trace) {
+  _resolvedAnimation(trace: TraceSpec): AnimationConfig {
     return {
       ...(this.spec.animation || {}),
       ...((trace && trace.animation) || {}),
@@ -79,21 +137,21 @@ Object.assign(ChartView.prototype, {
     };
   },
 
-  _animationEnabled(config) {
+  _animationEnabled(config: AnimationConfig) {
     if (!config._present) return false;
     if (config.enabled === false) return false;
     if (config.enabled === true) return true; // explicit opt-in overrides reduced motion
     return !this._prefersReducedMotion();
   },
 
-  _defaultEntrance(kind) {
+  _defaultEntrance(kind: string) {
     if (kind === "line" || kind === "area" || kind === "error_band") return "reveal";
     if (kind === "bar" || kind === "column") return "grow";
     if (kind === "scatter" || kind === "errorbar") return "scale";
     return "none";
   },
 
-  _setTransitionVisual(g, phase, progress, config) {
+  _setTransitionVisual(g: GpuTrace, phase: string, progress: number, config: AnimationConfig) {
     const p = Math.max(0, Math.min(1, progress));
     g._transitionOpacity = 1;
     g._transitionScale = 1;
@@ -126,7 +184,7 @@ Object.assign(ChartView.prototype, {
     if (enter === "grow") g._transitionGrow = p;
   },
 
-  _clearTransitionVisual(g) {
+  _clearTransitionVisual(g: GpuTrace) {
     delete g._transitionOpacity;
     delete g._transitionScale;
     delete g._transitionReveal;
@@ -146,17 +204,17 @@ Object.assign(ChartView.prototype, {
     ]);
   },
 
-  _emitAnimationLifecycle(stage, phase, extra = {}) {
+  _emitAnimationLifecycle(stage: string, phase: string, extra: Record<string, any> = {}) {
     const detail = { stage, phase, ...extra, view: this._eventView(`animation_${stage}`) };
     this._dispatchChartEvent(`animation_${stage}`, detail);
     this.comm?.send?.({ type: `animation_${stage}`, phase, ...extra });
   },
 
-  _runDataAnimation(phase, current, exiting = []) {
+  _runDataAnimation(phase: string, current: GpuTrace[], exiting: GpuTrace[] = []) {
     if (this._dataAnimRaf) cancelAnimationFrame(this._dataAnimRaf);
     const epoch = (this._dataAnimEpoch || 0) + 1;
     this._dataAnimEpoch = epoch;
-    const records = [];
+    const records: AnimationRecord[] = [];
     for (const g of current) {
       const config = this._resolvedAnimation(g.trace);
       const recordPhase = g._transitionPhase || phase;
@@ -221,7 +279,7 @@ Object.assign(ChartView.prototype, {
     return true;
   },
 
-  _finishDataAnimation(phase) {
+  _finishDataAnimation(phase: string) {
     this._dataAnim = null;
     if (this._transitionView) {
       this.view = { ...this._transitionView.to };
@@ -258,9 +316,9 @@ Object.assign(ChartView.prototype, {
     this._transitionOldTraces = null;
   },
 
-  _transitionMatches(previous, next, config) {
+  _transitionMatches(previous: GpuTrace, next: GpuTrace, config: AnimationConfig): TransitionMatch {
     let strategy = config.match || "index";
-    const pairs = [];
+    const pairs: [number, number][] = [];
     let fallback = next.trace.animation_fallback || null;
     if ((previous.n || 0) > 200000 || (next.n || 0) > 200000) {
       return {
@@ -310,7 +368,7 @@ Object.assign(ChartView.prototype, {
     };
   },
 
-  _recordAnimationFallback(trace, fallback) {
+  _recordAnimationFallback(trace: TraceSpec, fallback: string | null) {
     if (!trace || !fallback) return;
     trace.animation_fallback = fallback;
     if (this.root && this.root.dataset) {
@@ -318,7 +376,7 @@ Object.assign(ChartView.prototype, {
     }
   },
 
-  _preparePositionInterpolation(previous, next, config) {
+  _preparePositionInterpolation(previous: GpuTrace, next: GpuTrace, config: AnimationConfig) {
     const match = next._transitionMatch;
     const policies = config.interpolate || [];
     if (config.update !== "interpolate" || !policies.includes("position") || !match) return false;
@@ -333,8 +391,8 @@ Object.assign(ChartView.prototype, {
     }
     const startX = new Float32Array(next._cpu.x);
     const startY = new Float32Array(next._cpu.y);
-    const encode = (value, meta) => (value - (Number(meta.offset) || 0)) * (Number(meta.scale) || 1);
-    const displayedValue = (axis, index) => {
+    const encode = (value: number, meta: ColumnMeta) => (value - (Number(meta.offset) || 0)) * (Number(meta.scale) || 1);
+    const displayedValue = (axis: string, index: number) => {
       const cpu = previous._cpu[axis];
       const starts = previous[axis === "x" ? "_transitionPrevXValues" : "_transitionPrevYValues"];
       const progress = previous._transitionPositionProgress;
@@ -363,9 +421,9 @@ Object.assign(ChartView.prototype, {
     return true;
   },
 
-  _prepareBarPositionInterpolation(previous, next, match) {
-    const oldBar = previous._cpuBar;
-    const newBar = next._cpuBar;
+  _prepareBarPositionInterpolation(previous: GpuTrace, next: GpuTrace, match: TransitionMatch) {
+    const oldBar: BarCpu = previous._cpuBar;
+    const newBar: BarCpu = next._cpuBar;
     if (!oldBar || !newBar || previous.orientation !== next.orientation ||
         next.n !== newBar.pos.length || previous.n !== oldBar.pos.length) {
       match.fallback ||= "snap:layout-mismatch";
@@ -374,17 +432,17 @@ Object.assign(ChartView.prototype, {
     const startPos = new Float32Array(newBar.pos);
     const startValue1 = new Float32Array(newBar.value1);
     const startValue0 = new Float32Array(next.n);
-    const encode = (value, meta) => (value - (Number(meta.offset) || 0)) * (Number(meta.scale) || 1);
-    const decode = (value, meta) => value / (Number(meta.scale) || 1) + (Number(meta.offset) || 0);
-    const value0At = (bar, index) => bar.value0
+    const encode = (value: number, meta: ColumnMeta) => (value - (Number(meta.offset) || 0)) * (Number(meta.scale) || 1);
+    const decode = (value: number, meta: ColumnMeta) => value / (Number(meta.scale) || 1) + (Number(meta.offset) || 0);
+    const value0At = (bar: BarCpu, index: number) => bar.value0
       ? decode(bar.value0[index], bar.value0Meta)
       : Number(bar.value0Const) || 0;
-    const displayed = (values, current, meta, index) => {
+    const displayed = (values: Float32Array, current: Float32Array, meta: ColumnMeta, index: number) => {
       const progress = previous._transitionPositionProgress;
       if (!values || !Number.isFinite(progress)) return decode(current[index], meta);
       return decode(values[index] + (current[index] - values[index]) * progress, meta);
     };
-    const displayedValue0 = (index) => {
+    const displayedValue0 = (index: number) => {
       const starts = previous._transitionPrevValue0Values;
       const progress = previous._transitionPositionProgress;
       const current = value0At(oldBar, index);
@@ -432,7 +490,7 @@ Object.assign(ChartView.prototype, {
     return true;
   },
 
-  updatePayload(spec, buffer) {
+  updatePayload(spec: ChartSpec, buffer: PayloadBuffers) {
     if (this._destroyed || !spec || spec.protocol !== PROTOCOL) return false;
     if (this._dataAnimRaf) cancelAnimationFrame(this._dataAnimRaf);
     this._dataAnimRaf = null;
@@ -472,7 +530,7 @@ Object.assign(ChartView.prototype, {
     }
     this.gpuTraces = spec.traces.map((trace) => this._buildTrace(buffer, trace));
     for (const next of this.gpuTraces) {
-      const old = previous.find((candidate) => candidate.trace.id === next.trace.id && candidate.trace.kind === next.trace.kind);
+      const old = previous.find((candidate: GpuTrace) => candidate.trace.id === next.trace.id && candidate.trace.kind === next.trace.kind);
       if (old) {
         const config = this._resolvedAnimation(next.trace);
         old._transitionExitTrace = next.trace;
@@ -487,7 +545,7 @@ Object.assign(ChartView.prototype, {
       }
     }
     this._transitionOldTraces = previous;
-    const animateDomain = this.gpuTraces.some((g) => {
+    const animateDomain = this.gpuTraces.some((g: GpuTrace) => {
       const config = this._resolvedAnimation(g.trace);
       return this._animationEnabled(config) && config.update === "interpolate" &&
         (config.interpolate || []).includes("domain");
@@ -501,4 +559,4 @@ Object.assign(ChartView.prototype, {
     }
     return true;
   },
-});
+} as ThisType<ChartView> & Record<string, unknown>);

--- a/js/src/57_viewstate.ts
+++ b/js/src/57_viewstate.ts
@@ -1,4 +1,5 @@
 import { ChartView } from "./50_chartview";
+import type { GpuTrace, Hit, Row } from "./05_types";
 
 // Unified view state (spec/design/view-state.md): the canonical durable-state
 // document, the single apply-a-state-patch implementation every writer calls,
@@ -8,6 +9,40 @@ import { ChartView } from "./50_chartview";
 // History capacity (view-state.md §4): snapshots are a handful of floats;
 // the bound is for predictability, not memory.
 const XY_HISTORY_CAPACITY = 64;
+
+/** The geometric selection mirror (§2/§5.1): a box, a lasso, or the opaque
+ * marker standing in for a kernel-resolved rows-selection. */
+interface StateSelection {
+  rows?: boolean;
+  range?: { x0: number; x1: number; y0: number; y1: number };
+  polygon?: number[][];
+}
+
+/** A §2 state document, or the merge patch that writes one. */
+interface StatePatch {
+  v?: number;
+  ranges?: Record<string, number[]>;
+  selection?: StateSelection | null;
+}
+
+/** A history snapshot: always a complete document, never a partial patch. */
+interface DurableState {
+  v: number;
+  ranges: Record<string, number[]>;
+  selection: StateSelection | null;
+}
+
+/** One in-flight axis-band drag (§6), scoped to the axis its band belongs to. */
+interface BandDrag {
+  pointerId: number;
+  sx: number;
+  sy: number;
+  view: any;
+  d0: number;
+  mode: string | null;
+  interactionId: number;
+  changedAxes: string[];
+}
 
 Object.assign(ChartView.prototype, {
   // -- durable state (§2) ----------------------------------------------------
@@ -24,7 +59,7 @@ Object.assign(ChartView.prototype, {
     // The whole public JS control surface (§5.3) — one object on the chart
     // root, identical in notebook, Reflex, and standalone HTML mounts.
     this.root.xy = {
-      applyState: (patch, opts: any = {}) => this._applyStatePatch(patch, {
+      applyState: (patch: StatePatch, opts: any = {}) => this._applyStatePatch(patch, {
         source: "api",
         animate: opts.animate === true,
         history: opts.history !== false,
@@ -35,7 +70,7 @@ Object.assign(ChartView.prototype, {
     };
   },
 
-  _durableState() {
+  _durableState(): DurableState {
     const ranges = Object.fromEntries(
       this._axisIds().map((axisId) => [axisId, [...this._axisRange(axisId)]])
     );
@@ -46,14 +81,14 @@ Object.assign(ChartView.prototype, {
         ? { rows: true }
         : sel.range
           ? { range: { ...sel.range } }
-          : { polygon: sel.polygon.map((point) => [...point]) };
+          : { polygon: sel.polygon.map((point: number[]) => [...point]) };
     return { v: 1, ranges, selection };
   },
 
   // Validate one §2 document/patch. Returns an error string or null. v:1 is
   // strict: unknown keys and unknown axis IDs are errors, not ignored —
   // forward compatibility comes from bumping v.
-  _validateStatePatch(patch) {
+  _validateStatePatch(patch: any) {
     if (!patch || typeof patch !== "object" || Array.isArray(patch)) {
       return "state patch must be an object";
     }
@@ -108,7 +143,7 @@ Object.assign(ChartView.prototype, {
   // The one implementation of "apply a state patch" (§3): merge-patch
   // semantics, every entry point in view-state.md is a caller. Returns
   // true when the patch was accepted (even if it was a no-op).
-  _applyStatePatch(patch, opts: any = {}) {
+  _applyStatePatch(patch: StatePatch, opts: any = {}) {
     if (this._destroyed) return false;
     const error = this._validateStatePatch(patch);
     if (error) {
@@ -190,7 +225,7 @@ Object.assign(ChartView.prototype, {
     return true;
   },
 
-  _historyApply(snapshot) {
+  _historyApply(snapshot: DurableState) {
     // A stored snapshot mentions everything, but a rows-selection snapshot
     // carries only the opaque marker — restore the geometry it can express
     // and leave the marker out (rows-selections are non-durable, §5.1).
@@ -204,7 +239,7 @@ Object.assign(ChartView.prototype, {
   },
 
   _updateHistoryButtons() {
-    const set = (btn, enabled) => {
+    const set = (btn: HTMLButtonElement, enabled: boolean) => {
       if (!btn) return;
       btn.disabled = !enabled;
       btn.setAttribute("aria-disabled", String(!enabled));
@@ -216,7 +251,7 @@ Object.assign(ChartView.prototype, {
 
   // -- kernel-initiated navigation (§8) -------------------------------------
 
-  _navReset(axes) {
+  _navReset(axes: string[] | null) {
     const override = Array.isArray(axes)
       ? axes.filter((axisId) => this._axisIds().includes(axisId))
       : null;
@@ -226,7 +261,7 @@ Object.assign(ChartView.prototype, {
   // Kernel-resolved rows-selection (§5.1/§8): the same mask buffers the
   // selection reply ships, applied as a NON-durable selection — never in
   // history, reported in state only as the opaque marker.
-  _applyRowsSelection(msg, buffers) {
+  _applyRowsSelection(msg: Record<string, any>, buffers: any) {
     this._clearLassoOverlay();
     // A rows document replaces the whole selection. The message carries
     // buffers only for the traces it names, so deactivate every existing
@@ -254,7 +289,7 @@ Object.assign(ChartView.prototype, {
 
   // -- axis-band gestures (§6) ----------------------------------------------
 
-  _axisBandNavigable(axisId) {
+  _axisBandNavigable(axisId: string) {
     if (!this._interactionFlag("navigation", true)) return false;
     const pan = this._interactionFlag("pan", true)
       && this._axisPolicy("pan_axes").includes(axisId);
@@ -266,7 +301,7 @@ Object.assign(ChartView.prototype, {
   // The band cursor advertises the axis's actual capability (§6): a resize
   // arrow only when the axis can zoom; a pan-only axis shows a grab hand
   // instead, so the cursor never promises a zoom the policy would ignore.
-  _axisBandCursor(axisId, dim) {
+  _axisBandCursor(axisId: string, dim: string) {
     const zoom = this._interactionFlag("zoom", true)
       && this._axisPolicy("zoom_axes").includes(axisId);
     if (zoom) return dim === "x" ? "ew-resize" : "ns-resize";
@@ -326,7 +361,7 @@ Object.assign(ChartView.prototype, {
   },
 
   // Data value at a client coordinate along one axis, clamped to the plot box.
-  _axisBandValue(axisId, clientX, clientY) {
+  _axisBandValue(axisId: string, clientX: number, clientY: number) {
     const rect = this.canvas.getBoundingClientRect();
     const dim = this._axisDim(axisId);
     if (dim === "x") {
@@ -337,10 +372,10 @@ Object.assign(ChartView.prototype, {
     return this._dataFromCanvas(0, cssY, "x", axisId)[1];
   },
 
-  _bindAxisBand(band, axisId, dim) {
-    let drag = null;
+  _bindAxisBand(band: HTMLElement, axisId: string, dim: string) {
+    let drag: BandDrag | null = null;
 
-    this._listen(band, "wheel", (e) => {
+    this._listen(band, "wheel", (e: WheelEvent) => {
       if (!this._interactionFlag("navigation", true)) return;
       if (!this._interactionFlag("zoom", true)) return;
       if (!this._interactionFlag("wheel_zoom", true)) return;
@@ -353,7 +388,7 @@ Object.assign(ChartView.prototype, {
       this._queueWheelZoom(factor, fx, fy, [axisId]);
     }, { passive: false });
 
-    this._listen(band, "pointerdown", (e) => {
+    this._listen(band, "pointerdown", (e: PointerEvent) => {
       if (e.pointerType === "mouse" && e.button !== 0) return;
       if (!this._interactionFlag("navigation", true)) return;
       this._cancelViewAnimation();
@@ -381,7 +416,7 @@ Object.assign(ChartView.prototype, {
       && this._interactionFlag("box_zoom", true)
       && this._axisPolicy("zoom_axes").includes(axisId);
 
-    this._listen(band, "pointermove", (e) => {
+    this._listen(band, "pointermove", (e: PointerEvent) => {
       if (!drag || e.pointerId !== drag.pointerId) return;
       const dx = e.clientX - drag.sx;
       const dy = e.clientY - drag.sy;
@@ -450,7 +485,7 @@ Object.assign(ChartView.prototype, {
       e.preventDefault();
     });
 
-    const end = (e) => {
+    const end = (e: PointerEvent) => {
       if (!drag || e.pointerId !== drag.pointerId) return;
       const finished = drag;
       drag = null;
@@ -496,10 +531,10 @@ Object.assign(ChartView.prototype, {
 
   // -- structured hover payload (§7) ----------------------------------------
 
-  _seriesColorCss(g) {
+  _seriesColorCss(g: GpuTrace) {
     const c = g && g.color;
     if (!Array.isArray(c) || c.length < 3) return null;
-    const channel = (v) => Math.max(0, Math.min(255, Math.round(Number(v) * 255)));
+    const channel = (v: number) => Math.max(0, Math.min(255, Math.round(Number(v) * 255)));
     return `rgb(${channel(c[0])}, ${channel(c[1])}, ${channel(c[2])})`;
   },
 
@@ -507,12 +542,12 @@ Object.assign(ChartView.prototype, {
   // by exact axis ID (one entry per declared axis — a chart-root pixel maps
   // to a different value on every axis, so a bare {x, y} would be ambiguous
   // with a y2 declared).
-  _hoverPayload(row, hit, clientX, clientY, exact = false) {
+  _hoverPayload(row: Row, hit: Hit, clientX: number, clientY: number, exact = false) {
     const rootRect = this.root.getBoundingClientRect();
     const canvasRect = this.canvas.getBoundingClientRect();
     const cssX = Math.max(0, Math.min(canvasRect.width, clientX - canvasRect.left));
     const cssY = Math.max(0, Math.min(canvasRect.height, clientY - canvasRect.top));
-    const data = {};
+    const data: Record<string, number> = {};
     for (const axisId of this._axisIds()) {
       const dim = this._axisDim(axisId);
       const [x, y] = this._dataFromCanvas(
@@ -549,7 +584,7 @@ Object.assign(ChartView.prototype, {
   // inside the built-in tooltip container, so it inherits the placement
   // logic (flip-at-edges included) and every show/hide site; the built-in
   // line rendering and box chrome are suppressed while it is mounted.
-  setCustomTooltip(el) {
+  setCustomTooltip(el: HTMLElement | null) {
     if (!this.tooltip) return;
     if (!el) {
       this._customTooltip = null;
@@ -571,4 +606,4 @@ Object.assign(ChartView.prototype, {
     el.style.display = "";
     this.tooltip.replaceChildren(el);
   },
-});
+} as ThisType<ChartView> & Record<string, unknown>);

--- a/js/src/60_entries.ts
+++ b/js/src/60_entries.ts
@@ -1,3 +1,4 @@
+import type { ChartSpec, Comm, PayloadBuffers } from "./05_types";
 import { bytesToSpan, decodeFrame } from "./00_header";
 import { ChartView } from "./50_chartview";
 import { MARK_KINDS, markOf } from "./55_marks";
@@ -15,11 +16,19 @@ import "./57_viewstate";
 // Entry points
 // ---------------------------------------------------------------------------
 
+/** The slice of anywidget's model API the widget entry point uses. */
+interface AnywidgetModel {
+  get(key: string): any;
+  send(msg: Record<string, any>): void;
+  on(event: string, handler: (content: any, buffers: any) => void): void;
+  off?(event: string, handler: (content: any, buffers: any) => void): void;
+}
+
 /** First-paint buffers in the shape the spec declares (§29): packed is one
  * blob; split is one span per column. Aligned views stay zero-copy; only a
  * legacy unaligned view pays a narrow view-sized copy. A spec/transport
  * disagreement is a bug, never a fallback. */
-function payloadBuffers(spec, raw) {
+function payloadBuffers(spec: ChartSpec, raw: unknown): PayloadBuffers {
   if (spec.buffer_layout === "split") {
     if (!Array.isArray(raw)) {
       throw new Error("xy: spec says buffer_layout=split but the transport delivered one buffer");
@@ -32,14 +41,14 @@ function payloadBuffers(spec, raw) {
   return bytesToSpan(raw);
 }
 
-export function render({ model, el }) {
+export function render({ model, el }: { model: AnywidgetModel; el: HTMLElement }): () => void {
   const spec = model.get("spec");
   const buffer = payloadBuffers(spec, model.get("buffers"));
   const comm = {
-    send: (msg) => model.send(msg),
+    send: (msg: Record<string, any>) => model.send(msg),
     wantsViewChange: () => spec.interaction?._transport_view_change === true,
-    onMessage: (cb) => {
-      const handler = (content, buffers) => cb(content, buffers);
+    onMessage: (cb: (content: any, buffers?: any) => void) => {
+      const handler = (content: any, buffers: any) => cb(content, buffers);
       model.on("msg:custom", handler);
       return () => model.off?.("msg:custom", handler);
     },
@@ -50,10 +59,10 @@ export function render({ model, el }) {
 
 /** Standalone (static HTML export — no kernel). Retains typed CPU views of
  * shipped channels so hover can read approximate values without a kernel (§37). */
-export function renderStandalone(el, spec, arrayBuffer) {
+export function renderStandalone(el: HTMLElement, spec: ChartSpec, arrayBuffer: unknown): ChartView {
   const buffer = bytesToSpan(arrayBuffer);
   const view = new ChartView(el, spec, buffer, null);
-  const column = (idx) => view._columnView(buffer, spec.columns[idx]);
+  const column = (idx: number) => view._columnView(buffer, spec.columns[idx]);
   for (const g of view.gpuTraces) {
     if (markOf(g.trace.kind).retainCpu && g.tier !== "density") {
       g._cpu = {

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     // The client targets evergreen WebGL2 browsers (design dossier §32);
-    // Vite/esbuild does the emit, tsc is typecheck-only.
+    // vite/oxc does the emit, tsc is typecheck-only and gates every build
+    // (js/build.mjs runs it first — oxc strips types without checking them).
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
@@ -11,13 +12,30 @@
     "verbatimModuleSyntax": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    // Migration posture: the source was converted from untyped concat-order JS
-    // (see git history of js/src/*.js). Params and `this` in augmentation
-    // literals stay implicitly `any` until annotated; tighten these flags as
-    // real types land.
-    "strict": false,
-    "noImplicitAny": false,
-    "noImplicitThis": false
+
+    // Every parameter, local, and `this` in the client is typed: no value
+    // acquires `any` implicitly. Wire-shaped data is described in src/05_types.ts.
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "useUnknownInCatchVariables": true,
+
+    // Not yet enabled, in dependency order — each is its own reviewable change:
+    //
+    // 1. Remove `ChartView`'s `[key: string]: any` index signature
+    //    (src/50_chartview.ts). It is what still lets `this.typo` compile and
+    //    what stops the annotated method signatures in 51–57 from being
+    //    enforced at call sites. Requires declaring ChartView's full surface:
+    //    ~172 class methods, ~119 prototype-augmented methods across 51–57
+    //    (via `declare module` merging), and ~112 instance fields.
+    // 2. `strictNullChecks` — the client leans on truthiness guards throughout;
+    //    this is the flag that would catch the null-deref classes noted during
+    //    the annotation pass. Largest remaining win, largest diff.
+    // 3. `strict: true` once 1 and 2 land.
+    "strict": false
   },
   "include": ["src/**/*.ts"]
 }

--- a/tests/reflex_adapter/test_assets.py
+++ b/tests/reflex_adapter/test_assets.py
@@ -22,7 +22,10 @@ def test_client_source_is_the_installed_bundle():
     source = _client_source()
     assert source == pathlib.Path(xy.__file__).resolve().parent / "static" / "index.js"
     text = source.read_text(encoding="utf-8")
-    for marker in ("function renderStandalone(", "function decodeFrame(", "class ChartView"):
+    # The shipped bundle is minified (identifiers renamed), so the markers are
+    # the export aliases the minifier preserves — the same contract
+    # scripts/verify_wheel.py asserts on the packaged artifact.
+    for marker in ("as renderStandalone", "as decodeFrame", "as ChartView"):
         assert marker in text
 
 

--- a/tests/test_accessibility_contract.py
+++ b/tests/test_accessibility_contract.py
@@ -61,7 +61,7 @@ def test_categorical_axes_announce_categories_instead_of_numeric_padding() -> No
 
 def test_keyboard_navigation_reuses_hover_and_tooltip_pipeline() -> None:
     required = (
-        'this._listen(c, "keydown", (e) => this._onA11yKey(e))',
+        'this._listen(c, "keydown", (e: KeyboardEvent) => this._onA11yKey(e))',
         "const hit = { trace: g.trace.id, index: offset, g }",
         "this._showTooltip(hit, clientX, clientY)",
         "this._drawKeepPick()",

--- a/tests/test_benchmark_environment.py
+++ b/tests/test_benchmark_environment.py
@@ -227,9 +227,11 @@ def test_context_governor_reserves_pending_restores() -> None:
     client = (ROOT / "js" / "src" / "50_chartview.ts").read_text(encoding="utf-8")
 
     assert "view._ctxPendingReservation" in client
-    constructor = client[client.index("  constructor(") : client.index("  _listen(")]
+    constructor = client[client.index("  constructor(") : client.index("  _listen<")]
     assert 'this.root.textContent = "xy: WebGL2 unavailable in this browser.";' in constructor
-    init_gl = client[client.index("  _initGl(buffer) {") : client.index("  _buildTrace(")]
+    init_gl = client[
+        client.index("  _initGl(buffer: PayloadBuffers) {") : client.index("  _buildTrace(")
+    ]
     assert "WebGL2 unavailable in this browser" not in init_gl
     recover = client.index("  _recoverContext() {")
     reserve = client.index("XY_CONTEXT_GOVERNOR.reserve(this);", recover)
@@ -262,7 +264,7 @@ def test_context_governor_reserves_pending_restores() -> None:
 
     visibility_start = client.index("  _armContextVisibilityWatch() {")
     visibility_watch = client[
-        visibility_start : client.index("  _resize(cssW, cssH)", visibility_start)
+        visibility_start : client.index("  _resize(cssW: number, cssH: number)", visibility_start)
     ]
     assert 'this._listen(document, "visibilitychange"' in visibility_watch
     assert 'document.visibilityState === "hidden"' in visibility_watch
@@ -293,7 +295,7 @@ def test_context_governor_reserves_pending_restores() -> None:
     assert 'includes("shader compile: null")' in restored
     assert "this._scheduleContextRecovery();" in restored
 
-    pick_start = client.index("  _pickAt(cssX, cssY) {")
+    pick_start = client.index("  _pickAt(cssX: number, cssY: number) {")
     pick = client[pick_start : client.index("  _decodeValue(", pick_start)]
     assert "this.gl.isContextLost()" in pick
     assert "if (!this.gl || this.gl.isContextLost()) return null;" in pick
@@ -301,7 +303,9 @@ def test_context_governor_reserves_pending_restores() -> None:
 
 def test_triangle_mesh_resource_cleanup_deletes_every_coordinate_buffer() -> None:
     client = (ROOT / "js" / "src" / "50_chartview.ts").read_text(encoding="utf-8")
-    cleanup = client[client.index("_destroyTraceResources(g, texSeen)") :]
+    cleanup = client[
+        client.index("_destroyTraceResources(g: GpuTrace, texSeen: Set<WebGLTexture>)") :
+    ]
     cleanup = cleanup[: cleanup.index("_destroyGlResources()")]
     for name in ("x0Buf", "x1Buf", "x2Buf", "y0Buf", "y1Buf", "y2Buf"):
         assert f'"{name}"' in cleanup

--- a/tests/test_static_client_security.py
+++ b/tests/test_static_client_security.py
@@ -416,7 +416,7 @@ def test_client_hardens_responsive_visibility_recovery() -> None:
         "new IntersectionObserver",
         "this._io?.disconnect();",
         "const compact = this.size.w < 520;",
-        "_queueResize(cssW = null, cssH = null, measure = false)",
+        "_queueResize(cssW: number | null = null, cssH: number | null = null, measure = false)",
         'this._colorbar.dataset.xyCompact = compactVertical ? "true" : "false";',
     )
 
@@ -559,9 +559,9 @@ def test_client_lod_layer_stays_chart_agnostic_and_renderer_delegated() -> None:
     assert "future heatmap/histogram tier reuses it instead of copy-pasting" in source_lod
 
     lod_required = (
-        "function lodApplyDrill(view, g, upd, buffers)",
-        "function lodApplyDensityUpdate(view, g, upd, buffers)",
-        "function lodDrawDensityTier(view, g, x0, x1, y0, y1)",
+        "function lodApplyDrill(view: ChartView, g: GpuTrace, upd: LodDrillUpdate, buffers: PayloadBuffers)",
+        "function lodApplyDensityUpdate(view: ChartView, g: GpuTrace, upd: LodDensityUpdate, buffers: PayloadBuffers)",
+        "function lodDrawDensityTier(view: ChartView, g: GpuTrace, x0: number, x1: number, y0: number, y1: number)",
         "lodRememberDensity(view, g, g.density);",
         "view._drawDensity(g, density",
         "view._drawPoints(",
@@ -587,7 +587,7 @@ def test_client_lod_layer_stays_chart_agnostic_and_renderer_delegated() -> None:
 
 def test_client_coalesces_wheel_zoom_without_animation_lag() -> None:
     required = (
-        "_queueWheelZoom(factor, fx, fy, axesScope = null)",
+        "_queueWheelZoom(factor: number, fx: number, fy: number, axesScope: string[] | null = null)",
         "this._pendingWheelZoom.factor *= factor;",
         "this._wheelZoomRaf = requestAnimationFrame",
         "this._zoomAt(pending.factor, pending.fx, pending.fy, false, 120, {",
@@ -602,8 +602,8 @@ def test_client_coalesces_wheel_zoom_without_animation_lag() -> None:
 def test_client_can_disable_navigation_without_disabling_hover() -> None:
     required = (
         'if (!this._interactionFlag("navigation", true)) return;',
-        'this._listen(c, "wheel", (e) => {',
-        'this._listen(c, "pointermove", (e) => {',
+        'this._listen(c, "wheel", (e: WheelEvent) => {',
+        'this._listen(c, "pointermove", (e: PointerEvent) => {',
         "this._hover(e);",
     )
 
@@ -643,8 +643,8 @@ def test_client_point_hover_rows_use_category_display_labels() -> None:
 
 def test_client_exposes_axis_style_hooks() -> None:
     required = (
-        "_axisStyleNumber(axis, key, fallback)",
-        "_axisStylePaint(axis, key, fallback)",
+        "_axisStyleNumber(axis: AxisSpec, key: string, fallback: number)",
+        "_axisStylePaint(axis: AxisSpec, key: string, fallback: any)",
         '"grid_color"',
         '"axis_color"',
         '"tick_color"',
@@ -677,14 +677,14 @@ def test_log_axis_uses_separate_readable_label_ticks() -> None:
 
 def test_client_axis_tick_labels_have_collision_layout() -> None:
     required = (
-        "_axisTickTarget(axisId, fallback)",
+        "_axisTickTarget(axisId: string, fallback: number)",
         "_axisTickLabelStrategy(axis)",
         "_axisTickLabelAngle(axis)",
         "_axisTickLabelAnchor(axis)",
-        "_axisTickLabelMinGap(axis, dim)",
-        '_tickLabelsCollide(labels, dim, fontSize, minGap, anchor = "center")',
-        '_downsampleTickLabels(labels, dim, fontSize, minGap, anchor = "center")',
-        "_layoutTickLabels(axis, dim, labels)",
+        '_axisTickLabelMinGap(axis: AxisSpec, dim: "x" | "y")',
+        '_tickLabelsCollide(labels: any[], dim: "x" | "y", fontSize: number, minGap: number, anchor = "center")',
+        '_downsampleTickLabels(labels: any[], dim: "x" | "y", fontSize: number, minGap: number, anchor = "center")',
+        '_layoutTickLabels(axis: AxisSpec, dim: "x" | "y", labels: any[])',
         "tick_label_strategy",
         "tick_label_angle",
         "tick_label_anchor",
@@ -698,8 +698,11 @@ def test_client_axis_tick_labels_have_collision_layout() -> None:
 
 def test_client_draws_first_class_annotation_markers() -> None:
     required = (
-        "_annotationStrokePaint(style, fallback)",
-        "_drawAnnotationMarker(ctx, x, y, style, ann)",
+        "_annotationStrokePaint(style: StyleBag, fallback: Rgba)",
+        "_drawAnnotationMarker(\n"
+        "    ctx: CanvasRenderingContext2D, x: number, y: number,\n"
+        "    style: StyleBag, ann: AnnotationSpec,\n"
+        "  )",
         'ann.kind === "marker"',
         '"circle", "square", "diamond", "cross"',
         "d.style.color = this._annotationLabelPaint(style, this.theme.label)",
@@ -892,9 +895,9 @@ def test_client_named_axes_handle_silent_gutters_and_reversed_ticks() -> None:
         for marker in required:
             assert marker in text, f"{path} lost named-axis range/layout guard {marker!r}"
 
-        label_layout = text.split("_layoutTickLabels(axis, dim, labels)", 1)[1].split(
-            "_axisLabelCss(axis, dim, fallbackCss)", 1
-        )[0]
+        label_layout = text.split(
+            '_layoutTickLabels(axis: AxisSpec, dim: "x" | "y", labels: any[])', 1
+        )[1].split("_axisLabelCss(axis, dim, fallbackCss)", 1)[0]
         assert label_layout.index("strategyValue") < label_layout.index("labels.length <= 1"), (
             f"{path} lets a single label bypass tick_label_strategy='none'"
         )

--- a/tests/test_svg_export.py
+++ b/tests/test_svg_export.py
@@ -676,7 +676,7 @@ def test_colormap_stops_stay_in_sync_with_js_client() -> None:
     """The Python tables are ports of 10_colormaps.ts — every stop must appear
     verbatim in the JS source, and the map names must match."""
     js = (ROOT / "js" / "src" / "10_colormaps.ts").read_text(encoding="utf-8")
-    body = js.split("COLORMAP_STOPS = {", 1)[1].split("};", 1)[0]
+    body = js.split("COLORMAP_STOPS", 1)[1].split("= {", 1)[1].split("};", 1)[0]
     js_names = set(re.findall(r"^\s*(\w+): \[", body, re.MULTILINE))
     assert js_names == set(COLORMAP_STOPS), "colormap names diverged from 10_colormaps.ts"
     for name, stops in COLORMAP_STOPS.items():

--- a/tests/test_viewport_bounds.py
+++ b/tests/test_viewport_bounds.py
@@ -51,7 +51,7 @@ def test_axis_bounds_validation(factory) -> None:
 def test_client_clamps_pan_zoom_and_reversed_log_ranges() -> None:
     source = (ROOT / "js/src/53_interaction.ts").read_text(encoding="utf-8")
 
-    assert "_clampAxisRange(axisId, lo, hi, anchorFrac = 0.5)" in source
+    assert "_clampAxisRange(axisId: string, lo: number, hi: number, anchorFrac = 0.5)" in source
     assert "const reverse = c1 < c0" in source
     assert "const target = this._clampView(" in source
     assert 'source: "pan_drag"' in source


### PR DESCRIPTION
Stacked on #159 (base: `feat/ts-vite-client`). Merge that first.

## What

Turns the TypeScript conversion from "compiles" into "typechecked". **2321 diagnostics → 0** under the newly enabled flags:

```
noImplicitAny  noImplicitThis  strictFunctionTypes  strictBindCallApply
noImplicitReturns  noFallthroughCasesInSwitch  useUnknownInCatchVariables
```

Every parameter, local, and `this` in the client is now typed — no value acquires `any` implicitly. `tsc` already gates every build (`js/build.mjs` runs it first, since oxc strips types without checking them), so this is enforced on every PR.

## How

- **`js/src/05_types.ts`** (new) carries the wire contract the kernel emits: `ChartSpec`, `TraceSpec`, `AxisSpec`, `ChannelSpec`, `ColumnMeta`, `GpuTrace`, `Hit`, `Row`, `Comm`, `TickResult`, `Theme`, `MarkKind`, `Rgba`. Deliberately permissive where the wire is permissive — open index signatures stay, because tightening one is a compatibility decision to make alongside the Python that emits it.
- **`as ThisType<ChartView>`** on the prototype-augmentation literals (51–57) types `this` as ChartView instead of the object literal. That one type assertion resolved **1190** of the 2321 diagnostics, and erases at compile.
- Per-module types where no shared name fits: LOD drill/density updates, animation easings and transition records, view-state patches and durable state, interaction option bags, GL program/buffer tags (`XyProgram`, `XyBuffer`), `ColumnView`, `AxisMap`.
- `_listen` became generic over its event type so call sites keep precise handlers (`PointerEvent`, `WheelEvent`, …) under `strictFunctionTypes`.

## Types-only — proven, not asserted

The committed minified bundles in `python/xy/static/` are **byte-identical** before and after this change; the diff contains no bundle. Independently, three of the workers transpiled HEAD vs. working copies and byte-compared the emitted JS per file.

That check earned its keep twice: it caught a `&&` → `?.` rewrite that had slipped into a catch-narrowing fix, and a case where an interface placed above the first runtime statement absorbed a file's header comment and changed emit.

**Verification:** `tsc` clean · bundles byte-identical · full pytest **2208 passed** · render smoke `XY_OK` with pixel counts and context-loss hashes identical to the pre-typing run · ruff + pre-commit clean.

## Test fallout

Source-marker tests that grep exact client signatures are updated to the typed forms, preserving their parameter-contract intent. Separately, `tests/reflex_adapter/test_assets.py` still grepped *unminified* markers (`function renderStandalone(`) — it only runs when reflex is installed, so it was missed when the bundles began shipping minified in #159. Fixed here to use the same export-alias contract `verify_wheel.py` asserts.

## Latent bugs surfaced (reported, not fixed — types-only)

Typing the code found real issues. None are touched here; each deserves its own change:

1. `lodApplyDensityUpdate` reads `g.density.colormap/.color/.lut` unguarded, while every sibling access guards — a density update on a trace whose density was never built is an uncaught TypeError.
2. `RECT_MARK`/`BAR_MARK`/`SEGMENT_MARK`/`AREA_MARK`/`line` dereference `g.trace.style.color` unguarded; `style` is optional on the wire (`MESH_MARK` and hexbin do guard).
3. `54_kernel` builds `pendingTraceIds` with `Number(upd.id)` but tests membership with the raw `g.trace.id`; `TraceSpec.id` is `string | number`, so a string id silently skips the `clearPending` sweep.
4. `_onA11yKey` computes `hit.trace * 1e9 + hit.index` from a trace *id*; a string id makes `_hoverId` NaN and every `!== -1` guard read true forever.
5. `51_annotations` `liftBounds.width` is only safe via a two-expression short-circuit that a future edit could split.
6. `57_viewstate` `canBandPan()` returns truthy via `_axisContained` even when pan policy excludes the axis — possibly deliberate, worth a look.

Items 1, 2, and 5 are exactly the class `strictNullChecks` would catch, which motivates the order below.

## Deferred (documented in `js/tsconfig.json`)

1. Remove `ChartView`'s `[key: string]: any`. It is what still lets `this.typo` compile and what stops the annotated signatures in 51–57 from being enforced at call sites. Needs ~403 declared members (172 class methods, 119 augmentation methods via `declare module` merging, 112 instance fields) — mechanical, but its own reviewable PR.
2. `strictNullChecks` — largest remaining win, largest diff.
3. `strict: true` once 1 and 2 land.