### PR TITLE
Preserve names on filled contour heatmaps

### DIFF
--- a/python/xy/marks.py
+++ b/python/xy/marks.py
@@ -2185,13 +2185,20 @@ def contour(
                     banded,
                     x=dense_x,
                     y=dense_y,
-                    name=None,
+                    name=name,
                     colormap=colormap,
                     domain=(float(edges[0]), float(edges[-1])),
                     opacity=min(opacity, 0.9),
                 )
             else:
-                self.heatmap(arr, x=x, y=y, name=None, colormap=colormap, opacity=min(opacity, 0.7))
+                self.heatmap(
+                    arr,
+                    x=x,
+                    y=y,
+                    name=name,
+                    colormap=colormap,
+                    opacity=min(opacity, 0.7),
+                )
         x0, x1, y0, y1, level_values = _contour_segments(arr, xpos, ypos, level_values)
         if len(x0) == 0:
             raise ValueError("contour levels do not intersect the finite grid")

--- a/tests/test_plot_families.py
+++ b/tests/test_plot_families.py
@@ -292,6 +292,32 @@ def test_failing_filled_contour_rolls_back_the_heatmap() -> None:
     assert len(fig.store) == 0
 
 
+@pytest.mark.parametrize(
+    "levels",
+    [
+        np.array([0.0, 6.0, 12.0, 18.0, 24.0]),
+        np.array([12.0]),
+    ],
+    ids=["banded", "direct"],
+)
+@pytest.mark.parametrize(
+    ("name", "expected_name"), [("Predicted yield", "Predicted yield"), (None, None)]
+)
+def test_filled_contour_heatmap_retains_name(levels, name, expected_name) -> None:
+    fig = Figure().contour(
+        np.arange(25, dtype=float).reshape(5, 5),
+        levels=levels,
+        filled=True,
+        name=name,
+    )
+
+    spec, _ = fig.build_payload()
+
+    assert len(spec["traces"]) == 1
+    assert spec["traces"][0]["kind"] == "heatmap"
+    assert spec["traces"][0]["name"] == expected_name
+
+
 def test_failing_box_and_violin_commit_no_axis_categories() -> None:
     for mark in ("box", "violin"):
         fig = Figure()


### PR DESCRIPTION
### Motivation
- Filled contours translated to internal heatmap traces were losing the series `name`, causing legends to show a generic fallback instead of the supplied label.

### Description
- Forward the contour `name` to the internal `heatmap` call in both the banded (interpolated) and direct filled-surface branches in `python/xy/marks.py` so named filled contours keep their label.
- Add `test_filled_contour_heatmap_retains_name` to `tests/test_plot_families.py`, parameterized to cover both the banded and direct paths and both named and unnamed contours, asserting the compiled trace is a `heatmap` with the exact expected `name`.
- Run automatic formatting on the modified files with `ruff format`.

### Testing
- `ruff format python/xy/marks.py tests/test_plot_families.py` — formatted one file and completed successfully.
- `ruff check python/xy/marks.py tests/test_plot_families.py` — all lint checks passed.
- `PYTHONPATH=python pytest -q tests/test_plot_families.py -k 'filled_contour'` — executed focused tests: 5 passed, 23 deselected.
- Broader test collection including `tests/test_components.py` was attempted but failed during collection due to a missing generated bundle `python/xy/static/index.js` in the checkout; this is an environment limitation and not related to the code change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61362904b48333a7b42ff727df1d26)