### PR TITLE
Support FacetGrid in reflex_xy.chart by rendering per-panel static XYChart grid

### DIFF
--- a/docs/charts/facets-and-layers.md
+++ b/docs/charts/facets-and-layers.md
@@ -66,16 +66,7 @@ facet_detail_chart = xy.facet_chart(
 
 
 def facet_chart_demo():
-    facet_grid = facet_detail_chart.figure()
-    return rx.grid(
-        *[
-            reflex_xy.chart(panel, height="260px")
-            for panel in facet_grid.figures
-        ],
-        columns="2",
-        gap="3",
-        width="100%",
-    )
+    return reflex_xy.chart(facet_detail_chart)
 ~~~
 
 `cols` controls wrapping, `gap` controls panel spacing, and shared axes keep

--- a/python/reflex-xy/reflex_xy/component.py
+++ b/python/reflex-xy/reflex_xy/component.py
@@ -132,6 +132,10 @@ def _facet_grid(grid: Any, *, tooltip: Any, props: dict[str, Any]) -> Any:
     # HTML), while each panel retains the dimensions chosen by facet_chart.
     event_props = {key: value for key, value in props.items() if key.startswith("on_")}
     panels = []
+    # grid.labels needs no separate strip: facet_chart builds every panel
+    # figure with its facet label as the figure title, so the label ships
+    # inside each panel's payload and renders as the panel heading (the same
+    # contract FacetGrid.to_html relies on).
     for figure in grid.figures:
         panel_props = dict(event_props)
         panel_props.update(width="100%", height=f"{grid.panel_height}px")

--- a/python/reflex-xy/reflex_xy/component.py
+++ b/python/reflex-xy/reflex_xy/component.py
@@ -41,6 +41,8 @@ from typing import Any, Optional
 
 import reflex as rx
 
+from xy.facets import FacetGrid
+
 from .assets import WRAPPER_TAG, register
 from .payload_asset import payload_asset
 from .registry import _figure_of
@@ -117,6 +119,65 @@ def _tailwind_class_manifest(figure: Any) -> str:
     return " ".join(figure.dom_class_strings())
 
 
+def _facet_grid(grid: Any, *, tooltip: Any, props: dict[str, Any]) -> Any:
+    """Render a core ``FacetGrid`` as a responsive Reflex CSS grid.
+
+    A facet grid intentionally has no single wire payload: every panel is an
+    independent Figure with its own axes and LOD budget.  Preserve that core
+    contract by mounting one static XYChart per panel rather than trying to
+    feed the grid itself to :func:`payload_asset`.
+    """
+    # Semantic handlers belong on every panel. Layout/identity props belong
+    # only on the grid container (notably, duplicating an id would be invalid
+    # HTML), while each panel retains the dimensions chosen by facet_chart.
+    event_props = {key: value for key, value in props.items() if key.startswith("on_")}
+    panels = []
+    for figure in grid.figures:
+        panel_props = dict(event_props)
+        panel_props.update(width="100%", height=f"{grid.panel_height}px")
+        panel_props["src"] = payload_asset(figure)
+        class_manifest = _tailwind_class_manifest(figure)
+        if class_manifest:
+            panel_props["tailwind_class_tokens"] = class_manifest
+        panel = (
+            _component_cls.create(tooltip, **panel_props)
+            if tooltip
+            else _component_cls.create(**panel_props)
+        )
+        panels.append(panel)
+
+    grid_body = rx.box(
+        *panels,
+        class_name="xy-facet-grid",
+        display="grid",
+        grid_template_columns=f"repeat({grid.cols}, minmax(0, 1fr))",
+        gap=f"{grid.gap}px",
+        width="100%",
+    )
+    children = [grid_body]
+    if grid.title:
+        children.insert(
+            0,
+            rx.text(
+                grid.title,
+                class_name="xy-facet-title",
+                height=f"{grid._TITLE_H}px",
+                line_height=f"{grid._TITLE_H}px",
+                text_align="center",
+                font_weight="600",
+            ),
+        )
+    container_props = {key: value for key, value in props.items() if key not in event_props}
+    container_class = container_props.pop("class_name", "")
+    container_props.setdefault("width", "100%")
+    container_props.setdefault("height", f"{grid.grid_height + grid._title_height}px")
+    return rx.box(
+        *children,
+        class_name=f"xy-facet-document {container_class}".strip(),
+        **container_props,
+    )
+
+
 def chart(source: Any, *, tooltip: Any = None, **props: Any) -> Any:
     """Place a xy chart.
 
@@ -138,9 +199,9 @@ def chart(source: Any, *, tooltip: Any = None, **props: Any) -> Any:
     global _component_cls
     if _component_cls is None:
         _component_cls = _build_component_cls()
-    props.setdefault("width", "100%")
-    props.setdefault("height", "420px")
     if isinstance(source, (str, rx.Var)):
+        props.setdefault("width", "100%")
+        props.setdefault("height", "420px")
         props["token"] = source
     elif _is_chart_like(source):
         # Build a public Chart once, then reuse the cached Figure for both the
@@ -150,6 +211,10 @@ def chart(source: Any, *, tooltip: Any = None, **props: Any) -> Any:
         if tooltip is None and callable(getattr(source, "chrome_components", None)):
             tooltip = source.chrome_components().get("tooltip")
         figure = _figure_of(source)
+        if isinstance(figure, FacetGrid):
+            return _facet_grid(figure, tooltip=tooltip, props=props)
+        props.setdefault("width", "100%")
+        props.setdefault("height", "420px")
         props["src"] = payload_asset(figure)
         class_manifest = _tailwind_class_manifest(figure)
         if class_manifest:

--- a/spec/design/reflex-integration.md
+++ b/spec/design/reflex-integration.md
@@ -284,6 +284,15 @@ correct for free. What this tier gives up, deliberately: kernel round-trips
 (deep drilldown past the shipped tiers, exact server picks, streaming) and
 semantic events.
 
+`xy.facet_chart(...)` follows the same static tier, but preserves the core
+facet contract: because a `FacetGrid` is a composition of independent Figures
+rather than one Figure with a combined wire payload, the adapter emits a
+responsive CSS grid containing one content-addressed static `XYChart` per
+panel. The grid title, column count, gap, and panel height come from the core
+`FacetGrid`; container props stay on the grid while semantic event handlers
+are forwarded to each panel (with the static tier's event limitations
+unchanged).
+
 **`inline()` — fixed data that still wants the kernel.**
 `token = reflex_xy.inline(chart)` at **module scope** registers the figure
 under a content-addressed token (`xyin-<digest>`): every backend worker

--- a/spec/design/reflex-integration.md
+++ b/spec/design/reflex-integration.md
@@ -296,6 +296,17 @@ panel figure with its facet label as the figure title, so the label ships
 inside the panel's payload and the render client draws it as the panel
 heading — the same contract `FacetGrid.to_html` relies on.
 
+Design note: the considered alternative was a composite facet spec rendered
+by the client (one component instance laying out child payloads, as
+Vega-Lite's facet operator does). Per-panel composition was chosen because it
+matches every core composer (`to_html`, `widget()`, PNG export), keeps
+payload assets content-addressed per panel (one changed facet invalidates
+one file), and needs no new spec kind. Revisit the composite-spec approach
+only if facets grow cross-panel chrome (shared legends, row/column label
+strips) that a host-level CSS grid cannot express. Panel count is bounded in
+practice by the render client's shared WebGL context budget, which the
+per-panel path inherits unchanged.
+
 **`inline()` — fixed data that still wants the kernel.**
 `token = reflex_xy.inline(chart)` at **module scope** registers the figure
 under a content-addressed token (`xyin-<digest>`): every backend worker

--- a/spec/design/reflex-integration.md
+++ b/spec/design/reflex-integration.md
@@ -291,7 +291,10 @@ responsive CSS grid containing one content-addressed static `XYChart` per
 panel. The grid title, column count, gap, and panel height come from the core
 `FacetGrid`; container props stay on the grid while semantic event handlers
 are forwarded to each panel (with the static tier's event limitations
-unchanged).
+unchanged). Facet labels need no extra markup: `facet_chart` builds each
+panel figure with its facet label as the figure title, so the label ships
+inside the panel's payload and the render client draws it as the panel
+heading — the same contract `FacetGrid.to_html` relies on.
 
 **`inline()` — fixed data that still wants the kernel.**
 `token = reflex_xy.inline(chart)` at **module scope** registers the figure

--- a/tests/reflex_adapter/test_component.py
+++ b/tests/reflex_adapter/test_component.py
@@ -10,6 +10,7 @@ import reflex as rx
 import reflex_xy
 
 import xy
+from xy.channel import decode_frame
 
 
 class CompState(rx.State):
@@ -131,7 +132,13 @@ def test_static_facet_chart_compiles_as_grid_of_panel_payloads(app_cwd):
     assert "repeat(2, minmax(0, 1fr))" in rendered
     assert rendered.count("XYChart") == 2
     assert rendered.count("/xy/") == 2
-    assert len(list((pathlib.Path(app_cwd) / "assets" / "xy").glob("*.xyf"))) == 2
+    asset_files = list((pathlib.Path(app_cwd) / "assets" / "xy").glob("*.xyf"))
+    assert len(asset_files) == 2
+    # Facet identity is not in the JSX: each panel payload carries its facet
+    # label as the figure title (facets.py builds panels that way), which the
+    # render client draws as the panel heading.
+    titles = {decode_frame(path.read_bytes()).message["title"] for path in asset_files}
+    assert titles == {"West", "East"}
 
 
 def test_live_chart_does_not_claim_runtime_classes_are_compile_time_known(app_cwd):

--- a/tests/reflex_adapter/test_component.py
+++ b/tests/reflex_adapter/test_component.py
@@ -110,6 +110,30 @@ def test_static_chart_classes_are_visible_to_tailwind_source_scan(app_cwd):
         assert class_string in rendered
 
 
+def test_static_facet_chart_compiles_as_grid_of_panel_payloads(app_cwd):
+    data = {
+        "x": [0, 1, 2, 0, 1, 2],
+        "y": [1, 2, 3, 3, 2, 1],
+        "region": ["West", "West", "West", "East", "East", "East"],
+    }
+    facets = xy.facet_chart(
+        xy.scatter(x="x", y="y", color="#6e56cf"),
+        by="region",
+        data=data,
+        cols=2,
+        share_x=True,
+        share_y=True,
+    )
+
+    rendered = str(reflex_xy.chart(facets, id="regional-grid"))
+
+    assert "regional-grid" in rendered
+    assert "repeat(2, minmax(0, 1fr))" in rendered
+    assert rendered.count("XYChart") == 2
+    assert rendered.count("/xy/") == 2
+    assert len(list((pathlib.Path(app_cwd) / "assets" / "xy").glob("*.xyf"))) == 2
+
+
 def test_live_chart_does_not_claim_runtime_classes_are_compile_time_known(app_cwd):
     rendered = str(reflex_xy.chart("xyfig-runtime"))
     assert "tailwindClassTokens" not in rendered


### PR DESCRIPTION
### Motivation

- Fix the `AttributeError` and incorrect handling when a `FacetGrid`/`FacetChart` is passed to the Reflex wrapper, which previously tried to treat the grid like a single Figure and call `build_payload()` on it.  
- Preserve the core FacetGrid contract: each panel is an independent Figure with its own axes, LOD, and payload, so the wrapper must mount one panel chart per facet rather than folding the grid into a single payload.

### Description

- Add `_facet_grid()` in `python/reflex-xy/reflex_xy/component.py` to render a `FacetGrid` as a responsive Reflex CSS grid that mounts one static `XYChart` per panel and forwards per-panel semantic event handlers.  
- Detect `FacetGrid` instances in `chart()` and use `_facet_grid()` instead of calling `payload_asset` on the grid itself, while preserving Tailwind class manifests per panel and keeping container props (title, cols, gap, heights).  
- Add a regression test `test_static_facet_chart_compiles_as_grid_of_panel_payloads` in `tests/reflex_adapter/test_component.py` that verifies two-panel grids produce two `XYChart` mounts and two static payload files.  
- Document the FacetGrid static-tier behavior in `spec/design/reflex-integration.md` so the static/payload tier and event semantics are explicit.

### Testing

- Ran the focused component tests: `uv run pytest tests/reflex_adapter/test_component.py -q` and all tests passed (`8 passed`).  
- Ran linters/format checks: `uv run ruff check .` and `uv run ruff format --check .`, both succeeded.  
- Attempting to run the full `tests/reflex_adapter` collection failed to complete because `hypothesis` is not installed in the environment, and `pre-commit` could not be run due to PyPI/network access; these environment limitations prevented a full-suite collection and the pre-commit invocation from completing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60d6ceaa2083338c71d4a87979be0f)