### PR TITLE
Add backend selection handler benchmarks to CodSpeed suite

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -175,10 +175,20 @@ and request-to-next-frame measurements.
 
 `test_codspeed_animation.py` attributes the animation data plane separately:
 100k stable-key encoding, the plain 100k scatter payload, and the same payload
-with keyed transition columns. Run `bench_animation.py` for real-Chrome
+with keyed transition columns — both payload rows through the widget's
+production split transport. Run `bench_animation.py` for real-Chrome
 `updatePayload` time, animation-frame pacing, heap delta, and the hard
 previous+next scene bound; browser clocks and GPU work do not belong in
 CodSpeed simulation.
+
+`test_codspeed_selection.py` covers the backend handlers the client's gesture
+messages resolve to: hover pick readout with a categorical channel, zone-pruned
+and full-scan box select at 1M points, the lasso gesture unit through
+`channel.handle_message` (polygon ray casting plus the wire-mask reply), and
+the cross-filter rows-to-shipped-mask encoding over a NaN-dropped trace so the
+canonical-to-shipped translation is the path measured. `bench_interaction.py`
+stays authoritative for client input-to-pixel latency; these rows attribute a
+selection regression to the Python/kernel handler that caused it.
 
 ## Reference Hardware
 
@@ -204,7 +214,7 @@ JSON artifacts, retain failed/over-budget rows, and label the table
   stage is diagnostic because xy defers work until export.
 - Interactive TTFR is build + HTML serialization + chart-ready time.
 - Interaction browser rows are standalone client input-to-pixel-readback;
-  backend LOD work is in CodSpeed and workflow rows.
+  backend LOD and selection-handler work is in CodSpeed and workflow rows.
 - Dashboard rows attempt 10/20/50 charts, retain timings for partial dashboards,
   record per-chart context loss/restoration plus initial/scrolled nonblank IDs,
   and publish the largest stable loss-free count.

--- a/benchmarks/test_codspeed_animation.py
+++ b/benchmarks/test_codspeed_animation.py
@@ -3,6 +3,13 @@
 Browser frame pacing and GPU allocation lifetime are measured by
 ``bench_animation.py``. These rows isolate the Python work: stable identity
 encoding and the extra binary columns in an otherwise identical payload.
+
+The payload pair rows build ``build_payload_split`` — the widget's production
+first-paint transport — so the keyed-minus-plain gap is exactly the encoded
+key columns, without the packed layout's join copy (which production never
+pays; the packed path stays tracked by test_codspeed_kernels.py's
+test_build_payload and export rows). Repointing them from ``build_payload``
+created a one-time step change in these two series.
 """
 
 from __future__ import annotations
@@ -11,9 +18,36 @@ import numpy as np
 import pytest
 
 import xy
+from xy import kernels as k
 from xy.components import _encode_transition_keys
 
 N = 100_000
+
+
+@pytest.fixture(scope="session", autouse=True)
+def require_native_backend() -> None:
+    assert k.BACKEND == "native", (
+        "CodSpeed benchmarks must run against the native Rust backend; "
+        f"got {k.BACKEND!r}. Build the native core before running them."
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def warm_lazy_modules() -> None:
+    """Warm lazily-imported submodules before any measured region.
+
+    This module collects first alphabetically, so without its own warmup the
+    first payload row would pay lazy submodule import and first-build setup
+    for the whole package — the phantom regression documented in
+    test_codspeed_kernels.py — instead of tracking its own workload.
+    """
+    x = np.array([0.0, 1.0, 2.0, 3.0])
+    y = np.array([0.0, 1.0, 0.0, 1.0])
+    xy.scatter_chart(xy.scatter(x=x, y=y)).figure().build_payload_split()
+    xy.scatter_chart(
+        xy.scatter(x=x, y=y, key=["a", "b", "c", "d"]),
+        xy.animation(match="key", duration=250),
+    ).figure().build_payload_split()
 
 
 @pytest.fixture(scope="module")
@@ -44,16 +78,18 @@ def test_animation_encode_100k_stable_keys(benchmark, animation_data) -> None:
 
 def test_animation_plain_payload_100k(benchmark, payload_figures) -> None:
     plain, _animated = payload_figures
-    spec, blob = benchmark(plain.build_payload)
+    spec, buffers = benchmark(plain.build_payload_split)
     assert spec["traces"][0]["n_marks"] == N
     assert "keys" not in spec["traces"][0]
-    assert blob
+    # Two f32 geometry columns are the floor for the exact scatter tier.
+    assert sum(b.nbytes for b in buffers) >= N * 8
 
 
 def test_animation_keyed_payload_100k(benchmark, payload_figures) -> None:
     _plain, animated = payload_figures
-    spec, blob = benchmark(animated.build_payload)
+    spec, buffers = benchmark(animated.build_payload_split)
     trace = spec["traces"][0]
     assert trace["n_marks"] == N
     assert set(trace["keys"]) == {"lo", "hi"}
-    assert len(blob) > N * 8
+    # Geometry plus the two u32 stable-identity columns the keys add.
+    assert sum(b.nbytes for b in buffers) >= N * 16

--- a/benchmarks/test_codspeed_selection.py
+++ b/benchmarks/test_codspeed_selection.py
@@ -28,7 +28,7 @@ from xy import channel
 from xy import kernels as k
 from xy._figure import Figure  # harness type annotations only
 
-N_BUCKETS = 2048
+PX_WIDTH = 2048
 SELECT_N = 1_000_000
 PICK_N = 100_000
 CROSSFILTER_N = 100_000
@@ -55,7 +55,7 @@ def warm_lazy_modules() -> None:
     x = np.array([0.0, 1.0, 2.0, 3.0])
     y = np.array([0.0, 1.0, 0.0, 1.0])
     fig = xy.chart(xy.scatter(x=x, y=y)).figure()
-    fig.build_payload_split(N_BUCKETS)
+    fig.build_payload_split(PX_WIDTH)
     fig.pick(0, 0)
     channel.handle_message(fig, {"type": "select", "x0": 0.0, "x1": 3.0, "y0": 0.0, "y1": 1.0})
     channel.handle_message(
@@ -72,7 +72,7 @@ def sorted_x_figure() -> Figure:
     x = np.arange(SELECT_N, dtype=np.float64)
     y = rng.normal(0.0, 1.0, SELECT_N)
     fig = xy.chart(xy.scatter(x=x, y=y)).figure()
-    fig.build_payload_split(N_BUCKETS)
+    fig.build_payload_split(PX_WIDTH)
     return fig
 
 
@@ -83,7 +83,7 @@ def uniform_figure() -> Figure:
     x = rng.uniform(0.0, 100.0, SELECT_N).astype(np.float64, copy=False)
     y = rng.uniform(0.0, 100.0, SELECT_N).astype(np.float64, copy=False)
     fig = xy.chart(xy.scatter(x=x, y=y)).figure()
-    fig.build_payload_split(N_BUCKETS)
+    fig.build_payload_split(PX_WIDTH)
     return fig
 
 
@@ -95,7 +95,7 @@ def pick_figure() -> Figure:
     y = rng.normal(0.0, 1.0, PICK_N)
     categories = np.asarray([f"group-{i % 24:02d}" for i in range(PICK_N)])
     fig = xy.chart(xy.scatter(x=x, y=y, color=categories)).figure()
-    fig.build_payload_split(N_BUCKETS)
+    fig.build_payload_split(PX_WIDTH)
     return fig
 
 
@@ -109,7 +109,7 @@ def crossfilter_figure() -> Figure:
     y = rng.normal(0.0, 1.0, CROSSFILTER_N)
     y[::100] = np.nan
     fig = xy.chart(xy.scatter(x=x, y=y)).figure()
-    fig.build_payload_split(N_BUCKETS)
+    fig.build_payload_split(PX_WIDTH)
     return fig
 
 

--- a/benchmarks/test_codspeed_selection.py
+++ b/benchmarks/test_codspeed_selection.py
@@ -1,0 +1,165 @@
+"""CodSpeed benchmarks for the backend interaction/selection handlers.
+
+The browser rows in ``bench_interaction.py`` measure client input-to-pixel
+latency; these rows isolate the Python/kernel work each gesture message
+resolves to (§17/§34): hover pick readout, zone-pruned and full-scan box
+select, lasso ray casting, and the cross-filter row-mask encoding the
+view-state layer ships (view-state.md §5.1). None of them existed as CodSpeed
+rows before, so a selection regression could only surface as browser
+wall-clock noise; here it is attributed to the handler that caused it.
+
+Collection order matters: this module sorts after ``test_codspeed_kernels.py``
+and ``test_codspeed_pyplot.py``, so their fixture materialization order — and
+therefore their baselines — is unchanged (see the ordering note in
+test_codspeed_kernels.py).
+
+Run locally with:
+
+    codspeed run --mode simulation -- pytest benchmarks/test_codspeed_selection.py --codspeed
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import xy
+from xy import channel
+from xy import kernels as k
+from xy._figure import Figure  # harness type annotations only
+
+N_BUCKETS = 2048
+SELECT_N = 1_000_000
+PICK_N = 100_000
+CROSSFILTER_N = 100_000
+LASSO_VERTICES = 64
+
+
+@pytest.fixture(scope="session", autouse=True)
+def require_native_backend() -> None:
+    assert k.BACKEND == "native", (
+        "CodSpeed benchmarks must run against the native Rust backend; "
+        f"got {k.BACKEND!r}. Build the native core before running them."
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def warm_lazy_modules() -> None:
+    """Run every measured handler once, untimed, before any measured region.
+
+    CodSpeed simulation measures one-shot regions from a fresh checkout, and
+    running this module standalone would otherwise charge the first row for
+    lazy submodule imports and bytecode compilation instead of its own
+    workload (the phantom regression documented in test_codspeed_kernels.py).
+    """
+    x = np.array([0.0, 1.0, 2.0, 3.0])
+    y = np.array([0.0, 1.0, 0.0, 1.0])
+    fig = xy.chart(xy.scatter(x=x, y=y)).figure()
+    fig.build_payload_split(N_BUCKETS)
+    fig.pick(0, 0)
+    channel.handle_message(fig, {"type": "select", "x0": 0.0, "x1": 3.0, "y0": 0.0, "y1": 1.0})
+    channel.handle_message(
+        fig,
+        {"type": "select_polygon", "points": [[0.0, -1.0], [3.0, -1.0], [1.5, 2.0]]},
+    )
+    fig.selection_rows_message({0: np.array([0, 2], dtype=np.int64)})
+
+
+@pytest.fixture(scope="module")
+def sorted_x_figure() -> Figure:
+    """1M scatter with monotone x: tight zone maps, so pruning has real work."""
+    rng = np.random.default_rng(61)
+    x = np.arange(SELECT_N, dtype=np.float64)
+    y = rng.normal(0.0, 1.0, SELECT_N)
+    fig = xy.chart(xy.scatter(x=x, y=y)).figure()
+    fig.build_payload_split(N_BUCKETS)
+    return fig
+
+
+@pytest.fixture(scope="module")
+def uniform_figure() -> Figure:
+    """1M uniform scatter: every zone chunk overlaps, the full-scan path."""
+    rng = np.random.default_rng(67)
+    x = rng.uniform(0.0, 100.0, SELECT_N).astype(np.float64, copy=False)
+    y = rng.uniform(0.0, 100.0, SELECT_N).astype(np.float64, copy=False)
+    fig = xy.chart(xy.scatter(x=x, y=y)).figure()
+    fig.build_payload_split(N_BUCKETS)
+    return fig
+
+
+@pytest.fixture(scope="module")
+def pick_figure() -> Figure:
+    """100k exact scatter with a categorical channel for the hover readout."""
+    rng = np.random.default_rng(71)
+    x = np.arange(PICK_N, dtype=np.float64)
+    y = rng.normal(0.0, 1.0, PICK_N)
+    categories = np.asarray([f"group-{i % 24:02d}" for i in range(PICK_N)])
+    fig = xy.chart(xy.scatter(x=x, y=y, color=categories)).figure()
+    fig.build_payload_split(N_BUCKETS)
+    return fig
+
+
+@pytest.fixture(scope="module")
+def crossfilter_figure() -> Figure:
+    """100k exact scatter whose NaN rows were dropped at ship time (§19), so
+    canonical row ids and shipped vertex positions are distinct index spaces
+    and the rows-selection path must actually translate between them."""
+    rng = np.random.default_rng(73)
+    x = np.arange(CROSSFILTER_N, dtype=np.float64)
+    y = rng.normal(0.0, 1.0, CROSSFILTER_N)
+    y[::100] = np.nan
+    fig = xy.chart(xy.scatter(x=x, y=y)).figure()
+    fig.build_payload_split(N_BUCKETS)
+    return fig
+
+
+def test_pick_hover_categorical_readout(benchmark, pick_figure):
+    """Per-mousemove exact f64 row readout, including channel projection."""
+    row = benchmark(pick_figure.pick, 0, 54_321)
+    assert row is not None
+    assert row["index"] == 54_321
+    assert row["color_category"] == f"group-{54_321 % 24:02d}"
+
+
+def test_select_box_zone_pruned_1m(benchmark, sorted_x_figure):
+    """Box select over a 1% x-window: zone-map pruning plus candidate scan."""
+    x0, x1 = SELECT_N * 0.495, SELECT_N * 0.505
+    selected = benchmark(sorted_x_figure.select_range, x0, x1, -2.0, 2.0)
+    # ~10k rows in the window, ~95.4% of a unit normal within +/-2 sigma.
+    assert 8_000 < len(selected[0]) < 10_500
+
+
+def test_select_box_message_full_scan_1m(benchmark, uniform_figure):
+    """Full box-select gesture unit: dispatch, full scan, wire mask reply."""
+    message = {"type": "select", "x0": 30.0, "x1": 60.0, "y0": 30.0, "y1": 60.0, "seq": 3}
+    reply = benchmark(channel.handle_message, uniform_figure, message)
+    assert reply is not None
+    spec, buffers = reply
+    # A 30x30 box over the 100x100 uniform domain holds ~9% of 1M points.
+    assert 80_000 < spec["total"] < 100_000
+    assert len(buffers[0]) == 4 * spec["traces"][0]["count"]
+
+
+def test_select_lasso_message_1m(benchmark, uniform_figure):
+    """Lasso gesture unit: bbox prune, ray casting, wire mask reply."""
+    theta = np.linspace(0.0, 2.0 * np.pi, LASSO_VERTICES, endpoint=False)
+    polygon = [[50.0 + 20.0 * np.cos(t), 50.0 + 20.0 * np.sin(t)] for t in theta]
+    message = {"type": "select_polygon", "points": polygon, "seq": 4}
+    reply = benchmark(channel.handle_message, uniform_figure, message)
+    assert reply is not None
+    spec, buffers = reply
+    # A radius-20 disc covers ~12.6% of the 100x100 uniform domain.
+    assert 115_000 < spec["total"] < 137_000
+    assert len(buffers[0]) == 4 * spec["traces"][0]["count"]
+
+
+def test_selection_rows_message_crossfilter(benchmark, crossfilter_figure):
+    """Cross-filter rows -> validated, deduplicated, shipped-space wire mask."""
+    rows = np.arange(0, CROSSFILTER_N, 2, dtype=np.int64)
+    spec, buffers = benchmark(crossfilter_figure.selection_rows_message, {0: rows})
+    trace = spec["traces"][0]
+    assert spec["total"] == len(rows)
+    # Strictly fewer shipped positions than canonical rows proves the NaN-
+    # dropped translation path ran, not the identity fast path.
+    assert 0 < trace["count"] < len(rows)
+    assert len(buffers[0]) == 4 * trace["count"]

--- a/spec/benchmarks/methodology.md
+++ b/spec/benchmarks/methodology.md
@@ -226,8 +226,9 @@ and tier discipline applies to them rather than a threshold.
 wall time, so browser, install, and cross-library process benchmarks stay out of
 it — those live in `benchmark-refresh.yml`, and the workflow says so inline.
 
-The glob collects three modules — `test_codspeed_kernels.py`,
-`test_codspeed_pyplot.py`, and `test_codspeed_transport.py` — for 94 rows
+The glob collects five modules — `test_codspeed_animation.py`,
+`test_codspeed_kernels.py`, `test_codspeed_pyplot.py`,
+`test_codspeed_selection.py`, and `test_codspeed_transport.py` — for 102 rows
 total. These are trend-tracked in CodSpeed, not gated: none of them feed
 `scripts/check_regressions.py`, whose three inputs are §7's.
 
@@ -276,6 +277,31 @@ zero-copy `memoryview`s; `decode_frame` on both fixtures, asserting the decoded
 buffers alias the original body rather than copying it; and base64-JSON
 encode/decode comparators on the direct fixture, so the codec's advantage stays
 a continuously tracked ratio rather than a remembered one.
+
+**`benchmarks/test_codspeed_animation.py` — 3 rows.** Attribution for the
+declarative animation data plane: 100k stable-key encoding
+(`_encode_transition_keys`), the plain 100k scatter first payload, and the same
+payload with keyed transition columns. The payload pair builds
+`build_payload_split` — the widget's production first-paint transport — so the
+keyed-minus-plain gap is exactly the two shipped u32 identity columns, without
+the packed layout's join copy (which production never pays; the packed path
+stays tracked by the kernels module's `test_build_payload` and export rows).
+The module collects first alphabetically, so it carries its own native-backend
+assertion and lazy-import warmup fixture. Browser `updatePayload` time,
+animation-frame pacing, heap delta, and the previous+next scene bound stay in
+`bench_animation.py`.
+
+**`benchmarks/test_codspeed_selection.py` — 5 rows.** The backend
+interaction/selection handlers the client's gesture messages resolve to
+(design-dossier §17/§34): hover pick with a categorical channel readout;
+zone-pruned box select over a 1% window of a monotone-x 1M scatter; the full
+box-select and lasso gesture units through `channel.handle_message` on a
+uniform 1M scatter — full scan, polygon ray casting, and the wire-mask reply;
+and the cross-filter rows-to-shipped-mask encoding (view-state.md §5.1) over a
+NaN-dropped trace, so the canonical-to-shipped `searchsorted` translation is
+the path measured rather than the identity fast path. Browser input-to-pixel
+latency stays in `bench_interaction.py`; before this module a selection
+regression could only surface as browser wall-clock noise.
 
 **`benchmarks/test_codspeed_kernels.py` — 73 rows** (70 functions; two are
 parametrized, over 2 ingest flavors and 3 `bin_2d` thread-cap regimes). This is

--- a/spec/benchmarks/results.md
+++ b/spec/benchmarks/results.md
@@ -122,6 +122,13 @@ scope, not the kernels module alone. The suite asserts `xy.kernels.BACKEND ==
   `encode_frame` / `decode_frame` rows for density and direct payloads,
   a parts-encode row, and base64 encode/decode comparators standing in for the
   JSON-embedded prototype shape.
+- The animation data plane (`benchmarks/test_codspeed_animation.py`):
+  100k stable-key encoding plus a plain-versus-keyed split-payload pair, so
+  keyed-transition overhead stays attributed to the key columns.
+- The backend selection handlers (`benchmarks/test_codspeed_selection.py`):
+  hover pick readout, zone-pruned and full-scan box select, the lasso gesture
+  unit through `channel.handle_message`, and the cross-filter
+  rows-to-shipped-mask encoding.
 
 That keeps CodSpeed focused on native range queries, pyramid composition,
 tier-switch payload generation, payload prep, zoom latency, and memory-report

--- a/tests/test_benchmark_environment.py
+++ b/tests/test_benchmark_environment.py
@@ -118,6 +118,46 @@ def test_codspeed_suite_covers_native_core_hardening_workloads() -> None:
         assert "benchmark" in args, f"{name} must be timed by pytest-codspeed"
 
 
+def test_codspeed_suite_covers_backend_selection_workloads() -> None:
+    source = (ROOT / "benchmarks" / "test_codspeed_selection.py").read_text(encoding="utf-8")
+    required_markers = [
+        "SELECT_N = 1_000_000",
+        "PICK_N = 100_000",
+        "CROSSFILTER_N = 100_000",
+        "require_native_backend",
+        'k.BACKEND == "native"',
+    ]
+    for marker in required_markers:
+        assert marker in source
+
+    module = ast.parse(source)
+    functions = {node.name: node for node in module.body if isinstance(node, ast.FunctionDef)}
+    required_benchmarks = {
+        "test_pick_hover_categorical_readout",
+        "test_select_box_zone_pruned_1m",
+        "test_select_box_message_full_scan_1m",
+        "test_select_lasso_message_1m",
+        "test_selection_rows_message_crossfilter",
+    }
+    missing = sorted(required_benchmarks - set(functions))
+    assert missing == []
+
+    for name in sorted(required_benchmarks):
+        args = {arg.arg for arg in functions[name].args.args}
+        assert "benchmark" in args, f"{name} must be timed by pytest-codspeed"
+
+
+def test_codspeed_animation_module_guards_backend_and_split_transport() -> None:
+    source = (ROOT / "benchmarks" / "test_codspeed_animation.py").read_text(encoding="utf-8")
+    # This module collects first alphabetically, so it must carry its own
+    # backend assertion and lazy-import warmup, and its payload pair must
+    # track the widget's production split transport.
+    assert "require_native_backend" in source
+    assert 'k.BACKEND == "native"' in source
+    assert "warm_lazy_modules" in source
+    assert "build_payload_split" in source
+
+
 def test_codspeed_dependency_is_declared_and_shared_by_ci_and_runbook() -> None:
     pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
     workflow = (ROOT / ".github" / "workflows" / "codspeed.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
Adds comprehensive benchmarking for the backend interaction and selection handlers that process client gesture messages, isolating Python/kernel work that was previously only measurable as browser wall-clock noise.

## Summary

This change introduces `benchmarks/test_codspeed_selection.py`, a new CodSpeed benchmark module covering five critical backend handlers: hover pick readout, zone-pruned box select, full-scan box select, lasso polygon selection, and cross-filter row-mask encoding. These benchmarks measure the Python/kernel work each gesture message resolves to (design-dossier §17/§34), enabling selection regressions to be attributed to the specific handler that caused them rather than surfacing only as browser latency noise.

## Key Changes

- **New benchmark module** (`benchmarks/test_codspeed_selection.py`):
  - `test_pick_hover_categorical_readout`: Per-mousemove exact f64 row readout with channel projection (100k points)
  - `test_select_box_zone_pruned_1m`: Box select over 1% x-window of monotone-x 1M scatter (zone-map pruning path)
  - `test_select_box_message_full_scan_1m`: Full box-select gesture through `channel.handle_message` on uniform 1M scatter
  - `test_select_lasso_message_1m`: Lasso gesture with polygon ray casting on uniform 1M scatter
  - `test_selection_rows_message_crossfilter`: Cross-filter rows-to-shipped-mask encoding over NaN-dropped trace (canonical-to-shipped translation path)
  - Includes native-backend assertion and lazy-module warmup fixtures to prevent phantom regressions

- **Updated `benchmarks/test_codspeed_animation.py`**:
  - Added native-backend assertion and lazy-module warmup fixtures (module collects first alphabetically)
  - Changed payload benchmarks from `build_payload` to `build_payload_split` to track the widget's production first-paint transport
  - Updated assertions to reflect split-transport buffer structure

- **Updated specification and documentation**:
  - `spec/benchmarks/methodology.md`: Documents the five new selection handler rows and updates total CodSpeed row count from 94 to 102
  - `spec/benchmarks/results.md`: Adds selection handlers to the CodSpeed coverage summary
  - `benchmarks/README.md`: Describes the new selection benchmark module and its relationship to `bench_interaction.py`
  - `tests/test_benchmark_environment.py`: Adds validation that the new module exists with required markers and benchmarks

## Implementation Details

- Fixtures use realistic data scales: 1M points for select/lasso (testing zone-pruning and full-scan paths), 100k for pick and cross-filter
- Cross-filter fixture includes NaN rows dropped at ship time to exercise the canonical-to-shipped index translation path rather than the identity fast path
- Collection order preserved: animation module (first alphabetically) carries its own warmup; selection module sorts after kernels and pyplot modules
- All benchmarks assert `k.BACKEND == "native"` to ensure measurements are against the Rust core, not a fallback

https://claude.ai/code/session_01DKSERMBgoiCQCSwof35XXn