### PR TITLE
Derive the distribution version from git tags

### DIFF
--- a/.github/workflows/_build-docs-images.yml
+++ b/.github/workflows/_build-docs-images.yml
@@ -58,6 +58,9 @@ jobs:
         with:
           ref: ${{ inputs.source_ref }}
           persist-credentials: false
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
@@ -72,6 +75,14 @@ jobs:
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: 1.97.0
+
+      # `.dockerignore` excludes `.git`, so the backend image build cannot
+      # derive the version the way every other build does. Resolve it here,
+      # where the tags exist, and hand it to the image explicitly — otherwise
+      # the docs backend installs `xy` at the `0.0.0` fallback.
+      - name: Resolve the xy version
+        id: xy_version
+        run: echo "version=$(uvx uv-dynamic-versioning)" >> "$GITHUB_OUTPUT"
 
       - name: Install JS build toolchain
         run: npm ci
@@ -132,11 +143,13 @@ jobs:
           DEPOT_PROJECT: ${{ env.DEPOT_PROJECT }}
           IMAGE_TAG: ${{ inputs.image_tag }}
           BACKEND_IMAGE: ${{ env.BACKEND_IMAGE }}
+          XY_VERSION: ${{ steps.xy_version.outputs.version }}
         run: |
           depot build \
             --project "$DEPOT_PROJECT" \
             --file docs/app/dockerfiles/backend.Dockerfile \
             --tag "${BACKEND_IMAGE}:${IMAGE_TAG}" \
+            --build-arg "XY_VERSION=${XY_VERSION}" \
             --push \
             --platform linux/amd64,linux/arm64 \
             --provenance=false \

--- a/.github/workflows/benchmark-refresh.yml
+++ b/.github/workflows/benchmark-refresh.yml
@@ -24,6 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
@@ -54,6 +58,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
@@ -223,6 +231,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
@@ -251,6 +263,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -351,6 +367,10 @@ jobs:
             build_js: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         if: matrix.xy
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
@@ -424,6 +444,10 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
@@ -521,6 +545,10 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
       - name: Download cross-library benchmark parts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -572,6 +600,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
@@ -632,6 +664,10 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
@@ -702,6 +738,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -25,6 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: "3.12"
@@ -79,6 +83,10 @@ jobs:
         python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,10 @@ jobs:
           - { os: windows-latest, target: aarch64-pc-windows-msvc, plat: win_arm64, zig: false, native: false }
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           targets: ${{ matrix.target }}
@@ -131,6 +135,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
           toolchain: 1.97.0
@@ -187,6 +195,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
@@ -249,11 +261,15 @@ jobs:
       id-token: write # PyPI trusted publishing (OIDC) — no API token stored
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # The artifact verifiers check everything inside the wheels/sdist, but
-      # only this gate stops a mismatched tag from publishing whatever version
-      # sits in pyproject.toml: the tag must equal v<project.version> and
-      # CHANGELOG.md must carry a dated entry for it.
-      - name: Release version gate (tag == pyproject == CHANGELOG)
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
+      # The tag now *is* the version (pyproject derives it), so there is no
+      # second number left to disagree with it. What a tag can't vouch for is
+      # that the release was written up: this gate requires the tag to be shaped
+      # like a release tag and CHANGELOG.md to carry a dated entry for it.
+      - name: Release version gate (tag == CHANGELOG)
         if: github.event_name == 'push'
         run: python3 scripts/check_release_version.py
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -289,6 +305,10 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `v*` tag, and a shallow clone has none.
+          fetch-depth: 0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
@@ -308,12 +328,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          version=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
-          tag="v${version}"
-          if [[ "$EVENT_NAME" == "push" && "$REF_NAME" != "$tag" ]]; then
-            echo "tag $REF_NAME does not match project version $tag" >&2
-            exit 1
+          # The release asset hangs off the tag itself. On a tag push that is
+          # the ref; a manual dry run has no tag, so fall back to the newest
+          # release tag (the same one the version was derived from) rather than
+          # inventing one from a version that no longer lives in pyproject.
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            tag="$REF_NAME"
+          else
+            tag=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*')
           fi
+          test -n "$tag"
           python3 scripts/check_release_version.py --tag "$tag"
           wheel=$(find dist-pyodide -maxdepth 1 -name '*.whl' -print -quit)
           test -n "$wheel"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ in the README).
 
 ## [Unreleased]
 
+### Changed
+- The distribution version is derived from git tags (uv-dynamic-versioning)
+  rather than written in `pyproject.toml`. Tagging `vX.Y.Z` is now the whole
+  release action; the two numbers can no longer drift, as they had (pyproject
+  sat at `0.0.1` while `v0.0.2` was live). Builds between tags are versioned
+  `<next>.devN+<commit>`, which PyPI rejects by design — only a tag produces an
+  uploadable version. The docs-deploy CalVer tags (`2026.WW.N`) are excluded by
+  the `v` prefix the derivation matches on.
+- `xy.__version__` now reports the installed distribution's version instead of a
+  hardcoded string, resolved lazily on first access so `import xy` keeps its
+  import-time budget. An uninstalled source tree reports `0.0.0`.
+- The release gate (`scripts/check_release_version.py`) checks the tag against
+  `CHANGELOG.md` only; the tag-vs-pyproject leg is gone with the drift it
+  existed to catch. Building a release now requires an unshallow checkout —
+  `make check-ci` fails any workflow whose `actions/checkout` omits
+  `fetch-depth: 0`, since a tagless clone would silently build `0.0.0`.
+
 ### Migration notes
 - Mark `style={...}` now uses paint-specific CSS: `stroke` for line-like marks
   and `fill` for filled marks. The legacy `color=` argument remains supported,

--- a/docs/app/dockerfiles/backend.Dockerfile
+++ b/docs/app/dockerfiles/backend.Dockerfile
@@ -2,10 +2,17 @@ FROM rust:1.97.0-slim-bookworm AS rust-toolchain
 
 FROM python:3.13-slim-bookworm AS builder
 
+# `.dockerignore` excludes `.git`, so the build context cannot derive the xy
+# version from tags the way every other build does. CI passes the version it
+# resolved on the runner; a local `docker build` gets the same `0.0.0` fallback
+# a tagless tree would.
+ARG XY_VERSION=0.0.0
+
 ENV CARGO_HOME=/usr/local/cargo \
     RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:${PATH} \
     UV_LINK_MODE=copy \
+    UV_DYNAMIC_VERSIONING_BYPASS=${XY_VERSION} \
     XY_REQUIRE_CARGO=1
 
 COPY --from=rust-toolchain /usr/local/cargo /usr/local/cargo

--- a/docs/app/uv.lock
+++ b/docs/app/uv.lock
@@ -1690,7 +1690,6 @@ wheels = [
 
 [[package]]
 name = "xy"
-version = "0.0.1"
 source = { editable = "../../" }
 dependencies = [
     { name = "anywidget" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "uv-dynamic-versioning>=0.11"]
 build-backend = "hatchling.build"
 
 [project]
 name = "xy"
-version = "0.0.1"
+dynamic = ["version"]
 description = "Experimental Python charting engine with a native Rust core, binary columnar transport, and a GPU render client"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -50,6 +50,29 @@ bench = [
 codspeed = [
     "pytest-codspeed>=5,<6",
 ]
+
+# The distribution version is derived from git tags, never written down here:
+# `git tag vX.Y.Z && git push --tags` is the whole release action, so a tag can
+# no longer disagree with a checked-in number (they did drift — pyproject sat at
+# 0.0.1 while v0.0.2 was live). Dunamai's default tag pattern requires the `v`
+# prefix, which is exactly what keeps the docs-deploy CalVer tags (2026.WW.N,
+# disjoint from library versions by design) from being read as library releases.
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+# Builds off a tagged commit get the bare version; anything else gets
+# `<next>.devN+<commit>`, which is legible locally and unpublishable to PyPI on
+# purpose — only a tag can produce an uploadable version.
+bump = true
+# Only reached by a source tree with neither git metadata nor PKG-INFO (a
+# `git archive` tarball, say): such a build still succeeds, at an obviously
+# unreal version rather than a plausible-but-wrong one. It does *not* cover
+# unpacked sdists — those resolve from their own PKG-INFO, so `pip install
+# xy-X.Y.Z.tar.gz` keeps the published version without needing a repo.
+fallback-version = "0.0.0"
 
 [tool.hatch.build]
 # The render-client bundles are a generated artifact — built by hatch_build.py

--- a/python/xy/__init__.py
+++ b/python/xy/__init__.py
@@ -25,8 +25,6 @@ from __future__ import annotations
 from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.0.1"
-
 _EXPORTS = {
     "Annotation": ".components",
     "Animation": ".components",
@@ -214,7 +212,34 @@ def _load_export(name: str) -> Any:
     return value
 
 
+def _load_version() -> str:
+    """Resolve the installed distribution's version.
+
+    The version is not written down in the source tree at all — it is derived
+    from the `v*` git tag at build time (pyproject's uv-dynamic-versioning
+    config) and baked into the wheel's METADATA, so package metadata is the
+    only place that can answer this at runtime.
+
+    Resolved lazily, like every other export: `importlib.metadata` costs tens
+    of milliseconds against a 200 ms `import xy` budget (§33), which is a poor
+    trade for a string most callers never read. A source tree that was never
+    installed has no metadata to read, and reports the same unreal `0.0.0` the
+    build-time fallback uses.
+    """
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _distribution_version
+
+    try:
+        return _distribution_version("xy")
+    except PackageNotFoundError:
+        return "0.0.0"
+
+
 def __getattr__(name: str) -> Any:
+    if name == "__version__":
+        value = _load_version()
+        globals()["__version__"] = value
+        return value
     return _load_export(name)
 
 

--- a/scripts/check_public_api.py
+++ b/scripts/check_public_api.py
@@ -20,7 +20,6 @@ import os
 import subprocess
 import sys
 import textwrap
-import tomllib
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Optional
@@ -285,23 +284,34 @@ def validate_declarative_api_contract(
     return errors
 
 
-def validate_version_consistency(
-    pkg: ModuleType, pyproject_path: Path = ROOT / "pyproject.toml"
-) -> list[str]:
-    """Ensure import-time ``__version__`` matches package metadata."""
-    try:
-        data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError) as exc:
-        return [f"cannot read project version from {pyproject_path}: {exc}"]
+def validate_version_consistency(pkg: ModuleType, distribution: str = "xy") -> list[str]:
+    """Ensure import-time ``__version__`` matches installed package metadata.
 
-    project_version = str((data.get("project") or {}).get("version") or "").strip()
+    pyproject holds no version to compare against — it is derived from the git
+    tag at build time — so installed metadata is the reference. The check that
+    remains is worth keeping: `xy.__version__` is resolved lazily through
+    ``__getattr__``, and this is what catches it resolving to something other
+    than the version pip actually installed (a stale editable install shadowing
+    a wheel, say), rather than merely to *some* non-empty string.
+    """
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as distribution_version
+
+    try:
+        installed_version = distribution_version(distribution)
+    except PackageNotFoundError:
+        return [
+            f"distribution {distribution!r} is not installed, so xy.__version__ "
+            "cannot be checked — run this against an installed package"
+        ]
+
     public_version = getattr(pkg, "__version__", None)
     if not isinstance(public_version, str) or not public_version.strip():
         return [f"xy.__version__ must be a non-empty string, got {public_version!r}"]
-    if project_version != public_version:
+    if installed_version != public_version:
         return [
-            "xy.__version__ must match pyproject.toml project.version: "
-            f"{public_version!r} != {project_version!r}"
+            f"xy.__version__ must match the installed {distribution} distribution "
+            f"metadata: {public_version!r} != {installed_version!r}"
         ]
     return []
 

--- a/scripts/check_release_version.py
+++ b/scripts/check_release_version.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
-"""Release gate: the pushed tag, pyproject version, and CHANGELOG must agree.
+"""Release gate: the pushed tag and the CHANGELOG must agree.
 
-The wheel/sdist verifiers check everything *inside* the artifacts, but nothing
-else stops `git tag v0.2.0` from publishing whatever version happens to sit in
-pyproject.toml under a mismatched tag. This runs first in the publish job on
-tag pushes: the tag must equal `v` + the pyproject version, and CHANGELOG.md
-must carry a dated entry for that version (an "unreleased" heading fails —
+The tag *is* the version now — pyproject derives it via uv-dynamic-versioning —
+so the old tag-vs-pyproject leg of this gate is gone along with the drift it
+existed to catch. What a tag cannot vouch for is that anyone wrote down what
+changed, so this runs first in the publish job on tag pushes: CHANGELOG.md must
+carry a dated entry for the tagged version (an "unreleased" heading fails —
 date it as part of cutting the release).
+
+The tag must also be shaped like a release tag (`vX.Y.Z`), which is what the
+version derivation matches on; the docs-deploy CalVer tags (2026.WW.N) neither
+match it nor trigger this workflow.
 """
 
 from __future__ import annotations
@@ -15,25 +19,25 @@ import argparse
 import os
 import re
 import sys
-import tomllib
 from pathlib import Path
 from typing import Optional
 
 ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_PYPROJECT = ROOT / "pyproject.toml"
 DEFAULT_CHANGELOG = ROOT / "CHANGELOG.md"
+# The release tag shape uv-dynamic-versioning derives the distribution version
+# from: `v` + a PEP 440 release number, nothing else.
+TAG_RE = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$")
 
 
-def check_release(tag: str, pyproject: Path, changelog: Path) -> list[str]:
+def check_release(tag: str, changelog: Path) -> list[str]:
     errors: list[str] = []
-    try:
-        version = tomllib.loads(pyproject.read_text(encoding="utf-8"))["project"]["version"]
-    except (OSError, tomllib.TOMLDecodeError, KeyError) as exc:
-        return [f"cannot read project version from {pyproject}: {exc}"]
-    if tag != f"v{version}":
-        errors.append(
-            f"tag {tag!r} does not match pyproject version {version!r} (expected 'v{version}')"
-        )
+    match = TAG_RE.match(tag)
+    if match is None:
+        return [
+            f"tag {tag!r} is not a release tag — expected 'vX.Y.Z', the shape the "
+            "distribution version is derived from"
+        ]
+    version = match.group("version")
     try:
         text = changelog.read_text(encoding="utf-8")
     except OSError as exc:
@@ -57,20 +61,19 @@ def main(argv: Optional[list[str]] = None) -> int:
         default=os.environ.get("GITHUB_REF_NAME", ""),
         help="release tag (defaults to $GITHUB_REF_NAME)",
     )
-    parser.add_argument("--pyproject", type=Path, default=DEFAULT_PYPROJECT)
     parser.add_argument("--changelog", type=Path, default=DEFAULT_CHANGELOG)
     args = parser.parse_args(argv)
 
     if not args.tag:
         print("release version gate: no tag provided (--tag or GITHUB_REF_NAME)", file=sys.stderr)
         return 1
-    errors = check_release(args.tag, args.pyproject, args.changelog)
+    errors = check_release(args.tag, args.changelog)
     if errors:
         print("release version gate failed:", file=sys.stderr)
         for error in errors:
             print(f"- {error}", file=sys.stderr)
         return 1
-    print(f"release version gate OK: {args.tag} matches pyproject and CHANGELOG")
+    print(f"release version gate OK: {args.tag} has a dated CHANGELOG entry")
     return 0
 
 

--- a/scripts/verify_ci_workflow.py
+++ b/scripts/verify_ci_workflow.py
@@ -169,6 +169,42 @@ def _require_workflow_contains(
         errors.append(f"{workflow_label} workflow missing {description}: {missing}")
 
 
+def _require_unshallow_checkouts(errors: list[str], text: str, workflow_label: str) -> None:
+    """Every checkout must fetch full history, tags included.
+
+    The distribution version is derived from the latest `v*` tag
+    (uv-dynamic-versioning in pyproject), and `actions/checkout` defaults to a
+    depth-1 clone carrying no tags at all. Under that default the version
+    resolves to the `0.0.0` fallback *silently* — a build succeeds and ships the
+    wrong number rather than failing. So a shallow checkout here is a publishing
+    bug, not a performance tweak, and it is invisible until someone reads a
+    PyPI page. Cheap to require, expensive to notice late.
+    """
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if "uses: actions/checkout@" not in line:
+            continue
+        indent = len(line) - len(line.lstrip())
+        step: list[str] = []
+        for following in lines[index + 1 :]:
+            stripped = following.strip()
+            if not stripped:
+                continue
+            following_indent = len(following) - len(following.lstrip())
+            if following_indent < indent or (
+                following_indent == indent and stripped.startswith("-")
+            ):
+                break
+            step.append(stripped)
+        if "fetch-depth: 0" not in step:
+            errors.append(
+                f"{workflow_label} workflow has an actions/checkout step (line {index + 1}) "
+                "without `fetch-depth: 0` — the distribution version is derived from git "
+                "tags, which a shallow checkout does not fetch, so the build would quietly "
+                "fall back to 0.0.0"
+            )
+
+
 def _require_docs_spec_pr_paths_ignored(errors: list[str], text: str, workflow_label: str) -> None:
     """Require PR-only docs/spec changes to skip an expensive workflow."""
     lines = text.splitlines()
@@ -219,6 +255,7 @@ def validate_ci_workflow(path: Path = DEFAULT_CI_WORKFLOW) -> list[str]:
     jobs = _job_blocks(text)
     errors: list[str] = []
     _require_docs_spec_pr_paths_ignored(errors, text, "CI")
+    _require_unshallow_checkouts(errors, text, "CI")
     missing_jobs = sorted(REQUIRED_CI_JOBS - set(jobs))
     if missing_jobs:
         errors.append(f"CI workflow missing required jobs: {missing_jobs}")
@@ -582,6 +619,7 @@ def validate_codspeed_workflow(path: Path = DEFAULT_CODSPEED_WORKFLOW) -> list[s
     jobs = _job_blocks(text)
     errors: list[str] = []
     _require_docs_spec_pr_paths_ignored(errors, text, "CodSpeed")
+    _require_unshallow_checkouts(errors, text, "CodSpeed")
     missing_jobs = sorted(REQUIRED_CODSPEED_JOBS - set(jobs))
     if missing_jobs:
         errors.append(f"CodSpeed workflow missing required jobs: {missing_jobs}")
@@ -627,6 +665,7 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
 
     jobs = _job_blocks(text)
     errors: list[str] = []
+    _require_unshallow_checkouts(errors, text, "release")
     missing_jobs = sorted(REQUIRED_RELEASE_JOBS - set(jobs))
     if missing_jobs:
         errors.append(f"release workflow missing required jobs: {missing_jobs}")

--- a/scripts/verify_sdist.py
+++ b/scripts/verify_sdist.py
@@ -16,12 +16,9 @@ import json
 import re
 import sys
 import tarfile
-import tomllib
 from email.parser import Parser
-from pathlib import Path, PurePosixPath
+from pathlib import PurePosixPath
 from typing import Optional
-
-ROOT = Path(__file__).resolve().parents[1]
 
 REQUIRED_FILES = {
     ".github/workflows/ci.yml",
@@ -216,9 +213,13 @@ def _require_pkg_info(path: str, root: str) -> None:
     missing: list[str] = []
     if metadata.get("Name", "").strip() != "xy":
         missing.append("Name: xy")
-    project_version = _project_version()
-    if metadata.get("Version", "").strip() != project_version:
-        missing.append(f"Version: {project_version}")
+    # pyproject no longer carries a version to compare against — it is derived
+    # from the git tag at build time — so what stays checkable is the sdist's
+    # internal consistency: the `xy-<version>` root directory and the PKG-INFO
+    # that a wheel build reads back out of it must name the same version.
+    expected_version = root.split("-", 1)[1]
+    if metadata.get("Version", "").strip() != expected_version:
+        missing.append(f"Version: {expected_version}")
     if metadata.get("Requires-Python", "").strip() != ">=3.11":
         missing.append("Requires-Python: >=3.11")
     requirements = metadata.get_all("Requires-Dist") or []
@@ -235,17 +236,6 @@ def _require_pkg_info(path: str, root: str) -> None:
         missing.append(f"no Reflex runtime dependency ({reflex_requirements})")
     if missing:
         raise AssertionError(f"missing or invalid PKG-INFO lines: {missing}")
-
-
-def _project_version(pyproject_path: Path = ROOT / "pyproject.toml") -> str:
-    try:
-        data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError) as exc:
-        raise AssertionError(f"cannot read project version from {pyproject_path}: {exc}") from exc
-    version = str((data.get("project") or {}).get("version") or "").strip()
-    if not version:
-        raise AssertionError(f"{pyproject_path} is missing project.version")
-    return version
 
 
 def _require_file_contains(path: str, root: str, member: str, needles: set[str]) -> None:

--- a/scripts/verify_wheel.py
+++ b/scripts/verify_wheel.py
@@ -15,14 +15,15 @@ import csv
 import hashlib
 import re
 import sys
-import tomllib
 import zipfile
 from dataclasses import dataclass
 from email.parser import Parser
 from pathlib import Path
 from typing import Optional
 
-ROOT = Path(__file__).resolve().parents[1]
+# Mirrors verify_sdist's root-directory shape: a release version (`0.0.2`) plus
+# whatever PEP 440 suffix a between-tags build appends (`0.0.3.dev4+g63c0697`).
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:[A-Za-z0-9_.+!]*)?$")
 
 REQUIRED_FILES = {
     "xy/__init__.py",
@@ -62,6 +63,15 @@ def _dist_info_name(names: set[str], filename: str) -> str:
     if len(matches) != 1:
         raise AssertionError(f"expected exactly one {filename}, found {matches}")
     return matches[0]
+
+
+def _require_dist_info_version(names: set[str], expected_version: str) -> None:
+    """The `.dist-info` directory must be named for the same version as the file."""
+    directory = _dist_info_name(names, "METADATA").split("/", 1)[0]
+    if directory != f"xy-{expected_version}.dist-info":
+        raise AssertionError(
+            f"wheel has {directory!r} but its filename says version {expected_version!r}"
+        )
 
 
 def _require_unique_archive_members(infos: list[zipfile.ZipInfo]) -> None:
@@ -150,15 +160,14 @@ def _is_reflex_dependency(requirement: str) -> bool:
     return name == "reflex" or name.startswith("reflex-")
 
 
-def _require_metadata(names: set[str], data: bytes) -> None:
+def _require_metadata(names: set[str], data: bytes, expected_version: str) -> None:
     text = data.decode("utf-8")
     metadata = Parser().parsestr(text)
     missing: list[str] = []
     if metadata.get("Name", "").strip() != "xy":
         missing.append("Name: xy")
-    project_version = _project_version()
-    if metadata.get("Version", "").strip() != project_version:
-        missing.append(f"Version: {project_version}")
+    if metadata.get("Version", "").strip() != expected_version:
+        missing.append(f"Version: {expected_version}")
     if metadata.get("Requires-Python", "").strip() != ">=3.11":
         missing.append("Requires-Python: >=3.11")
     requirements = metadata.get_all("Requires-Dist") or []
@@ -178,14 +187,19 @@ def _require_metadata(names: set[str], data: bytes) -> None:
     _dist_info_name(names, "METADATA")
 
 
-def _project_version(pyproject_path: Path = ROOT / "pyproject.toml") -> str:
-    try:
-        data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError) as exc:
-        raise AssertionError(f"cannot read project version from {pyproject_path}: {exc}") from exc
-    version = str((data.get("project") or {}).get("version") or "").strip()
-    if not version:
-        raise AssertionError(f"{pyproject_path} is missing project.version")
+def _filename_version(path: Path) -> str:
+    """The version the wheel *claims* to be, taken from its own filename.
+
+    pyproject no longer carries a version to compare against — it is derived
+    from the git tag at build time — so the invariant this can still enforce is
+    internal consistency: the filename installers key off and the METADATA pip
+    records must agree. A build that resolved the version twice and differently
+    (say, a tagless CI checkout mid-way through) shows up as exactly that
+    disagreement.
+    """
+    version = path.name[:-4].split("-")[1]
+    if not VERSION_RE.match(version):
+        raise AssertionError(f"wheel filename has an unexpected version segment: {path.name}")
     return version
 
 
@@ -280,7 +294,9 @@ def verify_wheel(path: Path, *, expect_native: Optional[bool]) -> None:
         _require_only_shippable_roots(names)
         wheel = _parse_wheel(names, zf.read(_dist_info_name(names, "WHEEL")))
         _require_filename_tag(path, wheel.tags)
-        _require_metadata(names, zf.read(_dist_info_name(names, "METADATA")))
+        expected_version = _filename_version(path)
+        _require_dist_info_version(names, expected_version)
+        _require_metadata(names, zf.read(_dist_info_name(names, "METADATA")), expected_version)
         _require_record(zf, names)
 
     missing = sorted(REQUIRED_FILES - names)

--- a/spec/process/production-readiness.md
+++ b/spec/process/production-readiness.md
@@ -88,9 +88,9 @@ These must pass before publishing or making a broad performance claim.
 | Real chart render | A real composed chart exports and paints in Chromium | `python scripts/smoke_render.py <chromium>` |
 | Step tier update | A decimated `step` chart keeps its risers after a synthetic kernel `tier_update` replaces the vertex buffers | `python scripts/step_tier_smoke.py <chromium>` |
 | Dashboard reliability | 10/20/50-chart dashboards stay nonblank under the render client's context governor | `python benchmarks/bench_dashboard.py --chart-counts 10,20,50 --chromium <chromium> --json dashboard-smoke.json` then `python scripts/verify_benchmark_report.py dashboard-smoke.json --kind dashboard-browser` |
-| sdist | Source archive contains required source/bundles, benchmark regression harness/baseline, release docs/tests/scripts, the example apps' source, `PKG-INFO` version/dependencies matching `pyproject.toml`, no duplicate members, and no generated junk | `python scripts/verify_sdist.py dist/*.tar.gz` |
-| Native wheel | Platform wheel contains package-only files, exactly one native library, `METADATA` version/dependencies matching `pyproject.toml`, complete hash-checked `RECORD`, public export-surface markers, matching filename/`WHEEL` tags, and is tagged non-pure | `python scripts/verify_wheel.py dist/*.whl --expect-native` |
-| Fallback wheel | No-toolchain wheel contains package-only files, `METADATA` version/dependencies matching `pyproject.toml`, complete hash-checked `RECORD`, public export-surface markers, matching filename/`WHEEL` tags, is pure, and contains no native library | `python scripts/verify_wheel.py dist/*.whl --expect-pure` |
+| sdist | Source archive contains required source/bundles, benchmark regression harness/baseline, release docs/tests/scripts, the example apps' source, `PKG-INFO` version/dependencies matching the archive's own `xy-<version>` root, no duplicate members, and no generated junk | `python scripts/verify_sdist.py dist/*.tar.gz` |
+| Native wheel | Platform wheel contains package-only files, exactly one native library, `METADATA` version/dependencies matching the wheel's own filename and `.dist-info`, complete hash-checked `RECORD`, public export-surface markers, matching filename/`WHEEL` tags, and is tagged non-pure | `python scripts/verify_wheel.py dist/*.whl --expect-native` |
+| Fallback wheel | No-toolchain wheel contains package-only files, `METADATA` version/dependencies matching the wheel's own filename and `.dist-info`, complete hash-checked `RECORD`, public export-surface markers, matching filename/`WHEEL` tags, is pure, and contains no native library | `python scripts/verify_wheel.py dist/*.whl --expect-pure` |
 | Wheel size | Platform wheel remains small enough for notebook installs | CI budget: 15 MB |
 | Benchmark artifact | JSON benchmark reports carry schema, environment, categories, row status, and finite non-negative metrics; native reports must declare the native backend | `python scripts/verify_benchmark_report.py benchmark.json --kind scatter-vs`; repeat for line, install, core-2D, pyplot-vs-matplotlib, native, interaction, dashboard, and workflow artifacts |
 
@@ -325,8 +325,23 @@ Node, Chrome, `ruff`, `ty`, or `pytest` produce direct install/skip guidance.
 
 ## Release Checklist
 
+The tag *is* the version. `pyproject.toml` declares `dynamic = ["version"]` and
+uv-dynamic-versioning derives the distribution version from the latest `v*` git
+tag, so cutting a release is `git tag vX.Y.Z && git push --tags` — there is no
+number to bump in a file, and no file that can drift from the tag. Two
+consequences worth knowing:
+
+- Builds between tags are versioned `<next>.devN+<commit>`, which PyPI rejects
+  by design: only a tag can produce an uploadable version.
+- Every checkout that builds must be unshallow (`fetch-depth: 0`). A depth-1
+  clone fetches no tags and would *silently* build at the `0.0.0` fallback;
+  `make check-ci` enforces this.
+
 Before tagging a release:
 
+- Add a dated `## [X.Y.Z] — YYYY-MM-DD` heading to `CHANGELOG.md` for the
+  version being tagged. This is the one thing the tag cannot vouch for, and the
+  release gate blocks the publish without it.
 - Refresh benchmark reports or explicitly document why the previous report still
   applies.
 - Run `make check-full` locally or confirm the equivalent

--- a/tests/test_check_release_version.py
+++ b/tests/test_check_release_version.py
@@ -18,55 +18,63 @@ def _load_module():
 check_release_version = _load_module()
 
 
-def _files(tmp_path: Path, version: str, changelog_heading: str) -> tuple[Path, Path]:
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text(f'[project]\nname = "xy"\nversion = "{version}"\n')
+def _changelog(tmp_path: Path, changelog_heading: str) -> Path:
     changelog = tmp_path / "CHANGELOG.md"
     changelog.write_text(f"# Changelog\n\n{changelog_heading}\n\n- Something.\n")
-    return pyproject, changelog
+    return changelog
 
 
-def test_gate_passes_when_tag_version_and_changelog_agree(tmp_path: Path) -> None:
-    pyproject, changelog = _files(tmp_path, "0.2.0", "## [0.2.0] — 2026-07-09")
+def test_gate_passes_when_tag_and_changelog_agree(tmp_path: Path) -> None:
+    changelog = _changelog(tmp_path, "## [0.2.0] — 2026-07-09")
 
-    assert check_release_version.check_release("v0.2.0", pyproject, changelog) == []
+    assert check_release_version.check_release("v0.2.0", changelog) == []
 
 
 def test_gate_accepts_plain_hyphen_date_separator(tmp_path: Path) -> None:
-    pyproject, changelog = _files(tmp_path, "0.2.0", "## [0.2.0] - 2026-07-09")
+    changelog = _changelog(tmp_path, "## [0.2.0] - 2026-07-09")
 
-    assert check_release_version.check_release("v0.2.0", pyproject, changelog) == []
-
-
-def test_gate_rejects_tag_version_mismatch(tmp_path: Path) -> None:
-    pyproject, changelog = _files(tmp_path, "0.1.0", "## [0.1.0] — 2026-07-09")
-
-    errors = check_release_version.check_release("v0.2.0", pyproject, changelog)
-
-    assert any("does not match pyproject version" in e for e in errors)
+    assert check_release_version.check_release("v0.2.0", changelog) == []
 
 
 def test_gate_rejects_undated_changelog_entry(tmp_path: Path) -> None:
-    pyproject, changelog = _files(tmp_path, "0.1.0", "## [0.1.0] — unreleased development line")
+    changelog = _changelog(tmp_path, "## [0.1.0] — unreleased development line")
 
-    errors = check_release_version.check_release("v0.1.0", pyproject, changelog)
+    errors = check_release_version.check_release("v0.1.0", changelog)
 
     assert any("no dated" in e for e in errors)
 
 
 def test_gate_rejects_missing_changelog_entry(tmp_path: Path) -> None:
-    pyproject, changelog = _files(tmp_path, "0.3.0", "## [0.2.0] — 2026-07-09")
+    changelog = _changelog(tmp_path, "## [0.2.0] — 2026-07-09")
 
-    errors = check_release_version.check_release("v0.3.0", pyproject, changelog)
+    errors = check_release_version.check_release("v0.3.0", changelog)
 
     assert any("no dated" in e for e in errors)
 
 
+def test_gate_rejects_a_tag_that_is_not_a_release_tag(tmp_path: Path) -> None:
+    # The docs site deploys on CalVer tags (2026.WW.N) that the version
+    # derivation deliberately ignores; one must never publish a release.
+    changelog = _changelog(tmp_path, "## [2026.30.1] — 2026-07-24")
+
+    errors = check_release_version.check_release("2026.30.1", changelog)
+
+    assert any("is not a release tag" in e for e in errors)
+
+
+def test_gate_rejects_a_derived_development_version_tag(tmp_path: Path) -> None:
+    changelog = _changelog(tmp_path, "## [0.0.3.dev4] — 2026-07-24")
+
+    errors = check_release_version.check_release("v0.0.3.dev4+g63c0697", changelog)
+
+    assert any("is not a release tag" in e for e in errors)
+
+
 def test_main_requires_a_tag(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
-    pyproject, changelog = _files(tmp_path, "0.1.0", "## [0.1.0] — 2026-07-09")
+    changelog = _changelog(tmp_path, "## [0.1.0] — 2026-07-09")
 
-    rc = check_release_version.main(["--pyproject", str(pyproject), "--changelog", str(changelog)])
+    rc = check_release_version.main(["--changelog", str(changelog)])
 
     assert rc == 1
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.metadata
 import importlib.util
 import json
 import subprocess
@@ -340,47 +341,46 @@ def test_public_api_checker_rejects_stale_component_module_all() -> None:
     assert any("missing_value" in error and "undefined name" in error for error in errors)
 
 
-def test_public_api_checker_accepts_matching_project_version(tmp_path: Path) -> None:
-    fake = ModuleType("xy")
-    fake.__version__ = "1.2.3"
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text('[project]\nversion = "1.2.3"\n', encoding="utf-8")
+# The version reference is installed distribution metadata, not pyproject (which
+# no longer records one). These drive the check against a distribution that is
+# certainly installed wherever the suite runs — pytest itself — so they assert
+# the comparison rather than whatever version `xy` happens to be built at.
+REFERENCE_DISTRIBUTION = "pytest"
 
-    errors = check_public_api.validate_version_consistency(fake, pyproject)
+
+def test_public_api_checker_accepts_version_matching_installed_metadata() -> None:
+    fake = ModuleType("xy")
+    fake.__version__ = importlib.metadata.version(REFERENCE_DISTRIBUTION)
+
+    errors = check_public_api.validate_version_consistency(fake, REFERENCE_DISTRIBUTION)
 
     assert errors == []
 
 
-def test_public_api_checker_rejects_version_mismatch(tmp_path: Path) -> None:
+def test_public_api_checker_rejects_version_mismatch() -> None:
     fake = ModuleType("xy")
-    fake.__version__ = "1.2.3"
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text('[project]\nversion = "1.2.4"\n', encoding="utf-8")
+    fake.__version__ = "1.2.3-definitely-not-the-installed-version"
 
-    errors = check_public_api.validate_version_consistency(fake, pyproject)
+    errors = check_public_api.validate_version_consistency(fake, REFERENCE_DISTRIBUTION)
 
-    assert any("__version__" in error and "project.version" in error for error in errors)
+    assert any("__version__" in error and "metadata" in error for error in errors)
 
 
-def test_public_api_checker_rejects_missing_public_version(tmp_path: Path) -> None:
+def test_public_api_checker_rejects_missing_public_version() -> None:
     fake = ModuleType("xy")
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text('[project]\nversion = "1.2.3"\n', encoding="utf-8")
 
-    errors = check_public_api.validate_version_consistency(fake, pyproject)
+    errors = check_public_api.validate_version_consistency(fake, REFERENCE_DISTRIBUTION)
 
     assert any("__version__" in error and "non-empty string" in error for error in errors)
 
 
-def test_public_api_checker_rejects_unreadable_project_version(tmp_path: Path) -> None:
+def test_public_api_checker_rejects_uninstalled_distribution() -> None:
     fake = ModuleType("xy")
     fake.__version__ = "1.2.3"
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text("[project\n", encoding="utf-8")
 
-    errors = check_public_api.validate_version_consistency(fake, pyproject)
+    errors = check_public_api.validate_version_consistency(fake, "xy-not-a-real-distribution")
 
-    assert any("cannot read project version" in error for error in errors)
+    assert any("is not installed" in error for error in errors)
 
 
 def test_public_api_checker_accepts_empty_pep561_marker(tmp_path: Path) -> None:

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -738,3 +738,28 @@ def test_release_workflow_rejects_non_retryable_pypi_publish(tmp_path: Path) -> 
     errors = verify_ci_workflow.validate_release_workflow(path)
 
     assert any("release publish job" in error and "skip-existing" in error for error in errors)
+
+
+def test_release_workflow_rejects_shallow_checkout(tmp_path: Path) -> None:
+    """A depth-1 checkout fetches no tags, and the version is derived from them.
+
+    That failure is silent — the build succeeds at the 0.0.0 fallback and
+    publishes it — so the checker has to catch it instead of the release.
+    """
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release.yml"
+    path.write_text(workflow.replace("          fetch-depth: 0\n", ""), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("fetch-depth: 0" in error and "0.0.0" in error for error in errors)
+
+
+def test_ci_workflow_rejects_shallow_checkout(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+    path = tmp_path / "ci.yml"
+    path.write_text(workflow.replace("          fetch-depth: 0\n", ""), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_ci_workflow(path)
+
+    assert any("fetch-depth: 0" in error for error in errors)

--- a/uv.lock
+++ b/uv.lock
@@ -875,7 +875,6 @@ wheels = [
 
 [[package]]
 name = "xy"
-version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },


### PR DESCRIPTION
## What

`pyproject.toml` switches from a static `version = "0.0.1"` to
`dynamic = ["version"]`, resolved from the latest `v*` git tag by the
[`uv-dynamic-versioning`](https://github.com/ninoseki/uv-dynamic-versioning)
hatchling plugin.

Motivating drift: pyproject said `0.0.1` while `v0.0.2` was the live tag. After
this, `git tag vX.Y.Z && git push --tags` is the whole release action — there is
no second number left to disagree with the tag.

## Verified, not assumed

- **CalVer tags are excluded for free.** `git describe` on `main` returns
  `2026.30.1` (a docs-deploy tag, disjoint from library versions by design), but
  dunamai's default pattern requires the `v` prefix, so the plugin resolves
  `0.0.2`. No custom pattern needed.
- **Between-tag builds** resolve to `0.0.3.dev1+5fc6676` (`bump = true`) — a
  local segment PyPI rejects, so only a tag produces an uploadable version.
- **sdist → wheel needs no git.** The plugin reads `PKG-INFO` in an unpacked
  sdist; mangling it to `9.9.9` produced a `9.9.9` wheel. So
  `pip install xy-X.Y.Z.tar.gz` keeps the published version.
- **Installed-wheel smoke:** `xy.__version__ == "0.0.2"`, `import xy` at
  **3.5 ms** against the 200 ms budget, with `importlib.metadata` *not* eagerly
  imported.

## The load-bearing part: `fetch-depth: 0`

`actions/checkout` defaults to a depth-1 clone carrying no tags, under which the
version resolves to the `0.0.0` fallback **silently** — the build succeeds and
ships the wrong number rather than failing, invisible until someone reads a PyPI
page. This applies to the tag push that publishes to PyPI.

All 21 checkouts now set `fetch-depth: 0`, and `verify_ci_workflow.py` rejects
any workflow that omits it (negative-tested: fires on a shallow checkout, passes
on a deep one).

The docs backend image is the one build that legitimately has no git metadata
(`.dockerignore` excludes `.git`), so CI resolves the version on the runner and
passes it in via `UV_DYNAMIC_VERSIONING_BYPASS`.

## Ripple

- `xy.__version__` reads installed distribution metadata instead of a hardcoded
  string, resolved lazily through the existing `__getattr__`.
- `verify_wheel.py` / `verify_sdist.py` check each artifact against *itself*
  (filename ↔ `.dist-info` ↔ `METADATA`; sdist root ↔ `PKG-INFO`) rather than
  reading a pyproject version that no longer exists. The wheel gains a
  `.dist-info` name check the old comparison did not cover.
- The release gate drops its tag-vs-pyproject leg (now tautological), keeps
  tag ↔ CHANGELOG, and adds a check that the tag is shaped like a release tag.
- `uv` omits the version for dynamic-versioned editable packages, so `--frozen`
  syncs do not churn per commit. Both lockfiles pass `uv lock --check`.

## Test evidence

- Full suite: **2267 passed, 4 skipped**
- `check_public_api`, `verify_ci_workflow`, `ruff check`, `ruff format --check`: clean
- Real wheel + sdist built and both verifiers pass at the tag-derived `0.0.2`

## Note for whoever cuts the next release

`CHANGELOG.md` has no dated `## [0.0.2]` entry — only `0.0.1` and
`[Unreleased]`. That predates this PR, but the release gate will now block the
next tag until a dated heading exists for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Package versions are now derived from Git release tags, with installed packages reporting their distribution version.
  * Release builds and validation now use artifact and tag versions consistently.

* **Bug Fixes**
  * Improved release workflows by ensuring complete repository history and tags are available.
  * Release validation now requires a valid release tag and dated changelog entry.
  * Added safeguards against incorrectly versioned wheels, source archives, and builds.

* **Documentation**
  * Updated release procedures and versioning guidance, including changelog and checkout requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->