### PR TITLE
Legend click-to-toggle with tiered §34 re-aggregation

### DIFF
--- a/examples/reflex/xy_reflex_demo/xy_reflex_demo.py
+++ b/examples/reflex/xy_reflex_demo/xy_reflex_demo.py
@@ -21,6 +21,12 @@ via `inspect.getsource`.
    scatter from ``examples/fastapi`` — identical data and mark config — as one
    ``reflex_xy.inline`` token with zero transport code, for A/B-ing the two
    hosts. ``XY_LIVE_POINTS`` resizes it (both apps honor the same override).
+7. **Legend hover-highlight and click-to-toggle.** Left: named series on the
+   direct tier — hovering a legend row dims the others, clicking hides a
+   series entirely client-side (interaction spec §9/§10). Right: a categorical
+   density scatter behind an ``inline()`` token — clicking a category row
+   sends ``legend_toggle`` over the app websocket and the kernel re-bins the
+   surface with that category masked out (§34).
 
 Run from ``examples/reflex``::
 
@@ -116,6 +122,68 @@ def orbits_chart() -> xy.Chart:
 # Registered at import; the content-addressed token resolves on any backend
 # worker.
 ORBITS_TOKEN = reflex_xy.inline(orbits_chart())
+
+
+# --- legend interactivity (§7) ----------------------------------------------
+
+
+def legend_series_chart() -> xy.Chart:
+    """Three named series on the direct tier. Hovering a legend row dims the
+    other series; clicking a row hides its series — a pure client hide (0 wire
+    bytes), so both work even on this static-payload chart. Defaults are on;
+    ``xy.legend(highlight=False)`` / ``xy.legend(toggle=False)`` opt out."""
+    rng = np.random.default_rng(7)
+    marks = [
+        xy.scatter(
+            rng.normal(cx, 0.5, 60_000),
+            rng.normal(cy, 0.5, 60_000),
+            name=name,
+            opacity=0.7,
+        )
+        for name, cx, cy in (
+            ("baseline", -1.5, -0.8),
+            ("candidate", 0.0, 0.9),
+            ("control", 1.6, -0.4),
+        )
+    ]
+    return xy.scatter_chart(
+        *marks,
+        xy.legend(),
+        xy.x_axis(label="x"),
+        xy.y_axis(label="y"),
+        title="named series — hover dims, click hides",
+        width="100%",
+        height=300,
+    )
+
+
+def legend_category_chart() -> xy.Chart:
+    """One categorical density scatter: a legend row per category. Clicking a
+    row sends ``legend_toggle`` over the app websocket; the kernel drops that
+    category before re-binning the density surface (§34 — the reply's binning
+    is tagged ``-masked``) and the retained sample overlay filters instantly
+    while the re-bin is in flight."""
+    rng = np.random.default_rng(21)
+    n = 1_200_000
+    cat = rng.integers(0, 3, n)
+    centers = np.array([[-1.2, -0.6], [0.2, 1.1], [1.5, -0.9]])
+    x = rng.normal(centers[cat, 0], 0.55)
+    y = rng.normal(centers[cat, 1], 0.55)
+    labels = np.array(["sensor A", "sensor B", "sensor C"])[cat]
+    return xy.scatter_chart(
+        xy.scatter(x, y, color=labels, opacity=0.7, density=True),
+        xy.legend(),
+        xy.x_axis(label="x"),
+        xy.y_axis(label="y"),
+        title="categorical density — click a row to mask & re-bin",
+        width="100%",
+        height=300,
+    )
+
+
+# Kernel-served so category toggles reach `legend_toggle` and the masked
+# re-bin path; a static payload would only filter the local sample overlay.
+LEGEND_CATS_TOKEN = reflex_xy.inline(legend_category_chart())
 
 
 # --- the live drilldown, adapter-native (§6) --------------------------
@@ -519,6 +587,17 @@ def drilldown_view() -> rx.Component:
     return reflex_xy.chart(DRILLDOWN_TOKEN, height="430px", id="drilldown")
 
 
+# §7 wiring — legend interactivity ships with the charts; no handlers needed
+def legend_view() -> rx.Component:
+    return rx.grid(
+        reflex_xy.chart(legend_series_chart(), height="300px", id="legend-series"),
+        reflex_xy.chart(LEGEND_CATS_TOKEN, height="300px", id="legend-cats"),
+        columns="2",
+        gap="1rem",
+        width="100%",
+    )
+
+
 def index() -> rx.Component:
     return rx.container(
         rx.vstack(
@@ -617,6 +696,19 @@ def index() -> rx.Component:
                 "resizes both apps for side-by-side comparison.",
                 drilldown_view(),
                 code_accordion(drilldown_chart, drilldown_view),
+            ),
+            section(
+                "7 · Legend: hover to emphasize, click to toggle",
+                "Hover a legend row to dim every other series; click it to "
+                "hide/show what it stands for. Left: named series — a pure "
+                "client-side hide (0 wire bytes). Right: a categorical density "
+                "scatter served by the kernel — a category click sends "
+                "legend_toggle over the app websocket and the surface is "
+                "re-binned with the category masked out (§34). Both default "
+                "on: xy.legend(highlight=False) / xy.legend(toggle=False) "
+                "opt out.",
+                legend_view(),
+                code_accordion(legend_series_chart, legend_category_chart, legend_view),
             ),
             spacing="5",
             width="100%",

--- a/js/src/20_theme.ts
+++ b/js/src/20_theme.ts
@@ -2,6 +2,18 @@
 // Colors & theming (§36: chrome inherits CSS; marks read --chart-* tokens)
 // ---------------------------------------------------------------------------
 
+// A computed-style `rgb()`/`rgba()` string as unit RGBA, or null if the value
+// is not one (`transparent` resolves to rgba(0,0,0,0) and parses fine; a
+// keyword like `none` does not). Every consumer of a computed color goes
+// through here so the two readers below cannot drift.
+function parseRgbFunc(raw) {
+  const m = raw && raw.match(/rgba?\(([^)]+)\)/);
+  if (!m) return null;
+  const parts = m[1].split(/[,/\s]+/).filter(Boolean).map(Number);
+  const [r, g, b, a = 1] = parts;
+  return [r / 255, g / 255, b / 255, a];
+}
+
 function resolveCssColor(host, expr) {
   const probe = document.createElement("span");
   probe.style.display = "none";
@@ -9,11 +21,7 @@ function resolveCssColor(host, expr) {
   host.appendChild(probe);
   const rgb = getComputedStyle(probe).color;
   host.removeChild(probe);
-  const m = rgb.match(/rgba?\(([^)]+)\)/);
-  if (!m) return null;
-  const parts = m[1].split(/[,/\s]+/).filter(Boolean).map(Number);
-  const [r, g, b, a = 1] = parts;
-  return [r / 255, g / 255, b / 255, a];
+  return parseRgbFunc(rgb);
 }
 
 function cssToken(el, name) {
@@ -46,6 +54,23 @@ export function parseColor(host, c, fallback) {
     console.warn(`xy: unresolvable color ${JSON.stringify(expr)}; using fallback`);
   }
   return fallback;
+}
+
+// The color actually painted behind the chart's marks. The canvas is
+// transparent-capable, so when the theme sets no --chart-bg the visual
+// backdrop is the nearest ancestor that paints a background — walk up and
+// take the first non-transparent computed background-color. With nothing
+// painted anywhere, fall back by scheme: near-black under the `.dark`
+// ancestor convention (XY_CHROME_CSS below), else white. Legend dims blend
+// toward this color; blending toward a white fallback on a dark page reads
+// as sibling categories BRIGHTENING into pastels instead of fading.
+export function chartBackdrop(root, themeBg) {
+  if (Array.isArray(themeBg) && themeBg[3] > 0.01) return themeBg;
+  for (let el = root; el; el = el.parentElement) {
+    const c = parseRgbFunc(getComputedStyle(el).backgroundColor);
+    if (c && c[3] > 0.01) return [c[0], c[1], c[2], 1];
+  }
+  return root.closest && root.closest(".dark") ? [0.043, 0.051, 0.063, 1] : [1, 1, 1, 1];
 }
 
 export function readTheme(root) {

--- a/js/src/45_lod.ts
+++ b/js/src/45_lod.ts
@@ -742,6 +742,24 @@ export function lodDropPointCache(view, g) {
   g.drillCache = null;
 }
 
+// Drop every retired density window (textures + paired overlays) while
+// keeping the LIVE grid: a filter-state change (legend category toggle,
+// interaction spec §10) makes cached aggregates wrong, but the on-screen
+// grid stays as the stale-while-revalidate frame until the masked reply
+// replaces it (§17). The home sample overlay survives — it is the
+// standalone re-bin worker's CPU source and is filtered separately.
+export function lodDropDensityCache(view, g) {
+  for (const old of g.densityCache || []) {
+    if (!old || old === g.density) continue;
+    if (old.tex && old.tex !== (g.density && g.density.tex)) view.gl.deleteTexture(old.tex);
+    if (old.overlay && old.overlay !== g.sampleOverlay) {
+      view._destroySampleOverlay(old.overlay);
+      old.overlay = null;
+    }
+  }
+  g.densityCache = [];
+}
+
 // A retired cached window that covers the view swaps back in as the live
 // drill — the pan-back / zoom-ping-pong "render anything inside there" path
 // (T13). Alpha-continuous like a revive: the swap hands marks over at the

--- a/js/src/45_lod.ts
+++ b/js/src/45_lod.ts
@@ -1159,6 +1159,16 @@ function lodRememberDensityFacts(view, g, upd) {
   }
 }
 
+// Canonical string form of a §34 hidden-category set — the identity every
+// aggregate is keyed by: which predicate it was binned under. Grids are
+// stamped with it, requests carry it, and replies are admitted by it, so the
+// ONE canonicalization lives here (sorted, so a client-side Set and the
+// kernel's `hidden_categories` array always agree). Empty = unmasked, which
+// is what the build-time home grid carries.
+export function lodFilterKey(codes) {
+  return Array.from(codes || []).sort((a: any, b: any) => a - b).join(",");
+}
+
 // Apply a kernel "density"-mode update: new grid texture with eased exposure
 // normalization, previous grid kept for the crossfade, source remembered in
 // the per-trace cache.
@@ -1180,6 +1190,10 @@ export function lodApplyDensityUpdate(view, g, upd, buffers) {
   // still applies the reply: silence must never blank a frame (T1).
   // Standalone clients keep applying everything — their re-binned grids
   // are the only refinement they have.
+  // Filter identity of this reply (interaction spec §10 / §34): the grid is
+  // only interchangeable with textures binned under the SAME hidden-category
+  // set. The build-time home grid carries no key (= unmasked).
+  const replyFilterKey = lodFilterKey(upd.filter && upd.filter.hidden_categories);
   if (view.comm) {
     const sw = g._stepReqWin;
     const tol = sw ? (Math.abs(sw[1] - sw[0]) + Math.abs(sw[3] - sw[2])) * 1e-6 + 1e-300 : 0;
@@ -1190,7 +1204,11 @@ export function lodApplyDensityUpdate(view, g, upd, buffers) {
       g._stepReqWin = null;
     } else {
       const covering = lodDensityForView(view, g);
-      if (covering && covering.tex && view._viewInsideRange(covering.xRange, covering.yRange)) {
+      // A covering texture binned under a DIFFERENT hidden-category set is a
+      // stale predicate's aggregate (§34) — it must be repainted, never
+      // stood on, in either direction (mask applied or lifted).
+      if (covering && covering.tex && view._viewInsideRange(covering.xRange, covering.yRange) &&
+          (covering._filterKey || "") === replyFilterKey) {
         lodRememberDensityFacts(view, g, upd);
         return;
       }
@@ -1219,6 +1237,7 @@ export function lodApplyDensityUpdate(view, g, upd, buffers) {
     grid,
     rgba,
     filter,
+    _filterKey: replyFilterKey,
     tex: view._uploadGrid(
       grid, d.w, d.h, normMax, rgba, filter, view._fillOpacity(g.trace.style),
     ),

--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -23,6 +23,13 @@ const COLORBAR_THICKNESS = 18;
 const COLORBAR_GAP = 24;
 const COMPACT_COLORBAR_GAP = 8;
 let XY_A11Y_ID = 0;
+// Legend hover emphasis (interaction spec §9): opacity kept by non-hovered series on
+// the marks canvas, and by non-hovered rows in the legend box itself.
+const LEGEND_DIM_OPACITY = 0.2;
+const LEGEND_DIM_ROW = 0.4;
+// SVG gradient ids resolve document-wide; a module counter keeps every chart
+// instance's legend swatch ramps distinct.
+let legendGradientSeq = 0;
 const XY_SR_ONLY_STYLE =
   "position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;" +
   "clip:rect(0,0,0,0);white-space:nowrap;border:0;";
@@ -1717,28 +1724,47 @@ export class ChartView {
 
   _buildLegend(root) {
     const s = this.spec;
+    // A chrome rebuild replaces the row nodes mid-hover, so their pointerleave
+    // never fires; release any active dim state before dropping the old boxes.
+    this._clearLegendHover();
     this._legends = [];
     const items = [];
     if (s.show_legend !== false) {
-      for (const t of s.traces) {
+      // Two identically-encoded unnamed continuous traces must not stack two
+      // identical gradient rows; the row is about the encoding, so later
+      // traces join the first row's hover-target list instead.
+      const continuousRows = new Map();
+      s.traces.forEach((t, ti) => {
         // A density-tier surface encodes count as alpha and wears the mean
         // point color (LOD doc §2), so it gets no colormap gradient swatch —
         // a gradient would claim color == density. A named density trace
         // falls through to the plain marker swatch below, matching the
         // static SVG/raster exporters.
+        const line = ["line", "segments", "step", "stairs", "errorbar"].includes(t.kind);
         if (t.color && t.color.mode === "categorical") {
           t.color.categories.forEach((cat, i) =>
-            items.push({ swatch: t.color.palette[i], name: cat, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, style: t.style || {} }));
+            items.push({ swatch: t.color.palette[i], name: cat, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, style: t.style || {}, traces: [ti], cat: i }));
         } else if (t.color && t.color.mode === "continuous") {
-          items.push({ swatch: "gradient", cmap: t.color.colormap, name: t.name || "value" });
+          // Label precedence: explicit series name, then the encoding's own
+          // declarative label (the color="column" idiom), then the generic
+          // fallback for hand-built specs.
+          const name = t.name || t.color.label || "value";
+          const key = name + "\u0000" + t.color.colormap;
+          const existing = continuousRows.get(key);
+          if (existing) {
+            existing.traces.push(ti);
+            return;
+          }
+          const item = { swatch: "gradient", cmap: t.color.colormap, name, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, line, style: t.style || {}, traces: [ti] };
+          continuousRows.set(key, item);
+          items.push(item);
         } else if (t.name) {
           const c = (t.color && t.color.color) || (t.style && t.style.color);
           // Line-family kinds get a short line sample (honoring the dash), the
           // same handle the raster/SVG exporters draw — not a filled swatch.
-          const line = ["line", "segments", "step", "stairs", "errorbar"].includes(t.kind);
-          items.push({ swatch: c, name: t.name, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, line, style: t.style || {} });
+          items.push({ swatch: c, name: t.name, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, line, style: t.style || {}, traces: [ti] });
         }
-      }
+      });
       if (items.length) this._legendBox(root, items, s.legend || {});
     }
     // Manually added Legend artists ship explicit items + their own loc, so a
@@ -1756,7 +1782,7 @@ export class ChartView {
   }
 
   _legendBox(root, items, options) {
-    const lg = document.createElement("div");
+    const lg: any = document.createElement("div");
     const loc = options.loc || "upper right";
     const ncols = Math.max(1, Number(options.ncols) || 1);
     const horizontal = ncols > 1;
@@ -1773,6 +1799,7 @@ export class ChartView {
       title.style.gridColumn = `1 / span ${horizontal ? ncols : 1}`;
       lg.appendChild(title);
     }
+    const rows = [];
     for (const it of items) {
       const row = document.createElement("div");
       this._applySlot(row, "legend_item");
@@ -1782,11 +1809,19 @@ export class ChartView {
       sw.style.display = "inline-block";
       sw.style.verticalAlign = "-1px";
       let bg = it.swatch;
-      if (it.swatch === "gradient") {
+      // A continuous encoding paints the swatch with the colormap ramp, but
+      // the swatch keeps the mark's identity: a gradient-filled symbol for
+      // scatters, a gradient-stroked line sample for line-family kinds, and
+      // only the bare ramp chip when the mark has neither.
+      let gradientPaint = null;
+      if (it.swatch === "gradient" && (it.symbol || it.line)) {
+        gradientPaint = (svg) => this._legendGradientPaint(svg, it.cmap);
+      } else if (it.swatch === "gradient") {
         const stops = colormapStops(it.cmap);
         bg = `linear-gradient(90deg,${stops.map((c) => `rgb(${c[0]},${c[1]},${c[2]})`).join(",")})`;
         sw.style.background = bg;
-      } else if (it.symbol) {
+      }
+      if (it.symbol) {
         const ns = "http://www.w3.org/2000/svg";
         const svg = document.createElementNS(ns, "svg");
         svg.setAttribute("viewBox", "0 0 18 14");
@@ -1805,7 +1840,7 @@ export class ChartView {
           hexagon: "M9 2L13.3 4.5v5L9 12l-4.3-2.5v-5z",
           star: "M9 2l1.5 3.1 3.5.5-2.5 2.5.6 3.5L9 10l-3.1 1.6.6-3.5L4 5.6l3.5-.5z"
         };
-        const color = safeCssPaint(this.root, bg);
+        const color = gradientPaint ? gradientPaint(svg) : safeCssPaint(this.root, bg);
         if (it.symbol === "circle" || it.symbol === "point" || it.symbol === "pixel") {
           if (it.symbol === "pixel") path.setAttribute("d", "M8.5 6.5h1v1h-1z");
           else path.setAttribute("d", `M9 ${it.symbol === "point" ? 4.75 : 2.5}a${it.symbol === "point" ? 2.25 : 4.5} ${it.symbol === "point" ? 2.25 : 4.5} 0 1 0 0 ${it.symbol === "point" ? 4.5 : 9}a${it.symbol === "point" ? 2.25 : 4.5} ${it.symbol === "point" ? 2.25 : 4.5} 0 1 0 0 -${it.symbol === "point" ? 4.5 : 9}`);
@@ -1828,7 +1863,7 @@ export class ChartView {
         ln.setAttribute("y1", "6");
         ln.setAttribute("x2", "21");
         ln.setAttribute("y2", "6");
-        ln.setAttribute("stroke", safeCssPaint(this.root, bg));
+        ln.setAttribute("stroke", gradientPaint ? gradientPaint(svg) : safeCssPaint(this.root, bg));
         // ?? not ||: an explicit lw=0 keeps 0 and draws nothing, like the
         // exporters' dict-default and Matplotlib itself.
         ln.setAttribute("stroke-width", String(it.style?.width ?? 1.5));
@@ -1837,17 +1872,96 @@ export class ChartView {
         sw.appendChild(svg);
         sw.style.width = "22px";
         sw.style.height = "12px";
-      } else {
+      } else if (it.swatch !== "gradient") {
         sw.style.background = safeCssPaint(this.root, bg);
       }
       this._applySlot(sw, "legend_swatch");
       row.appendChild(sw);
       row.appendChild(document.createTextNode(it.name));
+      // Hover emphasis (interaction spec §9): rows backed by live traces dim the rest
+      // of the chart while hovered. Manually-added Legend artists carry no
+      // trace linkage, so extra_legends rows stay inert.
+      if (options.highlight !== false && it.traces && it.traces.length) {
+        row.addEventListener("pointerenter", () => this._setLegendHover(it, lg, row));
+        row.addEventListener("pointerleave", () => this._clearLegendHover());
+      }
+      rows.push(row);
       lg.appendChild(row);
     }
+    lg._xyItemRows = rows;
     root.appendChild(lg);
     this._legends.push(lg); // _resize refreshes each box's responsive anchor
     return lg;
+  }
+
+  // Paint an SVG swatch with the item's colormap ramp: registers a
+  // <linearGradient> in the swatch's own defs and returns its paint URL.
+  // IDs are document-global, so a module counter keeps multiple charts on
+  // one page from cross-referencing each other's ramps.
+  _legendGradientPaint(svg, cmap) {
+    const ns = "http://www.w3.org/2000/svg";
+    const id = `xy-legend-grad-${legendGradientSeq++}`;
+    const defs = document.createElementNS(ns, "defs");
+    const grad = document.createElementNS(ns, "linearGradient");
+    grad.setAttribute("id", id);
+    const stops = colormapStops(cmap);
+    stops.forEach((c, i) => {
+      const stop = document.createElementNS(ns, "stop");
+      stop.setAttribute("offset", `${(i / Math.max(1, stops.length - 1)) * 100}%`);
+      stop.setAttribute("stop-color", `rgb(${c[0]},${c[1]},${c[2]})`);
+      grad.appendChild(stop);
+    });
+    defs.appendChild(grad);
+    svg.appendChild(defs);
+    return `url(#${id})`;
+  }
+
+  // Legend hover emphasis: the hovered row's series keeps full opacity while
+  // every other series dims (and, for a categorical row, the trace's other
+  // categories dim through a background-blended palette LUT — the point
+  // shaders ignore LUT alpha, so the fade is baked into the RGB ramp).
+  // Whole density-tier traces dim through _drawDensity's uniform like any
+  // other series, but a categorical row cannot dim sibling categories inside
+  // an aggregated density plane (§28 — recorded in the dossier, not silent).
+  _setLegendHover(item, lg, hoveredRow) {
+    this._legendHover = item;
+    const keep = new Set(item.traces);
+    for (let i = 0; i < (this.gpuTraces || []).length; i++) {
+      const g = this.gpuTraces[i];
+      g._legendDim = keep.has(i) ? 1 : LEGEND_DIM_OPACITY;
+      if (g._legendPrevLut !== undefined) {
+        g.lut = g._legendPrevLut;
+        delete g._legendPrevLut;
+      }
+      const t = g.trace;
+      if (item.cat != null && keep.has(i) && g.tier !== "density" &&
+          t.color && t.color.mode === "categorical" && g.lut) {
+        g._legendPrevLut = g.lut;
+        g.lut = this._paletteLutDimmed(t.color.palette, item.cat);
+      }
+    }
+    for (const row of lg._xyItemRows || []) {
+      row.style.opacity = row === hoveredRow ? "" : String(LEGEND_DIM_ROW);
+    }
+    // Color-pass-only change: geometry and view are untouched, so the pick
+    // snapshot stays valid (§17).
+    this.draw(true);
+  }
+
+  _clearLegendHover() {
+    if (!this._legendHover) return;
+    this._legendHover = null;
+    for (const g of this.gpuTraces || []) {
+      delete g._legendDim;
+      if (g._legendPrevLut !== undefined) {
+        g.lut = g._legendPrevLut;
+        delete g._legendPrevLut;
+      }
+    }
+    for (const lg of this._legends || []) {
+      for (const row of lg._xyItemRows || []) row.style.opacity = "";
+    }
+    this.draw(true);
   }
 
   _positionLegend(lg, loc) {
@@ -2070,6 +2184,36 @@ export class ChartView {
       data[i * 4] = c[0] * 255;
       data[i * 4 + 1] = c[1] * 255;
       data[i * 4 + 2] = c[2] * 255;
+      data[i * 4 + 3] = 255;
+    }
+    const tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 256, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, data);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    this._lutCache.set(key, tex);
+    return tex;
+  }
+
+  // Palette LUT with every category except `keepIdx` blended toward the plot
+  // background — the legend-hover dim for categorical traces. RGB-only on
+  // purpose: the point/line shaders read `texture(u_lut, ...).rgb` and force
+  // alpha to 1, so an alpha-based fade would be a silent no-op.
+  _paletteLutDimmed(palette, keepIdx) {
+    const key = "pal:" + palette.join(",") + ":dim" + keepIdx + ":" + (this.theme.bg || "");
+    if (this._lutCache.has(key)) return this._lutCache.get(key);
+    const gl = this.gl;
+    const bg = parseColor(this.root, this.theme.bg || "#ffffff", [1, 1, 1, 1]);
+    const data = new Uint8Array(256 * 4);
+    for (let i = 0; i < 256; i++) {
+      const c = hexColor(palette[i % palette.length]);
+      const keep = i % palette.length === keepIdx % palette.length;
+      const w = keep ? 1 : LEGEND_DIM_OPACITY;
+      data[i * 4] = (c[0] * w + bg[0] * (1 - w)) * 255;
+      data[i * 4 + 1] = (c[1] * w + bg[1] * (1 - w)) * 255;
+      data[i * 4 + 2] = (c[2] * w + bg[2] * (1 - w)) * 255;
       data[i * 4 + 3] = 255;
     }
     const tex = gl.createTexture();
@@ -3199,7 +3343,7 @@ export class ChartView {
   }
 
   _drawPoints(g, xm, ym, opacityScale = 1) {
-    opacityScale *= g._transitionOpacity ?? 1;
+    opacityScale *= (g._transitionOpacity ?? 1) * (g._legendDim ?? 1);
     const animationScale = g._transitionScale ?? 1;
     if (this._canDrawSimplePoints(g)) {
       this._drawSimplePoints(g, xm, ym, opacityScale);
@@ -3432,7 +3576,7 @@ export class ChartView {
     // WebGL error that aborts the draw, so treat an invalid texture as "nothing
     // to draw" rather than risk it.
     if (!d || !d.tex || !gl.isTexture(d.tex)) return;
-    opacityScale *= g._transitionOpacity ?? 1;
+    opacityScale *= (g._transitionOpacity ?? 1) * (g._legendDim ?? 1);
     const prog = this.densityProg;
     gl.useProgram(prog);
     const u = (n) => uniformOf(gl, prog, n);
@@ -3506,7 +3650,7 @@ export class ChartView {
       h.xRange[xrev ? 1 : 0], h.xRange[xrev ? 0 : 1],
       h.yRange[yrev ? 1 : 0], h.yRange[yrev ? 0 : 1],
     );
-    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._transitionOpacity ?? 1));
+    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._transitionOpacity ?? 1) * (g._legendDim ?? 1));
     gl.uniform1i(u("u_truecolor"), h.truecolor ? 1 : 0);
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, h.tex);
@@ -3538,7 +3682,7 @@ export class ChartView {
     gl.uniform1f(u("u_revealSegments"), g.n - 1);
     gl.uniform1f(u("u_width"), (width ?? g.trace.style.width ?? 1.5) * this.dpr);
     const [r, gg, b, a] = color || g.color;
-    const strokeOpacity = this._strokeOpacity(g.trace.style) * (opacity ?? 1) * (g._transitionOpacity ?? 1);
+    const strokeOpacity = this._strokeOpacity(g.trace.style) * (opacity ?? 1) * (g._transitionOpacity ?? 1) * (g._legendDim ?? 1);
     gl.uniform4f(u("u_color"), r, gg, b, a * strokeOpacity);
     const dashed = this._lineDash(g);
     this._bindVao(
@@ -3585,7 +3729,7 @@ export class ChartView {
     gl.uniform1f(u("u_animationProgress"), g._transitionScale ?? 1);
     const [r, gg, b, a] = g.color;
     gl.uniform4f(u("u_color"), r, gg, b, a);
-    gl.uniform1f(u("u_opacity"), this._strokeOpacity(g.trace.style) * (g._transitionOpacity ?? 1));
+    gl.uniform1f(u("u_opacity"), this._strokeOpacity(g.trace.style) * (g._transitionOpacity ?? 1) * (g._legendDim ?? 1));
     gl.uniform1i(u("u_colorMode"), g.colorMode || 0);
     const dashed = this._segmentDash(g, prog);
     if (g.colorMode && g.lut) {
@@ -3707,7 +3851,7 @@ export class ChartView {
     for (const name of ["x0", "x1", "x2"]) this._setAxisUniforms(prog, "u_" + name, g[name + "Meta"], g.xAxis);
     for (const name of ["y0", "y1", "y2"]) this._setAxisUniforms(prog, "u_" + name, g[name + "Meta"], g.yAxis);
     gl.uniform1i(u("u_colorMode"), g.colorMode || 0);
-    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style));
+    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._legendDim ?? 1));
     gl.uniform4f(u("u_color"), g.color[0], g.color[1], g.color[2], g.color[3]);
     // Straight alpha: MESH_FS folds u_strokeOpacity and the per-item alpha
     // stack in and premultiplies there (uniform and buffer strokes alike).
@@ -3715,7 +3859,7 @@ export class ChartView {
     gl.uniform4f(u("u_stroke"), stroke[0], stroke[1], stroke[2], stroke[3]);
     gl.uniform1f(u("u_strokeWidth"), g.meshStrokeWidth || 0);
     gl.uniform1i(u("u_strokeMode"), g.strokeBuf ? 1 : 0);
-    gl.uniform1f(u("u_strokeOpacity"), this._strokeOpacity(g.trace.style));
+    gl.uniform1f(u("u_strokeOpacity"), this._strokeOpacity(g.trace.style) * (g._legendDim ?? 1));
     if (g.colorMode && g.lut) {
       gl.activeTexture(gl.TEXTURE0);
       gl.bindTexture(gl.TEXTURE_2D, g.lut);
@@ -3804,7 +3948,7 @@ export class ChartView {
     gl.uniform1f(u("u_revealProgress"), reveal);
     gl.uniform1f(u("u_revealSegments"), g.n - 1);
     const [r, gg, b, a] = g.color;
-    gl.uniform4f(u("u_color"), r, gg, b, a * this._fillOpacity(g.trace.style, 0.35) * (g._transitionOpacity ?? 1));
+    gl.uniform4f(u("u_color"), r, gg, b, a * this._fillOpacity(g.trace.style, 0.35) * (g._transitionOpacity ?? 1) * (g._legendDim ?? 1));
     gl.uniform2f(u("u_res"), this.canvas.width, this.canvas.height);
     this._setGradientUniforms(prog, g.grad);
     this._bindVao(g, "area", [g.xBuf._fcId, g.yBuf._fcId, g.baseBuf._fcId], () => {
@@ -3840,7 +3984,7 @@ export class ChartView {
     gl.uniform4f(u("u_edgePad"), edgePad[0], edgePad[1], edgePad[2], edgePad[3]);
     const [r, gg, b, a] = g.color;
     gl.uniform4f(u("u_color"), r, gg, b, a);
-    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._transitionOpacity ?? 1));
+    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._transitionOpacity ?? 1) * (g._legendDim ?? 1));
     gl.uniform1i(u("u_colorMode"), g.colorMode || 0);
     this._setRectStyleUniforms(prog, g);
     const colorOn = !!g.cBuf;
@@ -3914,7 +4058,7 @@ export class ChartView {
     gl.uniform1f(u("u_prevWidth"), g._transitionPrevWidth ?? g.width);
     const [r, gg, b, a] = g.color;
     gl.uniform4f(u("u_color"), r, gg, b, a);
-    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._transitionOpacity ?? 1));
+    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._transitionOpacity ?? 1) * (g._legendDim ?? 1));
     gl.uniform1i(u("u_colorMode"), g.colorMode || 0);
     this._setRectStyleUniforms(prog, g);
     const v0On = g.value0Mode === 1 && g.value0Buf;

--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -3,7 +3,7 @@ import { buildLutData, colormapStops } from "./10_colormaps";
 import { cssColor, ensureChromeStylesheet, hexColor, parseColor, readTheme, safeCssPaint } from "./20_theme";
 import { categoryTicks, fmtAxis, fmtGeneral, fmtLinear, fmtValue, linearTicks, logTicks, timeTicks } from "./30_ticks";
 import { AREA_FS, AREA_VS, ATTR_SLOTS, BAR_VS, DENSITY_FS, GRID_VS, HEATMAP_FS, LINE_FS, LINE_VS, MESH_FS, MESH_VS, PICK_FS, PICK_VS, POINT_FS, POINT_SIMPLE_FS, POINT_SIMPLE_VS, POINT_VS, RECT_FS, RECT_VS, SEGMENT_FS, SEGMENT_VS, makeProgram, uniformOf, xySmoothResample } from "./40_gl";
-import { lodCopyGrid, lodDecodeLogU8, lodDrawDensityTier, lodDropPointCache, lodRememberDensity, lodSampleForView, lodWriteGridTexture } from "./45_lod";
+import { lodCopyGrid, lodDecodeLogU8, lodDrawDensityTier, lodDropDensityCache, lodDropPointCache, lodRememberDensity, lodSampleForView, lodWriteGridTexture } from "./45_lod";
 import { markOf } from "./55_marks";
 
 // ---------------------------------------------------------------------------
@@ -27,6 +27,8 @@ let XY_A11Y_ID = 0;
 // the marks canvas, and by non-hovered rows in the legend box itself.
 const LEGEND_DIM_OPACITY = 0.2;
 const LEGEND_DIM_ROW = 0.4;
+// Legend click-toggle (interaction spec §10): opacity of a toggled-off row.
+const LEGEND_OFF_ROW = 0.35;
 // SVG gradient ids resolve document-wide; a module counter keeps every chart
 // instance's legend swatch ramps distinct.
 let legendGradientSeq = 0;
@@ -1677,6 +1679,7 @@ export class ChartView {
       : (this.spec.traces || []);
     for (const entry of traces) {
       const t = entry.trace || entry;
+      if (entry._legendHidden) continue; // hidden series badge nothing
       if (t.tier !== "density" || !t.density) continue;
       // Badge what is actually drawn: the overlay _drawDensitySample chose
       // for the current view (T9 pairing). Before the first frame runs, the
@@ -1728,6 +1731,10 @@ export class ChartView {
     // never fires; release any active dim state before dropping the old boxes.
     this._clearLegendHover();
     this._legends = [];
+    // Toggle state survives chrome/GPU rebuilds: it lives on the view keyed
+    // by spec-trace index, and freshly built rows re-adopt it below.
+    this._legendOffTraces = this._legendOffTraces || new Set();
+    this._legendOffCats = this._legendOffCats || new Map();
     const items = [];
     if (s.show_legend !== false) {
       // Two identically-encoded unnamed continuous traces must not stack two
@@ -1765,6 +1772,12 @@ export class ChartView {
           items.push({ swatch: c, name: t.name, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, line, style: t.style || {}, traces: [ti] });
         }
       });
+      for (const it of items) {
+        if (!it.traces) continue;
+        it.off = it.cat != null
+          ? !!this._legendOffCats.get(it.traces[0])?.has(it.cat)
+          : it.traces.every((ti) => this._legendOffTraces.has(ti));
+      }
       if (items.length) this._legendBox(root, items, s.legend || {});
     }
     // Manually added Legend artists ship explicit items + their own loc, so a
@@ -1885,7 +1898,14 @@ export class ChartView {
         row.addEventListener("pointerenter", () => this._setLegendHover(it, lg, row));
         row.addEventListener("pointerleave", () => this._clearLegendHover());
       }
-      rows.push(row);
+      // Click-to-toggle (interaction spec §10): hide/show what the row
+      // stands for. Same trace-linkage rule keeps extra_legends rows inert.
+      if (options.toggle !== false && it.traces && it.traces.length) {
+        row.style.cursor = "pointer";
+        row.addEventListener("click", () => this._legendToggle(it, row));
+      }
+      this._syncLegendRow(row, it);
+      rows.push({ row, it });
       lg.appendChild(row);
     }
     lg._xyItemRows = rows;
@@ -1924,6 +1944,7 @@ export class ChartView {
   // other series, but a categorical row cannot dim sibling categories inside
   // an aggregated density plane (§28 — recorded in the dossier, not silent).
   _setLegendHover(item, lg, hoveredRow) {
+    if (item.off) return; // a hidden series has nothing to emphasize
     this._legendHover = item;
     const keep = new Set(item.traces);
     for (let i = 0; i < (this.gpuTraces || []).length; i++) {
@@ -1940,8 +1961,10 @@ export class ChartView {
         g.lut = this._paletteLutDimmed(t.color.palette, item.cat);
       }
     }
-    for (const row of lg._xyItemRows || []) {
-      row.style.opacity = row === hoveredRow ? "" : String(LEGEND_DIM_ROW);
+    for (const pair of lg._xyItemRows || []) {
+      pair.row.style.opacity = pair.it.off
+        ? String(LEGEND_OFF_ROW)
+        : pair.row === hoveredRow ? "" : String(LEGEND_DIM_ROW);
     }
     // Color-pass-only change: geometry and view are untouched, so the pick
     // snapshot stays valid (§17).
@@ -1959,9 +1982,173 @@ export class ChartView {
       }
     }
     for (const lg of this._legends || []) {
-      for (const row of lg._xyItemRows || []) row.style.opacity = "";
+      for (const pair of lg._xyItemRows || []) this._syncLegendRow(pair.row, pair.it);
     }
     this.draw(true);
+  }
+
+  // Toggled-off rows stay visible but read as inactive; the state is also
+  // exposed as a data attribute so author styles can restyle it per slot.
+  _syncLegendRow(row, it) {
+    const off = !!it.off;
+    row.style.opacity = off ? String(LEGEND_OFF_ROW) : "";
+    row.style.filter = off ? "grayscale(1)" : "";
+    if (off) row.dataset.xyLegendOff = "";
+    else delete row.dataset.xyLegendOff;
+  }
+
+  // Legend click-to-toggle (interaction spec §10). Whole-trace rows hide
+  // locally — buffers and density grids are per-trace, so there is nothing
+  // to re-aggregate. Category rows are a §34 filter predicate: direct-tier
+  // traces re-filter from the CPU columns already on the client (0 wire
+  // bytes, §37 filter-toggle row), density tiers drop their now-stale local
+  // aggregates and re-request a kernel re-bin computed under the mask.
+  // Either way the kernel records the state so selections stay truthful.
+  _legendToggle(it, row) {
+    const off = !it.off;
+    it.off = off;
+    this._clearLegendHover();
+    this._syncLegendRow(row, it);
+    this._hideTooltip?.();
+    if (it.cat != null) {
+      const ti = it.traces[0];
+      let set = this._legendOffCats.get(ti);
+      if (!set) this._legendOffCats.set(ti, (set = new Set()));
+      if (off) set.add(it.cat);
+      else set.delete(it.cat);
+      if (this.comm) {
+        this.comm.send({
+          type: "legend_toggle", trace: this.spec.traces[ti].id, category: it.cat, hidden: off,
+        });
+      }
+      this._applyCategoryVisibility(ti);
+    } else {
+      for (const ti of it.traces) {
+        if (off) this._legendOffTraces.add(ti);
+        else this._legendOffTraces.delete(ti);
+        const g = this.gpuTraces && this.gpuTraces[ti];
+        if (g) g._legendHidden = off;
+        if (this.comm) {
+          this.comm.send({ type: "legend_toggle", trace: this.spec.traces[ti].id, hidden: off });
+        }
+      }
+      this._refreshReductionBadges();
+    }
+    this._pickDirty = true;
+    this._updatePickable();
+    this._dispatchChartEvent("legendtoggle", {
+      name: it.name,
+      hidden: off,
+      traces: it.traces.map((ti) => this.spec.traces[ti].id),
+      ...(it.cat != null ? { category: it.cat } : {}),
+    });
+    this.draw();
+  }
+
+  _applyCategoryVisibility(ti) {
+    const g = this.gpuTraces && this.gpuTraces[ti];
+    if (!g) return;
+    const hidden = this._legendOffCats.get(ti);
+    if (g.tier === "density") {
+      // Local aggregates were computed unfiltered — stale under the new
+      // predicate (§34), and a cached window that still "serves" the view
+      // would elide the kernel request that applies the mask. Drop them and
+      // re-request. The retained sample overlays are filtered locally so
+      // the pre-reply frame (and the kernel-less standalone page) stops
+      // drawing the hidden category immediately.
+      lodDropPointCache(this, g);
+      this._dropDrill(g);
+      lodDropDensityCache(this, g);
+      for (const s of [g.sampleOverlay, g.density && g.density.overlay]) {
+        if (s) this._filterScatterRows(s, hidden);
+      }
+      this._scheduleViewRequest(this.view, { delay: 0 });
+    } else {
+      this._filterScatterRows(g, hidden);
+    }
+  }
+
+  // Filter a scatter-shaped gpu entry's vertex buffers down to the rows whose
+  // categorical code is not hidden; an empty/absent set restores the full
+  // buffers. Gathers from the CPU views retained at build; per-point
+  // style/stroke buffers have no retained CPU copy, so they are read back
+  // once (WebGL2 getBufferSubData) and cached for later re-toggles.
+  // `_visMap` translates drawn vertex → shipped row (picks/readouts);
+  // `_visInv` maps shipped selection indices onto the filtered buffers.
+  _filterScatterRows(g, hidden) {
+    const gl = this.gl;
+    const codes = g._cpu && g._cpu.color;
+    if (!gl || !codes || g.colorMode !== 2) return;
+    if (g._fullN === undefined) g._fullN = g.n;
+    const full = g._fullN;
+    const readback = (buf, Type, comps) => {
+      const out = new Type(full * comps);
+      gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+      gl.getBufferSubData(gl.ARRAY_BUFFER, 0, out);
+      return out;
+    };
+    if (g.styleBuf && !g._cpuStyle) g._cpuStyle = readback(g.styleBuf, Float32Array, 4);
+    if (g.strokeBuf && !g._cpuStroke) g._cpuStroke = readback(g.strokeBuf, Uint8Array, 4);
+    let vis = null;
+    if (hidden && hidden.size) {
+      const idx = new Uint32Array(full);
+      let m = 0;
+      for (let i = 0; i < full; i++) if (!hidden.has(codes[i])) idx[m++] = i;
+      vis = idx.subarray(0, m);
+    }
+    const gather = (src, comps) => {
+      if (!vis) return src.length === full * comps ? src : src.subarray(0, full * comps);
+      const out = new (src.constructor)(vis.length * comps);
+      for (let j = 0; j < vis.length; j++) {
+        const r = vis[j];
+        for (let c = 0; c < comps; c++) out[j * comps + c] = src[r * comps + c];
+      }
+      return out;
+    };
+    const reupload = (buf, data) => {
+      if (!buf || !data) return;
+      gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+      gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
+    };
+    reupload(g.xBuf, gather(g._cpu.x, 1));
+    reupload(g.yBuf, gather(g._cpu.y, 1));
+    reupload(g.cBuf, gather(codes, 1));
+    if (g.sBuf && g._cpu.size) reupload(g.sBuf, gather(g._cpu.size, 1));
+    if (g.styleBuf && g._cpuStyle) reupload(g.styleBuf, gather(g._cpuStyle, 4));
+    if (g.strokeBuf && g._cpuStroke) reupload(g.strokeBuf, gather(g._cpuStroke, 4));
+    g.n = vis ? vis.length : full;
+    if (vis) {
+      g._visMap = vis;
+      const inv = new Int32Array(full).fill(-1);
+      for (let j = 0; j < vis.length; j++) inv[vis[j]] = j;
+      g._visInv = inv;
+    } else {
+      delete g._visMap;
+      delete g._visInv;
+    }
+    // A per-vertex selection mask built for the other vertex count would
+    // highlight arbitrary points; the kernel's canonical Selection (already
+    // hidden-aware) re-syncs the visual on the next brush.
+    g.selActive = false;
+    this._pickDirty = true;
+  }
+
+  // Rebuilds (context restore, streaming append) recreate gpuTraces from the
+  // spec, dropping transient per-trace state; toggle state lives on the view
+  // and is re-applied here after every rebuild.
+  _reapplyLegendVisibility() {
+    if (!this._legendOffTraces && !this._legendOffCats) return;
+    for (let i = 0; i < (this.gpuTraces || []).length; i++) {
+      const g = this.gpuTraces[i];
+      if (this._legendOffTraces && this._legendOffTraces.has(i)) g._legendHidden = true;
+      const cats = this._legendOffCats && this._legendOffCats.get(i);
+      if (!cats || !cats.size) continue;
+      if (g.tier === "density") {
+        if (g.sampleOverlay) this._filterScatterRows(g.sampleOverlay, cats);
+      } else {
+        this._filterScatterRows(g, cats);
+      }
+    }
   }
 
   _positionLegend(lg, loc) {
@@ -2123,6 +2310,7 @@ export class ChartView {
     gl.bindVertexArray(null);
 
     this.gpuTraces = this.spec.traces.map((t) => this._buildTrace(buffer, t));
+    this._reapplyLegendVisibility();
     this._updatePickable();
   }
 
@@ -3260,6 +3448,7 @@ export class ChartView {
     gl.clear(gl.COLOR_BUFFER_BIT);
 
     const drawTrace = (g) => {
+      if (g._legendHidden) return; // legend click-toggle (interaction spec §10)
       if (g.tier === "density") {
         // Tier frame (drill/fades/cache) lives in 45_lod.js — chart-agnostic.
         const [gx0, gx1] = this._axisRange(g.xAxis);
@@ -3508,13 +3697,15 @@ export class ChartView {
     const hit = this._hoverTarget;
     if (!hit || !hit.g) return;
     const g = hit.g;
-    if (g.trace.kind !== "scatter" || g.tier === "density") return;
-    if (!Number.isInteger(hit.index) || hit.index < 0 || hit.index >= g.n) return;
+    if (g.trace.kind !== "scatter" || g.tier === "density" || g._legendHidden) return;
+    // Filtered buffers are addressed by the drawn index, not the shipped one.
+    const index = hit.drawIndex ?? hit.index;
+    if (!Number.isInteger(index) || index < 0 || index >= g.n) return;
     const [x0, x1] = this._axisRange(g.xAxis);
     const [y0, y1] = this._axisRange(g.yAxis);
     this._drawHoverPoint(
       g,
-      hit.index,
+      index,
       this._map(g.xMeta, x0, x1, g.xAxis),
       this._map(g.yMeta, y0, y1, g.yAxis)
     );
@@ -4776,7 +4967,8 @@ export class ChartView {
     for (const g of this.gpuTraces) {
       // Density traces pick only while drilled to points (§5); the drill
       // sibling carries the buffers, the host g keeps the range → trace id.
-      const pg = g.tier === "density"
+      // Legend-hidden traces draw nothing, so they must pick nothing.
+      const pg = g._legendHidden ? null : g.tier === "density"
         ? (g.drill && !g._drillDying && this._viewInside(g.drill.win) ? g.drill : null)
         : (markOf(g.trace.kind).pointPick ? g : null);
       if (!pg || !pg.n || base + pg.n > 0x7fffffff) {
@@ -4864,7 +5056,13 @@ export class ChartView {
       (t) => t.pickBase > 0 && id >= t.pickBase && id < t.pickBase + t.pickCount
     );
     if (!g) return null;
-    return { trace: g.trace.id, index: id - g.pickBase, g };
+    const raw = id - g.pickBase;
+    // Category-filtered buffers draw a subset (interaction spec §10):
+    // `index` translates back to the shipped row so CPU readouts and kernel
+    // picks stay exact; `drawIndex` keeps addressing the filtered GPU
+    // buffers (hover marker).
+    const index = g._visMap ? g._visMap[raw] : raw;
+    return { trace: g.trace.id, index, drawIndex: raw, g };
   }
 
   _decodeValue(values, meta, index) {

--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -23,6 +23,13 @@ const COLORBAR_THICKNESS = 18;
 const COLORBAR_GAP = 24;
 const COMPACT_COLORBAR_GAP = 8;
 let XY_A11Y_ID = 0;
+// Legend hover emphasis (interaction spec §9): opacity kept by non-hovered series on
+// the marks canvas, and by non-hovered rows in the legend box itself.
+const LEGEND_DIM_OPACITY = 0.2;
+const LEGEND_DIM_ROW = 0.4;
+// SVG gradient ids resolve document-wide; a module counter keeps every chart
+// instance's legend swatch ramps distinct.
+let legendGradientSeq = 0;
 const XY_SR_ONLY_STYLE =
   "position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;" +
   "clip:rect(0,0,0,0);white-space:nowrap;border:0;";
@@ -1729,28 +1736,47 @@ export class ChartView {
 
   _buildLegend(root) {
     const s = this.spec;
+    // A chrome rebuild replaces the row nodes mid-hover, so their pointerleave
+    // never fires; release any active dim state before dropping the old boxes.
+    this._clearLegendHover();
     this._legends = [];
     const items = [];
     if (s.show_legend !== false) {
-      for (const t of s.traces) {
+      // Two identically-encoded unnamed continuous traces must not stack two
+      // identical gradient rows; the row is about the encoding, so later
+      // traces join the first row's hover-target list instead.
+      const continuousRows = new Map();
+      s.traces.forEach((t, ti) => {
         // A density-tier surface encodes count as alpha and wears the mean
         // point color (LOD doc §2), so it gets no colormap gradient swatch —
         // a gradient would claim color == density. A named density trace
         // falls through to the plain marker swatch below, matching the
         // static SVG/raster exporters.
+        const line = ["line", "segments", "step", "stairs", "errorbar"].includes(t.kind);
         if (t.color && t.color.mode === "categorical") {
           t.color.categories.forEach((cat, i) =>
-            items.push({ swatch: t.color.palette[i], name: cat, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, style: t.style || {} }));
+            items.push({ swatch: t.color.palette[i], name: cat, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, style: t.style || {}, traces: [ti], cat: i }));
         } else if (t.color && t.color.mode === "continuous") {
-          items.push({ swatch: "gradient", cmap: t.color.colormap, name: t.name || "value" });
+          // Label precedence: explicit series name, then the encoding's own
+          // declarative label (the color="column" idiom), then the generic
+          // fallback for hand-built specs.
+          const name = t.name || t.color.label || "value";
+          const key = name + "\u0000" + t.color.colormap;
+          const existing = continuousRows.get(key);
+          if (existing) {
+            existing.traces.push(ti);
+            return;
+          }
+          const item = { swatch: "gradient", cmap: t.color.colormap, name, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, line, style: t.style || {}, traces: [ti] };
+          continuousRows.set(key, item);
+          items.push(item);
         } else if (t.name) {
           const c = (t.color && t.color.color) || (t.style && t.style.color);
           // Line-family kinds get a short line sample (honoring the dash), the
           // same handle the raster/SVG exporters draw — not a filled swatch.
-          const line = ["line", "segments", "step", "stairs", "errorbar"].includes(t.kind);
-          items.push({ swatch: c, name: t.name, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, line, style: t.style || {} });
+          items.push({ swatch: c, name: t.name, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, line, style: t.style || {}, traces: [ti] });
         }
-      }
+      });
       if (items.length) this._legendBox(root, items, s.legend || {});
     }
     // Manually added Legend artists ship explicit items + their own loc, so a
@@ -1768,7 +1794,7 @@ export class ChartView {
   }
 
   _legendBox(root, items, options) {
-    const lg = document.createElement("div");
+    const lg: any = document.createElement("div");
     const loc = options.loc || "upper right";
     const ncols = Math.max(1, Number(options.ncols) || 1);
     const horizontal = ncols > 1;
@@ -1785,6 +1811,7 @@ export class ChartView {
       title.style.gridColumn = `1 / span ${horizontal ? ncols : 1}`;
       lg.appendChild(title);
     }
+    const rows = [];
     for (const it of items) {
       const row = document.createElement("div");
       this._applySlot(row, "legend_item");
@@ -1794,11 +1821,19 @@ export class ChartView {
       sw.style.display = "inline-block";
       sw.style.verticalAlign = "-1px";
       let bg = it.swatch;
-      if (it.swatch === "gradient") {
+      // A continuous encoding paints the swatch with the colormap ramp, but
+      // the swatch keeps the mark's identity: a gradient-filled symbol for
+      // scatters, a gradient-stroked line sample for line-family kinds, and
+      // only the bare ramp chip when the mark has neither.
+      let gradientPaint = null;
+      if (it.swatch === "gradient" && (it.symbol || it.line)) {
+        gradientPaint = (svg) => this._legendGradientPaint(svg, it.cmap);
+      } else if (it.swatch === "gradient") {
         const stops = colormapStops(it.cmap);
         bg = `linear-gradient(90deg,${stops.map((c) => `rgb(${c[0]},${c[1]},${c[2]})`).join(",")})`;
         sw.style.background = bg;
-      } else if (it.symbol) {
+      }
+      if (it.symbol) {
         const ns = "http://www.w3.org/2000/svg";
         const svg = document.createElementNS(ns, "svg");
         svg.setAttribute("viewBox", "0 0 18 14");
@@ -1817,7 +1852,7 @@ export class ChartView {
           hexagon: "M9 2L13.3 4.5v5L9 12l-4.3-2.5v-5z",
           star: "M9 2l1.5 3.1 3.5.5-2.5 2.5.6 3.5L9 10l-3.1 1.6.6-3.5L4 5.6l3.5-.5z"
         };
-        const color = safeCssPaint(this.root, bg);
+        const color = gradientPaint ? gradientPaint(svg) : safeCssPaint(this.root, bg);
         if (it.symbol === "circle" || it.symbol === "point" || it.symbol === "pixel") {
           if (it.symbol === "pixel") path.setAttribute("d", "M8.5 6.5h1v1h-1z");
           else path.setAttribute("d", `M9 ${it.symbol === "point" ? 4.75 : 2.5}a${it.symbol === "point" ? 2.25 : 4.5} ${it.symbol === "point" ? 2.25 : 4.5} 0 1 0 0 ${it.symbol === "point" ? 4.5 : 9}a${it.symbol === "point" ? 2.25 : 4.5} ${it.symbol === "point" ? 2.25 : 4.5} 0 1 0 0 -${it.symbol === "point" ? 4.5 : 9}`);
@@ -1840,7 +1875,7 @@ export class ChartView {
         ln.setAttribute("y1", "6");
         ln.setAttribute("x2", "21");
         ln.setAttribute("y2", "6");
-        ln.setAttribute("stroke", safeCssPaint(this.root, bg));
+        ln.setAttribute("stroke", gradientPaint ? gradientPaint(svg) : safeCssPaint(this.root, bg));
         // ?? not ||: an explicit lw=0 keeps 0 and draws nothing, like the
         // exporters' dict-default and Matplotlib itself.
         ln.setAttribute("stroke-width", String(it.style?.width ?? 1.5));
@@ -1849,17 +1884,96 @@ export class ChartView {
         sw.appendChild(svg);
         sw.style.width = "22px";
         sw.style.height = "12px";
-      } else {
+      } else if (it.swatch !== "gradient") {
         sw.style.background = safeCssPaint(this.root, bg);
       }
       this._applySlot(sw, "legend_swatch");
       row.appendChild(sw);
       row.appendChild(document.createTextNode(it.name));
+      // Hover emphasis (interaction spec §9): rows backed by live traces dim the rest
+      // of the chart while hovered. Manually-added Legend artists carry no
+      // trace linkage, so extra_legends rows stay inert.
+      if (options.highlight !== false && it.traces && it.traces.length) {
+        row.addEventListener("pointerenter", () => this._setLegendHover(it, lg, row));
+        row.addEventListener("pointerleave", () => this._clearLegendHover());
+      }
+      rows.push(row);
       lg.appendChild(row);
     }
+    lg._xyItemRows = rows;
     root.appendChild(lg);
     this._legends.push(lg); // _resize refreshes each box's responsive anchor
     return lg;
+  }
+
+  // Paint an SVG swatch with the item's colormap ramp: registers a
+  // <linearGradient> in the swatch's own defs and returns its paint URL.
+  // IDs are document-global, so a module counter keeps multiple charts on
+  // one page from cross-referencing each other's ramps.
+  _legendGradientPaint(svg, cmap) {
+    const ns = "http://www.w3.org/2000/svg";
+    const id = `xy-legend-grad-${legendGradientSeq++}`;
+    const defs = document.createElementNS(ns, "defs");
+    const grad = document.createElementNS(ns, "linearGradient");
+    grad.setAttribute("id", id);
+    const stops = colormapStops(cmap);
+    stops.forEach((c, i) => {
+      const stop = document.createElementNS(ns, "stop");
+      stop.setAttribute("offset", `${(i / Math.max(1, stops.length - 1)) * 100}%`);
+      stop.setAttribute("stop-color", `rgb(${c[0]},${c[1]},${c[2]})`);
+      grad.appendChild(stop);
+    });
+    defs.appendChild(grad);
+    svg.appendChild(defs);
+    return `url(#${id})`;
+  }
+
+  // Legend hover emphasis: the hovered row's series keeps full opacity while
+  // every other series dims (and, for a categorical row, the trace's other
+  // categories dim through a background-blended palette LUT — the point
+  // shaders ignore LUT alpha, so the fade is baked into the RGB ramp).
+  // Whole density-tier traces dim through _drawDensity's uniform like any
+  // other series, but a categorical row cannot dim sibling categories inside
+  // an aggregated density plane (§28 — recorded in the dossier, not silent).
+  _setLegendHover(item, lg, hoveredRow) {
+    this._legendHover = item;
+    const keep = new Set(item.traces);
+    for (let i = 0; i < (this.gpuTraces || []).length; i++) {
+      const g = this.gpuTraces[i];
+      g._legendDim = keep.has(i) ? 1 : LEGEND_DIM_OPACITY;
+      if (g._legendPrevLut !== undefined) {
+        g.lut = g._legendPrevLut;
+        delete g._legendPrevLut;
+      }
+      const t = g.trace;
+      if (item.cat != null && keep.has(i) && g.tier !== "density" &&
+          t.color && t.color.mode === "categorical" && g.lut) {
+        g._legendPrevLut = g.lut;
+        g.lut = this._paletteLutDimmed(t.color.palette, item.cat);
+      }
+    }
+    for (const row of lg._xyItemRows || []) {
+      row.style.opacity = row === hoveredRow ? "" : String(LEGEND_DIM_ROW);
+    }
+    // Color-pass-only change: geometry and view are untouched, so the pick
+    // snapshot stays valid (§17).
+    this.draw(true);
+  }
+
+  _clearLegendHover() {
+    if (!this._legendHover) return;
+    this._legendHover = null;
+    for (const g of this.gpuTraces || []) {
+      delete g._legendDim;
+      if (g._legendPrevLut !== undefined) {
+        g.lut = g._legendPrevLut;
+        delete g._legendPrevLut;
+      }
+    }
+    for (const lg of this._legends || []) {
+      for (const row of lg._xyItemRows || []) row.style.opacity = "";
+    }
+    this.draw(true);
   }
 
   _positionLegend(lg, loc) {
@@ -2082,6 +2196,36 @@ export class ChartView {
       data[i * 4] = c[0] * 255;
       data[i * 4 + 1] = c[1] * 255;
       data[i * 4 + 2] = c[2] * 255;
+      data[i * 4 + 3] = 255;
+    }
+    const tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 256, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, data);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    this._lutCache.set(key, tex);
+    return tex;
+  }
+
+  // Palette LUT with every category except `keepIdx` blended toward the plot
+  // background — the legend-hover dim for categorical traces. RGB-only on
+  // purpose: the point/line shaders read `texture(u_lut, ...).rgb` and force
+  // alpha to 1, so an alpha-based fade would be a silent no-op.
+  _paletteLutDimmed(palette, keepIdx) {
+    const key = "pal:" + palette.join(",") + ":dim" + keepIdx + ":" + (this.theme.bg || "");
+    if (this._lutCache.has(key)) return this._lutCache.get(key);
+    const gl = this.gl;
+    const bg = parseColor(this.root, this.theme.bg || "#ffffff", [1, 1, 1, 1]);
+    const data = new Uint8Array(256 * 4);
+    for (let i = 0; i < 256; i++) {
+      const c = hexColor(palette[i % palette.length]);
+      const keep = i % palette.length === keepIdx % palette.length;
+      const w = keep ? 1 : LEGEND_DIM_OPACITY;
+      data[i * 4] = (c[0] * w + bg[0] * (1 - w)) * 255;
+      data[i * 4 + 1] = (c[1] * w + bg[1] * (1 - w)) * 255;
+      data[i * 4 + 2] = (c[2] * w + bg[2] * (1 - w)) * 255;
       data[i * 4 + 3] = 255;
     }
     const tex = gl.createTexture();
@@ -3212,7 +3356,7 @@ export class ChartView {
   }
 
   _drawPoints(g, xm, ym, opacityScale = 1) {
-    opacityScale *= g._transitionOpacity ?? 1;
+    opacityScale *= (g._transitionOpacity ?? 1) * (g._legendDim ?? 1);
     const animationScale = g._transitionScale ?? 1;
     if (this._canDrawSimplePoints(g)) {
       this._drawSimplePoints(g, xm, ym, opacityScale);
@@ -3445,7 +3589,7 @@ export class ChartView {
     // WebGL error that aborts the draw, so treat an invalid texture as "nothing
     // to draw" rather than risk it.
     if (!d || !d.tex || !gl.isTexture(d.tex)) return;
-    opacityScale *= g._transitionOpacity ?? 1;
+    opacityScale *= (g._transitionOpacity ?? 1) * (g._legendDim ?? 1);
     const prog = this.densityProg;
     gl.useProgram(prog);
     const u = (n) => uniformOf(gl, prog, n);
@@ -3519,7 +3663,7 @@ export class ChartView {
       h.xRange[xrev ? 1 : 0], h.xRange[xrev ? 0 : 1],
       h.yRange[yrev ? 1 : 0], h.yRange[yrev ? 0 : 1],
     );
-    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._transitionOpacity ?? 1));
+    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._transitionOpacity ?? 1) * (g._legendDim ?? 1));
     gl.uniform1i(u("u_truecolor"), h.truecolor ? 1 : 0);
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, h.tex);
@@ -3551,7 +3695,7 @@ export class ChartView {
     gl.uniform1f(u("u_revealSegments"), g.n - 1);
     gl.uniform1f(u("u_width"), (width ?? g.trace.style.width ?? 1.5) * this.dpr);
     const [r, gg, b, a] = color || g.color;
-    const strokeOpacity = this._strokeOpacity(g.trace.style) * (opacity ?? 1) * (g._transitionOpacity ?? 1);
+    const strokeOpacity = this._strokeOpacity(g.trace.style) * (opacity ?? 1) * (g._transitionOpacity ?? 1) * (g._legendDim ?? 1);
     gl.uniform4f(u("u_color"), r, gg, b, a * strokeOpacity);
     const dashed = this._lineDash(g);
     this._bindVao(
@@ -3598,7 +3742,7 @@ export class ChartView {
     gl.uniform1f(u("u_animationProgress"), g._transitionScale ?? 1);
     const [r, gg, b, a] = g.color;
     gl.uniform4f(u("u_color"), r, gg, b, a);
-    gl.uniform1f(u("u_opacity"), this._strokeOpacity(g.trace.style) * (g._transitionOpacity ?? 1));
+    gl.uniform1f(u("u_opacity"), this._strokeOpacity(g.trace.style) * (g._transitionOpacity ?? 1) * (g._legendDim ?? 1));
     gl.uniform1i(u("u_colorMode"), g.colorMode || 0);
     const dashed = this._segmentDash(g, prog);
     if (g.colorMode && g.lut) {
@@ -3720,7 +3864,7 @@ export class ChartView {
     for (const name of ["x0", "x1", "x2"]) this._setAxisUniforms(prog, "u_" + name, g[name + "Meta"], g.xAxis);
     for (const name of ["y0", "y1", "y2"]) this._setAxisUniforms(prog, "u_" + name, g[name + "Meta"], g.yAxis);
     gl.uniform1i(u("u_colorMode"), g.colorMode || 0);
-    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style));
+    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._legendDim ?? 1));
     gl.uniform4f(u("u_color"), g.color[0], g.color[1], g.color[2], g.color[3]);
     // Straight alpha: MESH_FS folds u_strokeOpacity and the per-item alpha
     // stack in and premultiplies there (uniform and buffer strokes alike).
@@ -3728,7 +3872,7 @@ export class ChartView {
     gl.uniform4f(u("u_stroke"), stroke[0], stroke[1], stroke[2], stroke[3]);
     gl.uniform1f(u("u_strokeWidth"), g.meshStrokeWidth || 0);
     gl.uniform1i(u("u_strokeMode"), g.strokeBuf ? 1 : 0);
-    gl.uniform1f(u("u_strokeOpacity"), this._strokeOpacity(g.trace.style));
+    gl.uniform1f(u("u_strokeOpacity"), this._strokeOpacity(g.trace.style) * (g._legendDim ?? 1));
     if (g.colorMode && g.lut) {
       gl.activeTexture(gl.TEXTURE0);
       gl.bindTexture(gl.TEXTURE_2D, g.lut);
@@ -3817,7 +3961,7 @@ export class ChartView {
     gl.uniform1f(u("u_revealProgress"), reveal);
     gl.uniform1f(u("u_revealSegments"), g.n - 1);
     const [r, gg, b, a] = g.color;
-    gl.uniform4f(u("u_color"), r, gg, b, a * this._fillOpacity(g.trace.style, 0.35) * (g._transitionOpacity ?? 1));
+    gl.uniform4f(u("u_color"), r, gg, b, a * this._fillOpacity(g.trace.style, 0.35) * (g._transitionOpacity ?? 1) * (g._legendDim ?? 1));
     gl.uniform2f(u("u_res"), this.canvas.width, this.canvas.height);
     this._setGradientUniforms(prog, g.grad);
     this._bindVao(g, "area", [g.xBuf._fcId, g.yBuf._fcId, g.baseBuf._fcId], () => {
@@ -3853,7 +3997,7 @@ export class ChartView {
     gl.uniform4f(u("u_edgePad"), edgePad[0], edgePad[1], edgePad[2], edgePad[3]);
     const [r, gg, b, a] = g.color;
     gl.uniform4f(u("u_color"), r, gg, b, a);
-    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._transitionOpacity ?? 1));
+    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._transitionOpacity ?? 1) * (g._legendDim ?? 1));
     gl.uniform1i(u("u_colorMode"), g.colorMode || 0);
     this._setRectStyleUniforms(prog, g);
     const colorOn = !!g.cBuf;
@@ -3927,7 +4071,7 @@ export class ChartView {
     gl.uniform1f(u("u_prevWidth"), g._transitionPrevWidth ?? g.width);
     const [r, gg, b, a] = g.color;
     gl.uniform4f(u("u_color"), r, gg, b, a);
-    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._transitionOpacity ?? 1));
+    gl.uniform1f(u("u_opacity"), this._fillOpacity(g.trace.style) * (g._transitionOpacity ?? 1) * (g._legendDim ?? 1));
     gl.uniform1i(u("u_colorMode"), g.colorMode || 0);
     this._setRectStyleUniforms(prog, g);
     const v0On = g.value0Mode === 1 && g.value0Buf;

--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -1758,9 +1758,12 @@ export class ChartView {
             items.push({ swatch: t.color.palette[i], name: cat, symbol: t.kind === "scatter" ? (t.style?.symbol || "circle") : null, style: t.style || {}, traces: [ti], cat: i }));
         } else if (t.color && t.color.mode === "continuous") {
           // Label precedence: explicit series name, then the encoding's own
-          // declarative label (the color="column" idiom), then the generic
-          // fallback for hand-built specs.
-          const name = t.name || t.color.label || "value";
+          // declarative label (the color="column" idiom). No generic fallback:
+          // an unnamed encoding has nothing truthful to say, so it gets no
+          // row — matching the static exporters, which draw name-bearing
+          // entries only.
+          const name = t.name || t.color.label;
+          if (!name) return;
           const key = name + "\u0000" + t.color.colormap;
           const existing = continuousRows.get(key);
           if (existing) {

--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -1,6 +1,6 @@
 import { PROTOCOL, xyByteSpan } from "./00_header";
 import { buildLutData, colormapStops } from "./10_colormaps";
-import { cssColor, ensureChromeStylesheet, hexColor, parseColor, readTheme, safeCssPaint } from "./20_theme";
+import { chartBackdrop, cssColor, ensureChromeStylesheet, hexColor, parseColor, readTheme, safeCssPaint } from "./20_theme";
 import { categoryTicks, fmtAxis, fmtGeneral, fmtLinear, fmtValue, linearTicks, logTicks, timeTicks } from "./30_ticks";
 import { AREA_FS, AREA_VS, ATTR_SLOTS, BAR_VS, DENSITY_FS, GRID_VS, HEATMAP_FS, LINE_FS, LINE_VS, MESH_FS, MESH_VS, PICK_FS, PICK_VS, POINT_FS, POINT_SIMPLE_FS, POINT_SIMPLE_VS, POINT_VS, RECT_FS, RECT_VS, SEGMENT_FS, SEGMENT_VS, makeProgram, uniformOf, xySmoothResample } from "./40_gl";
 import { lodCopyGrid, lodDecodeLogU8, lodDrawDensityTier, lodDropDensityCache, lodDropPointCache, lodRememberDensity, lodSampleForView, lodWriteGridTexture } from "./45_lod";
@@ -1956,24 +1956,49 @@ export class ChartView {
   // categories dim through a background-blended palette LUT — the point
   // shaders ignore LUT alpha, so the fade is baked into the RGB ramp).
   // Whole density-tier traces dim through _drawDensity's uniform like any
-  // other series, but a categorical row cannot dim sibling categories inside
-  // an aggregated density plane (§28 — recorded in the dossier, not silent).
+  // other series; a categorical row dims siblings inside an aggregated plane
+  // at CELL granularity (_densityRgbaDimmed — §28-recorded approximation).
   _setLegendHover(item, lg, hoveredRow) {
     if (item.off) return; // a hidden series has nothing to emphasize
     this._legendHover = item;
     const keep = new Set(item.traces);
+    // Resolved once for the whole pass: every blend below wants the same
+    // backdrop, and resolving it per trace would re-walk the ancestor chain
+    // (a forced style recalc) and defeat the _lutCache hit.
+    const bg = chartBackdrop(this.root, this.theme.bg);
     for (let i = 0; i < (this.gpuTraces || []).length; i++) {
       const g = this.gpuTraces[i];
       g._legendDim = keep.has(i) ? 1 : LEGEND_DIM_OPACITY;
-      if (g._legendPrevLut !== undefined) {
-        g.lut = g._legendPrevLut;
-        delete g._legendPrevLut;
-      }
+      this._restoreLegendLuts(g);
       const t = g.trace;
-      if (item.cat != null && keep.has(i) && g.tier !== "density" &&
-          t.color && t.color.mode === "categorical" && g.lut) {
-        g._legendPrevLut = g.lut;
-        g.lut = this._paletteLutDimmed(t.color.palette, item.cat);
+      if (item.cat != null && keep.has(i) &&
+          t.color && t.color.mode === "categorical") {
+        if (g.tier === "density") {
+          // The plane cannot dim sibling categories exactly (§28), but its
+          // mean-color cells carry the categories' own drawn colors, so the
+          // LUT-dim rule applies at CELL granularity: classify each cell by
+          // nearest palette color and blend sibling cells toward the
+          // background; the hovered category's cells keep their full color.
+          // Mixed boundary cells dim by their nearest class — the recorded
+          // approximation of the exact per-point dim.
+          const d = g.density;
+          if (d && d.rgba && d.tex) {
+            g._legendHoverPrevTex = d.tex;
+            g._legendHoverTex = this._uploadGrid(
+              d.grid, d.w, d.h, d.normMax ?? d.max,
+              this._densityRgbaDimmed(d.rgba, t.color.palette, item.cat, bg),
+              d.filter, this._fillOpacity(t.style),
+            );
+            d.tex = g._legendHoverTex;
+          }
+          // The retained sample overlays ARE per-point scatters, so they dim
+          // siblings exactly, through the same palette LUT.
+          for (const s of this._densityOverlays(g)) {
+            this._dimLut(s, t.color.palette, item.cat, bg);
+          }
+        } else {
+          this._dimLut(g, t.color.palette, item.cat, bg);
+        }
       }
     }
     for (const pair of lg._xyItemRows || []) {
@@ -1991,15 +2016,101 @@ export class ChartView {
     this._legendHover = null;
     for (const g of this.gpuTraces || []) {
       delete g._legendDim;
-      if (g._legendPrevLut !== undefined) {
-        g.lut = g._legendPrevLut;
-        delete g._legendPrevLut;
-      }
+      this._restoreLegendLuts(g);
     }
     for (const lg of this._legends || []) {
       for (const pair of lg._xyItemRows || []) this._syncLegendRow(pair.row, pair.it);
     }
     this.draw(true);
+  }
+
+  // The per-point scatter entries a density-tier trace keeps alongside its
+  // aggregated plane (the retained deterministic sample and, when a reply
+  // carried one, the density's own overlay). Deduped: the two are often the
+  // same object.
+  _densityOverlays(g) {
+    return new Set([g.sampleOverlay, g.density && g.density.overlay].filter(Boolean));
+  }
+
+  // Swap a scatter-shaped entry's palette LUT for the hover-dimmed variant,
+  // stashing the original for _restoreLegendLuts.
+  _dimLut(s, palette, keepIdx, bg) {
+    if (!s || !s.lut) return;
+    s._legendPrevLut = s.lut;
+    s.lut = this._paletteLutDimmed(palette, keepIdx, bg);
+  }
+
+  // Undo any hover LUT swap on a trace and its density sample overlays,
+  // and put back the plane's original texture if hover dimmed it.
+  _restoreLegendLuts(g) {
+    for (const s of new Set([g, ...this._densityOverlays(g)])) {
+      if (s._legendPrevLut !== undefined) {
+        s.lut = s._legendPrevLut;
+        delete s._legendPrevLut;
+      }
+    }
+    if (g._legendHoverTex) {
+      // A density reply may have replaced g.density mid-hover; only restore
+      // onto the object still wearing the hover texture.
+      if (g.density && g.density.tex === g._legendHoverTex) {
+        g.density.tex = g._legendHoverPrevTex;
+      }
+      this.gl.deleteTexture(g._legendHoverTex);
+      g._legendHoverTex = null;
+      g._legendHoverPrevTex = null;
+    }
+  }
+
+  // Per-cell sibling dim for an aggregated categorical plane: each occupied
+  // cell classified by nearest palette color, non-hovered classes blended
+  // toward the background exactly like `_paletteLutDimmed` blends LUT
+  // entries. Alpha (the physical compositing of the cell's own points, LOD
+  // doc §2) is untouched — the dim is a color statement, not a count one.
+  _densityRgbaDimmed(rgba, palette, keepIdx, bg = chartBackdrop(this.root, this.theme.bg)) {
+    const cls = this._densityCellClasses(rgba, palette);
+    const keep = keepIdx % palette.length;
+    const w = LEGEND_DIM_OPACITY;
+    const out = new Uint8Array(rgba.length);
+    for (let i = 0, c = 0; i < rgba.length; i += 4, c++) {
+      const a = rgba[i + 3];
+      out[i + 3] = a;
+      if (!a) continue;
+      if (cls[c] === keep) {
+        out[i] = rgba[i]; out[i + 1] = rgba[i + 1]; out[i + 2] = rgba[i + 2];
+      } else {
+        out[i] = (rgba[i] / 255 * w + bg[0] * (1 - w)) * 255;
+        out[i + 1] = (rgba[i + 1] / 255 * w + bg[1] * (1 - w)) * 255;
+        out[i + 2] = (rgba[i + 2] / 255 * w + bg[2] * (1 - w)) * 255;
+      }
+    }
+    return out;
+  }
+
+  // Nearest-palette class per occupied cell of a mean-color plane. Depends
+  // only on (rgba, palette) — NOT on which row is hovered — so it is memoized
+  // against the plane's own buffer: scanning a legend's rows reclassifies the
+  // same grid once instead of once per row. Weak-keyed, so the map dies with
+  // the grid it describes (a reply replaces `density.rgba` wholesale).
+  _densityCellClasses(rgba, palette) {
+    if (!this._dimClassCache) this._dimClassCache = new WeakMap();
+    const paletteKey = palette.join(",");
+    const memo = this._dimClassCache.get(rgba);
+    if (memo && memo.paletteKey === paletteKey) return memo.classes;
+    const cols = palette.map((p) => hexColor(p));
+    const classes = new Uint8Array(rgba.length / 4);
+    for (let i = 0, c = 0; i < rgba.length; i += 4, c++) {
+      if (!rgba[i + 3]) continue;
+      const r = rgba[i] / 255, gc = rgba[i + 1] / 255, b = rgba[i + 2] / 255;
+      let best = 0, bestD = Infinity;
+      for (let k = 0; k < cols.length; k++) {
+        const dr = r - cols[k][0], dg = gc - cols[k][1], db = b - cols[k][2];
+        const dist = dr * dr + dg * dg + db * db;
+        if (dist < bestD) { bestD = dist; best = k; }
+      }
+      classes[c] = best;
+    }
+    this._dimClassCache.set(rgba, { paletteKey, classes });
+    return classes;
   }
 
   // Toggled-off rows stay visible but read as inactive; the state is also
@@ -2074,9 +2185,11 @@ export class ChartView {
       lodDropPointCache(this, g);
       this._dropDrill(g);
       lodDropDensityCache(this, g);
-      for (const s of [g.sampleOverlay, g.density && g.density.overlay]) {
-        if (s) this._filterScatterRows(s, hidden);
-      }
+      // The live home grid survives the cache drop (it is what draws until
+      // the reply) but must not elide the request — it was binned under the
+      // previous mask (§34).
+      g._filterDirty = true;
+      for (const s of this._densityOverlays(g)) this._filterScatterRows(s, hidden);
       this._scheduleViewRequest(this.view, { delay: 0 });
     } else {
       this._filterScatterRows(g, hidden);
@@ -2159,6 +2272,9 @@ export class ChartView {
       const cats = this._legendOffCats && this._legendOffCats.get(i);
       if (!cats || !cats.size) continue;
       if (g.tier === "density") {
+        // The rebuilt grid comes from the spec — unfiltered — so the next
+        // view request must re-bin under the mask, not stand on it.
+        g._filterDirty = true;
         if (g.sampleOverlay) this._filterScatterRows(g.sampleOverlay, cats);
       } else {
         this._filterScatterRows(g, cats);
@@ -2404,11 +2520,16 @@ export class ChartView {
   // background — the legend-hover dim for categorical traces. RGB-only on
   // purpose: the point/line shaders read `texture(u_lut, ...).rgb` and force
   // alpha to 1, so an alpha-based fade would be a silent no-op.
-  _paletteLutDimmed(palette, keepIdx) {
-    const key = "pal:" + palette.join(",") + ":dim" + keepIdx + ":" + (this.theme.bg || "");
+  // `bg` is the resolved backdrop (see chartBackdrop); callers that dim
+  // several entries in one pass resolve it once and pass it in. theme.bg is
+  // a resolved [r,g,b,a] (or null for a transparent chart, in which case the
+  // page paints the backdrop) — never a CSS string, so it must not go
+  // through parseColor, which would silently fall back to white and BRIGHTEN
+  // dimmed entries on dark pages.
+  _paletteLutDimmed(palette, keepIdx, bg = chartBackdrop(this.root, this.theme.bg)) {
+    const key = "pal:" + palette.join(",") + ":dim" + keepIdx + ":" + bg.join(",");
     if (this._lutCache.has(key)) return this._lutCache.get(key);
     const gl = this.gl;
-    const bg = parseColor(this.root, this.theme.bg || "#ffffff", [1, 1, 1, 1]);
     const data = new Uint8Array(256 * 4);
     for (let i = 0; i < 256; i++) {
       const c = hexColor(palette[i % palette.length]);
@@ -5472,6 +5593,10 @@ export class ChartView {
     for (const d of g.densityCache || []) textures.push(d && d.tex);
     if (g.density) textures.push(g.density.tex);
     if (g._shownDensity) textures.push(g._shownDensity.tex);
+    // Mid-hover the plane's ORIGINAL texture lives only here (density.tex is
+    // the dimmed one), and the paths that destroy a live trace — append,
+    // spec swap, animation — do not clear legend hover first.
+    textures.push(g._legendHoverTex, g._legendHoverPrevTex);
     for (const tex of textures) {
       if (tex && !texSeen.has(tex)) {
         texSeen.add(tex);
@@ -5481,6 +5606,8 @@ export class ChartView {
     g.drill = null;
     g.density = null;
     g._shownDensity = null;
+    g._legendHoverTex = null;
+    g._legendHoverPrevTex = null;
     g.densityCache = [];
     g.heatmap = null;
     g._cpu = null;

--- a/js/src/54_kernel.ts
+++ b/js/src/54_kernel.ts
@@ -444,6 +444,9 @@ Object.assign(ChartView.prototype, {
       this._destroyTraceResources(this.gpuTraces[i], texSeen);
       this.gpuTraces[i] = this._buildTrace(payload, ts);
     }
+    // Rebuilt entries lost their transient legend-toggle fields; re-apply
+    // from the view-held state (interaction spec §10).
+    this._reapplyLegendVisibility();
     this._updatePickable();
     this._scheduleViewRequest(this.view, { delay: 0 });
     this.draw();
@@ -517,6 +520,16 @@ Object.assign(ChartView.prototype, {
         const g = this.gpuTraces.find((t) => t.trace.id === upd.id && t.tier === "density");
         if (!g) continue;
         clearPending(g);
+        // Filter-state guard (interaction spec §10 / §34): a reply computed
+        // under a different hidden-category set than the client's current
+        // one would render a stale predicate's aggregate. The toggle that
+        // changed the set already scheduled a fresh request.
+        const ti = this.gpuTraces.indexOf(g);
+        const want = Array.from(
+          (this._legendOffCats && this._legendOffCats.get(ti)) || []
+        ).sort((a: any, b: any) => a - b);
+        const got = (upd.filter && upd.filter.hidden_categories) || [];
+        if (want.join(",") !== got.join(",")) continue;
         if (upd.mode === "points") { this._applyDrill(g, upd, buffers); continue; }
         lodApplyDensityUpdate(this, g, upd, buffers);
       }
@@ -630,7 +643,13 @@ Object.assign(ChartView.prototype, {
       ) continue;
       const idx = this._asU32(buffers[upd.buf]);
       const mask = new Float32Array(pg.n);
-      for (let i = 0; i < idx.length; i++) if (idx[i] < pg.n) mask[idx[i]] = 1;
+      // Category-filtered buffers (interaction spec §10) draw a subset: the
+      // kernel's shipped-space indices land on their filtered positions.
+      const inv = pg._visInv;
+      for (let i = 0; i < idx.length; i++) {
+        const j = inv ? (idx[i] < inv.length ? inv[idx[i]] : -1) : idx[i];
+        if (j >= 0 && j < pg.n) mask[j] = 1;
+      }
       this._applySelMask(pg, mask);
     }
   },

--- a/js/src/54_kernel.ts
+++ b/js/src/54_kernel.ts
@@ -3,7 +3,7 @@ import { buildLutData } from "./10_colormaps";
 import { parseColor } from "./20_theme";
 import {
   lodAggregateStands, lodAggregateStepWindow, lodApplyDensityUpdate, lodApplyDrill,
-  lodDrillServesView, lodDropDrill, lodPromoteCachedDrill, lodRememberDensity,
+  lodDrillServesView, lodDropDrill, lodFilterKey, lodPromoteCachedDrill, lodRememberDensity,
 } from "./45_lod";
 import { xyCreateRebinWorker } from "./46_worker";
 import { ChartView } from "./50_chartview";
@@ -125,7 +125,10 @@ Object.assign(ChartView.prototype, {
           // A ladder-step request's reply is the one density reply allowed
           // to repaint a covered view (lodApplyDensityUpdate).
           if (plan.step) g._stepReqWin = win;
-          g._lastDensityReq = { win, w: plotW, h: plotH, seq, sentAt: sendNow, answered: false };
+          g._lastDensityReq = {
+            win, w: plotW, h: plotH, seq, sentAt: sendNow, answered: false,
+            filterKey: this._traceFilterKey(g),
+          };
         }
       }
     };
@@ -159,8 +162,20 @@ Object.assign(ChartView.prototype, {
   _densityRequestDup(g, win, plotW, plotH, now) {
     const last = g._lastDensityReq;
     if (!last || !this._densityRequestSame(last, win, plotW, plotH)) return null;
+    // A twin window under a DIFFERENT hidden-category set (§34) is a new
+    // request, not a duplicate — "deterministic for unchanged data" assumes
+    // an unchanged predicate.
+    if ((last.filterKey || "") !== this._traceFilterKey(g)) return null;
     if (last.answered) return last;
     return now - last.sentAt < 1200 ? last : null;
+  },
+
+  // The §34 hidden-category set this trace's next reply will be computed
+  // under, as a canonical string key. Part of request identity (dup memo)
+  // and reply admission (the density_update filter guard).
+  _traceFilterKey(g) {
+    const ti = this.gpuTraces.indexOf(g);
+    return lodFilterKey(this._legendOffCats && this._legendOffCats.get(ti));
   },
 
   // What (if anything) this trace should ask the kernel for at `view`
@@ -173,7 +188,12 @@ Object.assign(ChartView.prototype, {
   _densityRequestPlan(g, view) {
     const [x0, x1] = this._axisRange(g.xAxis, view);
     const [y0, y1] = this._axisRange(g.yAxis, view);
-    if (!lodAggregateStands(this, g, x0, x1, y0, y1)) {
+    // Filter-dirty (interaction spec §10 / §34): every grid on the client was
+    // computed under a previous hidden-category set — including the standing
+    // home aggregate, which would otherwise elide the request entirely. Force
+    // the full-window re-bin; the flag clears when a reply stamped with the
+    // current mask applies.
+    if (g._filterDirty || !lodAggregateStands(this, g, x0, x1, y0, y1)) {
       return {
         win: [Math.min(x0, x1), Math.max(x0, x1), Math.min(y0, y1), Math.max(y0, y1)],
         step: false,
@@ -524,13 +544,16 @@ Object.assign(ChartView.prototype, {
         // under a different hidden-category set than the client's current
         // one would render a stale predicate's aggregate. The toggle that
         // changed the set already scheduled a fresh request.
-        const ti = this.gpuTraces.indexOf(g);
-        const want = Array.from(
-          (this._legendOffCats && this._legendOffCats.get(ti)) || []
-        ).sort((a: any, b: any) => a - b);
-        const got = (upd.filter && upd.filter.hidden_categories) || [];
-        if (want.join(",") !== got.join(",")) continue;
+        if (this._traceFilterKey(g) !== lodFilterKey(upd.filter && upd.filter.hidden_categories)) {
+          continue;
+        }
         if (upd.mode === "points") { this._applyDrill(g, upd, buffers); continue; }
+        // The current mask has an aggregate again; request planning may
+        // resume normal aggregate-stands elision. A points drill above must
+        // NOT clear the flag: it lands no grid under the mask, so the only
+        // standing aggregate is still the previous predicate's — planning
+        // keeps forcing the full-window re-bin until a stamped grid arrives.
+        g._filterDirty = false;
         lodApplyDensityUpdate(this, g, upd, buffers);
       }
       // Drill state changes what's pickable; hover needs the FBO ready.

--- a/python/xy/_figure.py
+++ b/python/xy/_figure.py
@@ -1409,6 +1409,11 @@ class Figure(AnnotationsMixin, PayloadMixin):
         f32 upload offsets so precision holds at deep zoom."""
         return interaction.decimate_view(self, x0, x1, px_width)
 
+    def legend_toggle(self, trace_id: int, hidden: bool, category: Optional[int] = None) -> None:
+        """Record a legend visibility toggle: whole trace, or one categorical
+        code. Selections, decimation, and density re-bins honor it (§34)."""
+        interaction.legend_toggle(self, trace_id, hidden, category)
+
     def append(
         self,
         trace_id: int,

--- a/python/xy/_payload.py
+++ b/python/xy/_payload.py
@@ -1095,7 +1095,7 @@ class PayloadMixin(_Host):
         sample = self._density_sample_spec(t, sel, visible, xr, yr, pw, sample_sel=sample_sel)
         if sample is not None:
             density["sample"] = sample
-        return {
+        entry = {
             "id": t.id,
             "kind": "scatter",
             "name": t.name,
@@ -1108,3 +1108,18 @@ class PayloadMixin(_Host):
             "y_axis": t.y_axis,
             "density": density,
         }
+        if categorical and t.color_ch is not None:
+            # Legend chrome needs the encoding even though the per-point codes
+            # aggregate into the mean-color plane: ship the channel spec slim
+            # (categories + palette, no per-point `buf`) so category rows
+            # exist for density-tier traces — the §10 category-toggle path is
+            # unreachable without them, and every client consumer of a color
+            # buffer already guards on `buf`. Continuous channels stay
+            # deliberately unshipped here: a gradient row would claim
+            # color == density.
+            color_spec = t.color_ch.spec()
+            color_spec["palette"] = channels.categorical_palette(
+                DEFAULT_PALETTE, len(t.color_ch.categories or ())
+            )
+            entry["color"] = color_spec
+        return entry

--- a/python/xy/_trace.py
+++ b/python/xy/_trace.py
@@ -56,6 +56,16 @@ class Trace:
     # Tri-state density override: None = auto (threshold), True/False = forced.
     # (A bool here silently ignored density=False — staff-review finding.)
     force_density: Optional[bool] = None
+    # Legend-toggle state (§34 filter predicates, interaction spec §10).
+    # `hidden` retires the whole trace from selections/decimation/density
+    # replies; `hidden_categories` holds excluded categorical codes and makes
+    # every re-bin/sample narrow its rows first — the pyramid fast path holds
+    # UNFILTERED aggregates and must be bypassed while this is non-empty.
+    hidden: bool = False
+    hidden_categories: set[int] = field(default_factory=set, compare=False)
+    # ((hidden set, column length) -> visible canonical rows), maintained by
+    # interaction._legend_visible_rows so per-view re-bins don't rescan codes.
+    _legend_vis_cache: Optional[Any] = field(default=None, init=False, repr=False, compare=False)
     # Shipped-row → canonical-row mapping, set by build_payload when the shipped
     # copy drops NaN rows (§19), and by the drill-in view path when a Tier-2
     # trace ships its visible subset. The client's GPU pick and selection masks

--- a/python/xy/channel.py
+++ b/python/xy/channel.py
@@ -243,6 +243,23 @@ def handle_message(
         if update["traces"]:
             return {"type": "density_update", "seq": seq, **update}, out
         return None
+    if kind == "legend_toggle":
+        # Legend visibility toggle (§34 predicate; interaction spec §10).
+        # Fire-and-forget state sync: no reply — the client hides locally and,
+        # for masked density tiers, re-requests through the normal
+        # density_view path, which now honors the recorded predicate.
+        try:
+            hidden = content["hidden"]
+            if not isinstance(hidden, bool):
+                return None
+            fig.legend_toggle(
+                content["trace"],
+                hidden,
+                content.get("category"),
+            )
+        except (KeyError, TypeError, ValueError, IndexError):
+            return None
+        return None
     if kind == "pick":
         # Hover/click drill: exact f64 row from canonical (§16/§17). The
         # client's drill_seq rejects picks that raced a subset swap.

--- a/python/xy/channels.py
+++ b/python/xy/channels.py
@@ -74,6 +74,10 @@ class ColorChannel:
     values: Optional[npt.NDArray[np.float64]] = None
     domain: Optional[tuple[float, float]] = None
     colormap: str = DEFAULT_COLORMAP
+    # Declarative source of the continuous values (the `color="temperature"`
+    # column-name idiom). Legend/colorbar chrome uses it when the trace itself
+    # is unnamed, so an encoding never has to fall back to a generic "value".
+    label: Optional[str] = None
     # categorical: integer code per point + the category labels + palette.
     codes: Optional[npt.NDArray[np.uint8] | npt.NDArray[np.uint32]] = None
     categories: Optional[list[str]] = None
@@ -96,11 +100,14 @@ class ColorChannel:
         if self.mode == "constant":
             return {"mode": "constant", "color": self.constant}
         if self.mode == "continuous":
-            return {
+            spec: dict[str, Any] = {
                 "mode": "continuous",
                 "colormap": self.colormap,
                 "domain": list(self.domain) if self.domain else None,
             }
+            if self.label is not None:
+                spec["label"] = self.label
+            return spec
         if self.mode == "direct_rgba":
             return {"mode": "direct_rgba", "components": 4, "dtype": "u8"}
         if self.mode == "match_fill":

--- a/python/xy/channels.py
+++ b/python/xy/channels.py
@@ -76,7 +76,7 @@ class ColorChannel:
     colormap: str = DEFAULT_COLORMAP
     # Declarative source of the continuous values (the `color="temperature"`
     # column-name idiom). Legend/colorbar chrome uses it when the trace itself
-    # is unnamed, so an encoding never has to fall back to a generic "value".
+    # is unnamed; with neither name nor label the encoding gets no legend row.
     label: Optional[str] = None
     # categorical: integer code per point + the category labels + palette.
     codes: Optional[npt.NDArray[np.uint8] | npt.NDArray[np.uint32]] = None

--- a/python/xy/channels.py
+++ b/python/xy/channels.py
@@ -544,6 +544,16 @@ def colormap_lut_rgba8(colormap: str) -> npt.NDArray[np.uint8]:
     return lut
 
 
+def categorical_palette(palette: list[str], n_categories: int) -> list[str]:
+    """The shipped `color.palette`: one color per category, repeating the base
+    palette once its colors run out.
+
+    The repeat rule is a wire contract — the client indexes this list by
+    category code (and folds wide codes modulo it) — so it has exactly one
+    definition, shared by every producer of a categorical color spec."""
+    return [palette[i % len(palette)] for i in range(n_categories)]
+
+
 def palette_rgba8(palette: list[str], n_categories: int) -> npt.NDArray[np.uint8]:
     """Categorical palette colors as straight-alpha RGBA8 LUT rows.
 
@@ -748,7 +758,7 @@ def ship_color_channel(
             color_spec["dtype"] = "u8"
         else:
             color_spec["buf"] = ship_scalar(codes)
-        color_spec["palette"] = [palette[i % len(palette)] for i in range(len(categories))]
+        color_spec["palette"] = categorical_palette(palette, len(categories))
 
     return color_spec
 

--- a/python/xy/components.py
+++ b/python/xy/components.py
@@ -238,6 +238,7 @@ class Legend(Component):
     ncols: int = 1
     title: Optional[str] = None
     highlight: bool = True
+    toggle: bool = True
     class_name: Optional[str] = None
     style: dict[str, StyleValue] = field(default_factory=dict)
     render: Any = None
@@ -2374,6 +2375,7 @@ def legend(
     ncols: int = 1,
     title: Optional[str] = None,
     highlight: bool = True,
+    toggle: bool = True,
     render: Any = None,
     class_name: Optional[str] = None,
     style: Optional[dict[str, StyleValue]] = None,
@@ -2388,6 +2390,8 @@ def legend(
         title: Optional legend title.
         highlight: Whether hovering a legend entry emphasizes its series by
             dimming the others (live client only; exports are static).
+        toggle: Whether clicking a legend entry hides/shows its series or
+            category (live client only; exports are static).
         render: Opaque renderer supplied by an adapter.
         class_name: DOM class name applied to the legend.
         style: Legend style overrides.
@@ -2399,6 +2403,7 @@ def legend(
         ncols=_optional_positive_int(ncols, "legend ncols") or 1,
         title=_optional_string(title, "legend title"),
         highlight=_strict_bool(highlight, "legend highlight"),
+        toggle=_strict_bool(toggle, "legend toggle"),
         class_name=_optional_string(class_name, "legend class_name"),
         style=_style_dict(style, "legend style"),
         render=render,
@@ -3197,6 +3202,9 @@ class Chart(Component):
                 # Highlight-on-hover defaults on; only the opt-out crosses the
                 # wire so existing specs stay byte-identical.
                 fig.legend_options["highlight"] = False
+            if not _strict_bool(node.toggle, "legend toggle"):
+                # Click-to-toggle likewise defaults on, opt-out only.
+                fig.legend_options["toggle"] = False
             if node.style:
                 # Carry the frame/frameon styling into the static-export spec so
                 # the raster/SVG legend can honor frameon=False (transparent bg).

--- a/python/xy/components.py
+++ b/python/xy/components.py
@@ -237,6 +237,7 @@ class Legend(Component):
     loc: Optional[str] = None
     ncols: int = 1
     title: Optional[str] = None
+    highlight: bool = True
     class_name: Optional[str] = None
     style: dict[str, StyleValue] = field(default_factory=dict)
     render: Any = None
@@ -2372,6 +2373,7 @@ def legend(
     loc: Optional[str] = None,
     ncols: int = 1,
     title: Optional[str] = None,
+    highlight: bool = True,
     render: Any = None,
     class_name: Optional[str] = None,
     style: Optional[dict[str, StyleValue]] = None,
@@ -2384,6 +2386,8 @@ def legend(
         loc: Legend placement within or around the plot.
         ncols: Number of legend columns.
         title: Optional legend title.
+        highlight: Whether hovering a legend entry emphasizes its series by
+            dimming the others (live client only; exports are static).
         render: Opaque renderer supplied by an adapter.
         class_name: DOM class name applied to the legend.
         style: Legend style overrides.
@@ -2394,6 +2398,7 @@ def legend(
         loc=_optional_string(loc, "legend loc"),
         ncols=_optional_positive_int(ncols, "legend ncols") or 1,
         title=_optional_string(title, "legend title"),
+        highlight=_strict_bool(highlight, "legend highlight"),
         class_name=_optional_string(class_name, "legend class_name"),
         style=_style_dict(style, "legend style"),
         render=render,
@@ -3159,6 +3164,16 @@ class Chart(Component):
                 class_name = _optional_string(m.class_name, f"{m.kind} class_name")
                 for trace in new_traces:
                     trace.style["class_name"] = class_name
+            color_label = _continuous_color_label(m)
+            if color_label is not None:
+                for trace in new_traces:
+                    channel = getattr(trace, "color_ch", None)
+                    if (
+                        channel is not None
+                        and channel.mode == "continuous"
+                        and channel.label is None
+                    ):
+                        channel.label = color_label
             _merge_tooltip_aliases(tooltip_aliases, m, new_traces)
             _merge_tooltip_sources(tooltip_sources, m, new_traces)
             colorbar_candidate = _declarative_colorbar_options(m, new_traces)
@@ -3178,6 +3193,10 @@ class Chart(Component):
             fig.legend_options = {"loc": node.loc, "ncols": node.ncols}
             if node.title is not None:
                 fig.legend_options["title"] = node.title
+            if not _strict_bool(node.highlight, "legend highlight"):
+                # Highlight-on-hover defaults on; only the opt-out crosses the
+                # wire so existing specs stay byte-identical.
+                fig.legend_options["highlight"] = False
             if node.style:
                 # Carry the frame/frameon styling into the static-export spec so
                 # the raster/SVG legend can honor frameon=False (transparent bg).
@@ -3786,6 +3805,27 @@ def _apply_mark_transition_metadata(
                     f"has {trace.n_points} logical rows"
                 )
             trace.transition_keys = keys
+
+
+def _continuous_color_label(mark: Mark) -> Optional[str]:
+    """Declarative label for a mark's continuous color channel.
+
+    Only genuine column names (or hexbin's derived metric) qualify — the mark
+    name is not a channel label, and the client already prefers ``t.name``
+    for legend rows. Attached to ``ColorChannel.label`` so unnamed encodings
+    stop rendering as a generic "value" swatch.
+    """
+    if mark.kind in {"scatter", "segments", "triangle_mesh"}:
+        color = mark.props.get("color")
+        if isinstance(color, str) and not _looks_like_css(color):
+            return color
+    elif mark.kind == "hexbin":
+        values = mark.props.get("C")
+        if isinstance(values, str):
+            return values
+        if values is None:
+            return "log(count + 1)" if mark.props.get("bins") == "log" else "count"
+    return None
 
 
 def _colorbar_source_title(mark: Mark) -> Optional[str]:

--- a/python/xy/components.py
+++ b/python/xy/components.py
@@ -3812,8 +3812,8 @@ def _continuous_color_label(mark: Mark) -> Optional[str]:
 
     Only genuine column names (or hexbin's derived metric) qualify — the mark
     name is not a channel label, and the client already prefers ``t.name``
-    for legend rows. Attached to ``ColorChannel.label`` so unnamed encodings
-    stop rendering as a generic "value" swatch.
+    for legend rows. Attached to ``ColorChannel.label``; an encoding with
+    neither a name nor a label renders no legend row at all.
     """
     if mark.kind in {"scatter", "segments", "triangle_mesh"}:
         color = mark.props.get("color")

--- a/python/xy/interaction.py
+++ b/python/xy/interaction.py
@@ -73,8 +73,8 @@ def _screen_shape(w: int, h: int) -> tuple[int, int]:
     return lod.screen_shape(w, h)
 
 
-def _hidden_category_array(t: "Trace") -> Optional[np.ndarray]:
-    """The trace's hidden categorical codes as a sorted array, or None.
+def _hidden_predicate(t: "Trace") -> Optional[tuple[np.ndarray, np.ndarray]]:
+    """(sorted hidden codes, live code column) for a masked trace, else None.
 
     None also covers a stale mask left behind after an encoding change —
     a hidden-category set is only meaningful against live categorical codes.
@@ -83,7 +83,7 @@ def _hidden_category_array(t: "Trace") -> Optional[np.ndarray]:
         return None
     if t.color_ch is None or t.color_ch.codes is None:
         return None
-    return np.fromiter(sorted(t.hidden_categories), dtype=np.int64)
+    return np.fromiter(sorted(t.hidden_categories), dtype=np.int64), t.color_ch.codes
 
 
 def _drop_hidden_rows(t: "Trace", indices: np.ndarray) -> np.ndarray:
@@ -92,11 +92,11 @@ def _drop_hidden_rows(t: "Trace", indices: np.ndarray) -> np.ndarray:
     Row-level pre-selection is the filter contract: no bin/sample kernel
     takes a mask, so every aggregation path narrows its rows first.
     """
-    hidden = _hidden_category_array(t)
-    if hidden is None or len(indices) == 0:
+    pred = _hidden_predicate(t)
+    if pred is None or len(indices) == 0:
         return indices
-    codes = t.color_ch.codes[indices]
-    return indices[~np.isin(codes, hidden)]
+    hidden, codes = pred
+    return indices[~np.isin(codes[indices], hidden)]
 
 
 def _legend_visible_rows(t: "Trace") -> Optional[np.ndarray]:
@@ -106,14 +106,15 @@ def _legend_visible_rows(t: "Trace") -> Optional[np.ndarray]:
     pan/zoom step and the O(N) code scan must not repeat while the predicate
     is unchanged. A streaming append changes the length and recomputes.
     """
-    hidden = _hidden_category_array(t)
-    if hidden is None:
+    pred = _hidden_predicate(t)
+    if pred is None:
         return None
-    key = (frozenset(t.hidden_categories), len(t.color_ch.codes))
+    hidden, codes = pred
+    key = (frozenset(t.hidden_categories), len(codes))
     cached = t._legend_vis_cache
     if cached is not None and cached[0] == key:
         return cached[1]
-    rows = np.flatnonzero(~np.isin(t.color_ch.codes, hidden))
+    rows = np.flatnonzero(~np.isin(codes, hidden))
     t._legend_vis_cache = (key, rows)
     return rows
 

--- a/python/xy/interaction.py
+++ b/python/xy/interaction.py
@@ -73,6 +73,91 @@ def _screen_shape(w: int, h: int) -> tuple[int, int]:
     return lod.screen_shape(w, h)
 
 
+def _hidden_category_array(t: "Trace") -> Optional[np.ndarray]:
+    """The trace's hidden categorical codes as a sorted array, or None.
+
+    None also covers a stale mask left behind after an encoding change —
+    a hidden-category set is only meaningful against live categorical codes.
+    """
+    if not t.hidden_categories:
+        return None
+    if t.color_ch is None or t.color_ch.codes is None:
+        return None
+    return np.fromiter(sorted(t.hidden_categories), dtype=np.int64)
+
+
+def _drop_hidden_rows(t: "Trace", indices: np.ndarray) -> np.ndarray:
+    """Narrow canonical row indices to legend-visible rows (§34 predicate).
+
+    Row-level pre-selection is the filter contract: no bin/sample kernel
+    takes a mask, so every aggregation path narrows its rows first.
+    """
+    hidden = _hidden_category_array(t)
+    if hidden is None or len(indices) == 0:
+        return indices
+    codes = t.color_ch.codes[indices]
+    return indices[~np.isin(codes, hidden)]
+
+
+def _legend_visible_rows(t: "Trace") -> Optional[np.ndarray]:
+    """Canonical rows outside the hidden-category set, or None when unmasked.
+
+    Cached per (hidden set, column length) on the trace: density_view runs per
+    pan/zoom step and the O(N) code scan must not repeat while the predicate
+    is unchanged. A streaming append changes the length and recomputes.
+    """
+    hidden = _hidden_category_array(t)
+    if hidden is None:
+        return None
+    key = (frozenset(t.hidden_categories), len(t.color_ch.codes))
+    cached = t._legend_vis_cache
+    if cached is not None and cached[0] == key:
+        return cached[1]
+    rows = np.flatnonzero(~np.isin(t.color_ch.codes, hidden))
+    t._legend_vis_cache = (key, rows)
+    return rows
+
+
+def _legend_filter_spec(t: "Trace") -> dict[str, Any]:
+    """The filter state a reply was computed under (§34/§37 filter_hash-lite).
+
+    Rides every masked reply so the client can drop one that raced a newer
+    toggle instead of rendering a stale predicate's aggregate.
+    """
+    return {"hidden_categories": sorted(int(c) for c in t.hidden_categories)}
+
+
+def legend_toggle(
+    fig: "Figure", trace_id: int, hidden: bool, category: Optional[int] = None
+) -> None:
+    """Record a legend visibility toggle (§34 predicate; interaction spec §10).
+
+    State-sync only, deliberately reply-free: the predicate lives on the
+    trace so every subsequent aggregation, decimation, and selection honors
+    it, and re-aggregation rides the normal `density_view` request the client
+    issues next — one predicate, one re-bin path, no second wire shape.
+    Flipping back to a previous state costs the kernel nothing new (§37's
+    filter-toggle row): the pyramid was never filtered and the visible-row
+    cache keys on the hidden set.
+    """
+    t = _trace(fig, trace_id)
+    if not isinstance(hidden, (bool, np.bool_)):
+        raise ValueError("legend_toggle hidden must be a boolean")
+    if category is None:
+        t.hidden = bool(hidden)
+        return
+    code = _integer_id(category, "category")
+    cc = t.color_ch
+    if cc is None or cc.mode != "categorical" or cc.categories is None:
+        raise ValueError("legend_toggle category requires a categorical color channel")
+    if not 0 <= code < len(cc.categories):
+        raise ValueError(f"legend_toggle category {code} is out of range")
+    if bool(hidden):
+        t.hidden_categories.add(code)
+    else:
+        t.hidden_categories.discard(code)
+
+
 def pick(
     fig: "Figure", trace_id: int, index: int, drill_seq: Optional[int] = None
 ) -> Optional[dict[str, Any]]:
@@ -202,6 +287,10 @@ def select_range(
             continue
         if tid is not None and t.id != tid:
             continue
+        # Legend-hidden traces are out of the selection universe entirely
+        # (§34): a brush must not report rows the user just excluded.
+        if t.hidden:
+            continue
         x_chunks = _zone_candidate_chunks(t.x, lo_x, hi_x)
         y_chunks = _zone_candidate_chunks(t.y, lo_y, hi_y)
         candidate_chunks = np.intersect1d(x_chunks, y_chunks, assume_unique=True)
@@ -215,6 +304,7 @@ def select_range(
                 t.x.values[candidates], t.y.values[candidates], lo_x, hi_x, lo_y, hi_y
             )
             out[t.id] = candidates[out[t.id]]
+        out[t.id] = _drop_hidden_rows(t, out[t.id])
     return out
 
 
@@ -336,6 +426,10 @@ def decimate_view(
     writer = lod.BufferWriter()
     for t in fig.traces:
         if t.kind not in {"line", "area"} or t.n_points <= DECIMATION_THRESHOLD:
+            continue
+        # A legend-hidden trace is not drawn; re-decimating it per pan/zoom
+        # would ship dead buffers (§34 — hidden means out of every pipeline).
+        if t.hidden:
             continue
         if t.kind == "area" and t.base is None:
             continue
@@ -672,9 +766,16 @@ def density_view(
     lo_x, hi_x = request.x_range
     lo_y, hi_y = request.y_range
     w, h = request.width, request.height
-    if not t.use_density():
+    if not t.use_density() or t.hidden:
         return {"traces": []}, []
     xv, yv = t.x.values, t.y.values
+    # Legend-toggle predicate (§34): hidden categories narrow the rows BEFORE
+    # any aggregation. Everything downstream — counts, tier decisions, grids,
+    # drill selections — then runs in visible-row space; drill selections are
+    # translated back to canonical via `vis_rows` before they ship or persist.
+    vis_rows = _legend_visible_rows(t)
+    if vis_rows is not None:
+        xv, yv = xv[vis_rows], yv[vis_rows]
     # Nonlinear axes aggregate in scale coordinates (§28) so grid cells are
     # uniform on screen. The raw-space tile pyramid can't compose such a grid,
     # so those traces always take the exact scan; selection/count queries stay
@@ -690,7 +791,7 @@ def density_view(
     # Mean point color plane (LOD doc §2): channel-bearing traces ship it
     # alongside the counts wherever a grid is produced below.
     rgba_grid: np.ndarray | None = None
-    bin_colors = channels.resolve_bin_colors(t.color_ch, None, DEFAULT_PALETTE)
+    bin_colors = channels.resolve_bin_colors(t.color_ch, vis_rows, DEFAULT_PALETTE)
     # Texture sampling for the density grid: "nearest" when the grid is at full
     # screen resolution (exact deep-zoom detail — crisp, no interpolation bleed),
     # "linear" when it is upsampled from a coarser tier (smooth aggregate).
@@ -705,8 +806,11 @@ def density_view(
     max_upsample = _PYRAMID_UNBOUNDED_UPSAMPLE if no_rescan else 2
     est = None
     # Nonlinear axes can't compose from the raw-space pyramid (see above) → no
-    # pyramid, exact scan instead.
-    pyr = None if nonlinear else _ensure_pyramid(t)
+    # pyramid, exact scan instead. A hidden-category mask also bypasses it:
+    # the pyramid holds UNFILTERED counts, and §34's whole point is that a
+    # static aggregate is wrong under any dynamic predicate — the masked view
+    # takes the honest Tier-B re-bin below, recorded via the binning label.
+    pyr = None if (nonlinear or vis_rows is not None) else _ensure_pyramid(t)
     if pyr is not None:
         est = kernels.pyramid_count(pyr, lo_x, hi_x, lo_y, hi_y)
         # Serve from the pyramid when the window is clearly aggregate territory,
@@ -820,6 +924,10 @@ def density_view(
         plan = lod.plan_view_lod(request, len(sel), SCATTER_DENSITY_THRESHOLD, t.drill_mode)
         visible = plan.visible
         if plan.exact:
+            if vis_rows is not None:
+                # range_indices ran in visible-row space; drill bookkeeping
+                # (shipped_sel, pick/selection translation) speaks canonical.
+                sel = vis_rows[sel]
             # Ship the widest aligned window that still fits the budget (T13)
             # so the client's point-window cache answers nearby pans/zooms
             # locally; the raw view window is the floor. `visible` describes
@@ -828,9 +936,13 @@ def density_view(
             padded = _padded_drill_window(fig, t, pyr, lo_x, hi_x, lo_y, hi_y)
             if padded is not None:
                 lo_x, hi_x, lo_y, hi_y, sel = padded
-            return _drill_points(
+                sel = _drop_hidden_rows(t, sel)
+            reply, reply_buffers = _drill_points(
                 fig, t, sel, len(sel), lo_x, hi_x, lo_y, hi_y, w, h, blend_visible=visible
             )
+            if vis_rows is not None:
+                reply["traces"][0]["filter"] = _legend_filter_spec(t)
+            return reply, reply_buffers
 
         lod.exit_drill(t)
         w, h = plan.grid_w, plan.grid_h
@@ -870,22 +982,18 @@ def density_view(
         density["color_agg"] = "mean"
     if t.color_ch and t.color_ch.mode == "constant" and t.color_ch.constant is not None:
         density["color"] = t.color_ch.constant
-    return (
-        {
-            "traces": [
-                {
-                    "id": trace_id,
-                    "mode": "density",
-                    "tier": plan.tier,
-                    "visible": visible,
-                    "reduction": plan.reduction,
-                    "binning": binning,
-                    "density": density,
-                }
-            ]
-        },
-        writer.buffers,
-    )
+    entry = {
+        "id": trace_id,
+        "mode": "density",
+        "tier": plan.tier,
+        "visible": visible,
+        "reduction": plan.reduction,
+        "binning": binning if vis_rows is None else binning + "-masked",
+        "density": density,
+    }
+    if vis_rows is not None:
+        entry["filter"] = _legend_filter_spec(t)
+    return {"traces": [entry]}, writer.buffers
 
 
 def _drill_points(

--- a/spec/api/interaction.md
+++ b/spec/api/interaction.md
@@ -425,6 +425,58 @@ by `t.name`, else the encoding's declarative `color.label` (the
 SVG/raster exports draw name-bearing entries only and have no hover state;
 this section is live-client behavior.
 
-Click-to-toggle (hiding a series) is **not** part of this contract — it
-invalidates precomputed density tiers and needs a kernel round-trip; see
-dossier §34 for the filtering model it belongs to.
+Click-to-toggle (hiding a series) is a separate contract: §10.
+
+## 10. Legend click-to-toggle
+
+Clicking a legend row hides — click again, shows — what the row stands for.
+This is the first shipped §34 filter predicate: a hidden series is out of
+*every* pipeline (drawing, picking, selections, decimation, aggregation),
+not merely transparent. Gating: `xy.legend(toggle=False)`; on by default,
+opt-out only on the wire. `extra_legends` rows stay inert (no trace
+linkage). A toggled-off row fades (35%, grayscale, `data-xy-legend-off`
+attribute for author styling) and is inert for §9 hover emphasis. The DOM
+event `xy:legendtoggle` fires with `{name, hidden, traces, category?}`.
+
+**State sync.** Every toggle sends `legend_toggle {trace, category?,
+hidden}` — fire-and-forget, no reply. The kernel records `Trace.hidden` /
+`Trace.hidden_categories`; from then on `select`/`select_polygon` exclude
+hidden rows, `decimate_view` skips hidden traces, and `density_view`
+narrows rows before any aggregation. Malformed toggles (unknown category,
+non-bool hidden) are dropped without mutating state.
+
+**Per entry kind:**
+
+- **Whole-trace rows** (named / constant / continuous — a deduped
+  continuous row hides *all* its backing traces): pure client hide. Vertex
+  buffers and density grids are per-trace, so nothing needs re-aggregation;
+  the trace skips the draw loop, the pick pass, and the reduction badges.
+- **Category rows on a direct-tier trace**: the client re-filters its
+  vertex buffers from the CPU columns retained at build — 0 wire bytes
+  (§37's filter-toggle row). Per-point style/stroke buffers, which keep no
+  CPU copy, are read back once (`getBufferSubData`) and cached. `_visMap`
+  translates drawn vertices back to shipped rows so hover readouts and
+  kernel picks stay exact; `_visInv` maps the kernel's shipped-space
+  selection indices onto the filtered buffers.
+- **Category rows on a density-tier trace**: local aggregates were computed
+  unfiltered and are stale under the predicate (§34) — worse, a cached
+  window that still "covers" the view would elide the kernel request
+  entirely. The client drops its density and point-window caches, filters
+  the retained sample overlays locally (the pre-reply frame stops showing
+  the category immediately), and re-requests through the normal
+  `density_view` path. The kernel bypasses the unfiltered pyramid (the
+  §34 point: static aggregates are wrong under any dynamic predicate),
+  re-bins the visible rows (Tier B), tags the reply's `binning` with
+  `-masked`, and stamps it with `filter: {hidden_categories}`. The client
+  compares that stamp against its current hidden set and drops
+  stale-predicate replies; drills ship only visible rows with canonical
+  `shipped_sel`.
+
+**Deliberate limits (recorded, not silent — §28):** toggles never rescale
+axes (the view is the user's; Fit Data is the re-fit tool). Toggle state
+does not enter durable view state or gesture history yet — a context-loss
+restore re-applies it from the live view object, but a full page reload
+starts all-visible. On a kernel-less standalone page, whole-trace and
+direct-tier category toggles are exact; a density-tier category toggle
+filters the sample overlays but the standalone worker's re-binned grid is
+not masked — kernel-connected sessions are exact.

--- a/spec/api/interaction.md
+++ b/spec/api/interaction.md
@@ -383,3 +383,48 @@ round-trip on hover; keyboard point traversal and the live-region readout;
 lasso vertex editing on an existing lasso; selection overlay rendering;
 modebar presence (subject only to the fit check); and view clamping to axis
 bounds. Everything in the §2 and §2.1 tables is configurable; nothing else is.
+
+## 9. Legend hover emphasis
+
+Hovering a legend row emphasizes the series it stands for: every other
+series drops to 20% of its computed opacity (`LEGEND_DIM_OPACITY`,
+`50_chartview.ts`), the other rows in the same legend box fade to 40%
+(`LEGEND_DIM_ROW`), and both restore on pointer-leave. Purely client-side —
+no kernel message, no view change — and the redraw runs with `keepPick`
+because only the color pass changes (dossier §17).
+
+Gating: `xy.legend(highlight=False)`. This is legend chrome, not an
+`interaction_config` switch: it rides `legend.highlight` in the spec's legend
+options, is **on by default**, and only the opt-out (`false`) crosses the
+wire. Hard-disabled rows: entries of `extra_legends` (manual Legend artists
+carry no trace linkage) are always inert.
+
+Mechanics per entry kind:
+
+- **Named / constant-color rows** emphasize their one backing trace via a
+  per-trace `_legendDim` factor folded into every mark family's opacity
+  uniform (points, simple points, lines, segments, areas, rects, bars,
+  meshes, heatmaps — and whole density-tier traces through `_drawDensity`'s
+  uniform).
+- **Continuous (gradient) rows** may back *several* traces: identical
+  unnamed encodings (same label, same colormap) collapse into one row, and
+  hovering it emphasizes all of them.
+- **Categorical rows** emphasize one category: the trace keeps full opacity
+  and swaps its palette LUT for a variant whose other entries are blended
+  toward `--chart-bg`. RGB-blend, not alpha: the mark shaders read
+  `texture(u_lut, …).rgb` and force alpha to 1, so an alpha fade would be a
+  silent no-op. The original LUT is restored on leave. A categorical row
+  cannot dim sibling categories *inside* an aggregated density plane — the
+  plane is one texture (§28: recorded, not silent); the whole trace still
+  dims when some other row is hovered.
+
+Legend entry labels (same build, `_buildLegend`): a continuous row is titled
+by `t.name`, else the encoding's declarative `color.label` (the
+`color="column"` idiom, attached by `Chart.figure()` to
+`ColorChannel.label`), else the literal `value` for hand-built specs. Static
+SVG/raster exports draw name-bearing entries only and have no hover state;
+this section is live-client behavior.
+
+Click-to-toggle (hiding a series) is **not** part of this contract — it
+invalidates precomputed density tiers and needs a kernel round-trip; see
+dossier §34 for the filtering model it belongs to.

--- a/spec/api/interaction.md
+++ b/spec/api/interaction.md
@@ -421,8 +421,10 @@ Mechanics per entry kind:
 Legend entry labels (same build, `_buildLegend`): a continuous row is titled
 by `t.name`, else the encoding's declarative `color.label` (the
 `color="column"` idiom, attached by `Chart.figure()` to
-`ColorChannel.label`), else the literal `value` for hand-built specs. Static
-SVG/raster exports draw name-bearing entries only and have no hover state;
+`ColorChannel.label`). There is no generic fallback: a trace with neither a
+name nor a label contributes no legend row, and a chart whose traces are all
+unnamed renders no legend box — the same rule the static SVG/raster exports
+follow (name-bearing entries only). Exports additionally have no hover state;
 this section is live-client behavior.
 
 Click-to-toggle (hiding a series) is **not** part of this contract — it

--- a/spec/api/interaction.md
+++ b/spec/api/interaction.md
@@ -413,10 +413,19 @@ Mechanics per entry kind:
   and swaps its palette LUT for a variant whose other entries are blended
   toward `--chart-bg`. RGB-blend, not alpha: the mark shaders read
   `texture(u_lut, …).rgb` and force alpha to 1, so an alpha fade would be a
-  silent no-op. The original LUT is restored on leave. A categorical row
-  cannot dim sibling categories *inside* an aggregated density plane — the
-  plane is one texture (§28: recorded, not silent); the whole trace still
-  dims when some other row is hovered.
+  silent no-op. The original LUT is restored on leave. An aggregated
+  density plane cannot dim sibling categories *exactly* (one texture,
+  §28), but its mean-color cells carry the categories' own drawn colors,
+  so the LUT-dim rule applies at CELL granularity: each occupied cell is
+  classified by nearest palette color, sibling-class cells blend toward
+  the background by the same factor, the hovered category's cells keep
+  their full color, and cell alpha (the physical compositing of the
+  cell's own points, LOD doc §2) is untouched. Mixed boundary cells dim
+  by their nearest class — the recorded (§28) approximation of the exact
+  per-point dim. The retained sample overlay dims its sibling points
+  through the same palette LUT. All of it restores on leave (the dimmed
+  plane is a temporary texture; the original is put back), and the whole
+  trace still dims when some other row is hovered.
 
 Legend entry labels (same build, `_buildLegend`): a continuous row is titled
 by `t.name`, else the encoding's declarative `color.label` (the
@@ -460,13 +469,27 @@ non-bool hidden) are dropped without mutating state.
   translates drawn vertices back to shipped rows so hover readouts and
   kernel picks stay exact; `_visInv` maps the kernel's shipped-space
   selection indices onto the filtered buffers.
-- **Category rows on a density-tier trace**: local aggregates were computed
-  unfiltered and are stale under the predicate (§34) — worse, a cached
-  window that still "covers" the view would elide the kernel request
-  entirely. The client drops its density and point-window caches, filters
-  the retained sample overlays locally (the pre-reply frame stops showing
-  the category immediately), and re-requests through the normal
-  `density_view` path. The kernel bypasses the unfiltered pyramid (the
+- **Category rows on a density-tier trace** (the rows exist because the
+  first-paint density entry ships a slim categorical `color` spec —
+  categories + palette, no per-point buffer; wire-protocol doc): local
+  aggregates were computed unfiltered and are stale under the predicate
+  (§34) — worse, a cached window that still "covers" the view would elide
+  the kernel request entirely, and so would the *standing home aggregate*
+  at an unzoomed view. The client drops its density and point-window
+  caches, filters the retained sample overlays locally (the pre-reply
+  frame stops showing the category immediately), marks the trace
+  **filter-dirty** — request planning skips aggregate-stands elision until
+  a reply stamped with the current hidden set lands an *aggregate*; a
+  stamped points-mode reply (masked drill) is admitted but leaves the flag
+  set, since it bins no grid under the mask and the standing aggregate is
+  still the previous predicate's — and re-requests
+  through the normal `density_view` path. Density textures are keyed by
+  the hidden set they were binned under: the display stands-rule (T13
+  facts-only landing) holds only between same-key textures, so a reply
+  carrying a different key repaints the standing surface — in either
+  direction, mask applied or lifted. The T13 duplicate-request memo carries
+  the same key: a sub-texel twin window under a different hidden set is a
+  new request, never an answered duplicate. The kernel bypasses the unfiltered pyramid (the
   §34 point: static aggregates are wrong under any dynamic predicate),
   re-bins the visible rows (Tier B), tags the reply's `binning` with
   `-masked`, and stamps it with `filter: {hidden_categories}`. The client

--- a/spec/design-dossier.md
+++ b/spec/design-dossier.md
@@ -1260,7 +1260,11 @@ hover readouts are real HTML/SVG in the DOM (§7). Fonts, color, spacing, border
 focus states: plain CSS, full inheritance and media queries, no bridge needed. The
 container (size, border, background, layout) is ordinary too, and the canvas is
 transparent-capable so a page background shows through. This covers most of what "make
-the chart match my site" actually means — typography and chrome.
+the chart match my site" actually means — typography and chrome. The legend is also
+an interaction surface: hovering a row emphasizes its series by dimming the rest
+(default on, `xy.legend(highlight=False)` opts out; full contract in
+`spec/api/interaction.md` §9). Click-to-toggle stays future work — it is a filter,
+not an emphasis, and belongs to the §34 filtering model.
 
 **(b) Marks — themed via a CSS-custom-property bridge.** The render client reads
 `--chart-*` custom properties off its container and maps them to GPU state, so the

--- a/spec/design-dossier.md
+++ b/spec/design-dossier.md
@@ -1222,6 +1222,15 @@ which tier served it — no silent full rescans.
 `link(fig_a, fig_b, on="x")` — the kernel-side core owns filter state so callbacks
 receive Arrow slices, not JSON.
 
+**Shipped slice:** the legend click-toggle predicate (`Trace.hidden` /
+`Trace.hidden_categories`, wire `legend_toggle`). It follows this section's
+rules exactly: the unfiltered pyramid is bypassed while a category mask is
+active (a Tier-B visible-window re-bin serves instead, `binning` tagged
+`-masked`), rows are narrowed before every bin/sample/drill, selections
+exclude hidden rows, and each masked reply carries the `filter` state it was
+computed under (§37's `filter_hash`, in literal form). Contract:
+`spec/api/interaction.md` §10.
+
 ## 35. Milestone amendments (round 3)
 
 - **Phase 0** adds the **wheel matrix + anywidget skeleton** (F1) — distribution is a
@@ -1263,8 +1272,10 @@ transparent-capable so a page background shows through. This covers most of what
 the chart match my site" actually means — typography and chrome. The legend is also
 an interaction surface: hovering a row emphasizes its series by dimming the rest
 (default on, `xy.legend(highlight=False)` opts out; full contract in
-`spec/api/interaction.md` §9). Click-to-toggle stays future work — it is a filter,
-not an emphasis, and belongs to the §34 filtering model.
+`spec/api/interaction.md` §9). Clicking a row toggles the series/category —
+the first shipped §34 predicate: state syncs to the kernel (`legend_toggle`),
+direct tiers re-filter client-side (0 bytes, §37), density tiers re-bin
+kernel-side under the mask (contract in `spec/api/interaction.md` §10).
 
 **(b) Marks — themed via a CSS-custom-property bridge.** The render client reads
 `--chart-*` custom properties off its container and maps them to GPU state, so the

--- a/spec/design/reflex-integration.md
+++ b/spec/design/reflex-integration.md
@@ -579,7 +579,10 @@ examples/reflex/  (repo root) reflex-xy showcase: figure-var drilldown with
                              and the fastapi live drilldown served adapter-
                              natively from an inline() token (same data and
                              XY_LIVE_POINTS override, zero transport code —
-                             the cross-host A/B for that chart)
+                             the cross-host A/B for that chart), plus legend
+                             hover-highlight and click-to-toggle (named series
+                             client-side; a categorical density inline() token
+                             whose category toggles re-bin kernel-side, §34)
 examples/fastapi/ (repo root) the same charts + a live 100M drilldown served
                              from a plain FastAPI app (no committed HTML)
 tests/reflex_adapter/        69 tests: token/registry/var/bridge/payload-asset

--- a/spec/design/wire-protocol.md
+++ b/spec/design/wire-protocol.md
@@ -200,6 +200,16 @@ states which representation this view resolved to:
   chrome uses to title gradient rows for unnamed traces instead of the
   generic `value` (interaction spec §9).
 
+**`legend_toggle`** — `{type, trace, category?, hidden}`, client → kernel,
+fire-and-forget (no reply, no seq). Records the §34 legend-toggle predicate
+on the trace (`hidden` retires the whole trace; `category` excludes one
+categorical code). Re-aggregation rides the next `density_view` request:
+a masked reply's `binning` gains a `-masked` suffix and the trace entry
+carries `filter: {hidden_categories: [...]}` — the filter state it was
+computed under (§37 filter_hash-lite) — which the client compares against
+its own current set, dropping stale-predicate replies (interaction spec
+§10).
+
 The client enforces `msg.seq` only when it is present, and additionally
 accepts `msg.trace` and `msg.stale` for pending-request bookkeeping — no
 current kernel path emits either field.

--- a/spec/design/wire-protocol.md
+++ b/spec/design/wire-protocol.md
@@ -193,7 +193,12 @@ states which representation this view resolved to:
   come from the kernel's canonical columns (`pick_result` above). The *build*
   payload keeps continuous channels as unit f32 — the client retains those
   columns CPU-side and denormalizes them for tooltip readouts, where 8-bit
-  steps would surface as wrong digits (`channels.ship_channels`).
+  steps would surface as wrong digits (`channels.ship_channels`). A
+  continuous color spec may additionally carry `label` — the declarative
+  column name behind the encoding (`ColorChannel.label`, attached by
+  `Chart.figure()` when `color=` was a column-name string) — which legend
+  chrome uses to title gradient rows for unnamed traces instead of the
+  generic `value` (interaction spec §9).
 
 The client enforces `msg.seq` only when it is present, and additionally
 accepts `msg.trace` and `msg.stale` for pending-request bookkeeping — no

--- a/spec/design/wire-protocol.md
+++ b/spec/design/wire-protocol.md
@@ -197,8 +197,9 @@ states which representation this view resolved to:
   continuous color spec may additionally carry `label` — the declarative
   column name behind the encoding (`ColorChannel.label`, attached by
   `Chart.figure()` when `color=` was a column-name string) — which legend
-  chrome uses to title gradient rows for unnamed traces instead of the
-  generic `value` (interaction spec §9).
+  chrome uses to title gradient rows for unnamed traces; with neither a
+  trace name nor a `label` the encoding renders no legend row at all
+  (interaction spec §9).
 
 The client enforces `msg.seq` only when it is present, and additionally
 accepts `msg.trace` and `msg.stale` for pending-request bookkeeping — no

--- a/spec/design/wire-protocol.md
+++ b/spec/design/wire-protocol.md
@@ -209,7 +209,13 @@ a masked reply's `binning` gains a `-masked` suffix and the trace entry
 carries `filter: {hidden_categories: [...]}` — the filter state it was
 computed under (§37 filter_hash-lite) — which the client compares against
 its own current set, dropping stale-predicate replies (interaction spec
-§10).
+§10). So that category rows exist to click at all, a categorical
+density-tier first-paint entry carries a **slim** `color` spec —
+`{mode: "categorical", categories, palette}`, no per-point `buf` (the codes
+aggregated into the mean-color plane) — which legend chrome consumes and
+every buffer consumer ignores (they all guard on `buf`). Continuous density
+entries ship no `color` spec, deliberately: a gradient row on an aggregated
+surface would claim color == density.
 
 The client enforces `msg.seq` only when it is present, and additionally
 accepts `msg.trace` and `msg.stale` for pending-request bookkeeping — no

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,9 +10,66 @@ import html
 import json
 import re
 import subprocess
+import sys
 from pathlib import Path
 
+import numpy as np
 import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
+
+# The `to_html` render call, whose shape the probe pages splice a view capture
+# into. Exported so probe tests assert against one list instead of each keeping
+# its own copy in sync with the exporter.
+RENDER_CALLS = (
+    'xy.renderStandalone(document.getElementById("chart"), spec, bytes.buffer);',
+    'xy.renderStandalone(document.getElementById("chart"), spec, buf);',
+)
+
+
+def probe_document(chart, probe: str, *, head: str = "") -> str:
+    """A `to_html` page instrumented for a browser probe.
+
+    Captures the live view as ``window.__fcProbeView`` (probe scripts drive it
+    directly) and splices `probe` — plus any `head` markup, e.g. a page
+    background the probe depends on — in before ``</body>``.
+    """
+    document = chart.to_html()
+    render_call = next((call for call in RENDER_CALLS if call in document), None)
+    assert render_call is not None, "to_html render call shape changed; update RENDER_CALLS"
+    document = document.replace(
+        render_call,
+        render_call.replace(
+            "xy.renderStandalone(", "window.__fcProbeView = xy.renderStandalone(", 1
+        ),
+        1,
+    )
+    return document.replace("</body>", head + probe + "\n</body>", 1)
+
+
+def density_category_chart(n: int = 400_000, seed: int = 7):
+    """A clustered 3-category density-tier scatter with a legend.
+
+    The shared fixture behind the density legend probes: big enough to land on
+    the density tier, clustered so each category owns a region of the
+    mean-color plane. Returns ``(chart, cat, x, y)`` — the per-point code
+    array and coordinates, for asserting masked counts and framing requests.
+    """
+    import xy
+
+    rng = np.random.default_rng(seed)
+    cat = rng.integers(0, 3, n)
+    centers = np.array([[-1.2, -0.6], [0.2, 1.1], [1.5, -0.9]])
+    x = rng.normal(centers[cat, 0], 0.4)
+    y = rng.normal(centers[cat, 1], 0.4)
+    labels = np.array(["A", "B", "C"])[cat]
+    chart = xy.scatter_chart(
+        xy.scatter(x, y, color=labels, density=True),
+        xy.legend(),
+        width=520,
+        height=340,
+    )
+    return chart, cat, x, y
 
 
 def _dump_dom(chromium: str, page: Path) -> str | None:

--- a/tests/test_legend_highlight.py
+++ b/tests/test_legend_highlight.py
@@ -1,0 +1,219 @@
+"""Legend entry labels and hover-highlight emphasis.
+
+Python side: a continuous color encoding built from a column name carries that
+name onto the wire (`color.label`), so unnamed traces stop rendering a generic
+"value" legend row; `xy.legend(highlight=...)` gates the hover behavior.
+
+Browser side: hovering a legend row dims every other series on the marks
+canvas (`_legendDim`), swaps a categorical trace's palette LUT so sibling
+categories fade, dims the other legend rows, and restores everything on leave.
+Identical unnamed continuous encodings collapse into one row whose hover
+emphasizes all backing traces.
+
+Skips (never fails) when no Chromium is available or the headless GL context
+can't come up, matching the repo's other browser probes.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from conftest import run_browser_probe
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "python"))
+
+import xy  # noqa: E402
+from xy.export import find_chromium  # noqa: E402
+
+_RENDER_CALLS = (
+    'xy.renderStandalone(document.getElementById("chart"), spec, bytes.buffer);',
+    'xy.renderStandalone(document.getElementById("chart"), spec, buf);',
+)
+
+
+def _data() -> dict[str, np.ndarray]:
+    return {
+        "x": np.arange(8.0),
+        "y": np.arange(8.0),
+        "temperature": np.linspace(0.0, 1.0, 8),
+    }
+
+
+def test_continuous_column_name_becomes_channel_label() -> None:
+    chart = xy.scatter_chart(xy.scatter("x", "y", data=_data(), color="temperature"))
+    trace = chart.figure().traces[0]
+    assert trace.color_ch is not None
+    assert trace.color_ch.label == "temperature"
+    assert trace.color_ch.spec()["label"] == "temperature"
+
+
+def test_continuous_array_color_ships_no_label() -> None:
+    data = _data()
+    chart = xy.scatter_chart(xy.scatter("x", "y", data=data, color=data["temperature"]))
+    trace = chart.figure().traces[0]
+    assert trace.color_ch is not None
+    assert trace.color_ch.label is None
+    assert "label" not in trace.color_ch.spec()
+
+
+def test_named_trace_keeps_both_name_and_channel_label() -> None:
+    chart = xy.scatter_chart(xy.scatter("x", "y", data=_data(), color="temperature", name="obs"))
+    trace = chart.figure().traces[0]
+    assert trace.name == "obs"
+    assert trace.color_ch.label == "temperature"
+
+
+def test_legend_highlight_option() -> None:
+    data = _data()
+    disabled = xy.scatter_chart(xy.scatter("x", "y", data=data), xy.legend(highlight=False))
+    assert disabled.figure().legend_options["highlight"] is False
+    # Default-on rides implicitly: existing specs stay byte-identical.
+    default = xy.scatter_chart(xy.scatter("x", "y", data=data), xy.legend())
+    assert "highlight" not in default.figure().legend_options
+    with pytest.raises(ValueError):
+        xy.legend(highlight="yes")
+
+
+_HIGHLIGHT_PROBE = """
+<script>
+(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  try {
+    const view = window.__fcProbeView;
+    if (!view) throw new Error("no probe view captured");
+    view._drawNow();
+    view._raf = null;
+    let rows = [];
+    for (let i = 0; i < 200; i++) {
+      rows = [...document.querySelectorAll('[data-xy-slot="legend_item"]')];
+      if (rows.length >= 4) break;
+      await sleep(25);
+    }
+    if (rows.length < 4) throw new Error(`expected 4 legend rows, got ${rows.length}`);
+    const rowNames = rows.map((row) => row.textContent);
+    const byName = (name) => rows.find((row) => row.textContent === name);
+
+    const gradientRow = byName("temperature");
+    const gradientSwatchSvg = !!gradientRow.querySelector("svg linearGradient");
+    const gradientSymbolFill = gradientRow.querySelector("svg path")?.getAttribute("fill") || "";
+
+    const dims = () => view.gpuTraces.map((g) => g._legendDim ?? null);
+    const hover = (row) => row.dispatchEvent(new PointerEvent("pointerenter"));
+    const leave = (row) => row.dispatchEvent(new PointerEvent("pointerleave"));
+
+    const alphaRow = byName("alpha");
+    hover(alphaRow);
+    const hoverAlphaDims = dims();
+    const rowOpacities = rows.map((row) => row.style.opacity);
+    leave(alphaRow);
+
+    hover(gradientRow);
+    const hoverTemperatureDims = dims();
+    leave(gradientRow);
+
+    const catRow = byName("A");
+    const catTrace = view.gpuTraces[3];
+    const lutBefore = catTrace.lut;
+    hover(catRow);
+    const hoverCategoryDims = dims();
+    const lutSwapped = catTrace._legendPrevLut !== undefined && catTrace.lut !== lutBefore;
+    leave(catRow);
+    const lutRestored = catTrace.lut === lutBefore && catTrace._legendPrevLut === undefined;
+    const afterLeaveDims = dims();
+
+    document.body.setAttribute(
+      "data-xy-legend-highlight",
+      JSON.stringify({
+        rowNames,
+        gradientSwatchSvg,
+        gradientSymbolFill,
+        hoverAlphaDims,
+        rowOpacities,
+        hoverTemperatureDims,
+        hoverCategoryDims,
+        lutSwapped,
+        lutRestored,
+        afterLeaveDims,
+      })
+    );
+  } catch (err) {
+    document.body.setAttribute(
+      "data-xy-legend-highlight-error",
+      String((err && err.stack) || err)
+    );
+  }
+})();
+</script>
+"""
+
+
+def test_browser_legend_hover_dims_other_series() -> None:
+    chromium = find_chromium()
+    if not chromium:
+        pytest.skip("no chromium available for the legend highlight probe")
+
+    data = _data()
+    chart = xy.scatter_chart(
+        # Trace 0: named, constant color — plain marker row.
+        xy.scatter("x", "y", data=data, name="alpha"),
+        # Traces 1+2: identical unnamed continuous encodings — must collapse
+        # into ONE "temperature" row that emphasizes both traces on hover.
+        xy.scatter("x", "y", data=data, color="temperature"),
+        xy.scatter("x", "y", data=data, color="temperature"),
+        # Trace 3: categorical — one row per category, LUT-dim on hover.
+        xy.scatter(
+            "x",
+            "y",
+            data=data,
+            color=np.array(["A", "B", "A", "B", "A", "B", "A", "B"]),
+        ),
+        xy.legend(),
+        width=520,
+        height=340,
+    )
+
+    document = chart.to_html()
+    render_call = next((call for call in _RENDER_CALLS if call in document), None)
+    assert render_call is not None, "to_html render call shape changed; update the probe swap"
+    capture_call = render_call.replace(
+        "xy.renderStandalone(", "window.__fcProbeView = xy.renderStandalone(", 1
+    )
+    document = document.replace(render_call, capture_call, 1)
+    document = document.replace("</body>", _HIGHLIGHT_PROBE + "\n</body>", 1)
+
+    with tempfile.TemporaryDirectory() as td:
+        page = Path(td) / "legend_highlight.html"
+        payload = run_browser_probe(
+            chromium,
+            document,
+            page,
+            "data-xy-legend-highlight",
+            label="legend highlight",
+        )
+
+    # The unnamed continuous traces surface their column name once, not two
+    # generic "value" rows; categorical categories keep one row each.
+    assert payload["rowNames"] == ["alpha", "temperature", "A", "B"], payload
+    # The continuous swatch keeps the scatter's marker identity: a symbol
+    # path filled with the colormap ramp, not a bare gradient chip.
+    assert payload["gradientSwatchSvg"] is True, payload
+    assert payload["gradientSymbolFill"].startswith("url(#"), payload
+
+    dim = 0.2
+    assert payload["hoverAlphaDims"] == [1, dim, dim, dim], payload
+    # The hovered row keeps full opacity; the other rows fade.
+    assert payload["rowOpacities"][0] == "", payload
+    assert all(opacity == "0.4" for opacity in payload["rowOpacities"][1:]), payload
+    # The deduped gradient row backs BOTH continuous traces.
+    assert payload["hoverTemperatureDims"] == [dim, 1, 1, dim], payload
+    # A category row emphasizes its trace and swaps in the dimmed palette LUT.
+    assert payload["hoverCategoryDims"] == [dim, dim, dim, 1], payload
+    assert payload["lutSwapped"] is True, payload
+    assert payload["lutRestored"] is True, payload
+    assert payload["afterLeaveDims"] == [None, None, None, None], payload

--- a/tests/test_legend_highlight.py
+++ b/tests/test_legend_highlight.py
@@ -1,8 +1,9 @@
 """Legend entry labels and hover-highlight emphasis.
 
 Python side: a continuous color encoding built from a column name carries that
-name onto the wire (`color.label`), so unnamed traces stop rendering a generic
-"value" legend row; `xy.legend(highlight=...)` gates the hover behavior.
+name onto the wire (`color.label`); `xy.legend(highlight=...)` gates the hover
+behavior. There is no generic fallback label — a trace with neither a name nor
+a label renders no legend row (matching the static exporters).
 
 Browser side: hovering a legend row dims every other series on the marks
 canvas (`_legendDim`), swaps a categorical trace's palette LUT so sibling
@@ -173,6 +174,10 @@ def test_browser_legend_hover_dims_other_series() -> None:
             data=data,
             color=np.array(["A", "B", "A", "B", "A", "B", "A", "B"]),
         ),
+        # Trace 4: unnamed continuous from a raw array — no name, no label,
+        # so it must contribute NO legend row (no generic fallback), while
+        # still dimming like any other series when a row is hovered.
+        xy.scatter("x", "y", data=data, color=data["temperature"] * 2.0),
         xy.legend(),
         width=520,
         height=340,
@@ -197,8 +202,8 @@ def test_browser_legend_hover_dims_other_series() -> None:
             label="legend highlight",
         )
 
-    # The unnamed continuous traces surface their column name once, not two
-    # generic "value" rows; categorical categories keep one row each.
+    # The unnamed labeled traces surface their column name once; the raw-array
+    # trace (no name, no label) gets NO row; categories keep one row each.
     assert payload["rowNames"] == ["alpha", "temperature", "A", "B"], payload
     # The continuous swatch keeps the scatter's marker identity: a symbol
     # path filled with the colormap ramp, not a bare gradient chip.
@@ -206,14 +211,15 @@ def test_browser_legend_hover_dims_other_series() -> None:
     assert payload["gradientSymbolFill"].startswith("url(#"), payload
 
     dim = 0.2
-    assert payload["hoverAlphaDims"] == [1, dim, dim, dim], payload
+    # The row-less trace 4 still dims with everything else on any hover.
+    assert payload["hoverAlphaDims"] == [1, dim, dim, dim, dim], payload
     # The hovered row keeps full opacity; the other rows fade.
     assert payload["rowOpacities"][0] == "", payload
     assert all(opacity == "0.4" for opacity in payload["rowOpacities"][1:]), payload
     # The deduped gradient row backs BOTH continuous traces.
-    assert payload["hoverTemperatureDims"] == [dim, 1, 1, dim], payload
+    assert payload["hoverTemperatureDims"] == [dim, 1, 1, dim, dim], payload
     # A category row emphasizes its trace and swaps in the dimmed palette LUT.
-    assert payload["hoverCategoryDims"] == [dim, dim, dim, 1], payload
+    assert payload["hoverCategoryDims"] == [dim, dim, dim, 1, dim], payload
     assert payload["lutSwapped"] is True, payload
     assert payload["lutRestored"] is True, payload
-    assert payload["afterLeaveDims"] == [None, None, None, None], payload
+    assert payload["afterLeaveDims"] == [None, None, None, None, None], payload

--- a/tests/test_legend_highlight.py
+++ b/tests/test_legend_highlight.py
@@ -24,18 +24,13 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from conftest import run_browser_probe
+from conftest import density_category_chart, probe_document, run_browser_probe
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "python"))
 
 import xy  # noqa: E402
 from xy.export import find_chromium  # noqa: E402
-
-_RENDER_CALLS = (
-    'xy.renderStandalone(document.getElementById("chart"), spec, bytes.buffer);',
-    'xy.renderStandalone(document.getElementById("chart"), spec, buf);',
-)
 
 
 def _data() -> dict[str, np.ndarray]:
@@ -183,14 +178,7 @@ def test_browser_legend_hover_dims_other_series() -> None:
         height=340,
     )
 
-    document = chart.to_html()
-    render_call = next((call for call in _RENDER_CALLS if call in document), None)
-    assert render_call is not None, "to_html render call shape changed; update the probe swap"
-    capture_call = render_call.replace(
-        "xy.renderStandalone(", "window.__fcProbeView = xy.renderStandalone(", 1
-    )
-    document = document.replace(render_call, capture_call, 1)
-    document = document.replace("</body>", _HIGHLIGHT_PROBE + "\n</body>", 1)
+    document = probe_document(chart, _HIGHLIGHT_PROBE)
 
     with tempfile.TemporaryDirectory() as td:
         page = Path(td) / "legend_highlight.html"
@@ -223,3 +211,171 @@ def test_browser_legend_hover_dims_other_series() -> None:
     assert payload["lutSwapped"] is True, payload
     assert payload["lutRestored"] is True, payload
     assert payload["afterLeaveDims"] == [None, None, None, None, None], payload
+
+
+_DENSITY_HOVER_PROBE = """
+<script>
+(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  try {
+    const view = window.__fcProbeView;
+    if (!view) throw new Error("no probe view captured");
+    view._drawNow();
+    view._raf = null;
+    let rows = [];
+    for (let i = 0; i < 200; i++) {
+      rows = [...document.querySelectorAll('[data-xy-slot="legend_item"]')];
+      if (rows.length >= 3) break;
+      await sleep(25);
+    }
+    if (rows.length < 3) throw new Error(`expected 3 category rows, got ${rows.length}`);
+    const byName = (name) => rows.find((row) => row.textContent === name);
+    const g = view.gpuTraces[0];
+    const overlay = g.sampleOverlay;
+    if (!overlay) throw new Error("density trace retained no sample overlay");
+    const overlayLutBefore = overlay.lut;
+    const texBefore = g.density.tex;
+
+    byName("B").dispatchEvent(new PointerEvent("pointerenter"));
+    const overlaySwapped =
+      overlay._legendPrevLut !== undefined && overlay.lut !== overlayLutBefore;
+    // The emphasis lives IN the plane: each cell classified by nearest
+    // palette color, sibling-category cells blended toward the background
+    // (the LUT-dim rule at cell granularity, §28-recorded approximation) —
+    // the hovered category's cells keep their full color, so no uniform
+    // recede dims the trace.
+    const texSwapped = g.density.tex !== texBefore;
+    const surfaceDim = g._legendDim ?? null;
+    const overlayDim = overlay._legendDim ?? null;
+
+    byName("B").dispatchEvent(new PointerEvent("pointerleave"));
+    const overlayRestored =
+      overlay.lut === overlayLutBefore && overlay._legendPrevLut === undefined;
+    const texRestored = g.density.tex === texBefore;
+
+    document.body.setAttribute(
+      "data-xy-density-hover",
+      JSON.stringify({
+        overlaySwapped, texSwapped, surfaceDim, overlayDim,
+        overlayRestored, texRestored,
+      })
+    );
+  } catch (err) {
+    document.body.setAttribute(
+      "data-xy-density-hover-error",
+      String((err && err.stack) || err)
+    );
+  }
+})();
+</script>
+"""
+
+
+def test_browser_density_category_hover_dims_overlay() -> None:
+    """Hovering a category row on a density-tier trace must emphasize the
+    category through the retained sample overlay's palette LUT — the
+    aggregated plane cannot dim sibling categories (§28, recorded), but the
+    overlay is a real per-point scatter and can, exactly."""
+    chromium = find_chromium()
+    if not chromium:
+        pytest.skip("no chromium available for the density hover probe")
+
+    chart, _cat, _x, _y = density_category_chart()
+    document = probe_document(chart, _DENSITY_HOVER_PROBE)
+
+    with tempfile.TemporaryDirectory() as td:
+        page = Path(td) / "density_hover.html"
+        payload = run_browser_probe(
+            chromium,
+            document,
+            page,
+            "data-xy-density-hover",
+            label="density hover",
+        )
+
+    # The overlay's palette LUT swaps to the dimmed variant on hover...
+    assert payload["overlaySwapped"] is True, payload
+    # ...and the plane swaps to a per-cell dimmed texture: sibling cells
+    # fade toward the background, the hovered category's cells stay vivid —
+    # so neither the trace nor the overlay needs a uniform dim.
+    assert payload["texSwapped"] is True, payload
+    # The hovered trace draws at full opacity — no uniform recede.
+    assert payload["surfaceDim"] == 1, payload
+    assert payload["overlayDim"] is None, payload
+    # Leave restores LUT and texture with no residue.
+    assert payload["overlayRestored"] is True, payload
+    assert payload["texRestored"] is True, payload
+
+
+_DARK_BACKDROP_PROBE = """
+<script>
+(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  try {
+    const view = window.__fcProbeView;
+    if (!view) throw new Error("no probe view captured");
+    view._drawNow();
+    view._raf = null;
+    for (let i = 0; i < 200 && !view.gpuTraces?.[0]?.density?.rgba; i++) await sleep(25);
+    const g = view.gpuTraces[0];
+    const d = g.density;
+    if (!d || !d.rgba) throw new Error("no mean-color plane");
+    const palette = g.trace.color.palette;
+    // Dim with category B hovered. Sibling cells blend toward the backdrop,
+    // and on this DARK page that can only make them darker — a cell that got
+    // BRIGHTER is the reported bug (blending toward a white fallback turns
+    // siblings into pastels). Asserted over the whole plane rather than one
+    // sampled cell, so the probe needs no copy of the classifier.
+    const dimmed = view._densityRgbaDimmed(d.rgba, palette, 1);
+    // Negative control: the same dim against the white fallback the bug used.
+    // It MUST brighten cells — otherwise the assertion below proves nothing.
+    const white = view._densityRgbaDimmed(d.rgba, palette, 1, [1, 1, 1, 1]);
+    let brightened = 0, darkened = 0, occupied = 0, whiteBrightened = 0;
+    for (let i = 0; i < d.rgba.length; i += 4) {
+      if (!d.rgba[i + 3]) continue;
+      occupied++;
+      const before = d.rgba[i] + d.rgba[i + 1] + d.rgba[i + 2];
+      const after = dimmed[i] + dimmed[i + 1] + dimmed[i + 2];
+      if (after > before) brightened++;
+      else if (after < before) darkened++;
+      if (white[i] + white[i + 1] + white[i + 2] > before) whiteBrightened++;
+    }
+    document.body.setAttribute(
+      "data-xy-dark-dim",
+      JSON.stringify({ occupied, brightened, darkened, whiteBrightened })
+    );
+  } catch (err) {
+    document.body.setAttribute("data-xy-dark-dim-error", String((err && err.stack) || err));
+  }
+})();
+</script>
+"""
+
+
+def test_browser_density_hover_dims_toward_dark_backdrop() -> None:
+    """A chart with no background of its own sits transparent over the page,
+    so the hover dim must blend sibling cells toward the page's actual
+    backdrop — on a dark page, dimming makes cells DARKER. Blending toward
+    a white fallback instead reads as sibling categories brightening into
+    pastels (the reported bug)."""
+    chromium = find_chromium()
+    if not chromium:
+        pytest.skip("no chromium available for the dark backdrop probe")
+
+    chart, _cat, _x, _y = density_category_chart()
+    document = probe_document(
+        chart, _DARK_BACKDROP_PROBE, head="<style>body{background:#0d1117}</style>"
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        page = Path(td) / "dark_backdrop.html"
+        payload = run_browser_probe(
+            chromium, document, page, "data-xy-dark-dim", label="dark backdrop dim"
+        )
+
+    assert payload["occupied"] > 0, payload
+    # Not one sibling cell brightened, and the dim actually did something.
+    assert payload["brightened"] == 0, payload
+    assert payload["darkened"] > 0, payload
+    # ...and the assertion has teeth: the old white fallback DOES brighten.
+    assert payload["whiteBrightened"] > 0, payload

--- a/tests/test_legend_toggle.py
+++ b/tests/test_legend_toggle.py
@@ -1,0 +1,279 @@
+"""Legend click-to-toggle: kernel state, masked re-aggregation, client hide.
+
+Kernel side (§34 predicate; interaction spec §10): the `legend_toggle`
+message records hidden traces/categories on the Trace; `density_view`
+re-bins under the mask (bypassing the unfiltered pyramid, tagging the
+binning label and the reply's `filter` state), drills ship only visible
+rows with canonical `shipped_sel`, selections exclude hidden rows, and
+`decimate_view` skips hidden traces.
+
+Client side: clicking a legend row hides the series — direct-tier
+categorical traces re-filter their vertex buffers locally from retained
+CPU columns (`_visMap` translates picks back to shipped rows), whole
+traces skip draw+pick, and the kernel is notified either way.
+
+Browser probes skip (never fail) without Chromium, like the repo's others.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from conftest import run_browser_probe
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "python"))
+
+import xy  # noqa: E402
+from xy import channel  # noqa: E402
+from xy._figure import Figure  # noqa: E402
+from xy.export import find_chromium  # noqa: E402
+
+_RENDER_CALLS = (
+    'xy.renderStandalone(document.getElementById("chart"), spec, bytes.buffer);',
+    'xy.renderStandalone(document.getElementById("chart"), spec, buf);',
+)
+
+
+def _density_fig(n: int = 400_000) -> tuple[Figure, np.ndarray]:
+    rng = np.random.default_rng(7)
+    x = rng.normal(size=n)
+    y = rng.normal(size=n)
+    cats = np.array(["A", "B", "C"])[rng.integers(0, 3, n)]
+    fig = Figure()
+    fig.scatter(x, y, color=cats, density=True)
+    fig.build_payload()
+    return fig, (x, y)
+
+
+def test_legend_toggle_masks_density_rebin() -> None:
+    fig, (x, y) = _density_fig()
+    t = fig.traces[0]
+    win = (x >= -3) & (x <= 3) & (y >= -3) & (y <= 3)
+
+    base = fig.density_view(0, -3, 3, -3, 3, 512, 384)[0]["traces"][0]
+    assert base["visible"] == int(win.sum())
+    assert "filter" not in base and "-masked" not in base["binning"]
+
+    reply = channel.handle_message(
+        fig, {"type": "legend_toggle", "trace": 0, "category": 1, "hidden": True}
+    )
+    assert reply is None  # fire-and-forget state sync
+    assert t.hidden_categories == {1}
+
+    entry = fig.density_view(0, -3, 3, -3, 3, 512, 384)[0]["traces"][0]
+    expect = int((win & (t.color_ch.codes != 1)).sum())
+    assert entry["binning"].endswith("-masked")
+    assert entry["visible"] == expect
+    assert entry["filter"] == {"hidden_categories": [1]}
+
+    # Untoggle restores the unmasked (pyramid-capable) path with no residue.
+    channel.handle_message(
+        fig, {"type": "legend_toggle", "trace": 0, "category": 1, "hidden": False}
+    )
+    entry = fig.density_view(0, -3, 3, -3, 3, 512, 384)[0]["traces"][0]
+    assert "-masked" not in entry["binning"]
+    assert entry["visible"] == int(win.sum())
+    assert "filter" not in entry
+
+
+def test_legend_toggle_drill_ships_only_visible_rows() -> None:
+    fig, _ = _density_fig()
+    t = fig.traces[0]
+    channel.handle_message(
+        fig, {"type": "legend_toggle", "trace": 0, "category": 1, "hidden": True}
+    )
+    entry = fig.density_view(0, -0.02, 0.02, -0.02, 0.02, 512, 384)[0]["traces"][0]
+    assert entry["mode"] == "points"
+    assert entry["filter"] == {"hidden_categories": [1]}
+    # shipped_sel is canonical: the shipped subset must contain no hidden rows,
+    # so pick/selection translation stays exact.
+    assert len(t.shipped_sel) == entry["visible"]
+    assert not np.any(t.color_ch.codes[t.shipped_sel] == 1)
+
+
+def test_legend_toggle_selection_and_hidden_trace() -> None:
+    fig, _ = _density_fig()
+    t = fig.traces[0]
+    channel.handle_message(
+        fig, {"type": "legend_toggle", "trace": 0, "category": 1, "hidden": True}
+    )
+    sel = fig.select_range(-10, 10, -10, 10)
+    assert not np.any(t.color_ch.codes[sel[0]] == 1)
+    assert len(sel[0]) == int((t.color_ch.codes != 1).sum())
+
+    channel.handle_message(fig, {"type": "legend_toggle", "trace": 0, "hidden": True})
+    assert fig.density_view(0, -3, 3, -3, 3, 512, 384)[0]["traces"] == []
+    assert fig.select_range(-10, 10, -10, 10) == {}
+
+
+def test_legend_toggle_skips_hidden_line_decimation() -> None:
+    n = 300_000
+    x = np.linspace(0, 1000, n)
+    y = np.sin(x / 7.0)
+    fig = Figure()
+    fig.line(x, y)
+    fig.build_payload()
+    assert fig.decimate_view(100.0, 200.0, 800)[0]["traces"]
+    fig.legend_toggle(0, True)
+    assert fig.decimate_view(100.0, 200.0, 800)[0]["traces"] == []
+
+
+def test_legend_toggle_validation_never_mutates() -> None:
+    fig, _ = _density_fig()
+    t = fig.traces[0]
+    # Out-of-range category, non-bool hidden, and a non-categorical trace all
+    # return None (malformed-client contract) and leave state untouched.
+    assert (
+        channel.handle_message(
+            fig, {"type": "legend_toggle", "trace": 0, "category": 99, "hidden": True}
+        )
+        is None
+    )
+    assert (
+        channel.handle_message(fig, {"type": "legend_toggle", "trace": 0, "hidden": "yes"}) is None
+    )
+    assert t.hidden_categories == set() and t.hidden is False
+
+    plain = Figure()
+    plain.scatter(np.arange(10.0), np.arange(10.0))
+    with pytest.raises(ValueError):
+        plain.legend_toggle(0, True, category=0)
+
+
+def test_legend_toggle_option() -> None:
+    data = {"x": np.arange(8.0), "y": np.arange(8.0)}
+    disabled = xy.scatter_chart(xy.scatter("x", "y", data=data), xy.legend(toggle=False))
+    assert disabled.figure().legend_options["toggle"] is False
+    default = xy.scatter_chart(xy.scatter("x", "y", data=data), xy.legend())
+    assert "toggle" not in default.figure().legend_options
+    with pytest.raises(ValueError):
+        xy.legend(toggle="yes")
+
+
+_TOGGLE_PROBE = """
+<script>
+(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  try {
+    const view = window.__fcProbeView;
+    if (!view) throw new Error("no probe view captured");
+    view._drawNow();
+    view._raf = null;
+    const sent = [];
+    view.comm = { send: (m) => sent.push(m) };
+    let rows = [];
+    for (let i = 0; i < 200; i++) {
+      rows = [...document.querySelectorAll('[data-xy-slot="legend_item"]')];
+      if (rows.length >= 3) break;
+      await sleep(25);
+    }
+    if (rows.length < 3) throw new Error(`expected 3 legend rows, got ${rows.length}`);
+    const byName = (name) => rows.find((row) => row.textContent === name);
+    const click = (row) => row.dispatchEvent(new MouseEvent("click"));
+    const cat = view.gpuTraces[1];
+    const fullN = cat.n;
+
+    // Category toggle: filtered buffers, pick map, kernel notified.
+    click(byName("A"));
+    const afterHideN = cat.n;
+    const hasVisMap = !!cat._visMap;
+    let mappedClean = true;
+    for (let j = 0; j < cat.n; j++) {
+      if (cat._cpu.color[cat._visMap[j]] === 0) mappedClean = false;
+    }
+    const rowOff = byName("A").dataset.xyLegendOff !== undefined;
+
+    // Hovering a toggled-off row must not emphasize anything.
+    byName("A").dispatchEvent(new PointerEvent("pointerenter"));
+    const offHoverDims = view.gpuTraces.map((g) => g._legendDim ?? null);
+    byName("A").dispatchEvent(new PointerEvent("pointerleave"));
+
+    // Untoggle restores the full buffers.
+    click(byName("A"));
+    const restoredN = cat.n;
+    const visMapCleared = !cat._visMap;
+
+    // Whole-trace toggle: draw+pick skip flag and kernel notification.
+    click(byName("alpha"));
+    const alphaHidden = !!view.gpuTraces[0]._legendHidden;
+    view._renderPick();
+    const alphaUnpickable = view.gpuTraces[0].pickCount === 0;
+    click(byName("alpha"));
+    const alphaRestored = !view.gpuTraces[0]._legendHidden;
+
+    document.body.setAttribute(
+      "data-xy-legend-toggle",
+      JSON.stringify({
+        fullN, afterHideN, hasVisMap, mappedClean, rowOff, offHoverDims,
+        restoredN, visMapCleared, alphaHidden, alphaUnpickable, alphaRestored,
+        sent,
+      })
+    );
+  } catch (err) {
+    document.body.setAttribute(
+      "data-xy-legend-toggle-error",
+      String((err && err.stack) || err)
+    );
+  }
+})();
+</script>
+"""
+
+
+def test_browser_legend_click_toggles_series() -> None:
+    chromium = find_chromium()
+    if not chromium:
+        pytest.skip("no chromium available for the legend toggle probe")
+
+    codes = np.array(["A", "A", "A", "A", "A", "B", "B", "B"])
+    data = {"x": np.arange(8.0), "y": np.arange(8.0)}
+    chart = xy.scatter_chart(
+        xy.scatter("x", "y", data=data, name="alpha"),
+        xy.scatter("x", "y", data=data, color=codes),
+        xy.legend(),
+        width=520,
+        height=340,
+    )
+
+    document = chart.to_html()
+    render_call = next((call for call in _RENDER_CALLS if call in document), None)
+    assert render_call is not None, "to_html render call shape changed; update the probe swap"
+    document = document.replace(
+        render_call,
+        render_call.replace(
+            "xy.renderStandalone(", "window.__fcProbeView = xy.renderStandalone(", 1
+        ),
+        1,
+    )
+    document = document.replace("</body>", _TOGGLE_PROBE + "\n</body>", 1)
+
+    with tempfile.TemporaryDirectory() as td:
+        page = Path(td) / "legend_toggle.html"
+        payload = run_browser_probe(
+            chromium, document, page, "data-xy-legend-toggle", label="legend toggle"
+        )
+
+    assert payload["fullN"] == 8 and payload["afterHideN"] == 3, payload
+    assert payload["hasVisMap"] is True and payload["mappedClean"] is True, payload
+    assert payload["rowOff"] is True, payload
+    # Off rows are inert for hover emphasis.
+    assert payload["offHoverDims"] == [None, None], payload
+    assert payload["restoredN"] == 8 and payload["visMapCleared"] is True, payload
+    assert payload["alphaHidden"] is True and payload["alphaUnpickable"] is True, payload
+    assert payload["alphaRestored"] is True, payload
+    # Kernel stays in sync: every click shipped a legend_toggle message.
+    kinds = [
+        (m.get("type"), m.get("trace"), m.get("category"), m.get("hidden")) for m in payload["sent"]
+    ]
+    assert kinds == [
+        ("legend_toggle", 1, 0, True),
+        ("legend_toggle", 1, 0, False),
+        ("legend_toggle", 0, None, True),
+        ("legend_toggle", 0, None, False),
+    ], payload["sent"]

--- a/tests/test_legend_toggle.py
+++ b/tests/test_legend_toggle.py
@@ -17,6 +17,8 @@ Browser probes skip (never fail) without Chromium, like the repo's others.
 
 from __future__ import annotations
 
+import base64
+import json
 import sys
 import tempfile
 from pathlib import Path
@@ -24,7 +26,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from conftest import run_browser_probe
+from conftest import density_category_chart, probe_document, run_browser_probe
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "python"))
@@ -33,11 +35,6 @@ import xy  # noqa: E402
 from xy import channel  # noqa: E402
 from xy._figure import Figure  # noqa: E402
 from xy.export import find_chromium  # noqa: E402
-
-_RENDER_CALLS = (
-    'xy.renderStandalone(document.getElementById("chart"), spec, bytes.buffer);',
-    'xy.renderStandalone(document.getElementById("chart"), spec, buf);',
-)
 
 
 def _density_fig(n: int = 400_000) -> tuple[Figure, np.ndarray]:
@@ -146,6 +143,29 @@ def test_legend_toggle_validation_never_mutates() -> None:
         plain.legend_toggle(0, True, category=0)
 
 
+def test_density_entry_ships_slim_categorical_spec() -> None:
+    # A categorical density trace aggregates its per-point codes into the
+    # mean-color plane, but the legend still needs the encoding to offer
+    # category rows — without them the §10 density-tier category toggle is
+    # unreachable. The spec ships slim: categories + palette, no `buf`.
+    fig, _ = _density_fig()
+    entry = fig.build_payload()[0]["traces"][0]
+    assert entry["tier"] == "density"
+    color = entry["color"]
+    assert color["mode"] == "categorical"
+    assert color["categories"] == ["A", "B", "C"]
+    assert len(color["palette"]) == 3
+    assert "buf" not in color
+
+    # Continuous stays deliberately unshipped: a gradient legend row on an
+    # aggregated surface would claim color == density.
+    cont = Figure()
+    rng = np.random.default_rng(3)
+    xs = rng.normal(size=1000)
+    cont.scatter(xs, rng.normal(size=1000), color=np.abs(xs), density=True)
+    assert "color" not in cont.build_payload()[0]["traces"][0]
+
+
 def test_legend_toggle_option() -> None:
     data = {"x": np.arange(8.0), "y": np.arange(8.0)}
     disabled = xy.scatter_chart(xy.scatter("x", "y", data=data), xy.legend(toggle=False))
@@ -226,6 +246,283 @@ _TOGGLE_PROBE = """
 """
 
 
+_DENSITY_TOGGLE_PROBE = """
+<script>
+(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const b64 = (s) => Uint8Array.from(atob(s), (c) => c.charCodeAt(0)).buffer;
+  try {
+    const view = window.__fcProbeView;
+    if (!view) throw new Error("no probe view captured");
+    view._drawNow();
+    view._raf = null;
+    const sent = [];
+    view.comm = { send: (m) => sent.push(m) };
+    let rows = [];
+    for (let i = 0; i < 200; i++) {
+      rows = [...document.querySelectorAll('[data-xy-slot="legend_item"]')];
+      if (rows.length >= 3) break;
+      await sleep(25);
+    }
+    if (rows.length < 3) throw new Error(`expected 3 category rows, got ${rows.length}`);
+    const byName = (name) => rows.find((row) => row.textContent === name);
+    const click = (row) => row.dispatchEvent(new MouseEvent("click"));
+    const g = view.gpuTraces[0];
+    const gridTotal = () => {
+      const d = g.density;
+      let s = 0;
+      for (let i = 0; i < d.grid.length; i++) s += d.grid[i];
+      return Math.round(s);
+    };
+    const totalBefore = gridTotal();
+
+    // Toggle category B off: the kernel must be notified AND a masked
+    // re-bin must be REQUESTED even though the standing home aggregate
+    // still covers the view (§10: filter-dirty beats aggregate-stands and
+    // the T13 duplicate memo).
+    click(byName("B"));
+    await sleep(50);
+    const maskReq = sent.find((m) => m.type === "density_view");
+
+    // Feed the client the kernel's actual masked reply (precomputed by the
+    // Python kernel below, byte-faithful envelope). It must REPLACE the
+    // standing unfiltered texture, not land facts-only (§34: a covering
+    // texture binned under another hidden set is a stale aggregate).
+    const reply = window.__fcMaskedReply;
+    reply.message.seq = maskReq ? maskReq.seq : -1;
+    view._onKernelMsg(reply.message, reply.buffers.map(b64));
+    const totalMasked = gridTotal();
+    const keyMasked = g.density._filterKey;
+
+    // Untoggle: same window, same screen — but a different hidden set, so
+    // the "answered duplicate" memo must not swallow the restore request.
+    click(byName("B"));
+    await sleep(50);
+    const restoreReq = sent.filter((m) => m.type === "density_view").length;
+    const toggleMsgs = sent.filter((m) => m.type === "legend_toggle");
+
+    document.body.setAttribute(
+      "data-xy-density-toggle",
+      JSON.stringify({
+        totalBefore, toggleMsgs, maskReqSent: !!maskReq,
+        totalMasked, keyMasked, densityViewCount: restoreReq,
+      })
+    );
+  } catch (err) {
+    document.body.setAttribute(
+      "data-xy-density-toggle-error",
+      String((err && err.stack) || err)
+    );
+  }
+})();
+</script>
+"""
+
+
+def test_browser_density_category_toggle_rebins() -> None:
+    """The §10 density-tier category toggle, end to end against the real
+    client: category rows exist (slim color spec), a toggle forces a masked
+    re-bin request past every T13 elision layer (aggregate-stands, the
+    answered-duplicate memo), the kernel's stamped reply repaints the
+    standing texture (never facts-only across filter keys), and the
+    untoggle re-requests. Each assertion is one of the elisions that
+    silently swallowed the round-trip."""
+    chromium = find_chromium()
+    if not chromium:
+        pytest.skip("no chromium available for the density toggle probe")
+
+    chart, cat, x, y = density_category_chart()
+
+    # The kernel's own masked reply for the home window — the byte-faithful
+    # envelope a live transport would deliver after the toggle's
+    # legend_toggle message.
+    fig = chart.figure()
+    fig.build_payload()
+    assert (
+        channel.handle_message(
+            fig, {"type": "legend_toggle", "trace": 0, "category": 1, "hidden": True}
+        )
+        is None
+    )
+    reply = channel.handle_message(
+        fig,
+        {
+            "type": "density_view",
+            "trace": 0,
+            "seq": 0,
+            "x0": float(x.min()),
+            "x1": float(x.max()),
+            "y0": float(y.min()),
+            "y1": float(y.max()),
+            "w": 512,
+            "h": 384,
+        },
+    )
+    assert reply is not None
+    masked_message, masked_buffers = reply
+    entry = masked_message["traces"][0]
+    assert entry["binning"].endswith("-masked") and entry["filter"] == {"hidden_categories": [1]}
+
+    reply_js = json.dumps(
+        {
+            "message": masked_message,
+            "buffers": [base64.b64encode(bytes(b)).decode() for b in masked_buffers],
+        }
+    )
+
+    document = probe_document(
+        chart,
+        _DENSITY_TOGGLE_PROBE,
+        head=f"<script>window.__fcMaskedReply = {reply_js};</script>",
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        page = Path(td) / "density_toggle.html"
+        payload = run_browser_probe(
+            chromium, document, page, "data-xy-density-toggle", label="density toggle"
+        )
+
+    # Home grid bins every point.
+    assert payload["totalBefore"] == pytest.approx(cat.size, rel=0.01), payload
+    # The toggle synced the kernel...
+    assert [(m["trace"], m["category"], m["hidden"]) for m in payload["toggleMsgs"]] == [
+        (0, 1, True),
+        (0, 1, False),
+    ], payload
+    # ...and REQUESTED the masked re-bin (aggregate-stands + dup-memo bypass).
+    assert payload["maskReqSent"] is True, payload
+    # The stamped reply repainted the standing texture: ~2/3 of the points.
+    assert payload["totalMasked"] == pytest.approx((cat != 1).sum(), rel=0.02), payload
+    assert payload["keyMasked"] == "1", payload
+    # The untoggle re-requested despite the answered same-window memo.
+    assert payload["densityViewCount"] == 2, payload
+
+
+_DRILL_DIRTY_PROBE = """
+<script>
+(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const b64 = (s) => Uint8Array.from(atob(s), (c) => c.charCodeAt(0)).buffer;
+  try {
+    const view = window.__fcProbeView;
+    if (!view) throw new Error("no probe view captured");
+    view._drawNow();
+    view._raf = null;
+    const sent = [];
+    view.comm = { send: (m) => sent.push(m) };
+    let rows = [];
+    for (let i = 0; i < 200; i++) {
+      rows = [...document.querySelectorAll('[data-xy-slot="legend_item"]')];
+      if (rows.length >= 3) break;
+      await sleep(25);
+    }
+    if (rows.length < 3) throw new Error(`expected 3 category rows, got ${rows.length}`);
+    const byName = (name) => rows.find((row) => row.textContent === name);
+    const g = view.gpuTraces[0];
+
+    byName("B").dispatchEvent(new MouseEvent("click"));
+    await sleep(50);
+    const maskReq = sent.find((m) => m.type === "density_view");
+    const dirtyAfterToggle = !!g._filterDirty;
+
+    // Feed the kernel's masked POINTS reply (a window under the drill
+    // budget). Its filter stamp matches the client's mask, so it is
+    // admitted — but it lands no aggregate under that mask: the only
+    // standing grid is still the unmasked home texture.
+    const reply = window.__fcMaskedDrillReply;
+    reply.message.seq = maskReq ? maskReq.seq : -1;
+    view._onKernelMsg(reply.message, reply.buffers.map(b64));
+    const drillApplied = !!g.drill;
+    const dirtyAfterDrill = !!g._filterDirty;
+
+    // The elision the flag exists to defeat (§10): with the unmasked home
+    // aggregate still standing (and filter-blind), request planning must
+    // keep forcing the full-window masked re-bin until a mask-stamped
+    // AGGREGATE lands — otherwise the stale texture draws forever once the
+    // drill retires.
+    const plan = view._densityRequestPlan(g, view.view);
+    const planForcesFullWindow = !!(plan && plan.step === false);
+
+    document.body.setAttribute(
+      "data-xy-drill-dirty",
+      JSON.stringify({ maskReqSent: !!maskReq, dirtyAfterToggle, drillApplied,
+                       dirtyAfterDrill, planForcesFullWindow })
+    );
+  } catch (err) {
+    document.body.setAttribute(
+      "data-xy-drill-dirty-error",
+      String((err && err.stack) || err)
+    );
+  }
+})();
+</script>
+"""
+
+
+def test_browser_masked_drill_reply_keeps_filter_dirty() -> None:
+    """A masked points-mode reply must NOT clear `_filterDirty`: it lands no
+    aggregate under the mask, so the unmasked home texture is still the only
+    standing grid. If the flag clears, `lodAggregateStands` (filter-blind)
+    re-arms the T13 elision and the stale unmasked surface draws indefinitely
+    once the drill retires, while the legend row reads hidden."""
+    chromium = find_chromium()
+    if not chromium:
+        pytest.skip("no chromium available for the drill filter-dirty probe")
+
+    chart, cat, x, y = density_category_chart()
+
+    fig = chart.figure()
+    fig.build_payload()
+    channel.handle_message(
+        fig, {"type": "legend_toggle", "trace": 0, "category": 1, "hidden": True}
+    )
+    reply = channel.handle_message(
+        fig,
+        {
+            "type": "density_view",
+            "trace": 0,
+            "seq": 0,
+            "x0": -0.02,
+            "x1": 0.02,
+            "y0": -0.02,
+            "y1": 0.02,
+            "w": 512,
+            "h": 384,
+        },
+    )
+    assert reply is not None
+    drill_message, drill_buffers = reply
+    entry = drill_message["traces"][0]
+    assert entry["mode"] == "points"
+    assert entry["filter"] == {"hidden_categories": [1]}
+
+    reply_js = json.dumps(
+        {
+            "message": drill_message,
+            "buffers": [base64.b64encode(bytes(b)).decode() for b in drill_buffers],
+        }
+    )
+
+    document = probe_document(
+        chart,
+        _DRILL_DIRTY_PROBE,
+        head=f"<script>window.__fcMaskedDrillReply = {reply_js};</script>",
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        page = Path(td) / "drill_dirty.html"
+        payload = run_browser_probe(
+            chromium, document, page, "data-xy-drill-dirty", label="drill filter-dirty"
+        )
+
+    assert payload["maskReqSent"] is True, payload
+    assert payload["dirtyAfterToggle"] is True, payload
+    assert payload["drillApplied"] is True, payload
+    # The contract under test: only a mask-stamped aggregate clears the flag.
+    assert payload["dirtyAfterDrill"] is True, payload
+    assert payload["planForcesFullWindow"] is True, payload
+
+
 def test_browser_legend_click_toggles_series() -> None:
     chromium = find_chromium()
     if not chromium:
@@ -241,17 +538,7 @@ def test_browser_legend_click_toggles_series() -> None:
         height=340,
     )
 
-    document = chart.to_html()
-    render_call = next((call for call in _RENDER_CALLS if call in document), None)
-    assert render_call is not None, "to_html render call shape changed; update the probe swap"
-    document = document.replace(
-        render_call,
-        render_call.replace(
-            "xy.renderStandalone(", "window.__fcProbeView = xy.renderStandalone(", 1
-        ),
-        1,
-    )
-    document = document.replace("</body>", _TOGGLE_PROBE + "\n</body>", 1)
+    document = probe_document(chart, _TOGGLE_PROBE)
 
     with tempfile.TemporaryDirectory() as td:
         page = Path(td) / "legend_toggle.html"


### PR DESCRIPTION
**Stacked on #249** — base is `feat/legend-highlight-labels`; this diff is only the toggle work. After #249 squash-merges, rebase with `git rebase --onto main feat/legend-highlight-labels feat/legend-click-toggle`.

## What

Clicking a legend row hides/shows its series or category — the first shipped slice of the dossier §34 filtering model.

**Wire (one new message):** `legend_toggle {trace, category?, hidden}`, fire-and-forget. The kernel records `Trace.hidden` / `Trace.hidden_categories`; re-aggregation rides the client's next `density_view` request rather than a second reply shape.

**Kernel:**
- `density_view` narrows rows to the visible set before any aggregation, **bypasses the unfiltered pyramid while a mask is active** (§34's core point — static aggregates are wrong under any dynamic predicate), tags masked replies `binning: *-masked`, and stamps them with `filter: {hidden_categories}` (§37 filter_hash-lite). Drills ship only visible rows with canonical `shipped_sel`.
- `select`/`select_polygon` exclude hidden traces and categories; `decimate_view` skips hidden traces. Visible-row scans cache per (hidden set, column length).

**Client, by entry kind:**
- *Whole-trace rows*: local hide — draw, pick, and badge skip; a deduped continuous row hides all its backing traces.
- *Category rows, direct tier*: vertex buffers re-filter from the retained CPU columns — **0 wire bytes** (§37 filter-toggle row). `_visMap`/`_visInv` keep picks, tooltips, and kernel selection masks exact; style/stroke buffers are read back once via `getBufferSubData`.
- *Category rows, density tier*: local density/point-window caches drop (a covered cached window would elide the kernel request), sample overlays filter locally, and the normal request path fetches the masked re-bin; **stale-predicate replies are dropped** by comparing the reply's filter stamp against the client's current set.
- Off rows fade + grayscale (`data-xy-legend-off`), stay inert for #249's hover emphasis; toggle state survives GPU rebuilds (context restore, append). Opt-out: `xy.legend(toggle=False)`; `xy:legendtoggle` DOM event.

**Recorded limits (spec §10):** toggles never autoscale; state doesn't enter durable view state/history yet; standalone (kernel-less) density grids stay unmasked (sample overlays do filter).

## Spec
`spec/api/interaction.md` §10 (full contract) · `spec/design/wire-protocol.md` (`legend_toggle` + `filter` stamp) · `spec/design-dossier.md` §34 shipped-slice note + §36 chrome note.

## Tests
`tests/test_legend_toggle.py`: kernel round-trips (masked re-bin counts vs NumPy ground truth, filtered drill + canonical `shipped_sel`, selection exclusion, decimation skip, validation-never-mutates) + a headless-Chromium probe (click → buffer filter 8→3 with clean pick map, inert off-row hover, restore, whole-trace hide + unpickable, exact wire message sequence).

Full suite: **2227 passed, 1 skipped**; ABI + render smokes pass; `node js/build.mjs` clean; pre-commit/ruff clean; `ty` back to the 3 pre-existing diagnostics.