### PR TITLE
Drop the lasso CodSpeed row

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -183,9 +183,8 @@ CodSpeed simulation.
 
 `test_codspeed_selection.py` covers the backend handlers the client's gesture
 messages resolve to: hover pick readout with a categorical channel, zone-pruned
-and full-scan box select at 1M points, the lasso gesture unit through
-`channel.handle_message` (polygon ray casting plus the wire-mask reply), and
-the cross-filter rows-to-shipped-mask encoding over a NaN-dropped trace so the
+and full-scan box select at 1M points, and the cross-filter
+rows-to-shipped-mask encoding over a NaN-dropped trace so the
 canonical-to-shipped translation is the path measured. `bench_interaction.py`
 stays authoritative for client input-to-pixel latency; these rows attribute a
 selection regression to the Python/kernel handler that caused it.

--- a/benchmarks/test_codspeed_selection.py
+++ b/benchmarks/test_codspeed_selection.py
@@ -3,8 +3,8 @@
 The browser rows in ``bench_interaction.py`` measure client input-to-pixel
 latency; these rows isolate the Python/kernel work each gesture message
 resolves to (§17/§34): hover pick readout, zone-pruned and full-scan box
-select, lasso ray casting, and the cross-filter row-mask encoding the
-view-state layer ships (view-state.md §5.1). None of them existed as CodSpeed
+select, and the cross-filter row-mask encoding the view-state layer ships
+(view-state.md §5.1). None of them existed as CodSpeed
 rows before, so a selection regression could only surface as browser
 wall-clock noise; here it is attributed to the handler that caused it.
 
@@ -32,7 +32,6 @@ PX_WIDTH = 2048
 SELECT_N = 1_000_000
 PICK_N = 100_000
 CROSSFILTER_N = 100_000
-LASSO_VERTICES = 64
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -58,10 +57,6 @@ def warm_lazy_modules() -> None:
     fig.build_payload_split(PX_WIDTH)
     fig.pick(0, 0)
     channel.handle_message(fig, {"type": "select", "x0": 0.0, "x1": 3.0, "y0": 0.0, "y1": 1.0})
-    channel.handle_message(
-        fig,
-        {"type": "select_polygon", "points": [[0.0, -1.0], [3.0, -1.0], [1.5, 2.0]]},
-    )
     fig.selection_rows_message({0: np.array([0, 2], dtype=np.int64)})
 
 
@@ -137,19 +132,6 @@ def test_select_box_message_full_scan_1m(benchmark, uniform_figure):
     spec, buffers = reply
     # A 30x30 box over the 100x100 uniform domain holds ~9% of 1M points.
     assert 80_000 < spec["total"] < 100_000
-    assert len(buffers[0]) == 4 * spec["traces"][0]["count"]
-
-
-def test_select_lasso_message_1m(benchmark, uniform_figure):
-    """Lasso gesture unit: bbox prune, ray casting, wire mask reply."""
-    theta = np.linspace(0.0, 2.0 * np.pi, LASSO_VERTICES, endpoint=False)
-    polygon = [[50.0 + 20.0 * np.cos(t), 50.0 + 20.0 * np.sin(t)] for t in theta]
-    message = {"type": "select_polygon", "points": polygon, "seq": 4}
-    reply = benchmark(channel.handle_message, uniform_figure, message)
-    assert reply is not None
-    spec, buffers = reply
-    # A radius-20 disc covers ~12.6% of the 100x100 uniform domain.
-    assert 115_000 < spec["total"] < 137_000
     assert len(buffers[0]) == 4 * spec["traces"][0]["count"]
 
 

--- a/spec/benchmarks/methodology.md
+++ b/spec/benchmarks/methodology.md
@@ -234,7 +234,7 @@ it — those live in `benchmark-refresh.yml`, and the workflow says so inline.
 
 The glob collects five modules — `test_codspeed_animation.py`,
 `test_codspeed_kernels.py`, `test_codspeed_pyplot.py`,
-`test_codspeed_selection.py`, and `test_codspeed_transport.py` — for 103 rows
+`test_codspeed_selection.py`, and `test_codspeed_transport.py` — for 102 rows
 total. These are trend-tracked in CodSpeed, not gated: none of them feed
 `scripts/check_regressions.py`, whose three inputs are §7's.
 
@@ -297,12 +297,12 @@ assertion and lazy-import warmup fixture. Browser `updatePayload` time,
 animation-frame pacing, heap delta, and the previous+next scene bound stay in
 `bench_animation.py`.
 
-**`benchmarks/test_codspeed_selection.py` — 5 rows.** The backend
+**`benchmarks/test_codspeed_selection.py` — 4 rows.** The backend
 interaction/selection handlers the client's gesture messages resolve to
 (design-dossier §17/§34): hover pick with a categorical channel readout;
 zone-pruned box select over a 1% window of a monotone-x 1M scatter; the full
-box-select and lasso gesture units through `channel.handle_message` on a
-uniform 1M scatter — full scan, polygon ray casting, and the wire-mask reply;
+box-select gesture unit through `channel.handle_message` on a uniform 1M
+scatter — full scan plus the wire-mask reply;
 and the cross-filter rows-to-shipped-mask encoding (view-state.md §5.1) over a
 NaN-dropped trace, so the canonical-to-shipped `searchsorted` translation is
 the path measured rather than the identity fast path. Browser input-to-pixel

--- a/spec/benchmarks/results.md
+++ b/spec/benchmarks/results.md
@@ -132,9 +132,8 @@ scope, not the kernels module alone. The suite asserts `xy.kernels.BACKEND ==
   100k stable-key encoding plus a plain-versus-keyed split-payload pair, so
   keyed-transition overhead stays attributed to the key columns.
 - The backend selection handlers (`benchmarks/test_codspeed_selection.py`):
-  hover pick readout, zone-pruned and full-scan box select, the lasso gesture
-  unit through `channel.handle_message`, and the cross-filter
-  rows-to-shipped-mask encoding.
+  hover pick readout, zone-pruned and full-scan box select, and the
+  cross-filter rows-to-shipped-mask encoding.
 
 That keeps CodSpeed focused on native range queries, pyramid composition,
 tier-switch payload generation, payload prep, zoom latency, and memory-report

--- a/tests/test_benchmark_environment.py
+++ b/tests/test_benchmark_environment.py
@@ -136,7 +136,6 @@ def test_codspeed_suite_covers_backend_selection_workloads() -> None:
         "test_pick_hover_categorical_readout",
         "test_select_box_zone_pruned_1m",
         "test_select_box_message_full_scan_1m",
-        "test_select_lasso_message_1m",
         "test_selection_rows_message_crossfilter",
     }
     missing = sorted(required_benchmarks - set(functions))


### PR DESCRIPTION
## What

`test_select_lasso_message_1m` is removed from `benchmarks/test_codspeed_selection.py`.

It reports noise, not signal. On #264 — a branch that touches only `_auto_cap_size` and `_zero_baseline_anchor`, nowhere near the selection path — it moved 90.5 ms → 124.2 ms, a 27% swing attributable to nothing in the diff. A row that flags a regression on an unrelated change trains everyone to ignore the report.

## What still covers the selection handlers

The module keeps four rows: hover pick readout, zone-pruned box select, full-scan box select, and the cross-filter rows-to-shipped-mask encoding. `select_polygon`'s ray casting is the one gesture no longer trend-tracked in CodSpeed; `bench_interaction.py` still measures the lasso end to end in the browser.

## Also updated

The removal touches everything that named the row or counted it: the `required_benchmarks` guardrail in `tests/test_benchmark_environment.py`, the untimed `select_polygon` warmup and the now-unused `LASSO_VERTICES` constant, and the module docstring, `benchmarks/README.md`, `spec/benchmarks/results.md`, and `spec/benchmarks/methodology.md` (selection module 5 → 4 rows, suite total 103 → 102).

`tests/test_benchmark_environment.py`: 13 passed. `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)