### PR TITLE
Let the modebar focus ring inherit --chart-focus

### DIFF
--- a/docs/styling/themes-and-tokens.md
+++ b/docs/styling/themes-and-tokens.md
@@ -297,13 +297,13 @@ move together across the whole chart.
 | `--chart-badge-bg` / `--chart-badge-text` | Reduction badges | light / dark |
 | `--chart-tick-label-max-width` | Maximum browser width of categorical y-axis tick labels | available edge space |
 | `--chart-modebar-bg` / `--chart-modebar-active` | Toolbar and active button | scheme-aware white/dark surface / `#edf1f6` light, `#121417` dark |
-| `--chart-modebar-focus` | Toolbar keyboard focus ring | `#1b212a` light, `#e2e5e9` dark |
+| `--chart-modebar-focus` | Toolbar keyboard focus ring | `--chart-focus`, else `#1b212a` light, `#e2e5e9` dark |
 | `--chart-selection` / `--chart-selection-fill` | Selection outline/fill | neutral grey matching the toolbar (follows a `.dark` root class) |
 | `--chart-zoom-selection` / `--chart-zoom-selection-fill` | Box-zoom outline/fill | same neutral grey as selection |
 | `--chart-crosshair` | Crosshair lines | translucent dark |
 | `--chart-annotation-text` | Annotation labels | falls back to `--chart-text` |
 | `--chart-cursor` / `--chart-cursor-pan` | Plot cursors | `crosshair` / `grab` |
-| `--chart-focus` | Keyboard focus outline | blue |
+| `--chart-focus` | Keyboard focus ring on the plot canvas, and on toolbar buttons unless `--chart-modebar-focus` is set | `#aa99ec` |
 
 You can define application-specific variables such as `--chart-accent` and use
 them from mark styles. XY validates the `var(...)` shape, then the browser
@@ -517,6 +517,12 @@ These neutral colors are built into every toolbar; an app does not need to map
 them to its own secondary palette. A `--chart-modebar-bg`,
 `--chart-modebar-active`, or `--chart-modebar-focus` value you set through
 `theme()`, chart `style=`, or a host stylesheet still wins in either mode.
+
+The toolbar's focus ring resolves in three steps: `--chart-modebar-focus`
+first, then `--chart-focus`, then the built-in scheme-aware neutral. So an app
+that themes focus once with `--chart-focus` gets one ring color across the plot
+canvas *and* the toolbar, and `--chart-modebar-focus` exists to break that tie
+when the toolbar needs its own.
 
 ## Dark mode in a standalone export
 

--- a/js/src/20_theme.ts
+++ b/js/src/20_theme.ts
@@ -149,7 +149,7 @@ export const XY_CHROME_CSS = `
 :where(.xy [data-xy-slot="canvas"][data-xy-dragmode="pan"]){cursor:var(--chart-cursor-pan,grab)}
 :where(.xy [data-xy-slot="canvas"][data-xy-dragmode="none"]){cursor:default}
 :where(.xy [data-xy-slot="canvas"]:focus-visible){outline:2px solid var(--chart-focus,#aa99ec);outline-offset:2px}
-:where(.xy) button[data-xy-slot="modebar_button"]:focus-visible{box-shadow:0 0 0 2px var(--chart-modebar-focus,var(--xy-modebar-focus)),0 0 0 3px var(--chart-modebar-bg,var(--xy-modebar-bg));outline:none}
+:where(.xy) button[data-xy-slot="modebar_button"]:focus-visible{box-shadow:0 0 0 2px var(--chart-modebar-focus,var(--chart-focus,var(--xy-modebar-focus))),0 0 0 3px var(--chart-modebar-bg,var(--xy-modebar-bg));outline:none}
 @media (prefers-reduced-motion:reduce){:where(.xy [data-xy-slot="modebar"]),:where(.xy) button[data-xy-slot="modebar_button"],:where(.xy [data-xy-modebar-menu-indicator]){transition-duration:0s!important}:where(.xy [data-xy-modebar-drag-handle]){transform:translate3d(calc(-100% - 5px),-50%,0);transition:opacity 120ms ease}:where(.xy [data-xy-slot="modebar"][data-xy-modebar-drag-peek-side="right"] [data-xy-modebar-drag-handle]){transform:translate3d(calc(100% + 5px),-50%,0)}}
 @media (forced-colors:active){:where(.xy [data-xy-slot="modebar"],.xy [data-xy-slot="tooltip"]){border:1px solid CanvasText}:where(.xy) button[data-xy-slot="modebar_button"].xy-active{outline:2px solid Highlight}:where(.xy [data-xy-slot="canvas"]:focus){outline:2px solid Highlight}}
 }

--- a/spec/api/styling.md
+++ b/spec/api/styling.md
@@ -285,13 +285,13 @@ Set them on `.xy` or any ancestor:
 | `--chart-badge-bg` / `--chart-badge-text` | Reduction badges | `rgba(255,255,255,.82)` / `#0f172a` (light; see below) |
 | `--chart-tick-label-max-width` | Maximum browser width of categorical y-axis tick labels | available space between the transformed label and chart edge |
 | `--chart-modebar-bg` / `--chart-modebar-active` | Modebar / active button | `#fff` / `#edf1f6` light; `#1b1d20` / `#121417` dark |
-| `--chart-modebar-focus` | Modebar keyboard focus ring | `#1b212a` light; `#e2e5e9` dark |
+| `--chart-modebar-focus` | Modebar keyboard focus ring | falls back to `--chart-focus`, then `#1b212a` light; `#e2e5e9` dark |
 | `--chart-selection` / `--chart-selection-fill` | Box/lasso/x-range/y-range select | modebar grey: `rgba(92,101,115,.6)` / `…,.12)` (light; see below) |
 | `--chart-zoom-selection` / `--chart-zoom-selection-fill` | Box-zoom drag rectangle | same modebar grey as selection (see below) |
 | `--chart-crosshair` | Crosshair lines | `rgba(15,23,42,.42)` |
 | `--chart-annotation-text` | Annotation label color | falls back to `--chart-text` |
 | `--chart-cursor` / `--chart-cursor-pan` | Plot cursor (box-zoom / pan) | `crosshair` / `grab` |
-| `--chart-focus` | Keyboard focus ring on the plot canvas | `#aa99ec` |
+| `--chart-focus` | Keyboard focus ring on the plot canvas, and on modebar buttons when `--chart-modebar-focus` is unset | `#aa99ec` |
 
 The modebar, badge, and selection-band defaults are **scheme-aware**: a `.dark`
 class on the chart root or any ancestor flips the internal fallbacks — the

--- a/spec/design-dossier.md
+++ b/spec/design-dossier.md
@@ -1294,7 +1294,8 @@ author expects.
   `readTheme()`: `--chart-bg`, `--chart-grid`, `--chart-axis`, `--chart-text`. Chrome
   tokens read by the stylesheet: `--chart-tooltip-bg` / `--chart-tooltip-text`,
   `--chart-legend-bg`, `--chart-badge-bg` / `--chart-badge-text`, `--chart-modebar-bg` /
-  `--chart-modebar-active`, `--chart-selection` / `--chart-selection-fill`,
+  `--chart-modebar-active` / `--chart-modebar-focus`,
+  `--chart-selection` / `--chart-selection-fill`,
   `--chart-zoom-selection` / `--chart-zoom-selection-fill`, `--chart-crosshair`,
   `--chart-annotation-text`, `--chart-cursor` / `--chart-cursor-pan`, `--chart-focus`.
   Unset tokens fall back to a built-in theme (`currentColor` at documented opacities for

--- a/spec/design/reflex-shaped-api.md
+++ b/spec/design/reflex-shaped-api.md
@@ -247,6 +247,7 @@ Recommended token surface:
 | `--chart-selection` | Box select fill/stroke |
 | `--chart-modebar-bg` | Modebar and modebar-menu background |
 | `--chart-modebar-active` | Modebar active/hovered button background |
+| `--chart-modebar-focus` | Modebar keyboard focus ring (falls back to `--chart-focus`) |
 
 `--chart-accent` is not an XY token; the renderer never reads it. It is a
 caller-defined convention variable that XY only passes through when a mark

--- a/tests/test_ui_issue_regressions.py
+++ b/tests/test_ui_issue_regressions.py
@@ -86,6 +86,10 @@ def test_modebar_active_button_uses_dark_active_color(tmp_path: Path) -> None:
     const darkBarBackground = getComputedStyle(bar).backgroundColor;
     active.focus();
     const darkFocusShadow = getComputedStyle(active).boxShadow;
+    // An app that themes focus once with --chart-focus keeps a single ring
+    // color across the canvas and the toolbar.
+    view.root.style.setProperty("--chart-focus", "#0000ff");
+    const inheritedFocusShadow = getComputedStyle(active).boxShadow;
     view.root.style.setProperty("--chart-modebar-active", "#ff00ff");
     view.root.style.setProperty("--chart-modebar-focus", "#00ff00");
     const customActiveBackground = getComputedStyle(active).backgroundColor;
@@ -94,6 +98,7 @@ def test_modebar_active_button_uses_dark_active_color(tmp_path: Path) -> None:
       darkActiveBackground,
       darkBarBackground,
       darkFocusShadow,
+      inheritedFocusShadow,
       customActiveBackground,
       customFocusShadow,
     }));
@@ -105,6 +110,7 @@ def test_modebar_active_button_uses_dark_active_color(tmp_path: Path) -> None:
     assert result["darkActiveBackground"] == "rgb(18, 20, 23)", result
     assert result["darkBarBackground"] == "rgb(27, 29, 32)", result
     assert "rgb(226, 229, 233)" in result["darkFocusShadow"], result
+    assert "rgb(0, 0, 255)" in result["inheritedFocusShadow"], result
     assert result["customActiveBackground"] == "rgb(255, 0, 255)", result
     assert "rgb(0, 255, 0)" in result["customFocusShadow"], result
 


### PR DESCRIPTION
Follow-up to #234.

#234 gave modebar buttons their own focus token, but it *replaced*
`--chart-focus` rather than layering over it. An app that themes focus once —
as the xy docs site does, with `--chart-focus: var(--primary-9)` in
`docs/app/xy_docs/xy_docs.py` — keeps its color on the plot canvas and silently
loses it on the toolbar, so a single chart renders two different focus-ring
colors with no one token that unifies them.

## Change

The ring now resolves in three steps instead of two:

```css
box-shadow:0 0 0 2px var(--chart-modebar-focus,var(--chart-focus,var(--xy-modebar-focus))),…
```

- Neither token set → the scheme-aware neutral #234 introduced, unchanged
  (and still the contrast win over the old `#aa99ec`, which was 2.5:1 on the
  light toolbar and failed WCAG 1.4.11).
- `--chart-focus` set → canvas and toolbar share one ring.
- `--chart-modebar-focus` set → the toolbar keeps its own, as before.

Also corrects the token tables the change left behind: the docs-site row still
described `--chart-focus` as "blue" (it is `#aa99ec`) and did not mention the
narrowed scope, and `--chart-modebar-focus` was missing from the two spec
inventories that enumerate the vocabulary.

## Verification

Measured with `getComputedStyle` in a Reflex app running the client built from
`js/src`, after real `Tab` navigation (programmatic `.focus()` stops matching
`:focus-visible` once a mouse has touched the page):

| tokens set | canvas ring | toolbar ring (light) | toolbar ring (dark) |
|---|---|---|---|
| none | `#aa99ec` | `rgb(27,33,42)` | `rgb(226,229,233)` |
| `--chart-focus: #e5484d` | `rgb(229,72,77)` | **`rgb(229,72,77)`** | **`rgb(229,72,77)`** |
| + `--chart-modebar-focus: #12a594` | `rgb(229,72,77)` | `rgb(18,165,148)` | `rgb(18,165,148)` |

The middle row is the fix; on `main` those cells read `rgb(27,33,42)` /
`rgb(226,229,233)`.

`test_modebar_active_button_uses_dark_active_color` gains an
`inheritedFocusShadow` assertion covering the middle row. Reverting just the CSS
line and rebuilding fails it on exactly that assertion, so the guard bites.