### PR TITLE
Fail browser probes when chromium crashes, instead of skipping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,10 @@ jobs:
         # full Figure.to_png path runs here rather than skipping.
         run: |
           export XY_CHROMIUM="$(node -e "console.log(require('playwright').chromium.executablePath())")"
+          # Chromium is installed here, so a probe that cannot launch it is a
+          # defect: fail rather than skip, so the browser layer cannot pass by
+          # absence. (A crash or non-zero exit already fails unconditionally.)
+          export XY_REQUIRE_BROWSER=1
           .venv/bin/pytest -q
 
       # End-to-end: a real Figure (line decimation + scatter) through to_html's

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import html
 import json
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -15,8 +16,19 @@ from pathlib import Path
 import pytest
 
 
-def _dump_dom(chromium: str, page: Path) -> str | None:
-    """One headless render pass; None on a chromium-level failure (retryable)."""
+class _BrowserUnavailable(RuntimeError):
+    """The browser binary could not be executed at all — environmental."""
+
+
+def _dump_dom(chromium: str, page: Path) -> tuple[str | None, str | None]:
+    """One headless render pass.
+
+    Returns ``(dom, failure)``; exactly one is set. A ``failure`` string means
+    the browser *ran* and did not produce a usable DOM — a crash, an abort, or a
+    hang. That is a defect, not an environmental miss, so it must never be
+    allowed to degrade into a skip. Only a browser that cannot be spawned at all
+    raises `_BrowserUnavailable`.
+    """
     try:
         proc = subprocess.run(
             [
@@ -38,8 +50,13 @@ def _dump_dom(chromium: str, page: Path) -> str | None:
             timeout=120,
         )
     except subprocess.TimeoutExpired:
-        return None
-    return proc.stdout if proc.returncode == 0 else None
+        return None, "chromium timed out after 120s"
+    except OSError as exc:  # binary vanished, not executable, exec format error
+        raise _BrowserUnavailable(str(exc)) from exc
+    if proc.returncode != 0:
+        tail = " / ".join((proc.stderr or "").strip().splitlines()[-3:])
+        return None, f"chromium exited {proc.returncode}: {tail or '(no stderr)'}"
+    return proc.stdout, None
 
 
 def run_browser_probe(
@@ -54,9 +71,13 @@ def run_browser_probe(
 
     The probe script reports success by JSON-encoding its payload into
     ``result_attribute`` on ``<body>`` and failure into
-    ``{result_attribute}-error``. Returns the parsed result payload. If Chromium
-    never returns a DOM the test is skipped as an environmental miss; once a
-    DOM is returned, probe errors and missing results fail the test.
+    ``{result_attribute}-error``. Returns the parsed result payload.
+
+    Every way of *not* getting a result fails the test: a chromium crash or
+    non-zero exit, a timeout, a probe error, or a missing result attribute. The
+    lone skip left is a browser that cannot be spawned at all, and setting
+    ``XY_REQUIRE_BROWSER=1`` turns even that into a failure so CI cannot pass by
+    absence.
 
     Headless probes on shared runners have transient warm-up misses (virtual
     time / GL init) that a relaunch clears; a genuine regression fails every
@@ -65,9 +86,19 @@ def run_browser_probe(
     page.write_text(document, encoding="utf-8")
     last: str | None = None
     for _ in range(3):
-        dom = _dump_dom(chromium, page)
-        if dom is None:
+        try:
+            dom, failure = _dump_dom(chromium, page)
+        except _BrowserUnavailable as exc:
+            if os.environ.get("XY_REQUIRE_BROWSER"):
+                pytest.fail(
+                    f"{label}: XY_REQUIRE_BROWSER is set but chromium "
+                    f"({chromium}) could not be launched: {exc}"
+                )
+            pytest.skip(f"headless chromium could not be launched: {exc}")
+        if failure is not None:
+            last = failure
             continue
+        assert dom is not None
         error = re.search(rf'{re.escape(result_attribute)}-error="([^"]*)"', dom)
         if error:
             last = f"probe error: {html.unescape(error.group(1))}"
@@ -76,6 +107,4 @@ def run_browser_probe(
         if match:
             return json.loads(html.unescape(match.group(1)))
         last = "probe did not finish (no result attribute)"
-    if last:
-        pytest.fail(f"{label} could not run after retries: {last}")
-    pytest.skip("headless chromium unavailable/failed after retries")
+    pytest.fail(f"{label} could not run after 3 attempts: {last}")


### PR DESCRIPTION
> Supersedes #261, which GitHub auto-closed when the branch was renamed to match this scope. Same commit, same diff.

## The bug

`tests/conftest.py::_dump_dom` collapsed two very different outcomes into one `None`:

```python
def _dump_dom(chromium: str, page: Path) -> str | None:
    """One headless render pass; None on a chromium-level failure (retryable)."""
    try:
        proc = subprocess.run([...], timeout=120)
    except subprocess.TimeoutExpired:
        return None                                        # hung
    return proc.stdout if proc.returncode == 0 else None   # crashed
```

Its caller treated `None` as "nothing to report" and continued. After three attempts `last` was still unset, so control reached the final line:

```python
    if last:
        pytest.fail(f"{label} could not run after retries: {last}")
    pytest.skip("headless chromium unavailable/failed after retries")   # <-- always taken
```

A chromium that **ran and died** was therefore indistinguishable from a chromium that **was never installed**, and both produced a skip.

## Why this failure mode is the worst one to hide

The regressions that crash the renderer are the most severe ones this project can ship — a bad shader, a null deref in `renderStandalone`, a malformed bundle, a WebGL context that never initialises. Those are exactly the ones that produced a green run.

Measured on `main`, pointing `XY_CHROMIUM` at a script that does nothing but `exit 1`:

```
1 failed, 2175 passed, 50 skipped
```

Four of those skips are the normal environmental ones (`reflex`, `httpx`, no PDF oracle). **The other 46 are browser tests that silently skipped instead of failing.** The single failure is `test_figure.py::test_to_png_full_path`, which reaches chromium through a different path and already raised.

The relationship is inverted from what you want: a subtle regression fails a value assertion, but a total one skipped. And `make test` is a bare `pytest -q`, where skips render as an unremarkable `s` in the progress dots — no summary, no warning, **exit code 0**.

## Reproduce it

```bash
printf '#!/bin/sh\nexit 1\n' > /tmp/crashy-chrome && chmod +x /tmp/crashy-chrome
XY_CHROMIUM=/tmp/crashy-chrome pytest tests/test_view_state_client.py -q ; echo "exit=$?"
```

| | on `main` | on this branch |
|---|---|---|
| Result | `17 skipped` | `17 failed` |
| Exit code | **0** | **1** |
| Message | — | `chromium exited 1` |

Whole suite, same fake browser: `1 failed / 50 skipped` on `main` → `47 failed / 4 skipped` here.

## The change

`_dump_dom` now returns `(dom, failure)` — exactly one is set — and separates *the browser ran and failed* from *the browser could not be started*:

```python
    except subprocess.TimeoutExpired:
        return None, "chromium timed out after 120s"
    except OSError as exc:  # binary vanished, not executable, exec format error
        raise _BrowserUnavailable(str(exc)) from exc
    if proc.returncode != 0:
        tail = " / ".join((proc.stderr or "").strip().splitlines()[-3:])
        return None, f"chromium exited {proc.returncode}: {tail or '(no stderr)'}"
    return proc.stdout, None
```

Only `OSError` on spawn is environmental. Everything else is a defect, carries a diagnostic string, and fails. The trailing unconditional `pytest.skip` is deleted, so `last` is always set by the time the loop exits and the final `pytest.fail` is unconditional.

| Situation | Before | After |
|---|---|---|
| Crash / non-zero exit | skip | **fail** — `chromium exited N: <stderr tail>` |
| Timeout after 120s | skip | **fail** — `chromium timed out after 120s` |
| Probe threw (`-error` attribute) | fail | fail — unchanged |
| Rendered, no result attribute | fail | fail — unchanged |
| Binary cannot be spawned | skip | skip, now naming the exec error |
| Binary cannot be spawned, `XY_REQUIRE_BROWSER=1` | skip | **fail** |

`XY_REQUIRE_BROWSER=1` is exported in `ci.yml` beside the existing `XY_CHROMIUM`, so the browser layer cannot pass by absence on a runner where Playwright's chromium failed to install.

## Deliberately preserved

The **3-attempt retry** is unchanged, and so is the reasoning in the docstring: headless probes on shared runners have transient warm-up misses (virtual time, GL init) that a relaunch clears. A crash still gets three chances before failing — this PR changes only what happens once all three are exhausted. No retry was added, no timeout shortened.

## Verification

| Check | Result |
|---|---|
| `test_view_state_client.py` under a crashing browser | **17 failed**, exit 1 — was 17 skipped, exit 0 |
| Full suite under a crashing browser | **47 failed, 4 skipped** — was 1 failed, 50 skipped |
| Unlaunchable binary, env unset | skips, reporting `Exec format error` |
| Unlaunchable binary, `XY_REQUIRE_BROWSER=1` | **fails** |
| Full suite, real browser | **2222 passed, 4 skipped, 0 failed** — unchanged from base |
| `ruff check .` / `ruff format --check .` | pass |
| `scripts/verify_ci_workflow.py` | pass |

## Risk

The plausible objection is CI flakiness — turning skips into failures could surface infrastructure noise as red builds. Two things bound that:

1. A genuine transient still gets 3 relaunches; only three *consecutive* browser-level failures fail the test, the same threshold that already governed probe errors.
2. The `test` job installs chromium via Playwright immediately before running pytest, so a browser that will not start there is a real problem worth a red build.

If it does prove noisy, `XY_REQUIRE_BROWSER` can be dropped from `ci.yml` independently — that reverts only the last row of the decision table.

## Not covered here

26 per-test guards across 22 files call `pytest.skip` on `find_chromium() is None` **before** `run_browser_probe` is reached, so `XY_REQUIRE_BROWSER` does not fire for the "no browser installed at all" case. That is precisely the `python_floor` job's situation: it sets no `XY_CHROMIUM` and installs no Playwright, so whether the browser layer runs there depends on whether the runner image happens to ship Chrome on `PATH`. Rewiring those call sites is separate work.

## How this was found

A test-suite audit. The defect was confirmed by fault injection, not by reading control flow — the reproduction above is the evidence.