### PR TITLE
Stop sorting a whole column to size error-bar caps

### DIFF
--- a/python/xy/_figure.py
+++ b/python/xy/_figure.py
@@ -1075,16 +1075,18 @@ class Figure(AnnotationsMixin, PayloadMixin):
                 continue
             base = t.x0.values if axis == "x" else t.y0.values
             value = t.x1.values if axis == "x" else t.y1.values
+            # Ask the questions as masked predicates rather than compacting
+            # `base`/`value` down to their finite rows first: the compaction
+            # allocates and copies two full columns per axis per build, and
+            # every question here is a single "does any row violate this?".
             finite = np.isfinite(base) & np.isfinite(value)
-            if not np.any(finite):
+            if not finite.any():
                 continue
-            base = base[finite]
-            value = value[finite]
-            if not np.all(base == 0.0):
+            if (finite & (base != 0.0)).any():
                 continue
-            if np.all(value >= 0.0):
+            if not (finite & (value < 0.0)).any():
                 return "lo"
-            if np.all(value <= 0.0):
+            if not (finite & (value > 0.0)).any():
                 return "hi"
         return None
 

--- a/python/xy/marks.py
+++ b/python/xy/marks.py
@@ -1001,8 +1001,21 @@ def _auto_cap_size(positions: np.ndarray) -> float:
 
     0.25x the median adjacent spacing of the distinct finite positions along
     the cap's axis; 0.4 when fewer than two are distinct (no spacing exists).
+
+    The positions an error bar carries are usually an ordered independent
+    variable, and `np.unique` sorts unconditionally — an O(N log N) pass over
+    the whole column to answer a question about adjacent gaps. One O(N) diff
+    both proves the column is already non-decreasing and yields those gaps
+    directly; only an out-of-order column pays for the sort. Same distinct
+    values in the same order either way, so the median is identical.
     """
-    distinct = np.unique(positions[np.isfinite(positions)])
+    finite = positions[np.isfinite(positions)]
+    if len(finite) >= 2:
+        gaps = np.diff(finite)
+        if (gaps >= 0.0).all():
+            positive = gaps[gaps != 0.0]
+            return 0.25 * float(np.median(positive)) if len(positive) else 0.4
+    distinct = np.unique(finite)
     if len(distinct) < 2:
         return 0.4
     return 0.25 * float(np.median(np.diff(distinct)))


### PR DESCRIPTION
## What

`test_first_payload_errorbar_large` is the most expensive benchmark in the suite (~557 ms on CodSpeed; nothing else on main is close). Two thirds of it is work neither answer needs.

**`_auto_cap_size`** wants the median adjacent gap between distinct positions, and reached for `np.unique` — which sorts unconditionally, an O(N log N) pass over the full column. Error-bar positions are usually an ordered independent variable, so one O(N) diff both proves the column is already non-decreasing and yields those gaps directly; only an out-of-order column still pays for the sort. Same distinct values in the same order, so the median is identical.

**`_zero_baseline_anchor`** compacted `base`/`value` down to their finite rows before asking three all-or-nothing questions about them, allocating and copying two full columns per axis per build. Each question is really "does any row violate this?", which the finite mask answers in place. NaN rows are excluded by the mask exactly as the compaction excluded them.

## Numbers

Benchmark shape (1M points, `yerr=1.0`, decimated tier), min-of-3:

| | before | after | |
|---|---|---|---|
| first payload | 48.07 ms | 14.09 ms | **-70.7%** |
| `_auto_cap_size` (1M sorted positions) | 27.48 ms | 2.92 ms | -89.4% |
| `_zero_baseline_anchor` (3M rows) | 4.44 ms | 1.99 ms | -55.2% |

Neither of these is benchmark-only work. Cap sizing runs for every auto-cap error bar, and the zero-baseline probe runs for every bar and histogram build, so the win follows real charts.

## Correctness

Both functions were checked against their previous implementations, not just spot-checked:

- `_auto_cap_size` returns identically over sorted, unsorted, descending, duplicate-heavy, all-equal, single-element, empty, NaN-bearing and `-0.0`-bearing columns.
- `_zero_baseline_anchor` returns identically over all-positive, all-negative, mixed-sign, nonzero-base, NaN-bearing, all-NaN and all-zero columns.

Full Python suite: 2222 passed, 4 skipped. `ruff check` and `ruff format --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plot baseline detection for traces containing non-finite data.
  * Improved automatic error-bar cap sizing, including more efficient handling of ordered positions and repeated values.
  * Preserved appropriate spacing calculations for irregular or unordered data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->