### PR TITLE
chore: gitignore Reflex .web build output and generated assets/xy payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__/
 .ruff_cache/
 node_modules/
 *.egg-info/
+.web/
+**/assets/xy/*.xyf


### PR DESCRIPTION
Running or compiling a Reflex example app leaves untracked build output in the worktree. Ignore it at the repo root:

- `.web/` — Reflex's frontend build directory, matched at any depth (covers `examples/reflex/.web/`, `docs/app/.web/`, and any future example app).
- `**/assets/xy/*.xyf` — content-hash-named binary chart payloads written by `reflex_xy.payload_asset` into a compiling app's `assets/xy/`. Scoped to that directory so `.xyf` fixtures elsewhere (e.g. test corpora) remain trackable.

Both are regenerable artifacts; no tracked files are affected.