### PR TITLE
Ship continuous color/size and density_val as u8 on the live drill wire

### DIFF
--- a/js/src/45_lod.ts
+++ b/js/src/45_lod.ts
@@ -392,7 +392,7 @@ export function lodApplyDrill(view, g, upd, buffers) {
       : view._asF32(buffers[upd.color.buf]);
     const colorBufferName = d.colorMode === 3 ? "rgbaBuf" : "cBuf";
     if (!d[colorBufferName]) d[colorBufferName] = gl.createBuffer();
-    d[colorBufferName]._fcType = colorValues instanceof Uint8Array ? gl.UNSIGNED_BYTE : gl.FLOAT;
+    view._tagChannelBuf(d[colorBufferName], colorValues, d.colorMode === 1);
     gl.bindBuffer(gl.ARRAY_BUFFER, d[colorBufferName]);
     gl.bufferData(gl.ARRAY_BUFFER, colorValues, gl.STATIC_DRAW);
     if (d.colorMode !== 3) {
@@ -406,9 +406,13 @@ export function lodApplyDrill(view, g, upd, buffers) {
   d.sizeRange = [2, 18];
   if (upd.size && upd.size.mode === "continuous") {
     d.sizeMode = 1;
+    const sizeValues = upd.size.dtype === "u8"
+      ? view._asU8(buffers[upd.size.buf])
+      : view._asF32(buffers[upd.size.buf]);
     if (!d.sBuf) d.sBuf = gl.createBuffer();
+    view._tagChannelBuf(d.sBuf, sizeValues, true);
     gl.bindBuffer(gl.ARRAY_BUFFER, d.sBuf);
-    gl.bufferData(gl.ARRAY_BUFFER, view._asF32(buffers[upd.size.buf]), gl.STATIC_DRAW);
+    gl.bufferData(gl.ARRAY_BUFFER, sizeValues, gl.STATIC_DRAW);
     d.sizeRange = upd.size.range_px;
   }
   const styleChannel = (name) => upd.channels && upd.channels[name];
@@ -453,9 +457,13 @@ export function lodApplyDrill(view, g, upd, buffers) {
   // colormap, so the texture->marks swap doesn't recolor the chart; deeper
   // zooms ship smaller blends and the native colors ease in.
   if (upd.density_val && upd.density_val.buf !== undefined) {
+    const dvalValues = upd.density_val.dtype === "u8"
+      ? view._asU8(buffers[upd.density_val.buf])
+      : view._asF32(buffers[upd.density_val.buf]);
     if (!d.dBuf) d.dBuf = gl.createBuffer();
+    view._tagChannelBuf(d.dBuf, dvalValues, true);
     gl.bindBuffer(gl.ARRAY_BUFFER, d.dBuf);
-    gl.bufferData(gl.ARRAY_BUFFER, view._asF32(buffers[upd.density_val.buf]), gl.STATIC_DRAW);
+    gl.bufferData(gl.ARRAY_BUFFER, dvalValues, gl.STATIC_DRAW);
     d.dlut = view._lut(upd.density_colormap || "viridis");
     const first = d.lodBlend === undefined;
     d.lodBlend = Math.min(1, upd.lod_blend ?? 0);

--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -2975,15 +2975,24 @@ export class ChartView {
   // Tag a (re)uploaded per-point channel buffer with its element type. u8
   // uploads of unit-scalar channels (continuous color/size, density_val) bind
   // normalized so the shader keeps seeing [0,1]; categorical codes stay
-  // un-normalized (the shader addresses palette texels with the raw code). A
-  // dtype change re-ids the buffer so any VAO holding the old pointer config
-  // rebuilds instead of silently misreading the bytes.
+  // un-normalized (the shader addresses palette texels with the raw code).
+  // Any pointer-config change — dtype OR normalization — re-ids the buffer so
+  // a VAO holding the old configuration rebuilds instead of silently
+  // misreading the bytes. Normalization can flip with the dtype unchanged: a
+  // reused cBuf crossing categorical (u8 codes, un-normalized) ↔ continuous
+  // (u8 coordinates, normalized) keeps UNSIGNED_BYTE both ways.
   _tagChannelBuf(buf, values, normalized) {
     const gl = this.gl;
     const type = values instanceof Uint8Array ? gl.UNSIGNED_BYTE : gl.FLOAT;
-    if (buf._fcType !== undefined && buf._fcType !== type) buf._fcId = ++this._bufSeq;
+    const isNormalized = !!normalized && type === gl.UNSIGNED_BYTE;
+    if (
+      buf._fcType !== undefined &&
+      (buf._fcType !== type || buf._fcNormalized !== isNormalized)
+    ) {
+      buf._fcId = ++this._bufSeq;
+    }
     buf._fcType = type;
-    buf._fcNormalized = !!normalized && type === gl.UNSIGNED_BYTE;
+    buf._fcNormalized = isNormalized;
   }
 
   _initPickTarget() {

--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -2360,7 +2360,7 @@ export class ChartView {
         : this._asF32(buffers[sample.color.buf]);
       const colorBufferName = s.colorMode === 3 ? "rgbaBuf" : "cBuf";
       s[colorBufferName] = gl.createBuffer();
-      s[colorBufferName]._fcType = colorValues instanceof Uint8Array ? gl.UNSIGNED_BYTE : gl.FLOAT;
+      this._tagChannelBuf(s[colorBufferName], colorValues, s.colorMode === 1);
       gl.bindBuffer(gl.ARRAY_BUFFER, s[colorBufferName]);
       gl.bufferData(gl.ARRAY_BUFFER, colorValues, gl.STATIC_DRAW);
       if (s.colorMode !== 3) {
@@ -2371,9 +2371,13 @@ export class ChartView {
     }
     if (sample.size && sample.size.mode === "continuous") {
       s.sizeMode = 1;
+      const sizeValues = sample.size.dtype === "u8"
+        ? this._asU8(buffers[sample.size.buf])
+        : this._asF32(buffers[sample.size.buf]);
       s.sBuf = gl.createBuffer();
+      this._tagChannelBuf(s.sBuf, sizeValues, true);
       gl.bindBuffer(gl.ARRAY_BUFFER, s.sBuf);
-      gl.bufferData(gl.ARRAY_BUFFER, this._asF32(buffers[sample.size.buf]), gl.STATIC_DRAW);
+      gl.bufferData(gl.ARRAY_BUFFER, sizeValues, gl.STATIC_DRAW);
       s.sizeRange = sample.size.range_px;
     }
     const channel = (name) => sample.channels && sample.channels[name];
@@ -2962,8 +2966,24 @@ export class ChartView {
     const gl = this.gl;
     gl.bindBuffer(gl.ARRAY_BUFFER, buf);
     gl.enableVertexAttribArray(slot);
-    gl.vertexAttribPointer(slot, size, buf._fcType || gl.FLOAT, normalized, 0, byteOffset);
+    gl.vertexAttribPointer(
+      slot, size, buf._fcType || gl.FLOAT, normalized || !!buf._fcNormalized, 0, byteOffset,
+    );
     gl.vertexAttribDivisor(slot, divisor);
+  }
+
+  // Tag a (re)uploaded per-point channel buffer with its element type. u8
+  // uploads of unit-scalar channels (continuous color/size, density_val) bind
+  // normalized so the shader keeps seeing [0,1]; categorical codes stay
+  // un-normalized (the shader addresses palette texels with the raw code). A
+  // dtype change re-ids the buffer so any VAO holding the old pointer config
+  // rebuilds instead of silently misreading the bytes.
+  _tagChannelBuf(buf, values, normalized) {
+    const gl = this.gl;
+    const type = values instanceof Uint8Array ? gl.UNSIGNED_BYTE : gl.FLOAT;
+    if (buf._fcType !== undefined && buf._fcType !== type) buf._fcId = ++this._bufSeq;
+    buf._fcType = type;
+    buf._fcNormalized = !!normalized && type === gl.UNSIGNED_BYTE;
   }
 
   _initPickTarget() {

--- a/python/xy/_payload.py
+++ b/python/xy/_payload.py
@@ -877,10 +877,17 @@ class PayloadMixin(_Host):
         self._ship_trace_styles(entry, t, sel_arg, pw)
         return self._transition_entry(entry, t, pw, sel_arg)
 
-    def _ship_channels(self, t: Trace, sel, ship_scalar, ship_u8) -> tuple[Any, Any]:  # noqa: ANN001
+    def _ship_channels(
+        self, t: Trace, sel, ship_scalar, ship_u8, *, quantize_continuous: bool = False
+    ) -> tuple[Any, Any]:  # noqa: ANN001
         """Ship a trace's color/size channels (delegates to channels.py — the
-        same wire shape serves the build path and drill-in view updates)."""
-        return channels.ship_channels(t, sel, ship_scalar, ship_u8, DEFAULT_PALETTE)
+        same wire shape serves the build path and drill-in view updates).
+        `quantize_continuous` is for live-interaction callers only; the build
+        path keeps unit f32 because tooltips denormalize the shipped columns
+        (see channels.ship_channels)."""
+        return channels.ship_channels(
+            t, sel, ship_scalar, ship_u8, DEFAULT_PALETTE, quantize_continuous=quantize_continuous
+        )
 
     @staticmethod
     def _ship_trace_styles(entry: dict[str, Any], t: Trace, sel, pw: "_PayloadWriter") -> None:  # noqa: ANN001

--- a/python/xy/channels.py
+++ b/python/xy/channels.py
@@ -512,12 +512,25 @@ def normalize_to_unit(values: npt.NDArray[np.float64], domain: tuple[float, floa
     return kernels.normalize_f32(values, domain, nonfinite="zero")
 
 
+def quantize_unit_u8(values: npt.NDArray[np.float64], domain: tuple[float, float]) -> np.ndarray:
+    """Normalize over `domain` and quantize to u8 (0..255 spanning [0,1]).
+
+    The lossy sibling of :func:`normalize_to_unit`, for wire paths where the
+    value is only ever a GPU LUT/ramp coordinate (a colormap texture has 256
+    texels; a size ramp spans ~16 px) and is never read back into a displayed
+    number — 75% less traffic than f32, same rendered output (§29)."""
+    unit = normalize_to_unit(values, domain)
+    return np.rint(np.clip(unit, 0.0, 1.0) * 255.0).astype(np.uint8)
+
+
 def ship_channels(
     trace: Any,
     sel: Any,
     ship_scalar: Any,
     ship_u8: Any,
     palette: list[str],
+    *,
+    quantize_continuous: bool = False,
 ) -> tuple[Any, Any]:
     """Ship a trace's color and size channels in the standard wire shape
     (design dossier §29/§36c): per-point channels carry a `buf` index into the blob; constant
@@ -527,9 +540,18 @@ def ship_channels(
     Slices *before* normalizing: normalization is element-wise over a
     precomputed global domain, and drill updates call this per zoom step —
     normalizing all N rows to ship a 200k window is O(N) work for nothing.
+
+    `quantize_continuous` ships continuous color/size as u8 LUT coordinates
+    (`dtype: "u8"` marker) instead of unit f32. Live-interaction paths opt in:
+    their hover/pick answers come from the server's canonical columns, so the
+    quantization is invisible. The build path must NOT opt in — it retains the
+    shipped columns CPU-side (`_cpu.color`/`_cpu.size`) and denormalizes them
+    for tooltip readouts, where 8-bit steps would show as wrong digits.
     Returns (color_spec, size_spec)."""
     cc = trace.color_ch or ColorChannel(mode="constant", constant=None)
-    color_spec = ship_color_channel(cc, sel, ship_scalar, ship_u8, palette)
+    color_spec = ship_color_channel(
+        cc, sel, ship_scalar, ship_u8, palette, quantize_continuous=quantize_continuous
+    )
     sc = trace.size_ch or SizeChannel(mode="constant")
     size_spec = sc.spec()
     if sc.mode == "continuous":
@@ -538,12 +560,22 @@ def ship_channels(
         if values is None or domain is None:
             raise ValueError("continuous size channel missing values or domain")
         vals = values if sel is None else values[sel]
-        size_spec["buf"] = ship_scalar(normalize_to_unit(vals, domain))
+        if quantize_continuous:
+            size_spec["buf"] = ship_u8(quantize_unit_u8(vals, domain))
+            size_spec["dtype"] = "u8"
+        else:
+            size_spec["buf"] = ship_scalar(normalize_to_unit(vals, domain))
     return color_spec, size_spec
 
 
 def ship_color_channel(
-    cc: ColorChannel, sel: Any, ship_scalar: Any, ship_u8: Any, palette: list[str]
+    cc: ColorChannel,
+    sel: Any,
+    ship_scalar: Any,
+    ship_u8: Any,
+    palette: list[str],
+    *,
+    quantize_continuous: bool = False,
 ) -> dict[str, Any]:
     """Ship one fill/stroke paint channel in the common wire representation."""
     color_spec = cc.spec()
@@ -563,7 +595,11 @@ def ship_color_channel(
         if values is None or domain is None:
             raise ValueError("continuous color channel missing values or domain")
         vals = values if sel is None else values[sel]
-        color_spec["buf"] = ship_scalar(normalize_to_unit(vals, domain))
+        if quantize_continuous:
+            color_spec["buf"] = ship_u8(quantize_unit_u8(vals, domain))
+            color_spec["dtype"] = "u8"
+        else:
+            color_spec["buf"] = ship_scalar(normalize_to_unit(vals, domain))
     elif cc.mode == "categorical":
         code_values = cc.codes
         categories = cc.categories

--- a/python/xy/interaction.py
+++ b/python/xy/interaction.py
@@ -501,7 +501,9 @@ def _density_sample_update(
         fig._axis_scale(t.x_axis),
         fig._axis_scale(t.y_axis),
     )
-    color_spec, size_spec = fig._ship_channels(t, sample_sel, writer.add_f32, writer.add_u8)
+    color_spec, size_spec = fig._ship_channels(
+        t, sample_sel, writer.add_f32, writer.add_u8, quantize_continuous=True
+    )
     style = dict(t.style)
     try:
         style["opacity"] = min(float(style.get("opacity", 0.8)), 0.55)
@@ -531,6 +533,15 @@ def _density_sample_update(
             t.style_channels, sample_sel, writer.add_f32, writer.add_u8
         )
     return sample
+
+
+def _quantize_dval(dval: np.ndarray) -> np.ndarray:
+    """Quantize per-point local log-density ([0,1] by construction) to u8.
+
+    The value is only a LUT coordinate for the density→points color handoff
+    (§5) — 256 levels exceed what the crossfade can show, at a quarter of the
+    f32 wire bytes (§29)."""
+    return np.rint(np.clip(dval, 0.0, 1.0) * 255.0).astype(np.uint8)
 
 
 def _has_point_channels(t: "Trace") -> bool:
@@ -573,7 +584,9 @@ def _ship_index_points(
     writer = lod.BufferWriter()
     x_ref, y_ref = lod.add_window_xy(writer, xs, ys, lo_x, hi_x, lo_y, hi_y)
     gw, gh = lod.grid_shape(request.width, request.height, visible)
-    dval_buf = writer.add_f32(lod.local_log_density(xs, ys, lo_x, hi_x, lo_y, hi_y, gw, gh))
+    dval_buf = writer.add_u8(
+        _quantize_dval(lod.local_log_density(xs, ys, lo_x, hi_x, lo_y, hi_y, gw, gh))
+    )
     drill_seq = lod.enter_drill(t, np.empty(0, dtype=np.uint32))
     lod_blend = float(min(1.0, visible / SCATTER_DENSITY_THRESHOLD))
     color_spec = (
@@ -593,7 +606,7 @@ def _ship_index_points(
         "y": y_ref,
         "color": color_spec,
         "size": size_spec,
-        "density_val": {"buf": dval_buf},
+        "density_val": {"buf": dval_buf, "dtype": "u8"},
         "lod_blend": lod_blend,
         "density_colormap": channels.DEFAULT_COLORMAP,
         "drill_seq": drill_seq,
@@ -826,7 +839,9 @@ def _drill_points(
     )
     buffers = writer.buffers
 
-    color_spec, size_spec = fig._ship_channels(t, sel, writer.add_f32, writer.add_u8)
+    color_spec, size_spec = fig._ship_channels(
+        t, sel, writer.add_f32, writer.add_u8, quantize_continuous=True
+    )
 
     # Local log-density per drilled point, binned at the same screen-derived
     # grid shape density would use — in the same (scale-coordinate) binning
@@ -834,7 +849,9 @@ def _drill_points(
     gw, gh = lod.grid_shape(w, h, visible)
     dx, (d_x0, d_x1) = fig._binning_coords(t.x_axis, xs, (lo_x, hi_x))
     dy, (d_y0, d_y1) = fig._binning_coords(t.y_axis, ys, (lo_y, hi_y))
-    dval_buf = writer.add_f32(lod.local_log_density(dx, dy, d_x0, d_x1, d_y0, d_y1, gw, gh))
+    dval_buf = writer.add_u8(
+        _quantize_dval(lod.local_log_density(dx, dy, d_x0, d_x1, d_y0, d_y1, gw, gh))
+    )
     drill_seq = lod.enter_drill(t, sel)
     # 1.0 right at the boundary → density-colored points; →0 as zoom deepens.
     lod_blend = float(min(1.0, visible / SCATTER_DENSITY_THRESHOLD))
@@ -859,7 +876,7 @@ def _drill_points(
         "y": y_ref,
         "color": color_spec,
         "size": size_spec,
-        "density_val": {"buf": dval_buf},
+        "density_val": {"buf": dval_buf, "dtype": "u8"},
         "lod_blend": lod_blend,
         "density_colormap": cmap,
         "drill_seq": drill_seq,

--- a/spec/design/wire-protocol.md
+++ b/spec/design/wire-protocol.md
@@ -137,6 +137,18 @@ states which representation this view resolved to:
   style}`. `x_range`/`y_range` are the window these points cover; the client
   falls back to the density overview the moment the view leaves it.
 
+  Channel encodings on this (and the sampled-overlay) live wire: `x`/`y` are
+  offset-encoded f32 (position precision is load-bearing, dossier §16), but
+  every unit-scalar channel — continuous `color`, continuous `size`,
+  `density_val` — ships as **u8 LUT coordinates** with a `dtype: "u8"`
+  marker (absent means f32; the client accepts both), and categorical color
+  ships u8 codes. The quantization is safe precisely because these values are
+  never read back into displayed numbers on a live path: hover/pick answers
+  come from the kernel's canonical columns (`pick_result` above). The *build*
+  payload keeps continuous channels as unit f32 — the client retains those
+  columns CPU-side and denormalizes them for tooltip readouts, where 8-bit
+  steps would surface as wrong digits (`channels.ship_channels`).
+
 The client enforces `msg.seq` only when it is present, and additionally
 accepts `msg.trace` and `msg.stale` for pending-request bookkeeping — no
 current kernel path emits either field.

--- a/tests/test_scatter.py
+++ b/tests/test_scatter.py
@@ -597,6 +597,41 @@ def test_categorical_drill_update_ships_u8_codes() -> None:
     assert set(codes.tolist()) == set(range(7))
 
 
+def test_continuous_drill_update_ships_u8_but_build_payload_stays_f32() -> None:
+    """Live drill/sample wire quantizes continuous color+size+density_val to u8
+    (readbacks resolve server-side); the build payload keeps unit f32 because
+    the client retains those columns CPU-side and denormalizes them for
+    tooltip readouts (channels.ship_channels)."""
+    n = SCATTER_DENSITY_THRESHOLD + 10_000
+    rng = np.random.default_rng(7)
+    x = rng.uniform(0.0, 100.0, n)
+    y = rng.uniform(0.0, 100.0, n)
+    c = rng.uniform(0.0, 1.0, n)
+    s = rng.uniform(2.0, 16.0, n)
+    fig = Figure().scatter(x, y, color=c, size=s, density=True)
+
+    update, buffers = fig.density_view(0, 0.0, 5.0, 0.0, 5.0, 640, 400)
+    tr = update["traces"][0]
+    assert tr["mode"] == "points"
+    for spec in (tr["color"], tr["size"], tr["density_val"]):
+        assert spec["dtype"] == "u8"
+        assert len(buffers[spec["buf"]]) == tr["visible"]  # 1 byte/point
+    sbuf = np.frombuffer(buffers[tr["size"]["buf"]], dtype=np.uint8)
+    vis = (x >= 0) & (x <= 5) & (y >= 0) & (y <= 5)
+    expected = (s[vis] - s.min()) / (s.max() - s.min())
+    np.testing.assert_allclose(sbuf / 255.0, expected, atol=0.5 / 255.0 + 1e-6)
+
+    # Build path: same channels, but full-precision unit f32, no dtype marker.
+    small = Figure().scatter(x[:1000], y[:1000], color=c[:1000], size=s[:1000])
+    spec, blob = small.build_payload()
+    entry = spec["traces"][0]
+    for chan in (entry["color"], entry["size"]):
+        assert "dtype" not in chan
+        col = spec["columns"][chan["buf"]]
+        vals = np.frombuffer(blob, dtype=np.float32, count=col["len"], offset=col["byte_offset"])
+        assert vals.min() >= 0.0 and vals.max() <= 1.0
+
+
 def test_small_scatter_stays_direct():
     fig = Figure().scatter(np.arange(1000.0), np.arange(1000.0))
     assert not fig.traces[0].use_density()
@@ -694,9 +729,12 @@ def test_density_view_drills_to_points_when_window_fits():
     xs = np.frombuffer(bufs[tr["x"]["buf"]], dtype=np.float32)
     assert len(xs) == inwin
     assert tr["x"]["offset"] == pytest.approx(5.0)  # §16 window-centered
-    assert tr["color"]["mode"] == "continuous"
-    cbuf = np.frombuffer(bufs[tr["color"]["buf"]], dtype=np.float32)
-    assert len(cbuf) == inwin and cbuf.min() >= 0.0 and cbuf.max() <= 1.0
+    # Continuous channels on the drill wire are u8 LUT coordinates (§29:
+    # live-interaction readbacks resolve server-side, so quantization is
+    # invisible; the ramp/colormap only has ~256 useful levels anyway).
+    assert tr["color"]["mode"] == "continuous" and tr["color"]["dtype"] == "u8"
+    cbuf = np.frombuffer(bufs[tr["color"]["buf"]], dtype=np.uint8)
+    assert len(cbuf) == inwin
     assert fig.traces[0].drill_mode is True
     # pick speaks drilled indices: shipped 0 -> a canonical row in the window
     row = fig.pick(0, 0)
@@ -705,18 +743,18 @@ def test_density_view_drills_to_points_when_window_fits():
     # Color-continuous handoff: per-point local log-density in [0,1], a blend
     # weight = visible/budget, and the colormap the density surface uses —
     # so freshly drilled points wear the density ramp (§5, never a palette jump).
-    dbuf = np.frombuffer(bufs[tr["density_val"]["buf"]], dtype=np.float32)
+    assert tr["density_val"]["dtype"] == "u8"
+    dbuf = np.frombuffer(bufs[tr["density_val"]["buf"]], dtype=np.uint8)
     assert len(dbuf) == inwin
-    assert dbuf.min() >= 0.0 and dbuf.max() <= 1.0
-    assert dbuf.max() == pytest.approx(1.0)  # the hottest cell hits the ramp top
+    assert dbuf.max() == 255  # the hottest cell hits the ramp top
     assert tr["lod_blend"] == pytest.approx(inwin / SCATTER_DENSITY_THRESHOLD)
     assert tr["density_colormap"] == "viridis"  # continuous channel's colormap
     # Channels are normalized over the *global* domain after slicing (staff
-    # review: slice-first must not change values — colors stay view-stable).
-    cbuf2 = np.frombuffer(bufs[tr["color"]["buf"]], dtype=np.float32)
+    # review: slice-first must not change values — colors stay view-stable),
+    # then quantized: every byte within half a step of the exact unit value.
     vis = (x >= 0) & (x <= 10) & (y >= 0) & (y <= 10)
     expected = (c[vis] - c.min()) / (c.max() - c.min())
-    np.testing.assert_allclose(cbuf2, expected.astype(np.float32), rtol=1e-5, atol=1e-6)
+    np.testing.assert_allclose(cbuf / 255.0, expected, atol=0.5 / 255.0 + 1e-6)
 
 
 def test_interaction_windows_reject_nonfinite_bounds():


### PR DESCRIPTION
Live drill and sample-overlay updates ship continuous color/size channels and the `density_val` crossfade weight as **u8 LUT coordinates** (`dtype: "u8"` marker; absent means f32 — the client accepts both), mirroring what categorical codes already do. Base: `main`. No build artifacts in the diff — bundles regenerate via `node js/build.mjs` / packaging (#214).

## Measured impact

Same 190,105-point drill window on the FastAPI `/drilldown` example (100M-point source), before/after captures diffed buffer-by-buffer:

| Metric | before (f32) | after (u8) | Δ |
|---|---|---|---|
| Drill payload on the wire (b64-in-JSON transport) | 5,070,199 B | 2,788,978 B | **−45.0%** |
| Raw buffer bytes per drill | 3,802,100 B | 2,091,155 B | −45.0% |
| Bytes/point (raw) | 20 | 11 | dossier budget is 12–24 B/pt direct |
| Channel bytes/point (color + size + density_val) | 12 | 3 | **−75%** |
| x/y position buffers | 760,420 B ×2 | byte-identical | unchanged (f32 offset-encoded, §16) |
| Max quantization error (unit range) | — | 0.00196 (= ½/255 bound) | invisible: 256-texel LUT / ~16 px ramp |
| Server response time (same window) | ~4.0 s | ~4.0 s | encode is not the bottleneck |
| Rendering | — | pixel-equivalent | verified in-browser, 0 console errors |

## Where quantization is safe — and where it is forbidden

The split is by **readback**, enforced by making u8 opt-in per call site (`quantize_continuous` on `ship_channels`):

- **Live drill/sample paths opt in** — these payloads are rebuilt wholesale per view and their hover/pick answers come from the kernel's canonical f64 columns, so 8-bit channel coordinates are invisible everywhere but the wire.
- **The build payload must not** — the client retains those columns CPU-side (`_cpu.color`/`_cpu.size`) and denormalizes them for tooltip readouts, where 8-bit steps would surface as wrong digits. Pinned by test.

## How

- `channels.py`: `quantize_unit_u8` + `quantize_continuous` threading through `ship_channels`/`ship_color_channel`; the two live-interaction call sites in `interaction.py` opt in; `density_val` quantizes via `_quantize_dval` ([0,1] by construction).
- Client: u8 unit scalars bind as **normalized** attributes (shader unchanged, still sees [0,1]); categorical codes stay un-normalized. `_tagChannelBuf` re-ids a buffer on dtype change so cached VAOs rebuild rather than misread bytes. f32 remains accepted, so the encoding is backward-detectable per message.
- Spec: `wire-protocol.md` documents the live-wire channel encodings and the durable/ephemeral contract.

## Relation to the #186–188 append stack (not yet on main)

- When the stack lands, this re-expresses through its `ship_continuous` chokepoint as `enc: "u8"` alongside `enc: "raw"` with a protocol bump — that variant is implemented and verified on branch `alek/u8-drill-wire-stacked` (protocol v9), ready to swap in.
- The review fixes to the stack's `_raw_wire_ok` guard (P1 f32-collapsed domains, P2 `seterr(over="raise")` crash) live on branch `alek/raw-wire-f32-guard` — they patch code that doesn't exist on main, so they ride separately when the stack rolls up.

## Verified

- Full suite 2,244 passed; ruff / format / `ty` clean (no new diagnostics); `node js/build.mjs`.
- New test pins both halves: drill wire ships 1 B/pt u8 within half a quantization step of the exact unit value; build payload stays f32 with no `dtype` marker.
- Live end-to-end on the 100M-point FastAPI drilldown: identical rendering before/after for the same view window, buffers on-GPU as normalized `UNSIGNED_BYTE`, x/y byte-identical to the pre-change capture, all three u8 channels within the 0.5/255 bound, zero console errors.