### PR TITLE
Fail browser probes when chromium crashes, instead of skipping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,10 @@ jobs:
         # full Figure.to_png path runs here rather than skipping.
         run: |
           export XY_CHROMIUM="$(node -e "console.log(require('playwright').chromium.executablePath())")"
+          # Chromium is installed here, so a probe that cannot launch it is a
+          # defect: fail rather than skip, so the browser layer cannot pass by
+          # absence. (A crash or non-zero exit already fails unconditionally.)
+          export XY_REQUIRE_BROWSER=1
           .venv/bin/pytest -q
 
       # End-to-end: a real Figure (line decimation + scatter) through to_html's

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import html
 import json
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -15,8 +16,19 @@ from pathlib import Path
 import pytest
 
 
-def _dump_dom(chromium: str, page: Path) -> str | None:
-    """One headless render pass; None on a chromium-level failure (retryable)."""
+class _BrowserUnavailable(RuntimeError):
+    """The browser binary could not be executed at all — environmental."""
+
+
+def _dump_dom(chromium: str, page: Path) -> tuple[str | None, str | None]:
+    """One headless render pass.
+
+    Returns ``(dom, failure)``; exactly one is set. A ``failure`` string means
+    the browser *ran* and did not produce a usable DOM — a crash, an abort, or a
+    hang. That is a defect, not an environmental miss, so it must never be
+    allowed to degrade into a skip. Only a browser that cannot be spawned at all
+    raises `_BrowserUnavailable`.
+    """
     try:
         proc = subprocess.run(
             [
@@ -38,8 +50,13 @@ def _dump_dom(chromium: str, page: Path) -> str | None:
             timeout=120,
         )
     except subprocess.TimeoutExpired:
-        return None
-    return proc.stdout if proc.returncode == 0 else None
+        return None, "chromium timed out after 120s"
+    except OSError as exc:  # binary vanished, not executable, exec format error
+        raise _BrowserUnavailable(str(exc)) from exc
+    if proc.returncode != 0:
+        tail = " / ".join((proc.stderr or "").strip().splitlines()[-3:])
+        return None, f"chromium exited {proc.returncode}: {tail or '(no stderr)'}"
+    return proc.stdout, None
 
 
 def run_browser_probe(
@@ -54,9 +71,13 @@ def run_browser_probe(
 
     The probe script reports success by JSON-encoding its payload into
     ``result_attribute`` on ``<body>`` and failure into
-    ``{result_attribute}-error``. Returns the parsed result payload. If Chromium
-    never returns a DOM the test is skipped as an environmental miss; once a
-    DOM is returned, probe errors and missing results fail the test.
+    ``{result_attribute}-error``. Returns the parsed result payload.
+
+    Every way of *not* getting a result fails the test: a chromium crash or
+    non-zero exit, a timeout, a probe error, or a missing result attribute. The
+    lone skip left is a browser that cannot be spawned at all, and setting
+    ``XY_REQUIRE_BROWSER=1`` turns even that into a failure so CI cannot pass by
+    absence.
 
     Headless probes on shared runners have transient warm-up misses (virtual
     time / GL init) that a relaunch clears; a genuine regression fails every
@@ -65,9 +86,19 @@ def run_browser_probe(
     page.write_text(document, encoding="utf-8")
     last: str | None = None
     for _ in range(3):
-        dom = _dump_dom(chromium, page)
-        if dom is None:
+        try:
+            dom, failure = _dump_dom(chromium, page)
+        except _BrowserUnavailable as exc:
+            if os.environ.get("XY_REQUIRE_BROWSER"):
+                pytest.fail(
+                    f"{label}: XY_REQUIRE_BROWSER is set but chromium "
+                    f"({chromium}) could not be launched: {exc}"
+                )
+            pytest.skip(f"headless chromium could not be launched: {exc}")
+        if failure is not None:
+            last = failure
             continue
+        assert dom is not None
         error = re.search(rf'{re.escape(result_attribute)}-error="([^"]*)"', dom)
         if error:
             last = f"probe error: {html.unescape(error.group(1))}"
@@ -76,6 +107,4 @@ def run_browser_probe(
         if match:
             return json.loads(html.unescape(match.group(1)))
         last = "probe did not finish (no result attribute)"
-    if last:
-        pytest.fail(f"{label} could not run after retries: {last}")
-    pytest.skip("headless chromium unavailable/failed after retries")
+    pytest.fail(f"{label} could not run after 3 attempts: {last}")


### PR DESCRIPTION
`run_browser_probe` could not distinguish *"chromium is missing"* from *"chromium ran and died"*. `_dump_dom` returned `None` for both, so three crashed attempts left `last` unset and fell through to `pytest.skip`.

The effect: a client regression that hard-crashes the renderer — a bad shader, a null deref in `renderStandalone`, a broken bundle — turned **all 36 browser tests green**. Under `make test` those skips print as a bare `s` and the run exits 0. The worse the breakage, the more reliably it was hidden.

**Confirmed, not inferred:** pointing `XY_CHROMIUM` at a script that `exit 1`s gave `1 skipped`, exit 0.

## Change

`_dump_dom` now returns `(dom, failure)` and separates the two cases:

| Situation | Before | After |
|---|---|---|
| Crash / non-zero exit | skip | **fail** |
| Timeout | skip | **fail** |
| Probe error, missing result attribute | fail | fail |
| Cannot spawn the binary at all | skip | skip, with the exec error as the reason |
| Cannot spawn, `XY_REQUIRE_BROWSER=1` | skip | **fail** |

The trailing unconditional `pytest.skip` is gone — every way of not getting a result now fails. CI exports `XY_REQUIRE_BROWSER=1` beside the existing `XY_CHROMIUM` so the browser layer cannot pass by absence.

## Verification

- Crashing browser now **fails** (was: `1 skipped`, exit 0).
- Unlaunchable browser skips with the exec error as the reason, and **fails** under `XY_REQUIRE_BROWSER=1`.
- Full suite on this base: **2222 passed, 4 skipped, 0 failed** — unchanged.
- `ruff check`, `ruff format --check`, and `scripts/verify_ci_workflow.py` pass.

## Not covered here

22 tests skip at their own `find_chromium() is None` check *before* reaching `conftest`, so `XY_REQUIRE_BROWSER` does not fire for the "no browser installed at all" case — which is the `python_floor` job's situation, since it sets no `XY_CHROMIUM` and installs no Playwright. Rewiring those call sites is separate work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved browser-based test reliability by distinguishing unavailable browsers from temporary launch or rendering failures.
  * Browser test issues now provide clearer failure messages and retry transient failures before reporting an error.
  * Environments without a usable browser are handled explicitly, with stricter validation in continuous integration.

* **Chores**
  * Updated automated checks to ensure browser-dependent functionality is validated consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->