### PR TITLE
Fix pyplot savefig output dimensions

### DIFF
--- a/python/xy/pyplot/_grid.py
+++ b/python/xy/pyplot/_grid.py
@@ -230,7 +230,13 @@ def stitch_png(
 ) -> bytes:
     from xy import _png, _raster  # sanctioned escape hatch (see module doc)
 
-    scale = 2.0
+    # pyplot charts are already built at ``figsize * dpi`` logical pixels.
+    # Rasterizing those pixels at the core exporter's 2x quality default made
+    # savefig silently double both output dimensions and every point-sized
+    # artist compared with Matplotlib.  The pyplot compatibility boundary is
+    # physical pixels, so keep its raster scale at one; callers that use the
+    # native Figure API directly retain that API's explicit 2x default.
+    scale = 1.0
     if (
         len(charts) == 1
         and positions is None
@@ -267,7 +273,10 @@ def stitch_png(
 
     if positions is not None and canvas_size is not None:
         background = np.asarray(_raster._parse_color(facecolor), dtype=np.uint8)
-        canvas = np.empty((canvas_size[1] * 2, canvas_size[0] * 2, 4), dtype=np.uint8)
+        canvas = np.empty(
+            (round(canvas_size[1] * scale), round(canvas_size[0] * scale), 4),
+            dtype=np.uint8,
+        )
         canvas[...] = background
         for tile, (left, bottom, _width, height) in zip(tiles, positions, strict=True):
             x = round(left * canvas.shape[1])

--- a/python/xy/pyplot/_mplfig.py
+++ b/python/xy/pyplot/_mplfig.py
@@ -950,7 +950,7 @@ class Figure:
             canvas_size=canvas_size if positions is not None else None,
             facecolor=self._facecolor,
             bbox_tight=bbox_tight,
-            pad_pixels=max(0, round(pad_inches * float(self._dpi or 100.0) * 2.0)),
+            pad_pixels=max(0, round(pad_inches * float(self._dpi or 100.0))),
         )
 
     def _to_html(self) -> str:

--- a/tests/pyplot/test_layout_text_parity_fixes.py
+++ b/tests/pyplot/test_layout_text_parity_fixes.py
@@ -92,7 +92,7 @@ def test_subplots_adjust_positions_grid_panels_in_every_exporter() -> None:
         ax.text(0.5, 0.5, str((2, 3, i)), fontsize=18, ha="center")
     html = fig._to_html()
     assert len(re.findall(r'style="position:absolute;left:', html)) == 6
-    assert _png_pixels(fig).shape[:2] == (960, 1280)  # the full 640x480 canvas at 2x
+    assert _png_pixels(fig).shape[:2] == (480, 640)  # the requested 640x480 canvas
     assert _svg(fig).count("<svg x=") == 6
 
 

--- a/tests/pyplot/test_rc_color_export_contracts.py
+++ b/tests/pyplot/test_rc_color_export_contracts.py
@@ -86,6 +86,7 @@ def test_savefig_file_objects_support_common_export_options() -> None:
     fig.savefig(tight, format="png", bbox_inches="tight", pad_inches=0)
     regular_size = struct.unpack(">II", regular.getvalue()[16:24])
     tight_size = struct.unpack(">II", tight.getvalue()[16:24])
+    assert regular_size == (320, 240)
     # a strict shrink on both axes: equality would mean tight-crop is a no-op
     assert tight_size[0] < regular_size[0] and tight_size[1] < regular_size[1]
 
@@ -109,6 +110,8 @@ def test_savefig_dpi_changes_output_dimensions_without_mutating_figure() -> None
 
     low = dimensions(60)
     high = dimensions(120)
+    assert low == (240, 180)
+    assert high == (480, 360)
     assert high[0] == 2 * low[0]
     assert high[1] == 2 * low[1]
     assert fig.get_dpi() == 80

--- a/tests/pyplot/test_reference_semantics.py
+++ b/tests/pyplot/test_reference_semantics.py
@@ -216,11 +216,11 @@ def _normalize_mask(mask: np.ndarray, size: int = 256) -> np.ndarray:
 
 @pytest.mark.parametrize("family", ["line", "bar", "image"])
 def test_reference_pngs_have_tolerant_perceptual_and_geometry_agreement(family: str) -> None:
-    # xy rasterizes its 320x240 logical canvas at 2x.  Render the Matplotlib
-    # reference at the same physical size and effective DPI so point-sized
-    # strokes, markers, and text remain comparable at 640x480.
+    # Both backends rasterize the 4x3-inch figure at the requested 80 DPI, so
+    # point-sized strokes, markers, and text are compared at the same physical
+    # size rather than hiding a pyplot-only 2x export scale in the reference.
     xyfig, xyax = xyplt.subplots(figsize=(4, 3), dpi=80)
-    mplfig, mplax = mplplt.subplots(figsize=(4, 3), dpi=160)
+    mplfig, mplax = mplplt.subplots(figsize=(4, 3), dpi=80)
     if family == "line":
         for ax in (xyax, mplax):
             ax.plot([0, 1, 2, 3], [0, 2, 1, 3], "o-", color="#2563eb", linewidth=2)
@@ -236,9 +236,9 @@ def test_reference_pngs_have_tolerant_perceptual_and_geometry_agreement(family: 
             ax.set_title("image")
     xybytes = xyfig._to_png()
     reference = BytesIO()
-    mplfig.savefig(reference, format="png", dpi=160)
+    mplfig.savefig(reference, format="png", dpi=80)
     xypixels, mplpixels = _png_pixels(xybytes), _png_pixels(reference.getvalue())
-    assert xypixels.shape == mplpixels.shape == (480, 640, 4)
+    assert xypixels.shape == mplpixels.shape == (240, 320, 4)
     xymask, mplmask = _foreground_mask(xypixels), _foreground_mask(mplpixels)
     normalized_xy = _dilate(_normalize_mask(xymask))
     normalized_mpl = _dilate(_normalize_mask(mplmask))

--- a/tests/pyplot/test_state_and_figs.py
+++ b/tests/pyplot/test_state_and_figs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import struct
 from pathlib import Path
 
 import numpy as np
@@ -91,12 +92,16 @@ def test_savefig_png_svg_html(tmp_path: Path) -> None:
 
 
 def test_grid_savefig_png_stitches(tmp_path: Path) -> None:
-    _fig, axes = plt.subplots(1, 2)
+    fig, axes = plt.subplots(1, 2)
     axes[0].plot([0, 1], [1, 2])
     axes[1].bar(["a", "b"], [2, 1])
     target = tmp_path / "grid.png"
     plt.savefig(target)
-    assert target.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
+    data = target.read_bytes()
+    assert data.startswith(b"\x89PNG\r\n\x1a\n")
+    assert struct.unpack(">II", data[16:24]) == tuple(
+        round(value * fig.get_dpi()) for value in fig.get_size_inches()
+    )
 
 
 def test_add_axes_png_uses_native_facecolor_parser() -> None:


### PR DESCRIPTION
## What changed

- Rasterize `xy.pyplot` PNG exports at one physical pixel per `figsize * dpi` pixel.
- Stop doubling composed subplot canvases and `bbox_inches="tight"` padding.
- Update the Matplotlib reference tests to compare equal DPI with equal DPI.
- Add exact dimension assertions for single-panel, multi-panel, and explicit-`dpi` savefig paths.

## Why

The pyplot shim already builds each chart at `figsize * dpi`, but `stitch_png()` passed the native renderer its separate 2x quality default and doubled composed canvases again. As a result, a Matplotlib-compatible 640x480 figure was exported as 1280x960, and point-sized artists were also rendered at the wrong effective DPI.

This change applies a 1:1 physical-pixel contract only at the pyplot compatibility boundary. The native `Figure.to_png()` API retains its explicit 2x default.

## Impact

In the scoped 88-example static-2D Matplotlib gallery comparison:

- exact output dimensions improve from **0/73 to 71/73** paired figures;
- 7 figures improve from `similar` to the stricter `near` fidelity tier;
- no figure regresses in automatic fidelity;
- execution support remains unchanged at 52 paired / 36 unsupported.

The two remaining dimension mismatches are separate issues: `matshow` aspect handling (640x480 versus 480x480) and a one-pixel centimeter conversion rounding difference.

## Validation

- `536 passed, 65 skipped` — complete `tests/pyplot` suite
- `58 passed` — focused savefig/layout/reference tests
- Ruff lint and format checks pass
- `cargo build --release` passes
- 88-example Matplotlib gallery sweep completed