### PR TITLE
Reject raw-encode domains that collapse after f32 conversion

### DIFF
--- a/python/xy/channels.py
+++ b/python/xy/channels.py
@@ -507,13 +507,16 @@ _F32_ABS_MAX = 3.0e38
 def _raw_wire_ok(domain: tuple[float, float]) -> bool:
     lo, hi = float(domain[0]), float(domain[1])
     span = hi - lo
-    return (
-        abs(lo) < _F32_ABS_MAX
-        and abs(hi) < _F32_ABS_MAX
-        and np.isfinite(span)
-        and span > 0.0
-        and float(np.float32(span)) > 0.0
-    )
+    if not (abs(lo) < _F32_ABS_MAX and abs(hi) < _F32_ABS_MAX and np.isfinite(span) and span > 0.0):
+        return False
+    # The shader only ever sees f32: endpoints distinct in f64 can still
+    # round to the same f32 (e.g. [1e30, 1e30 + 1e20]), collapsing every
+    # shipped value onto the domain floor; and a tiny-but-representable span
+    # (e.g. [0, 1e-45]) sends an infinite reciprocal into the map uniform.
+    # Either way the raw encode would render wrong silently — fall back to
+    # the unit encode, which normalizes in f64 before the wire.
+    lo32, hi32 = float(np.float32(lo)), float(np.float32(hi))
+    return lo32 < hi32 and bool(np.isfinite(np.float32(1.0 / (hi32 - lo32))))
 
 
 def ship_continuous(spec: dict[str, Any], vals: Any, domain: Any, ship_scalar: Any) -> None:

--- a/python/xy/channels.py
+++ b/python/xy/channels.py
@@ -514,9 +514,12 @@ def _raw_wire_ok(domain: tuple[float, float]) -> bool:
     # shipped value onto the domain floor; and a tiny-but-representable span
     # (e.g. [0, 1e-45]) sends an infinite reciprocal into the map uniform.
     # Either way the raw encode would render wrong silently — fall back to
-    # the unit encode, which normalizes in f64 before the wire.
+    # the unit encode, which normalizes in f64 before the wire. The reciprocal
+    # bound is compared in f64 (never cast through f32): a demoting cast emits
+    # an overflow warning, which np.seterr(over="raise") setups turn into a
+    # FloatingPointError inside build_payload.
     lo32, hi32 = float(np.float32(lo)), float(np.float32(hi))
-    return lo32 < hi32 and bool(np.isfinite(np.float32(1.0 / (hi32 - lo32))))
+    return lo32 < hi32 and 1.0 / (hi32 - lo32) <= float(np.finfo(np.float32).max)
 
 
 def ship_continuous(spec: dict[str, Any], vals: Any, domain: Any, ship_scalar: Any) -> None:

--- a/tests/test_scatter.py
+++ b/tests/test_scatter.py
@@ -272,6 +272,39 @@ def test_continuous_channel_falls_back_to_unit_for_f32_hostile_domain():
     assert cbuf.min() >= 0.0 and cbuf.max() <= 1.0
 
 
+def test_continuous_channel_falls_back_when_domain_collapses_in_f32():
+    # Endpoints distinct in f64 but equal after f32 rounding: the raw encode
+    # would ship every value as the same f32 and the shader would map them
+    # all to the domain floor. Must fall back to the unit encode, which
+    # normalizes in f64 before the wire.
+    x = np.arange(3.0)
+    val = np.array([1e30, 1e30 + 5e19, 1e30 + 1e20])
+    assert np.float32(val[0]) == np.float32(val[-1])  # the hostile premise
+    fig = Figure().scatter(x, x, color=val)
+    spec, blob = fig.build_payload()
+    tr = spec["traces"][0]
+    assert "enc" not in tr["color"]
+    cbuf = _col(spec, blob, tr["color"]["buf"])
+    assert cbuf.min() >= 0.0 and cbuf.max() <= 1.0
+    assert cbuf.max() > cbuf.min()  # f64 normalization keeps the spread
+
+
+def test_continuous_channel_falls_back_when_f32_inverse_span_overflows():
+    # A span representable in f32 whose reciprocal is not (subnormal spans):
+    # the client's map uniform would carry Inf and every mapped value would
+    # be Inf/NaN. Must fall back to the unit encode.
+    x = np.arange(3.0)
+    val = np.array([0.0, 5e-46, 1e-45])
+    lo32, hi32 = np.float32(val[0]), np.float32(val[-1])
+    assert lo32 < hi32 and not np.isfinite(np.float32(1.0 / (float(hi32) - float(lo32))))
+    fig = Figure().scatter(x, x, color=val)
+    spec, blob = fig.build_payload()
+    tr = spec["traces"][0]
+    assert "enc" not in tr["color"]
+    cbuf = _col(spec, blob, tr["color"]["buf"])
+    assert cbuf.min() >= 0.0 and cbuf.max() <= 1.0
+
+
 def test_categorical_color_palette():
     n = 30
     cats = np.array(["red", "green", "blue"] * 10)

--- a/tests/test_scatter.py
+++ b/tests/test_scatter.py
@@ -292,13 +292,18 @@ def test_continuous_channel_falls_back_when_domain_collapses_in_f32():
 def test_continuous_channel_falls_back_when_f32_inverse_span_overflows():
     # A span representable in f32 whose reciprocal is not (subnormal spans):
     # the client's map uniform would carry Inf and every mapped value would
-    # be Inf/NaN. Must fall back to the unit encode.
+    # be Inf/NaN. Must fall back to the unit encode — and the guard itself
+    # must decide by f64 comparison, not by casting the reciprocal through
+    # f32: that cast warns on overflow, and np.seterr(over="raise") setups
+    # (np.errstate below) would turn the intentional probe into a
+    # FloatingPointError inside build_payload.
     x = np.arange(3.0)
     val = np.array([0.0, 5e-46, 1e-45])
-    lo32, hi32 = np.float32(val[0]), np.float32(val[-1])
-    assert lo32 < hi32 and not np.isfinite(np.float32(1.0 / (float(hi32) - float(lo32))))
-    fig = Figure().scatter(x, x, color=val)
-    spec, blob = fig.build_payload()
+    lo32, hi32 = float(np.float32(val[0])), float(np.float32(val[-1]))
+    assert lo32 < hi32 and 1.0 / (hi32 - lo32) > float(np.finfo(np.float32).max)
+    with np.errstate(over="raise"):
+        fig = Figure().scatter(x, x, color=val)
+        spec, blob = fig.build_payload()
     tr = spec["traces"][0]
     assert "enc" not in tr["color"]
     cbuf = _col(spec, blob, tr["color"]["buf"])


### PR DESCRIPTION
Review fixes for #187's `_raw_wire_ok` guard, split out of #221 when that PR retargeted to main (these fixes belong to the raw-encode code, which lives on this stack).

- **P1** — the guard accepted domains whose f64 span survives an f32 cast but whose *endpoints* collapse to the same f32 (`[1e30, 1e30 + 1e20]`): every shipped value rounds to `f32(lo)` and the shader maps them all to the domain floor. It also accepted spans whose f32 reciprocal overflows (`[0, 1e-45]`), sending `Inf` into the map uniform. Both now require `float32(lo) < float32(hi)` and a finite f32 inverse span, falling back to the f64-normalized unit encode; tests pin both cases.
- **P2** — the reciprocal bound is compared in f64 against `np.finfo(np.float32).max`, never cast through `np.float32`: the demoting cast warns on overflow for exactly the subnormal spans being rejected, and `np.seterr(over="raise")` setups would turn that into a `FloatingPointError` inside `build_payload`. The overflow test runs its probe under `np.errstate(over="raise")` to pin it.

Full `tests/test_scatter.py` passes (82); the fallback tests also pass with `-W error::RuntimeWarning` (no warnings emitted).