### PR TITLE
Fix integration sidebar hover and selected-state alignment

### DIFF
--- a/docs/app/tests/test_docs_site.py
+++ b/docs/app/tests/test_docs_site.py
@@ -1403,8 +1403,7 @@ def test_xy_sidebar_reuses_memoized_official_navigation_rows() -> None:
     assert rendered.count("group/details") == accordion_count
     assert rendered.count("guideMarginClass") == expected_leaf_count
     assert rendered.count(
-        "absolute left-0 top-1/2 -z-10 h-8 w-full "
-        "-translate-y-1/2 rounded-lg bg-secondary-3"
+        "absolute left-0 top-1/2 -z-10 h-8 w-full -translate-y-1/2 rounded-lg bg-secondary-3"
     ) == len(INTEGRATION_LINK_ICONS)
     assert rendered.count(
         "ml-[2.5rem] flex h-8 w-[calc(100%-2.5rem)] items-center "

--- a/docs/app/tests/test_docs_site.py
+++ b/docs/app/tests/test_docs_site.py
@@ -56,6 +56,7 @@ from xy_docs.gallery import (
 from xy_docs.markdown import XyDocsMarkdownTransformer, render_xy_markdown_page
 from xy_docs.navbar import XY_GITHUB_STARS, XY_REPOSITORY_URL, xy_docs_navbar
 from xy_docs.sidebar import (
+    INTEGRATION_LINK_ICONS,
     SIDEBAR_SECTION_GROUPS,
     xy_docs_sidebar,
     xy_docs_sidebar_comp,
@@ -1401,6 +1402,19 @@ def test_xy_sidebar_reuses_memoized_official_navigation_rows() -> None:
     assert rendered.count('jsx("summary"') == accordion_count
     assert rendered.count("group/details") == accordion_count
     assert rendered.count("guideMarginClass") == expected_leaf_count
+    assert rendered.count(
+        "absolute left-0 top-1/2 -z-10 h-8 w-full "
+        "-translate-y-1/2 rounded-lg bg-secondary-3"
+    ) == len(INTEGRATION_LINK_ICONS)
+    assert rendered.count(
+        "ml-[2.5rem] flex h-8 w-[calc(100%-2.5rem)] items-center "
+        "justify-start text-secondary-11 transition-colors "
+        "group-hover:text-primary-10 dark:group-hover:text-primary-9 "
+        "xl:max-w-[14rem]"
+    ) == len(INTEGRATION_LINK_ICONS)
+    assert rendered.count("group relative block h-8 w-full no-underline") == len(
+        INTEGRATION_LINK_ICONS
+    )
     assert sorted(section[0] for section in grouped_sections) == sorted(
         section[0] for section in DOCS_SECTIONS
     )

--- a/docs/app/uv.lock
+++ b/docs/app/uv.lock
@@ -1709,6 +1709,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-codspeed", marker = "extra == 'codspeed'", specifier = ">=5,<6" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.8" },
+    { name = "starlette", marker = "extra == 'dev'", specifier = ">=0.36" },
     { name = "ty", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev", "bench", "codspeed"]

--- a/docs/app/xy_docs/sidebar.py
+++ b/docs/app/xy_docs/sidebar.py
@@ -68,23 +68,39 @@ def _top_level_link(
 ) -> rx.Component:
     """Render an icon-led direct link aligned with sidebar group headings."""
     active = url == href
-    row_classes = (
-        "relative m-0 flex h-8 w-[calc(100%-2.5rem)] items-center "
-        "justify-start !ml-[2.5rem] rounded-lg !px-0 !py-1 no-underline "
-        "transition-colors xl:max-w-[14rem]"
-    )
     return rx.el.li(
-        rx.link(
-            rx.icon(tag=icon, size=16, class_name="mr-4 shrink-0"),
-            rx.text(title, class_name="m-0 text-sm font-[525]"),
-            href=href,
-            underline="none",
-            aria_current=rx.cond(active, "page", None),
-            class_name=rx.cond(
+        rx.el.a(
+            rx.cond(
                 active,
-                f"{row_classes} bg-secondary-3 text-primary-10",
-                (f"{row_classes} bg-transparent text-secondary-11 hover:text-secondary-12"),
+                rx.el.div(
+                    class_name=(
+                        "absolute left-0 top-1/2 -z-10 h-8 w-full "
+                        "-translate-y-1/2 rounded-lg bg-secondary-3"
+                    ),
+                ),
+                rx.fragment(),
             ),
+            rx.box(
+                rx.icon(tag=icon, size=16, class_name="mr-4 shrink-0"),
+                rx.text(title, class_name="m-0 text-sm font-[525]"),
+                class_name=rx.cond(
+                    active,
+                    (
+                        "ml-[2.5rem] flex h-8 w-[calc(100%-2.5rem)] "
+                        "items-center justify-start text-primary-10 "
+                        "xl:max-w-[14rem]"
+                    ),
+                    (
+                        "ml-[2.5rem] flex h-8 w-[calc(100%-2.5rem)] "
+                        "items-center justify-start text-secondary-11 "
+                        "transition-colors group-hover:text-primary-10 "
+                        "dark:group-hover:text-primary-9 xl:max-w-[14rem]"
+                    ),
+                ),
+            ),
+            href=href,
+            aria_current=rx.cond(active, "page", None),
+            class_name="group relative block h-8 w-full no-underline",
         ),
         class_name="m-0 w-full list-none border-none bg-transparent p-0",
     )


### PR DESCRIPTION
## Summary

- Update the Reflex, Notebooks, and Matplotlib sidebar links to use the primary color on hover
- Make the selected `bg-secondary-3` background span the full sidebar row
- Preserve the existing icon and label indentation
- Match the selected-state layout used by the Learn, Build, and API Reference items
- Add regression coverage for the integration sidebar styles

## Testing

- `uv run ruff check xy_docs/sidebar.py tests/test_docs_site.py`
- `uv run pytest tests/test_docs_site.py -q`
- `.venv/bin/reflex compile --dry`

All checks passed and 61 tests passed.