### PR TITLE
Make Reflex the single application runtime in the runtime decision doc

### DIFF
--- a/docs/advanced/runtime-and-deployment.md
+++ b/docs/advanced/runtime-and-deployment.md
@@ -1,76 +1,134 @@
 ---
 title: Choosing a Runtime and Deployment Mode
-description: Use Reflex for deployed interactive apps, notebooks for exploration, standalone HTML for sharing, or static renderers for reports.
+description: XY applications run on Reflex. Choose a Reflex data tier for apps, and a notebook, HTML file, or static image for everything that is not an app.
 ---
 
 # Choosing a Runtime and Deployment Mode
 
-For a deployed interactive application, start with Reflex. XY charts become
-first-class components in an all-Python web app: Reflex handles UI, state,
-events, and deployment, while XY handles data transport, rendering, and
-interaction math. Start with a fixed chart and move to a session-backed figure
-when the app needs live data without rewriting the chart definition.
+If you are building an application, the runtime is Reflex. XY does not ship a
+second application runtime and does not embed into another web framework. The
+choice you actually make is *inside* Reflex: which data tier a chart uses.
 
-XY also works outside an application. Use notebooks for exploration,
-standalone HTML for a portable interactive result, and PNG or SVG for static
-output.
+Everything else here — notebooks, standalone HTML, PNG, SVG — is not an
+application runtime. Those are exploration and output.
 
-## Start with Reflex for Applications
+## Applications run on Reflex
 
-Reflex gives XY the application capabilities a standalone chart cannot:
+XY charts are first-class Reflex components in an all-Python app. Reflex owns
+UI, state, events, and deployment; XY owns transport, rendering, and
+interaction math.
 
 - Compose XY charts with normal Reflex components in Python.
 - Drive charts from per-session state with `@reflex_xy.figure`.
-- Connect hover, click, selection, and view changes to normal Reflex event
-  handlers, then stream updates with `reflex_xy.append`.
+- Connect hover, click, selection, and view changes to Reflex event handlers,
+  then stream updates with `reflex_xy.append`.
 - Reuse the app's existing websocket and XY's binary data plane instead of
   deploying a separate chart service.
-- Compile fixed charts into assets that work with `reflex export` and need no
-  backend connection.
 
-The adapter is still experimental and installed from the matching XY Git tag.
-See the [Reflex integration guide](/docs/xy/integrations/reflex/) for the
-current installation and API boundary.
+`reflex-xy` is experimental and is **not a published package**. Install it from
+the matching XY Git tag, and do not put `pip install reflex-xy` in production
+automation. See [Deployment Recipes](/docs/xy/guides/deployment-recipes/).
 
-## Compare the modes
+## Choose a data tier
 
-| Mode | Best for |
+The chart definition is identical in every tier. What changes is where its data
+comes from, and therefore what the chart can still do after you deploy.
+
+| Tier | Data comes from | Live Python | Events | `append()` | Exact row selection | `reflex export` |
+| --- | --- | --- | --- | --- | --- | --- |
+| `reflex_xy.chart(chart)` | fixed, compiled into an asset | no | browser-local | no | no | yes |
+| `reflex_xy.inline(chart)` | fixed, kept in the XY registry | yes | yes | yes | yes | no |
+| `@reflex_xy.figure` | per-session Reflex state | yes | yes | yes | yes | no |
+
+Browser-local means hover, pan, zoom, and selection still work in the page;
+they just cannot reach Python.
+
+Start at the top. A fixed `xy.Chart` becomes a content-addressed asset that
+needs no backend connection and survives `reflex export`. Move down only when
+the chart must answer with data it did not ship with — a drill-down, a fresh
+query, the exact rows behind a lasso.
+
+Despite its name, `inline()` is the live, kernel-backed fixed-data tier; passing
+a `Chart` directly is the static tier. Call `inline()` at module scope so every
+backend worker registers the same content-addressed token.
+
+There is also `reflex_xy.register()`, an imperative dev-tier escape hatch. Its
+figure lives only in the registering process and cannot be rebuilt after a
+worker restart or on another node, so do not deploy it.
+
+## Moving down a tier is a wrapper change
+
+The chart definition does not change; only its source does.
+
+~~~python
+# Fixed asset tier
+def page():
+    return rx.vstack(
+        reflex_xy.chart(
+            xy.scatter_chart(xy.scatter(x="orders", y="revenue", data=daily))
+        )
+    )
+
+
+# Session-backed tier — same chart, now driven by state
+class Dashboard(rx.State):
+    channel: str = "web"
+
+    @reflex_xy.figure
+    def revenue(self) -> xy.Chart:
+        rows = daily[daily.channel == self.channel]
+        return xy.scatter_chart(xy.scatter(x="orders", y="revenue", data=rows))
+
+
+def page():
+    return rx.vstack(reflex_xy.chart(Dashboard.revenue))
+~~~
+
+See the [Reflex integration guide](/docs/xy/integrations/reflex/) for component
+props, event payloads, and the API boundary.
+
+## Outside an application
+
+Not every chart belongs in an app. The same definition runs in a notebook and
+exports to files.
+
+~~~python
+chart = xy.scatter_chart(xy.scatter(x="orders", y="revenue", data=daily))
+
+chart.show()                 # notebook widget — live Python, dies with the kernel
+chart.to_html("out.html")    # one portable interactive file, no server
+chart.to_png("out.png")      # static raster
+chart.to_svg("out.svg")      # static vector
+~~~
+
+| Output | Best for | Live Python |
+| --- | --- | --- |
+| Notebook widget | Exploration, callbacks, streaming, exact refinement | yes |
+| Standalone HTML | A portable interactive file that works without a server | no |
+| Static images | Reports, tests, thumbnails, batch output | no |
+
+For formats beyond PNG and SVG — JPEG, WebP, PDF, and batch `write_images` —
+and for the native-versus-Chromium engine choice, see
+[Display and Export](/docs/xy/guides/display-and-export/).
+
+## Know what each choice costs you
+
+| Choice | The catch |
 | --- | --- |
-| Reflex `@reflex_xy.figure` | Stateful Python applications with per-session data, events, streaming, and exact live refinement |
-| Reflex fixed chart | Exportable Reflex sites and application views with fixed data and browser interaction |
-| Reflex `inline()` | Fixed application data that still needs live Python round-trips and Reflex events |
-| Notebook widget | Exploration, callbacks, streaming, and exact live refinement |
-| Standalone HTML | A portable interactive file that works without a server |
-| Native PNG | Fast reports, tests, thumbnails, and batch output |
-| Chromium PNG | Static output matching browser fonts, CSS, and WebGL rendering |
-| SVG | Scalable or editable browser-free output |
+| Fixed Reflex chart | No Python round-trip: no drill-down, no exact selection resolution. |
+| `register()` | Not rebuildable after a worker restart or on another node. Dev only. |
+| Notebook widget | Dies with the kernel; not shareable as-is. |
+| Standalone HTML | A snapshot — later `append()` calls never reach it. It needs inline script and style plus a `blob:` worker under its emitted CSP, and anyone who downloads it can read the embedded data. |
+| Native PNG | Cannot apply author `custom_css`. Use renderable chart and mark styles, or `Engine.chromium`. |
+| Chromium PNG | Requires a browser on the machine that renders. |
+| SVG | Density and heatmap layers embed raster data, so output is not fully vector. Requesting SVG from the browser engine raises `ValueError`. |
+| Any streaming tier | `append()` covers scatter and line traces only, and facets support neither append nor pick. |
 
-## Follow the decision path
+Full list: [Limitations and Alpha Status](/docs/xy/api-reference/limitations-and-alpha-status/).
 
-1. **Building an interactive application? Start with Reflex.** Pass an
-   `xy.Chart` directly when its data is fixed and exportable. Use
-   `@reflex_xy.figure` when data depends on the current session or Reflex
-   state. Use module-scope `inline()` for fixed data that still needs live
-   Python refinement.
-2. **Exploring data? Use the notebook widget.** It keeps callbacks, streaming,
-   and exact refinement close to the analysis kernel.
-3. **Sharing an interactive result without a server?** Use standalone HTML.
-4. **Producing a static artifact?** Choose native PNG for speed, SVG for
-   scalable output, or Chromium PNG for browser-level visual fidelity.
+## Where to go next
 
-## Understand the deployment boundary
-
-Reflex makes the live Python boundary explicit. A direct `xy.Chart` becomes a
-content-addressed asset that works with `reflex export`. An `inline()` or
-`@reflex_xy.figure` source stays connected to the Reflex backend through the
-app's existing websocket, enabling events, streaming, and exact row
-resolution.
-
-Notebook widgets also keep a live Python figure. Standalone HTML and fixed
-Reflex charts retain browser-local hover, pan, zoom, and selection, but cannot
-call a Python process after deployment. PNG and SVG are final static artifacts.
-
-For most deployed interactive work, continue with
-[Reflex](/docs/xy/integrations/reflex/). For exploration, see
-[Notebooks](/docs/xy/integrations/notebooks/). For portable files and static
-rendering, see [Display and Export](/docs/xy/guides/display-and-export/).
+- Applications → [Reflex integration](/docs/xy/integrations/reflex/)
+- Exploration → [Notebooks](/docs/xy/integrations/notebooks/)
+- Files and static output → [Display and Export](/docs/xy/guides/display-and-export/)
+- Hosting, CSP, offline → [Serving, CSP, and offline use](/docs/xy/guides/serving-csp-and-offline-use/)


### PR DESCRIPTION
## Why

`docs/advanced/runtime-and-deployment.md` listed `@reflex_xy.figure` as one of eight peer rows in a single "Compare the modes" table, alongside `Standalone HTML` and `Native PNG`, and told the reader to "**start with** Reflex." That framing implies XY has more than one application runtime. It does not — nothing in the docs names another framework, and there is no embedding path.

The page also had two structural problems:

- **Nothing pointed at it.** Two inbound links, both from pages that duplicate its content (`advanced/index.md`, which prints a near-identical table and *then* links here for "the full decision guide", and `guides/deployment-recipes.md`). No links from `docs/index.md`, `overview/first-chart.md`, `integrations/reflex.md`, `integrations/notebooks.md`, or `guides/display-and-export.md` — none of the pages a reader making this decision is actually on.
- **No code.** One of only eight code-free pages out of 70; the other seven are index, changelog, and policy pages. Its central claim — the chart definition stays the same, only the runtime changes — was asserted four times and never shown.

## What changed

Two levels instead of one flat list:

1. **Applications run on Reflex.** Stated, not offered. Notebooks, HTML, and static images move to their own section as exploration and output, not competing runtimes.
2. **The only real choice is the Reflex data tier**, so the capability matrix lives there: live Python / events / `append()` / exact row selection / `reflex export`, with a start-at-the-top rule (fixed asset by default; move down only when the chart must answer with data it did not ship with).

Also folded in:

- Two code blocks: the fixed → session-backed wrapper change, and the four non-app one-liners off an identical `chart`.
- A "what each choice costs you" table, assembled from constraints already documented in `limitations-and-alpha-status.md`, `serving-csp-and-offline-use.md`, and `deployment-recipes.md` but absent here: HTML is a snapshot needing inline script/style and a `blob:` worker, with readable embedded data; native PNG cannot apply `custom_css`; SVG embeds raster for density and heatmap layers and raises `ValueError` from the browser engine; `append()` covers scatter and line only.
- `reflex_xy.register()` documented as a dev-tier escape hatch — it is public in `reflex_xy.__all__` but appeared in no doc page.
- The adapter warning now matches `deployment-recipes.md`, which is stronger: `reflex-xy` is not a published package.
- Formats beyond PNG/SVG (JPEG, WebP, PDF, batch `write_images`) defer to `display-and-export.md` rather than being silently omitted from a table that claims to compare modes.

558 → ~750 words.

## Verification

- All six internal `/docs/xy/…` links resolve to real pages.
- `codespell --toml docs/app/pyproject.toml` passes; `ruff` skipped the change (no Python touched).
- **The docs-app test suite was not run locally** — neither `.venv` in this checkout has `reflex` installed and provisioning it needs a Rust + JS build. No test asserts on this page's content (`grep` for `runtime-and-deployment` across `docs/app/tests/`, `tests/`, `scripts/` returns nothing), and the nav/sitemap tests key off `config.py`, which is untouched. CI covers it.

## Deliberately not in this PR

The page still overlaps three others, and consolidating means deciding which one wins:

- `integrations/reflex.md:191` has its own "Choose a Data Tier" table with more precise call sites. Either it drops to a pointer, or this page does and shrinks to a signpost.
- `advanced/index.md:111` "Runtime and output choices" should become a link.
- Inbound links from `first-chart.md` ("Choose your next step") and `display-and-export.md` are still missing.

Worth doing, but it is an information-architecture call rather than a copy fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rewrote the runtime and deployment guide with clearer guidance on how XY charts operate within Reflex applications.
  * Added a comparison of available data tiers, including live data, browser-local charts, and fixed figures.
  * Documented deployment, streaming, event handling, export support, and usage limitations.
  * Added examples and updated navigation for application, notebook, HTML, image, and SVG workflows.
  * Clarified experimental installation requirements for `reflex-xy`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->