### PR TITLE
Legend hover emphasis + real labels for continuous encodings

### DIFF
--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -23,6 +23,13 @@ const COLORBAR_THICKNESS = 18;
 const COLORBAR_GAP = 24;
 const COMPACT_COLORBAR_GAP = 8;
 let XY_A11Y_ID = 0;
+// Legend hover emphasis (interaction spec §9): opacity kept by non-hovered series on
+// the marks canvas, and by non-hovered rows in the legend box itself.
+const LEGEND_DIM_OPACITY = 0.2;
+const LEGEND_DIM_ROW = 0.4;
+// SVG gradient ids resolve document-wide; a module counter keeps every chart
+// instance's legend swatch ramps distinct.
+let legendGradientSeq = 0;
 const XY_SR_ONLY_STYLE =
   "position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;" +
   "clip:rect(0,0,0,0);white-space:nowrap;border:0;";
@@ -1729,28 +1736,47 @@ export class ChartView {
 
   _buildLegend(root) {
     const s = this.spec;
+    // A chrome rebuild replaces the row nodes mid-hover, so their pointerleave
+    // never fires; release any active dim state before dropping the old boxes.
+    this._clearLegendHover();
     this._legends = [];
     const items = [];
     if (s.show_legend !== false) {
-      for (const t of s.traces) {
+      // Two identically-encoded unnamed continuous traces must not stack two
+      // identical gradient rows; the row is about the encoding, so later
+      // traces join the first row's hover-target list instead.
+      const continuousRows = new Map();
+      s.traces.forEach((t, ti) => {
         // A density-tier surface encodes count as alpha and wears the mean
         // point color (LOD doc §2), so it gets no colormap gradient swatch —
         // a gradient would claim color == density. A named density trace
         // falls through to the plain marker swatch below, matching the
         // static SVG/raster exporters.
+        const line = ["line", "segments", "step", "stairs", "errorbar"].includes(t.kind);
         if (t.color && t.color.mode === "categorical") {
           t.color.categories.forEach((cat, i) =>
-            items.push({ swatch: t.color.palette[i], name: cat, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, style: t.style || {} }));
+            items.push({ swatch: t.color.palette[i], name: cat, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, style: t.style || {}, traces: [ti], cat: i }));
         } else if (t.color && t.color.mode === "continuous") {
-          items.push({ swatch: "gradient", cmap: t.color.colormap, name: t.name || "value" });
+          // Label precedence: explicit series name, then the encoding's own
+          // declarative label (the color="column" idiom), then the generic
+          // fallback for hand-built specs.
+          const name = t.name || t.color.label || "value";
+          const key = name + "\u0000" + t.color.colormap;
+          const existing = continuousRows.get(key);
+          if (existing) {
+            existing.traces.push(ti);
+            return;
+          }
+          const item = { swatch: "gradient", cmap: t.color.colormap, name, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, line, style: t.style || {}, traces: [ti] };
+          continuousRows.set(key, item);
+          items.push(item);
         } else if (t.name) {
           const c = (t.color && t.color.color) || (t.style && t.style.color);
           // Line-family kinds get a short line sample (honoring the dash), the
           // same handle the raster/SVG exporters draw — not a filled swatch.
-          const line = ["line", "segments", "step", "stairs", "errorbar"].includes(t.kind);
-          items.push({ swatch: c, name: t.name, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, line, style: t.style || {} });
+          items.push({ swatch: c, name: t.name, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, line, style: t.style || {}, traces: [ti] });
         }
-      }
+      });
       if (items.length) this._legendBox(root, items, s.legend || {});
     }
     // Manually added Legend artists ship explicit items + their own loc, so a
@@ -1768,7 +1794,7 @@ export class ChartView {
   }
 
   _legendBox(root, items, options) {
-    const lg = document.createElement("div");
+    const lg: any = document.createElement("div");
     const loc = options.loc || "upper right";
     const ncols = Math.max(1, Number(options.ncols) || 1);
     const horizontal = ncols > 1;
@@ -1785,6 +1811,7 @@ export class ChartView {
       title.style.gridColumn = `1 / span ${horizontal ? ncols : 1}`;
       lg.appendChild(title);
     }
+    const rows = [];
     for (const it of items) {
       const row = document.createElement("div");
       this._applySlot(row, "legend_item");
@@ -1794,11 +1821,19 @@ export class ChartView {
       sw.style.display = "inline-block";
       sw.style.verticalAlign = "-1px";
       let bg = it.swatch;
-      if (it.swatch === "gradient") {
+      // A continuous encoding paints the swatch with the colormap ramp, but
+      // the swatch keeps the mark's identity: a gradient-filled symbol for
+      // scatters, a gradient-stroked line sample for line-family kinds, and
+      // only the bare ramp chip when the mark has neither.
+      let gradientPaint = null;
+      if (it.swatch === "gradient" && (it.symbol || it.line)) {
+        gradientPaint = (svg) => this._legendGradientPaint(svg, it.cmap);
+      } else if (it.swatch === "gradient") {
         const stops = colormapStops(it.cmap);
         bg = `linear-gradient(90deg,${stops.map((c) => `rgb(${c[0]},${c[1]},${c[2]})`).join(",")})`;
         sw.style.background = bg;
-      } else if (it.symbol) {
+      }
+      if (it.symbol) {
         const ns = "http://www.w3.org/2000/svg";
         const svg = document.createElementNS(ns, "svg");
         svg.setAttribute("viewBox", "0 0 18 14");
@@ -1817,7 +1852,7 @@ export class ChartView {
           hexagon: "M9 2L13.3 4.5v5L9 12l-4.3-2.5v-5z",
           star: "M9 2l1.5 3.1 3.5.5-2.5 2.5.6 3.5L9 10l-3.1 1.6.6-3.5L4 5.6l3.5-.5z"
         };
-        const color = safeCssPaint(this.root, bg);
+        const color = gradientPaint ? gradientPaint(svg) : safeCssPaint(this.root, bg);
         if (it.symbol === "circle" || it.symbol === "point" || it.symbol === "pixel") {
           if (it.symbol === "pixel") path.setAttribute("d", "M8.5 6.5h1v1h-1z");
           else path.setAttribute("d", `M9 ${it.symbol === "point" ? 4.75 : 2.5}a${it.symbol === "point" ? 2.25 : 4.5} ${it.symbol === "point" ? 2.25 : 4.5} 0 1 0 0 ${it.symbol === "point" ? 4.5 : 9}a${it.symbol === "point" ? 2.25 : 4.5} ${it.symbol === "point" ? 2.25 : 4.5} 0 1 0 0 -${it.symbol === "point" ? 4.5 : 9}`);
@@ -1840,7 +1875,7 @@ export class ChartView {
         ln.setAttribute("y1", "6");
         ln.setAttribute("x2", "21");
         ln.setAttribute("y2", "6");
-        ln.setAttribute("stroke", safeCssPaint(this.root, bg));
+        ln.setAttribute("stroke", gradientPaint ? gradientPaint(svg) : safeCssPaint(this.root, bg));
         // ?? not ||: an explicit lw=0 keeps 0 and draws nothing, like the
         // exporters' dict-default and Matplotlib itself.
         ln.setAttribute("stroke-width", String(it.style?.width ?? 1.5));
@@ -1849,17 +1884,96 @@ export class ChartView {
         sw.appendChild(svg);
         sw.style.width = "22px";
         sw.style.height = "12px";
-      } else {
+      } else if (it.swatch !== "gradient") {
         sw.style.background = safeCssPaint(this.root, bg);
       }
       this._applySlot(sw, "legend_swatch");
       row.appendChild(sw);
       row.appendChild(document.createTextNode(it.name));
+      // Hover emphasis (interaction spec §9): rows backed by live traces dim the rest
+      // of the chart while hovered. Manually-added Legend artists carry no
+      // trace linkage, so extra_legends rows stay inert.
+      if (options.highlight !== false && it.traces && it.traces.length) {
+        row.addEventListener("pointerenter", () => this._setLegendHover(it, lg, row));
+        row.addEventListener("pointerleave", () => this._clearLegendHover());
+      }
+      rows.push(row);
       lg.appendChild(row);
     }
+    lg._xyItemRows = rows;
     root.appendChild(lg);
     this._legends.push(lg); // _resize refreshes each box's responsive anchor
     return lg;
+  }
+
+  // Paint an SVG swatch with the item's colormap ramp: registers a
+  // <linearGradient> in the swatch's own defs and returns its paint URL.
+  // IDs are document-global, so a module counter keeps multiple charts on
+  // one page from cross-referencing each other's ramps.
+  _legendGradientPaint(svg, cmap) {
+    const ns = "http://www.w3.org/2000/svg";
+    const id = `xy-legend-grad-${legendGradientSeq++}`;
+    const defs = document.createElementNS(ns, "defs");
+    const grad = document.createElementNS(ns, "linearGradient");
+    grad.setAttribute("id", id);
+    const stops = colormapStops(cmap);
+    stops.forEach((c, i) => {
+      const stop = document.createElementNS(ns, "stop");
+      stop.setAttribute("offset", `${(i / Math.max(1, stops.length - 1)) * 100}%`);
+      stop.setAttribute("stop-color", `rgb(${c[0]},${c[1]},${c[2]})`);
+      grad.appendChild(stop);
+    });
+    defs.appendChild(grad);
+    svg.appendChild(defs);
+    return `url(#${id})`;
+  }
+
+  // Legend hover emphasis: the hovered row's series keeps full opacity while
+  // every other series dims (and, for a categorical row, the trace's other
+  // categories dim through a background-blended palette LUT — the point
+  // shaders ignore LUT alpha, so the fade is baked into the RGB ramp).
+  // Whole density-tier traces dim through _drawDensity's uniform like any
+  // other series, but a categorical row cannot dim sibling categories inside
+  // an aggregated density plane (§28 — recorded in the dossier, not silent).
+  _setLegendHover(item, lg, hoveredRow) {
+    this._legendHover = item;
+    const keep = new Set(item.traces);
+    for (let i = 0; i < (this.gpuTraces || []).length; i++) {
+      const g = this.gpuTraces[i];
+      g._legendDim = keep.has(i) ? 1 : LEGEND_DIM_OPACITY;
+      if (g._legendPrevLut !== undefined) {
+        g.lut = g._legendPrevLut;
+        delete g._legendPrevLut;
+      }
+      const t = g.trace;
+      if (item.cat != null && keep.has(i) && g.tier !== "density" &&
+          t.color && t.color.mode === "categorical" && g.lut) {
+        g._legendPrevLut = g.lut;
+        g.lut = this._paletteLutDimmed(t.color.palette, item.cat);
+      }
+    }
+    for (const row of lg._xyItemRows || []) {
+      row.style.opacity = row === hoveredRow ? "" : String(LEGEND_DIM_ROW);
+    }
+    // Color-pass-only change: geometry and view are untouched, so the pick
+    // snapshot stays valid (§17).
+    this.draw(true);
+  }
+
+  _clearLegendHover() {
+    if (!this._legendHover) return;
+    this._legendHover = null;
+    for (const g of this.gpuTraces || []) {
+      delete g._legendDim;
+      if (g._legendPrevLut !== undefined) {
+        g.lut = g._legendPrevLut;
+        delete g._legendPrevLut;
+      }
+    }
+    for (const lg of this._legends || []) {
+      for (const row of lg._xyItemRows || []) row.style.opacity = "";
+    }
+    this.draw(true);
   }
 
   _positionLegend(lg, loc) {
@@ -2082,6 +2196,36 @@ export class ChartView {
       data[i * 4] = c[0] * 255;
       data[i * 4 + 1] = c[1] * 255;
       data[i * 4 + 2] = c[2] * 255;
+      data[i * 4 + 3] = 255;
+    }
+    const tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 256, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, data);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    this._lutCache.set(key, tex);
+    return tex;
+  }
+
+  // Palette LUT with every category except `keepIdx` blended toward the plot
+  // background — the legend-hover dim for categorical traces. RGB-only on
+  // purpose: the point/line shaders read `texture(u_lut, ...).rgb` and force
+  // alpha to 1, so an alpha-based fade would be a silent no-op.
+  _paletteLutDimmed(palette, keepIdx) {
+    const key = "pal:" + palette.join(",") + ":dim" + keepIdx + ":" + (this.theme.bg || "");
+    if (this._lutCache.has(key)) return this._lutCache.get(key);
+    const gl = this.gl;
+    const bg = parseColor(this.root, this.theme.bg || "#ffffff", [1, 1, 1, 1]);
+    const data = new Uint8Array(256 * 4);
+    for (let i = 0; i < 256; i++) {
+      const c = hexColor(palette[i % palette.length]);
+      const keep = i % palette.length === keepIdx % palette.length;
+      const w = keep ? 1 : LEGEND_DIM_OPACITY;
+      data[i * 4] = (c[0] * w + bg[0] * (1 - w)) * 255;
+      data[i * 4 + 1] = (c[1] * w + bg[1] * (1 - w)) * 255;
+      data[i * 4 + 2] = (c[2] * w + bg[2] * (1 - w)) * 255;
       data[i * 4 + 3] = 255;
     }
     const tex = gl.createTexture();
@@ -3212,7 +3356,7 @@ export class ChartView {
   }
 
   _drawPoints(g, xm, ym, opacityScale = 1) {
-    opacityScale *= g._transitionOpacity ?? 1;
+    opacityScale *= (g._transitionOpacity ?? 1) * (g._legendDim ?? 1);
     const animationScale = g._transitionScale ?? 1;
     if (this._canDrawSimplePoints(g)) {
       this._drawSimplePoints(g, xm, ym, opacityScale);
@@ -3445,7 +3589,7 @@ export class ChartView {
     // WebGL error that aborts the draw, so treat an invalid texture as "nothing
     // to draw" rather than risk it.
     if (!d || !d.tex || !gl.isTexture(d.tex)) return;
-    opacityScale *= g._transitionOpacity ?? 1;
+    opacityScale *= (g._transitionOpacity ?? 1) * (g._legendDim ?? 1);
     const prog = this.densityProg;
     gl.useProgram(prog);
     const u = (n) => uniformOf(gl, prog, n);
@@ -3519,7 +3663,7 @@ export class ChartView {
       h.xRange[xrev ? 1 : 0], h.xRange[xrev ? 0 : 1],
       h.yRange[yrev ? 1 : 0], h.yRange[yrev ? 0 : 1],
     );
-    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._transitionOpacity ?? 1));
+    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._transitionOpacity ?? 1) * (g._legendDim ?? 1));
     gl.uniform1i(u("u_truecolor"), h.truecolor ? 1 : 0);
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, h.tex);
@@ -3551,7 +3695,7 @@ export class ChartView {
     gl.uniform1f(u("u_revealSegments"), g.n - 1);
     gl.uniform1f(u("u_width"), (width ?? g.trace.style.width ?? 1.5) * this.dpr);
     const [r, gg, b, a] = color || g.color;
-    const strokeOpacity = this._strokeOpacity(g.trace.style) * (opacity ?? 1) * (g._transitionOpacity ?? 1);
+    const strokeOpacity = this._strokeOpacity(g.trace.style) * (opacity ?? 1) * (g._transitionOpacity ?? 1) * (g._legendDim ?? 1);
     gl.uniform4f(u("u_color"), r, gg, b, a * strokeOpacity);
     const dashed = this._lineDash(g);
     this._bindVao(
@@ -3598,7 +3742,7 @@ export class ChartView {
     gl.uniform1f(u("u_animationProgress"), g._transitionScale ?? 1);
     const [r, gg, b, a] = g.color;
     gl.uniform4f(u("u_color"), r, gg, b, a);
-    gl.uniform1f(u("u_opacity"), this._strokeOpacity(g.trace.style) * (g._transitionOpacity ?? 1));
+    gl.uniform1f(u("u_opacity"), this._strokeOpacity(g.trace.style) * (g._transitionOpacity ?? 1) * (g._legendDim ?? 1));
     gl.uniform1i(u("u_colorMode"), g.colorMode || 0);
     const dashed = this._segmentDash(g, prog);
     if (g.colorMode && g.lut) {
@@ -3720,7 +3864,7 @@ export class ChartView {
     for (const name of ["x0", "x1", "x2"]) this._setAxisUniforms(prog, "u_" + name, g[name + "Meta"], g.xAxis);
     for (const name of ["y0", "y1", "y2"]) this._setAxisUniforms(prog, "u_" + name, g[name + "Meta"], g.yAxis);
     gl.uniform1i(u("u_colorMode"), g.colorMode || 0);
-    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style));
+    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._legendDim ?? 1));
     gl.uniform4f(u("u_color"), g.color[0], g.color[1], g.color[2], g.color[3]);
     // Straight alpha: MESH_FS folds u_strokeOpacity and the per-item alpha
     // stack in and premultiplies there (uniform and buffer strokes alike).
@@ -3728,7 +3872,7 @@ export class ChartView {
     gl.uniform4f(u("u_stroke"), stroke[0], stroke[1], stroke[2], stroke[3]);
     gl.uniform1f(u("u_strokeWidth"), g.meshStrokeWidth || 0);
     gl.uniform1i(u("u_strokeMode"), g.strokeBuf ? 1 : 0);
-    gl.uniform1f(u("u_strokeOpacity"), this._strokeOpacity(g.trace.style));
+    gl.uniform1f(u("u_strokeOpacity"), this._strokeOpacity(g.trace.style) * (g._legendDim ?? 1));
     if (g.colorMode && g.lut) {
       gl.activeTexture(gl.TEXTURE0);
       gl.bindTexture(gl.TEXTURE_2D, g.lut);
@@ -3817,7 +3961,7 @@ export class ChartView {
     gl.uniform1f(u("u_revealProgress"), reveal);
     gl.uniform1f(u("u_revealSegments"), g.n - 1);
     const [r, gg, b, a] = g.color;
-    gl.uniform4f(u("u_color"), r, gg, b, a * this._fillOpacity(g.trace.style, 0.35) * (g._transitionOpacity ?? 1));
+    gl.uniform4f(u("u_color"), r, gg, b, a * this._fillOpacity(g.trace.style, 0.35) * (g._transitionOpacity ?? 1) * (g._legendDim ?? 1));
     gl.uniform2f(u("u_res"), this.canvas.width, this.canvas.height);
     this._setGradientUniforms(prog, g.grad);
     this._bindVao(g, "area", [g.xBuf._fcId, g.yBuf._fcId, g.baseBuf._fcId], () => {
@@ -3853,7 +3997,7 @@ export class ChartView {
     gl.uniform4f(u("u_edgePad"), edgePad[0], edgePad[1], edgePad[2], edgePad[3]);
     const [r, gg, b, a] = g.color;
     gl.uniform4f(u("u_color"), r, gg, b, a);
-    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._transitionOpacity ?? 1));
+    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._transitionOpacity ?? 1) * (g._legendDim ?? 1));
     gl.uniform1i(u("u_colorMode"), g.colorMode || 0);
     this._setRectStyleUniforms(prog, g);
     const colorOn = !!g.cBuf;
@@ -3927,7 +4071,7 @@ export class ChartView {
     gl.uniform1f(u("u_prevWidth"), g._transitionPrevWidth ?? g.width);
     const [r, gg, b, a] = g.color;
     gl.uniform4f(u("u_color"), r, gg, b, a);
-    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._transitionOpacity ?? 1));
+    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._transitionOpacity ?? 1) * (g._legendDim ?? 1));
     gl.uniform1i(u("u_colorMode"), g.colorMode || 0);
     this._setRectStyleUniforms(prog, g);
     const v0On = g.value0Mode === 1 && g.value0Buf;

--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -1758,9 +1758,12 @@ export class ChartView {
             items.push({ swatch: t.color.palette[i], name: cat, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, style: t.style || {}, traces: [ti], cat: i }));
         } else if (t.color && t.color.mode === "continuous") {
           // Label precedence: explicit series name, then the encoding's own
-          // declarative label (the color="column" idiom), then the generic
-          // fallback for hand-built specs.
-          const name = t.name || t.color.label || "value";
+          // declarative label (the color="column" idiom). No generic fallback:
+          // an unnamed encoding has nothing truthful to say, so it gets no
+          // row — matching the static exporters, which draw name-bearing
+          // entries only.
+          const name = t.name || t.color.label;
+          if (!name) return;
           const key = name + "\u0000" + t.color.colormap;
           const existing = continuousRows.get(key);
           if (existing) {

--- a/python/xy/channels.py
+++ b/python/xy/channels.py
@@ -74,6 +74,10 @@ class ColorChannel:
     values: Optional[npt.NDArray[np.float64]] = None
     domain: Optional[tuple[float, float]] = None
     colormap: str = DEFAULT_COLORMAP
+    # Declarative source of the continuous values (the `color="temperature"`
+    # column-name idiom). Legend/colorbar chrome uses it when the trace itself
+    # is unnamed, so an encoding never has to fall back to a generic "value".
+    label: Optional[str] = None
     # categorical: integer code per point + the category labels + palette.
     codes: Optional[npt.NDArray[np.uint8] | npt.NDArray[np.uint32]] = None
     categories: Optional[list[str]] = None
@@ -96,11 +100,14 @@ class ColorChannel:
         if self.mode == "constant":
             return {"mode": "constant", "color": self.constant}
         if self.mode == "continuous":
-            return {
+            spec: dict[str, Any] = {
                 "mode": "continuous",
                 "colormap": self.colormap,
                 "domain": list(self.domain) if self.domain else None,
             }
+            if self.label is not None:
+                spec["label"] = self.label
+            return spec
         if self.mode == "direct_rgba":
             return {"mode": "direct_rgba", "components": 4, "dtype": "u8"}
         if self.mode == "match_fill":

--- a/python/xy/channels.py
+++ b/python/xy/channels.py
@@ -76,7 +76,7 @@ class ColorChannel:
     colormap: str = DEFAULT_COLORMAP
     # Declarative source of the continuous values (the `color="temperature"`
     # column-name idiom). Legend/colorbar chrome uses it when the trace itself
-    # is unnamed, so an encoding never has to fall back to a generic "value".
+    # is unnamed; with neither name nor label the encoding gets no legend row.
     label: Optional[str] = None
     # categorical: integer code per point + the category labels + palette.
     codes: Optional[npt.NDArray[np.uint8] | npt.NDArray[np.uint32]] = None

--- a/python/xy/components.py
+++ b/python/xy/components.py
@@ -237,6 +237,7 @@ class Legend(Component):
     loc: Optional[str] = None
     ncols: int = 1
     title: Optional[str] = None
+    highlight: bool = True
     class_name: Optional[str] = None
     style: dict[str, StyleValue] = field(default_factory=dict)
     render: Any = None
@@ -2372,6 +2373,7 @@ def legend(
     loc: Optional[str] = None,
     ncols: int = 1,
     title: Optional[str] = None,
+    highlight: bool = True,
     render: Any = None,
     class_name: Optional[str] = None,
     style: Optional[dict[str, StyleValue]] = None,
@@ -2384,6 +2386,8 @@ def legend(
         loc: Legend placement within or around the plot.
         ncols: Number of legend columns.
         title: Optional legend title.
+        highlight: Whether hovering a legend entry emphasizes its series by
+            dimming the others (live client only; exports are static).
         render: Opaque renderer supplied by an adapter.
         class_name: DOM class name applied to the legend.
         style: Legend style overrides.
@@ -2394,6 +2398,7 @@ def legend(
         loc=_optional_string(loc, "legend loc"),
         ncols=_optional_positive_int(ncols, "legend ncols") or 1,
         title=_optional_string(title, "legend title"),
+        highlight=_strict_bool(highlight, "legend highlight"),
         class_name=_optional_string(class_name, "legend class_name"),
         style=_style_dict(style, "legend style"),
         render=render,
@@ -3159,6 +3164,16 @@ class Chart(Component):
                 class_name = _optional_string(m.class_name, f"{m.kind} class_name")
                 for trace in new_traces:
                     trace.style["class_name"] = class_name
+            color_label = _continuous_color_label(m)
+            if color_label is not None:
+                for trace in new_traces:
+                    channel = getattr(trace, "color_ch", None)
+                    if (
+                        channel is not None
+                        and channel.mode == "continuous"
+                        and channel.label is None
+                    ):
+                        channel.label = color_label
             _merge_tooltip_aliases(tooltip_aliases, m, new_traces)
             _merge_tooltip_sources(tooltip_sources, m, new_traces)
             colorbar_candidate = _declarative_colorbar_options(m, new_traces)
@@ -3178,6 +3193,10 @@ class Chart(Component):
             fig.legend_options = {"loc": node.loc, "ncols": node.ncols}
             if node.title is not None:
                 fig.legend_options["title"] = node.title
+            if not _strict_bool(node.highlight, "legend highlight"):
+                # Highlight-on-hover defaults on; only the opt-out crosses the
+                # wire so existing specs stay byte-identical.
+                fig.legend_options["highlight"] = False
             if node.style:
                 # Carry the frame/frameon styling into the static-export spec so
                 # the raster/SVG legend can honor frameon=False (transparent bg).
@@ -3786,6 +3805,27 @@ def _apply_mark_transition_metadata(
                     f"has {trace.n_points} logical rows"
                 )
             trace.transition_keys = keys
+
+
+def _continuous_color_label(mark: Mark) -> Optional[str]:
+    """Declarative label for a mark's continuous color channel.
+
+    Only genuine column names (or hexbin's derived metric) qualify — the mark
+    name is not a channel label, and the client already prefers ``t.name``
+    for legend rows. Attached to ``ColorChannel.label`` so unnamed encodings
+    stop rendering as a generic "value" swatch.
+    """
+    if mark.kind in {"scatter", "segments", "triangle_mesh"}:
+        color = mark.props.get("color")
+        if isinstance(color, str) and not _looks_like_css(color):
+            return color
+    elif mark.kind == "hexbin":
+        values = mark.props.get("C")
+        if isinstance(values, str):
+            return values
+        if values is None:
+            return "log(count + 1)" if mark.props.get("bins") == "log" else "count"
+    return None
 
 
 def _colorbar_source_title(mark: Mark) -> Optional[str]:

--- a/python/xy/components.py
+++ b/python/xy/components.py
@@ -3812,8 +3812,8 @@ def _continuous_color_label(mark: Mark) -> Optional[str]:
 
     Only genuine column names (or hexbin's derived metric) qualify — the mark
     name is not a channel label, and the client already prefers ``t.name``
-    for legend rows. Attached to ``ColorChannel.label`` so unnamed encodings
-    stop rendering as a generic "value" swatch.
+    for legend rows. Attached to ``ColorChannel.label``; an encoding with
+    neither a name nor a label renders no legend row at all.
     """
     if mark.kind in {"scatter", "segments", "triangle_mesh"}:
         color = mark.props.get("color")

--- a/python/xy/components.py
+++ b/python/xy/components.py
@@ -237,10 +237,12 @@ class Legend(Component):
     loc: Optional[str] = None
     ncols: int = 1
     title: Optional[str] = None
-    highlight: bool = True
     class_name: Optional[str] = None
     style: dict[str, StyleValue] = field(default_factory=dict)
     render: Any = None
+    # New fields append after ``render``: Legend is public and positional
+    # construction over the released field order must keep binding.
+    highlight: bool = True
 
 
 @dataclass

--- a/spec/api/interaction.md
+++ b/spec/api/interaction.md
@@ -383,3 +383,48 @@ round-trip on hover; keyboard point traversal and the live-region readout;
 lasso vertex editing on an existing lasso; selection overlay rendering;
 modebar presence (subject only to the fit check); and view clamping to axis
 bounds. Everything in the §2 and §2.1 tables is configurable; nothing else is.
+
+## 9. Legend hover emphasis
+
+Hovering a legend row emphasizes the series it stands for: every other
+series drops to 20% of its computed opacity (`LEGEND_DIM_OPACITY`,
+`50_chartview.ts`), the other rows in the same legend box fade to 40%
+(`LEGEND_DIM_ROW`), and both restore on pointer-leave. Purely client-side —
+no kernel message, no view change — and the redraw runs with `keepPick`
+because only the color pass changes (dossier §17).
+
+Gating: `xy.legend(highlight=False)`. This is legend chrome, not an
+`interaction_config` switch: it rides `legend.highlight` in the spec's legend
+options, is **on by default**, and only the opt-out (`false`) crosses the
+wire. Hard-disabled rows: entries of `extra_legends` (manual Legend artists
+carry no trace linkage) are always inert.
+
+Mechanics per entry kind:
+
+- **Named / constant-color rows** emphasize their one backing trace via a
+  per-trace `_legendDim` factor folded into every mark family's opacity
+  uniform (points, simple points, lines, segments, areas, rects, bars,
+  meshes, heatmaps — and whole density-tier traces through `_drawDensity`'s
+  uniform).
+- **Continuous (gradient) rows** may back *several* traces: identical
+  unnamed encodings (same label, same colormap) collapse into one row, and
+  hovering it emphasizes all of them.
+- **Categorical rows** emphasize one category: the trace keeps full opacity
+  and swaps its palette LUT for a variant whose other entries are blended
+  toward `--chart-bg`. RGB-blend, not alpha: the mark shaders read
+  `texture(u_lut, …).rgb` and force alpha to 1, so an alpha fade would be a
+  silent no-op. The original LUT is restored on leave. A categorical row
+  cannot dim sibling categories *inside* an aggregated density plane — the
+  plane is one texture (§28: recorded, not silent); the whole trace still
+  dims when some other row is hovered.
+
+Legend entry labels (same build, `_buildLegend`): a continuous row is titled
+by `t.name`, else the encoding's declarative `color.label` (the
+`color="column"` idiom, attached by `Chart.figure()` to
+`ColorChannel.label`), else the literal `value` for hand-built specs. Static
+SVG/raster exports draw name-bearing entries only and have no hover state;
+this section is live-client behavior.
+
+Click-to-toggle (hiding a series) is **not** part of this contract — it
+invalidates precomputed density tiers and needs a kernel round-trip; see
+dossier §34 for the filtering model it belongs to.

--- a/spec/api/interaction.md
+++ b/spec/api/interaction.md
@@ -421,8 +421,10 @@ Mechanics per entry kind:
 Legend entry labels (same build, `_buildLegend`): a continuous row is titled
 by `t.name`, else the encoding's declarative `color.label` (the
 `color="column"` idiom, attached by `Chart.figure()` to
-`ColorChannel.label`), else the literal `value` for hand-built specs. Static
-SVG/raster exports draw name-bearing entries only and have no hover state;
+`ColorChannel.label`). There is no generic fallback: a trace with neither a
+name nor a label contributes no legend row, and a chart whose traces are all
+unnamed renders no legend box — the same rule the static SVG/raster exports
+follow (name-bearing entries only). Exports additionally have no hover state;
 this section is live-client behavior.
 
 Click-to-toggle (hiding a series) is **not** part of this contract — it

--- a/spec/design-dossier.md
+++ b/spec/design-dossier.md
@@ -1265,7 +1265,11 @@ hover readouts are real HTML/SVG in the DOM (§7). Fonts, color, spacing, border
 focus states: plain CSS, full inheritance and media queries, no bridge needed. The
 container (size, border, background, layout) is ordinary too, and the canvas is
 transparent-capable so a page background shows through. This covers most of what "make
-the chart match my site" actually means — typography and chrome.
+the chart match my site" actually means — typography and chrome. The legend is also
+an interaction surface: hovering a row emphasizes its series by dimming the rest
+(default on, `xy.legend(highlight=False)` opts out; full contract in
+`spec/api/interaction.md` §9). Click-to-toggle stays future work — it is a filter,
+not an emphasis, and belongs to the §34 filtering model.
 
 **(b) Marks — themed via a CSS-custom-property bridge.** The render client reads
 `--chart-*` custom properties off its container and maps them to GPU state, so the

--- a/spec/design/wire-protocol.md
+++ b/spec/design/wire-protocol.md
@@ -193,7 +193,12 @@ states which representation this view resolved to:
   come from the kernel's canonical columns (`pick_result` above). The *build*
   payload keeps continuous channels as unit f32 — the client retains those
   columns CPU-side and denormalizes them for tooltip readouts, where 8-bit
-  steps would surface as wrong digits (`channels.ship_channels`).
+  steps would surface as wrong digits (`channels.ship_channels`). A
+  continuous color spec may additionally carry `label` — the declarative
+  column name behind the encoding (`ColorChannel.label`, attached by
+  `Chart.figure()` when `color=` was a column-name string) — which legend
+  chrome uses to title gradient rows for unnamed traces instead of the
+  generic `value` (interaction spec §9).
 
 The client enforces `msg.seq` only when it is present, and additionally
 accepts `msg.trace` and `msg.stale` for pending-request bookkeeping — no

--- a/spec/design/wire-protocol.md
+++ b/spec/design/wire-protocol.md
@@ -197,8 +197,9 @@ states which representation this view resolved to:
   continuous color spec may additionally carry `label` — the declarative
   column name behind the encoding (`ColorChannel.label`, attached by
   `Chart.figure()` when `color=` was a column-name string) — which legend
-  chrome uses to title gradient rows for unnamed traces instead of the
-  generic `value` (interaction spec §9).
+  chrome uses to title gradient rows for unnamed traces; with neither a
+  trace name nor a `label` the encoding renders no legend row at all
+  (interaction spec §9).
 
 The client enforces `msg.seq` only when it is present, and additionally
 accepts `msg.trace` and `msg.stale` for pending-request bookkeeping — no

--- a/tests/test_legend_highlight.py
+++ b/tests/test_legend_highlight.py
@@ -1,0 +1,219 @@
+"""Legend entry labels and hover-highlight emphasis.
+
+Python side: a continuous color encoding built from a column name carries that
+name onto the wire (`color.label`), so unnamed traces stop rendering a generic
+"value" legend row; `xy.legend(highlight=...)` gates the hover behavior.
+
+Browser side: hovering a legend row dims every other series on the marks
+canvas (`_legendDim`), swaps a categorical trace's palette LUT so sibling
+categories fade, dims the other legend rows, and restores everything on leave.
+Identical unnamed continuous encodings collapse into one row whose hover
+emphasizes all backing traces.
+
+Skips (never fails) when no Chromium is available or the headless GL context
+can't come up, matching the repo's other browser probes.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from conftest import run_browser_probe
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "python"))
+
+import xy  # noqa: E402
+from xy.export import find_chromium  # noqa: E402
+
+_RENDER_CALLS = (
+    'xy.renderStandalone(document.getElementById("chart"), spec, bytes.buffer);',
+    'xy.renderStandalone(document.getElementById("chart"), spec, buf);',
+)
+
+
+def _data() -> dict[str, np.ndarray]:
+    return {
+        "x": np.arange(8.0),
+        "y": np.arange(8.0),
+        "temperature": np.linspace(0.0, 1.0, 8),
+    }
+
+
+def test_continuous_column_name_becomes_channel_label() -> None:
+    chart = xy.scatter_chart(xy.scatter("x", "y", data=_data(), color="temperature"))
+    trace = chart.figure().traces[0]
+    assert trace.color_ch is not None
+    assert trace.color_ch.label == "temperature"
+    assert trace.color_ch.spec()["label"] == "temperature"
+
+
+def test_continuous_array_color_ships_no_label() -> None:
+    data = _data()
+    chart = xy.scatter_chart(xy.scatter("x", "y", data=data, color=data["temperature"]))
+    trace = chart.figure().traces[0]
+    assert trace.color_ch is not None
+    assert trace.color_ch.label is None
+    assert "label" not in trace.color_ch.spec()
+
+
+def test_named_trace_keeps_both_name_and_channel_label() -> None:
+    chart = xy.scatter_chart(xy.scatter("x", "y", data=_data(), color="temperature", name="obs"))
+    trace = chart.figure().traces[0]
+    assert trace.name == "obs"
+    assert trace.color_ch.label == "temperature"
+
+
+def test_legend_highlight_option() -> None:
+    data = _data()
+    disabled = xy.scatter_chart(xy.scatter("x", "y", data=data), xy.legend(highlight=False))
+    assert disabled.figure().legend_options["highlight"] is False
+    # Default-on rides implicitly: existing specs stay byte-identical.
+    default = xy.scatter_chart(xy.scatter("x", "y", data=data), xy.legend())
+    assert "highlight" not in default.figure().legend_options
+    with pytest.raises(ValueError):
+        xy.legend(highlight="yes")
+
+
+_HIGHLIGHT_PROBE = """
+<script>
+(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  try {
+    const view = window.__fcProbeView;
+    if (!view) throw new Error("no probe view captured");
+    view._drawNow();
+    view._raf = null;
+    let rows = [];
+    for (let i = 0; i < 200; i++) {
+      rows = [...document.querySelectorAll('[data-xy-slot="legend_item"]')];
+      if (rows.length >= 4) break;
+      await sleep(25);
+    }
+    if (rows.length < 4) throw new Error(`expected 4 legend rows, got ${rows.length}`);
+    const rowNames = rows.map((row) => row.textContent);
+    const byName = (name) => rows.find((row) => row.textContent === name);
+
+    const gradientRow = byName("temperature");
+    const gradientSwatchSvg = !!gradientRow.querySelector("svg linearGradient");
+    const gradientSymbolFill = gradientRow.querySelector("svg path")?.getAttribute("fill") || "";
+
+    const dims = () => view.gpuTraces.map((g) => g._legendDim ?? null);
+    const hover = (row) => row.dispatchEvent(new PointerEvent("pointerenter"));
+    const leave = (row) => row.dispatchEvent(new PointerEvent("pointerleave"));
+
+    const alphaRow = byName("alpha");
+    hover(alphaRow);
+    const hoverAlphaDims = dims();
+    const rowOpacities = rows.map((row) => row.style.opacity);
+    leave(alphaRow);
+
+    hover(gradientRow);
+    const hoverTemperatureDims = dims();
+    leave(gradientRow);
+
+    const catRow = byName("A");
+    const catTrace = view.gpuTraces[3];
+    const lutBefore = catTrace.lut;
+    hover(catRow);
+    const hoverCategoryDims = dims();
+    const lutSwapped = catTrace._legendPrevLut !== undefined && catTrace.lut !== lutBefore;
+    leave(catRow);
+    const lutRestored = catTrace.lut === lutBefore && catTrace._legendPrevLut === undefined;
+    const afterLeaveDims = dims();
+
+    document.body.setAttribute(
+      "data-xy-legend-highlight",
+      JSON.stringify({
+        rowNames,
+        gradientSwatchSvg,
+        gradientSymbolFill,
+        hoverAlphaDims,
+        rowOpacities,
+        hoverTemperatureDims,
+        hoverCategoryDims,
+        lutSwapped,
+        lutRestored,
+        afterLeaveDims,
+      })
+    );
+  } catch (err) {
+    document.body.setAttribute(
+      "data-xy-legend-highlight-error",
+      String((err && err.stack) || err)
+    );
+  }
+})();
+</script>
+"""
+
+
+def test_browser_legend_hover_dims_other_series() -> None:
+    chromium = find_chromium()
+    if not chromium:
+        pytest.skip("no chromium available for the legend highlight probe")
+
+    data = _data()
+    chart = xy.scatter_chart(
+        # Trace 0: named, constant color — plain marker row.
+        xy.scatter("x", "y", data=data, name="alpha"),
+        # Traces 1+2: identical unnamed continuous encodings — must collapse
+        # into ONE "temperature" row that emphasizes both traces on hover.
+        xy.scatter("x", "y", data=data, color="temperature"),
+        xy.scatter("x", "y", data=data, color="temperature"),
+        # Trace 3: categorical — one row per category, LUT-dim on hover.
+        xy.scatter(
+            "x",
+            "y",
+            data=data,
+            color=np.array(["A", "B", "A", "B", "A", "B", "A", "B"]),
+        ),
+        xy.legend(),
+        width=520,
+        height=340,
+    )
+
+    document = chart.to_html()
+    render_call = next((call for call in _RENDER_CALLS if call in document), None)
+    assert render_call is not None, "to_html render call shape changed; update the probe swap"
+    capture_call = render_call.replace(
+        "xy.renderStandalone(", "window.__fcProbeView = xy.renderStandalone(", 1
+    )
+    document = document.replace(render_call, capture_call, 1)
+    document = document.replace("</body>", _HIGHLIGHT_PROBE + "\n</body>", 1)
+
+    with tempfile.TemporaryDirectory() as td:
+        page = Path(td) / "legend_highlight.html"
+        payload = run_browser_probe(
+            chromium,
+            document,
+            page,
+            "data-xy-legend-highlight",
+            label="legend highlight",
+        )
+
+    # The unnamed continuous traces surface their column name once, not two
+    # generic "value" rows; categorical categories keep one row each.
+    assert payload["rowNames"] == ["alpha", "temperature", "A", "B"], payload
+    # The continuous swatch keeps the scatter's marker identity: a symbol
+    # path filled with the colormap ramp, not a bare gradient chip.
+    assert payload["gradientSwatchSvg"] is True, payload
+    assert payload["gradientSymbolFill"].startswith("url(#"), payload
+
+    dim = 0.2
+    assert payload["hoverAlphaDims"] == [1, dim, dim, dim], payload
+    # The hovered row keeps full opacity; the other rows fade.
+    assert payload["rowOpacities"][0] == "", payload
+    assert all(opacity == "0.4" for opacity in payload["rowOpacities"][1:]), payload
+    # The deduped gradient row backs BOTH continuous traces.
+    assert payload["hoverTemperatureDims"] == [dim, 1, 1, dim], payload
+    # A category row emphasizes its trace and swaps in the dimmed palette LUT.
+    assert payload["hoverCategoryDims"] == [dim, dim, dim, 1], payload
+    assert payload["lutSwapped"] is True, payload
+    assert payload["lutRestored"] is True, payload
+    assert payload["afterLeaveDims"] == [None, None, None, None], payload

--- a/tests/test_legend_highlight.py
+++ b/tests/test_legend_highlight.py
@@ -1,8 +1,9 @@
 """Legend entry labels and hover-highlight emphasis.
 
 Python side: a continuous color encoding built from a column name carries that
-name onto the wire (`color.label`), so unnamed traces stop rendering a generic
-"value" legend row; `xy.legend(highlight=...)` gates the hover behavior.
+name onto the wire (`color.label`); `xy.legend(highlight=...)` gates the hover
+behavior. There is no generic fallback label — a trace with neither a name nor
+a label renders no legend row (matching the static exporters).
 
 Browser side: hovering a legend row dims every other series on the marks
 canvas (`_legendDim`), swaps a categorical trace's palette LUT so sibling
@@ -173,6 +174,10 @@ def test_browser_legend_hover_dims_other_series() -> None:
             data=data,
             color=np.array(["A", "B", "A", "B", "A", "B", "A", "B"]),
         ),
+        # Trace 4: unnamed continuous from a raw array — no name, no label,
+        # so it must contribute NO legend row (no generic fallback), while
+        # still dimming like any other series when a row is hovered.
+        xy.scatter("x", "y", data=data, color=data["temperature"] * 2.0),
         xy.legend(),
         width=520,
         height=340,
@@ -197,8 +202,8 @@ def test_browser_legend_hover_dims_other_series() -> None:
             label="legend highlight",
         )
 
-    # The unnamed continuous traces surface their column name once, not two
-    # generic "value" rows; categorical categories keep one row each.
+    # The unnamed labeled traces surface their column name once; the raw-array
+    # trace (no name, no label) gets NO row; categories keep one row each.
     assert payload["rowNames"] == ["alpha", "temperature", "A", "B"], payload
     # The continuous swatch keeps the scatter's marker identity: a symbol
     # path filled with the colormap ramp, not a bare gradient chip.
@@ -206,14 +211,15 @@ def test_browser_legend_hover_dims_other_series() -> None:
     assert payload["gradientSymbolFill"].startswith("url(#"), payload
 
     dim = 0.2
-    assert payload["hoverAlphaDims"] == [1, dim, dim, dim], payload
+    # The row-less trace 4 still dims with everything else on any hover.
+    assert payload["hoverAlphaDims"] == [1, dim, dim, dim, dim], payload
     # The hovered row keeps full opacity; the other rows fade.
     assert payload["rowOpacities"][0] == "", payload
     assert all(opacity == "0.4" for opacity in payload["rowOpacities"][1:]), payload
     # The deduped gradient row backs BOTH continuous traces.
-    assert payload["hoverTemperatureDims"] == [dim, 1, 1, dim], payload
+    assert payload["hoverTemperatureDims"] == [dim, 1, 1, dim, dim], payload
     # A category row emphasizes its trace and swaps in the dimmed palette LUT.
-    assert payload["hoverCategoryDims"] == [dim, dim, dim, 1], payload
+    assert payload["hoverCategoryDims"] == [dim, dim, dim, 1, dim], payload
     assert payload["lutSwapped"] is True, payload
     assert payload["lutRestored"] is True, payload
-    assert payload["afterLeaveDims"] == [None, None, None, None], payload
+    assert payload["afterLeaveDims"] == [None, None, None, None, None], payload


### PR DESCRIPTION
## What

Two legend gaps closed toward matplotlib/Highcharts-class parity:

**1. Continuous legend entries stop falling back to `value`**
- The `color="column"` idiom now attaches the column name to the channel (`ColorChannel.label`) and ships it on the wire; the client titles gradient rows `t.name || color.label`. An encoding with neither renders no legend row at all — the generic `value` fallback is gone.
- Identical unnamed continuous encodings (same label + colormap) collapse into **one** legend row instead of stacking duplicates.
- The gradient swatch keeps the mark's identity: symbol path (scatter) or line sample (line-family) filled/stroked with an SVG `linearGradient`, not a bare ramp chip.

**2. Legend hover emphasis (Highcharts-style)**
- Hovering a legend row dims every other series to 20% via a per-trace `_legendDim` factor folded into every mark family's opacity uniform (points, lines, segments, areas, rects, bars, meshes, heatmaps, and whole density tiers via `_drawDensity`).
- Categorical rows dim sibling categories through a background-blended palette LUT — RGB blend, because the mark shaders read `texture(u_lut,…).rgb` and force alpha to 1.
- Non-hovered legend rows fade to 40%; everything restores on pointer-leave, and stale dim state is released on chrome rebuilds.
- Default **on**; `xy.legend(highlight=False)` opts out (only the opt-out crosses the wire, existing specs stay byte-identical). `extra_legends` rows are inert (no trace linkage). Redraws use `keepPick` — color-pass-only change (§17).

Click-to-toggle is deliberately **not** in this PR: it's a filter that invalidates the LOD pyramid (dossier §34) and needs a kernel round-trip.

## Spec
- `spec/api/interaction.md` §9 — full contract (mechanics per entry kind, label precedence, density-plane caveat recorded per §28).
- `spec/design/wire-protocol.md` — continuous color `label` field.
- `spec/design-dossier.md` — chrome section notes the legend as an interaction surface.

## Tests
- `tests/test_legend_highlight.py`: wire-level label/highlight tests + a headless-Chromium probe asserting row labels, dedupe, gradient-symbol swatch, exact dim factors on hover of named/continuous/categorical rows, row fade, LUT swap/restore, and full cleanup on leave.
- Full suite: **2220 passed, 1 skipped**; ABI + render smokes pass; `node js/build.mjs` clean; pre-commit/ruff clean; the 3 `ty` diagnostics pre-exist on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced legend hover emphasis: hovering a legend row now visually dims non-hovered series consistently across supported WebGL mark types.
  * Continuous color legends now support gradient swatches and can infer a legend label from the continuous color column when trace names are missing.
  * Added `xy.legend(highlight=...)` / `Legend.highlight` opt-out for the hover emphasis behavior (default remains on).

* **Documentation**
  * Documented the legend hover emphasis contract and continuous legend labeling rules.

* **Tests**
  * Added Python and browser coverage for label inference, legend-row deduping, hover dimming, and categorical palette swap/restore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
