### PR TITLE
Stream standalone HTML payloads to disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,10 @@ in the README).
   contract without importing the widget stack.
 
 ### Changed
+- Standalone `to_html(path)` now streams base64 payload blocks through its
+  atomic temporary file and releases the packed blob before reading the
+  compatibility return string, avoiding the former payload-scale chunk-list
+  and joined-script allocations.
 - **Responsive, author-defeatable browser chrome.** XY's visual defaults now
   live in a low-priority cascade layer, so Tailwind utilities, ordinary author
   CSS, and slot styles override them without `!important`. Long legends remain

--- a/docs/guides/display-and-export.md
+++ b/docs/guides/display-and-export.md
@@ -114,6 +114,9 @@ chart.to_html("chart.html")
 HTML export is self-contained: it includes the chart spec, binary data, and
 bundled render client. It keeps zoom, pan, hover, selection, and built-in chart
 chrome and does not need a browser or network connection at export time.
+When a path is supplied, payload chunks stream through the atomic output file
+instead of being retained together in memory; the returned string remains
+identical to the written document for compatibility.
 
 Pass `custom_css=` to include author CSS for chrome classes and tokens in the
 exported document. Standalone HTML uses inline scripts and styles by design;

--- a/python/xy/export.py
+++ b/python/xy/export.py
@@ -176,6 +176,27 @@ def _base64_chunks(blob: bytes) -> list[str]:
     return [base64.b64encode(view[i : i + step]).decode("ascii") for i in range(0, len(view), step)]
 
 
+_B64_SCRIPT_PREFIX = b'<script>__xyChunks.push("'
+_B64_SCRIPT_SUFFIX = b'");</script>'
+
+
+def _write_base64_chunk_scripts(stream: Any, blob: bytes) -> None:
+    """Write payload script blocks without retaining base64 text chunks.
+
+    Path exports use a binary temporary file so the encoded bytes can be
+    written directly: no ASCII decode, chunk list, or joined scripts string.
+    """
+    if not blob:
+        return
+    view = memoryview(blob)
+    for index, start in enumerate(range(0, len(view), _B64_CHUNK_BYTES)):
+        if index:
+            stream.write(b"\n")
+        stream.write(_B64_SCRIPT_PREFIX)
+        stream.write(base64.b64encode(view[start : start + _B64_CHUNK_BYTES]))
+        stream.write(_B64_SCRIPT_SUFFIX)
+
+
 # Inline decoder for the chunked base64 payload. Prefers the native Uint8Array
 # base64 decoder (baseline across browsers since 2025) and falls back to a tight
 # `atob` + `charCodeAt` loop into a preallocated array — far cheaper than
@@ -304,10 +325,8 @@ def to_html(
     # valid JS string literal verbatim and can never close the <script>. Quote
     # it directly rather than via `json.dumps`, whose full-string escape scan
     # dominated small-chart export cost.
-    chunk_scripts = "\n".join(
-        f'<script>__xyChunks.push("{c}");</script>' for c in _base64_chunks(blob)
-    )
-    doc = f"""<!doctype html>
+    blob_len = len(blob)
+    head = f"""<!doctype html>
 <html>
 <head><meta charset="utf-8">
 <meta http-equiv="Content-Security-Policy" content="{_STANDALONE_CSP}">
@@ -321,19 +340,52 @@ html,body{{margin:0;width:100%;min-height:100%;font-family:system-ui,sans-serif;
 <div id="chart"></div>
 <script>{client_js}</script>
 <script>var __xyChunks = [];</script>
-{chunk_scripts}
+"""
+    tail = f"""
 <script>
   {_DECODE_B64_JS}
   const spec = {spec_js};
-  const buf = xyDecodeB64(__xyChunks, {len(blob)});
+  const buf = xyDecodeB64(__xyChunks, {blob_len});
   __xyChunks.length = 0;
   xy.renderStandalone(document.getElementById("chart"), spec, buf);
 </script>
 </body>
 </html>"""
-    if path is not None:
-        _atomic_write_text(path, doc)
-    return doc
+    if path is None:
+        chunk_scripts = "\n".join(
+            f'<script>__xyChunks.push("{chunk}");</script>' for chunk in _base64_chunks(blob)
+        )
+        return head + chunk_scripts + tail
+
+    # Stream the payload-scale portion through an atomic same-directory temp
+    # file. Only after the packed blob is released do we read the completed
+    # document required by the longstanding `to_html(path) -> str` contract.
+    target = Path(path)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=target.parent,
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            fd = -1
+            stream.write(head.encode("utf-8"))
+            _write_base64_chunk_scripts(stream, blob)
+            stream.write(tail.encode("utf-8"))
+            stream.flush()
+            os.fsync(stream.fileno())
+        del blob
+        doc = tmp_path.read_text(encoding="utf-8")
+        os.replace(tmp_path, target)
+        return doc
+    except Exception:
+        if fd != -1:
+            with suppress(OSError):
+                os.close(fd)
+        with suppress(FileNotFoundError):
+            tmp_path.unlink()
+        raise
 
 
 _NOTEBOOK_DIMENSION_RE = _re.compile(r"^[0-9]+(?:\.[0-9]+)?(?:px|%|vw|vh|rem|em)?$")

--- a/spec/design/wire-protocol.md
+++ b/spec/design/wire-protocol.md
@@ -264,6 +264,11 @@ the packed blob as chunked base64:
   chunking removes. Base64 text (`[A-Za-z0-9+/=]`) contains no quote,
   backslash, newline, or `<`, so it is quoted verbatim and can never close the
   element.
+- Path exports write those blocks directly to the same-directory atomic temp
+  file one at a time. They retain neither the full base64 chunk list nor a
+  joined scripts string, and release the packed blob before reading back the
+  completed document required by the `to_html(path) -> str` compatibility
+  contract. In-memory `to_html()` necessarily assembles its returned string.
 - `xyDecodeB64(chunks, total)` allocates `Uint8Array(total)` and prefers
   `setFromBase64`, falling back to an `atob` + `charCodeAt` loop into the
   preallocated array.

--- a/spec/process/production-readiness.md
+++ b/spec/process/production-readiness.md
@@ -105,9 +105,10 @@ reports, and sharing a single file, but it has a clear security contract:
   `</script>` inside future client source cannot terminate the script element.
 - The export rejects `NaN` and infinity in JSON metadata instead of emitting
   browser-dependent invalid JavaScript.
-- Path-based exports write through a same-directory temporary file and only
-  replace the target after the full document is flushed, so failed writes do
-  not corrupt the previous standalone artifact.
+- Path-based exports stream base64 blocks through a same-directory temporary
+  file and only replace the target after the full document is flushed, so
+  payload-scale text is not retained twice and failed writes do not corrupt
+  the previous standalone artifact.
 - The standalone file emits a defensive `Content-Security-Policy` meta tag that
   blocks network fetches, external worker scripts, objects, forms, and external
   images, and pins `base-uri 'none'`, while allowing the inline scripts/styles

--- a/tests/test_figure.py
+++ b/tests/test_figure.py
@@ -1221,6 +1221,45 @@ def test_to_html_path_writes_exact_document(tmp_path: Path):
     assert decoded["title"] == 'export "quoted" & <safe>'
 
 
+def test_to_html_path_streams_chunks_without_materializing_chunk_list(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    target = tmp_path / "streamed.html"
+    fig = Figure(title="streamed export").line(np.arange(32.0), np.arange(32.0))
+    monkeypatch.setattr(export_module, "_B64_CHUNK_BYTES", 3)
+    expected = fig.to_html()
+
+    def unexpected_chunk_list(_blob: bytes) -> list[str]:
+        raise AssertionError("path export must stream base64 instead of building a chunk list")
+
+    monkeypatch.setattr(export_module, "_base64_chunks", unexpected_chunk_list)
+    actual = fig.to_html(target)
+
+    assert actual == expected
+    assert target.read_text(encoding="utf-8") == expected
+
+
+def test_to_html_stream_failure_preserves_existing_file_and_cleans_temp(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    target = tmp_path / "stream-failure.html"
+    target.write_text("old chart artifact", encoding="utf-8")
+    fig = Figure().line(np.arange(32.0), np.arange(32.0))
+
+    def fail_encode(_view: memoryview) -> bytes:
+        raise OSError("synthetic base64 failure")
+
+    monkeypatch.setattr(export_module.base64, "b64encode", fail_encode)
+
+    with pytest.raises(OSError, match="synthetic base64 failure"):
+        fig.to_html(target)
+
+    assert target.read_text(encoding="utf-8") == "old chart artifact"
+    assert not list(tmp_path.glob(".stream-failure.html.*.tmp"))
+
+
 def test_to_html_path_keeps_existing_file_on_atomic_replace_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Root cause

`to_html(path=...)` followed the same construction path as in-memory export: it retained the packed binary blob, a decoded base64 chunk list, the joined script-block string, and the final HTML document at the same time. Large standalone exports therefore peaked near five times their payload size even though the destination was already a file.

## Changes

- split standalone HTML construction into small head/tail sections
- stream each base64 script block directly to a same-directory binary temp file
- avoid ASCII decoding, the chunk list, and the joined script-block allocation on path exports
- release the packed blob before reading the completed file for the existing `to_html(path) -> str` compatibility contract
- preserve atomic replacement and clean up temporary files on encode/write failures
- keep in-memory `to_html()` output byte-for-byte unchanged
- document the path-export memory contract and add changelog coverage

## Measured impact

A deterministic `tracemalloc` probe constructs the payload inside the measured region and writes the resulting standalone document:

| payload | output HTML | main peak | this branch peak | reduction |
|---:|---:|---:|---:|---:|
| 24 MiB | 32 MiB | 120.14 MiB | 72.14 MiB | 40.0% |
| 72 MiB | 96 MiB | 360.25 MiB | 192.25 MiB | 46.6% |

The 72 MiB case crosses the production 48 MiB base64 chunk boundary. Exact output parity is also covered with an artificially small multi-chunk boundary.

Optional gzip remains separate: it changes the standalone decoding protocol and should be selected from benchmark-corpus compression ratios rather than bundled into the allocation fix.

## Verification

- `pytest -q --ignore=tests/reflex_adapter --ignore=tests/test_bench_transport.py --deselect=tests/test_figure.py::test_to_png_full_path`: **2087 passed, 94 skipped, 1 deselected**
- `pytest -q tests/test_figure.py -k 'to_html and not to_png'`: **15 passed**
- `pytest -q tests/test_docs_examples.py`: **46 passed**
- docs app: `pytest -q tests`: **72 passed, 1 xfailed**
- docs app Ruff check/format and codespell: passed
- `ty check python/xy/export.py`: passed
- `pre-commit run --all-files`: passed
- `git diff --check`: passed

The aggregate `security_export` helper on current main contains one stale, nonexistent pytest node ID and aborts before execution; the underlying security/export tests are included in the successful 2,087-test run above.

Closes #167