### PR TITLE
Add support-request URL to pyplot compatibility errors and tests

### DIFF
--- a/python/xy/pyplot/_translate.py
+++ b/python/xy/pyplot/_translate.py
@@ -13,6 +13,7 @@ import numpy as np
 from ._colors import resolve_color
 
 COMPAT_URL = "https://github.com/reflex-dev/xy/blob/main/spec/matplotlib/compat.md"
+SUPPORT_REQUEST_URL = "https://github.com/reflex-dev/xy/issues"
 
 # Matplotlib's unscaled named dash patterns, in points (rcParams
 # lines.{dashed,dotted,dashdot}_pattern). Matplotlib multiplies these by the
@@ -72,7 +73,8 @@ MARKER_TO_SYMBOL = {
 def not_implemented(name: str, alternative: Optional[str] = None) -> "NotImplementedError":
     hint = f" Try {alternative} instead." if alternative else ""
     return NotImplementedError(
-        f"xy.pyplot does not implement {name}.{hint} See the compatibility table: {COMPAT_URL}"
+        f"xy.pyplot does not implement {name}.{hint} See the compatibility table: {COMPAT_URL}. "
+        f"Request support: {SUPPORT_REQUEST_URL}"
     )
 
 
@@ -134,5 +136,6 @@ def check_unsupported(kwargs: dict[str, Any], where: str) -> None:
         names = ", ".join(sorted(kwargs))
         raise TypeError(
             f"xy.pyplot {where} got unsupported keyword(s): {names}. "
-            f"See the compatibility table: {COMPAT_URL}"
+            f"See the compatibility table: {COMPAT_URL}. "
+            f"Request support: {SUPPORT_REQUEST_URL}"
         )

--- a/tests/pyplot/test_boundaries.py
+++ b/tests/pyplot/test_boundaries.py
@@ -11,7 +11,12 @@ import sys
 import textwrap
 from pathlib import Path
 
+import pytest
+
+from xy.pyplot._translate import check_unsupported, not_implemented
+
 PACKAGE = Path(__file__).resolve().parents[2] / "python" / "xy"
+SUPPORT_REQUEST_URL = "https://github.com/reflex-dev/xy/issues"
 
 
 def _run_fresh(code: str) -> None:
@@ -82,6 +87,22 @@ def test_shim_never_imports_real_matplotlib_statically() -> None:
                 assert not any(a.name.split(".")[0] == "matplotlib" for a in node.names), path
             if isinstance(node, ast.ImportFrom):
                 assert (node.module or "").split(".")[0] != "matplotlib", path
+
+
+def test_unsupported_errors_link_to_support_requests() -> None:
+    assert str(not_implemented("polar charts")) == (
+        "xy.pyplot does not implement polar charts. See the compatibility table: "
+        "https://github.com/reflex-dev/xy/blob/main/spec/matplotlib/compat.md. "
+        f"Request support: {SUPPORT_REQUEST_URL}"
+    )
+    with pytest.raises(TypeError) as exc_info:
+        check_unsupported({"projection": "polar"}, "subplot()")
+    assert str(exc_info.value) == (
+        "xy.pyplot subplot() got unsupported keyword(s): projection. "
+        "See the compatibility table: "
+        "https://github.com/reflex-dev/xy/blob/main/spec/matplotlib/compat.md. "
+        f"Request support: {SUPPORT_REQUEST_URL}"
+    )
 
 
 def test_complete_supported_corpus_runs_when_matplotlib_imports_fail() -> None:


### PR DESCRIPTION
### Motivation
- Provide users a direct link to request support when a matplotlib-compatible pyplot feature is not implemented or when unsupported kwargs are passed.

### Description
- Add `SUPPORT_REQUEST_URL` constant to `python/xy/pyplot/_translate.py` and append it to the messages produced by `not_implemented` and `check_unsupported`.
- Update `tests/pyplot/test_boundaries.py` to include a new test `test_unsupported_errors_link_to_support_requests` that asserts error messages contain the support-request URL.

### Testing
- Ran the updated unit tests in `tests/pyplot/test_boundaries.py` via `pytest`, which executed the new `test_unsupported_errors_link_to_support_requests` and the existing boundary tests; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62582be6d883338c490779e741a51b)