### PR TITLE
Deploy docs on semver release tags instead of CalVer

### DIFF
--- a/.github/workflows/deploy-docs-stg.yml
+++ b/.github/workflows/deploy-docs-stg.yml
@@ -7,15 +7,15 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Existing XY docs deploy tag (CalVer, for example 2026.26.1)"
+        description: "Existing XY release tag (semver, for example v0.1.0)"
         required: true
         type: string
   push:
-    # CalVer deploy tags (2026.WW.N) — matches the flexgen/helm-charts release
-    # scheme and stays disjoint from the library's semver v* tags, which
-    # trigger release.yml (PyPI/Cargo) and must NOT deploy the docs site.
-    tags:
-      - "20[0-9][0-9].[0-9]*"
+    # The library's semver release tags — the same `v*` tags release.yml
+    # publishes to PyPI from, so the docs site ships the version it documents.
+    # Deploying an arbitrary commit outside a release is workflow_dispatch's
+    # job (or deploy-docs-dev.yml, which tracks main on every push).
+    tags: ["v*"]
 
 permissions:
   contents: read
@@ -42,8 +42,11 @@ jobs:
           EVENT_SHA: ${{ github.sha }}
           REPO: ${{ github.repository }}
         run: |
-          if [[ ! "$VERSION" =~ ^20[0-9]{2}\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::version must be CalVer like 2026.26.1"
+          # Same shape release.yml gates on (tag == v<pyproject version>),
+          # minus PEP 440 local versions: `+` is not a legal Docker tag
+          # character and this value becomes the image tag.
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9.-]*$ ]]; then
+            echo "::error::version must be a semver release tag like v0.1.0"
             exit 1
           fi
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
@@ -93,35 +96,14 @@ jobs:
     steps:
       - run: echo "Approved for production promotion"
 
-  release:
-    name: Create GitHub Release
-    needs: [prepare, await-prod-approval]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: write
-    steps:
-      - name: Create release if needed
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.prepare.outputs.version }}
-          SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
-          REPO: ${{ github.repository }}
-        run: |
-          if gh release view "$VERSION" --repo "$REPO" >/dev/null 2>&1; then
-            echo "::notice::Release $VERSION already exists"
-            exit 0
-          fi
-          NOTES=$(printf "Production deployment of XY docs.\n\n**Source SHA:** \`%s\`\n**Image tag:** \`%s\`" "$SOURCE_SHA" "$VERSION")
-          gh release create "$VERSION" \
-            --repo "$REPO" \
-            --title "Release $VERSION" \
-            --notes "$NOTES" \
-            --target "$SOURCE_SHA"
+  # No GitHub Release job here: on a `v*` tag release.yml owns the release
+  # (it gates tag == pyproject == CHANGELOG and attaches the Pyodide wheel with
+  # generated notes). A second creator would race it and could win, stamping a
+  # library release with docs-deployment notes.
 
   helm-pr-prod:
     name: Update Production Helm Values
-    needs: [prepare, await-prod-approval, release]
+    needs: [prepare, await-prod-approval]
     permissions:
       contents: read
     uses: ./.github/workflows/_helm-docs-pr.yml

--- a/.github/workflows/deploy-docs-stg.yml
+++ b/.github/workflows/deploy-docs-stg.yml
@@ -42,11 +42,20 @@ jobs:
           EVENT_SHA: ${{ github.sha }}
           REPO: ${{ github.repository }}
         run: |
-          # Same shape release.yml gates on (tag == v<pyproject version>),
-          # minus PEP 440 local versions: `+` is not a legal Docker tag
-          # character and this value becomes the image tag.
-          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9.-]*$ ]]; then
-            echo "::error::version must be a semver release tag like v0.1.0"
+          # Shape check only — the real gate (tag == pyproject == CHANGELOG)
+          # runs below against the tagged tree. Deliberately PEP 440, not
+          # strict SemVer: release.yml requires tag == "v" + the pyproject
+          # version, so an rc tags as `v0.2.0rc1` (no dash) and a post-release
+          # as `v0.2.0.post1`. Local versions are excluded because `+` is not a
+          # legal Docker tag character and this value becomes the image tag,
+          # and the trailing class cannot end in a separator. 128 chars is the
+          # ceiling the reusable build/helm workflows enforce.
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-]?[A-Za-z0-9]+)*$ ]]; then
+            echo "::error::version must be a release tag like v0.1.0, v0.2.0rc1 or v0.2.0.post1"
+            exit 1
+          fi
+          if (( ${#VERSION} > 128 )); then
+            echo "::error::version must be <=128 characters (Docker tag limit)"
             exit 1
           fi
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
@@ -60,6 +69,18 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "source_sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      # A semver-shaped tag is not necessarily a releasable one. Run the same
+      # gate release.yml runs, against the tagged tree, so a stray `v9.9.9`
+      # cannot deploy docs for a library version that can never be published.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.resolve.outputs.source_sha }}
+          persist-credentials: false
+      - name: Release version gate (tag == pyproject == CHANGELOG)
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: python3 scripts/check_release_version.py --tag "$VERSION"
 
   build:
     name: Build Versioned Images
@@ -99,11 +120,50 @@ jobs:
   # No GitHub Release job here: on a `v*` tag release.yml owns the release
   # (it gates tag == pyproject == CHANGELOG and attaches the Pyodide wheel with
   # generated notes). A second creator would race it and could win, stamping a
-  # library release with docs-deployment notes.
+  # library release with docs-deployment notes. The flip side of not owning it
+  # is that this workflow must confirm it happened before promoting prod.
+  verify-library-release:
+    name: Verify Library Release Published
+    needs: [prepare, await-prod-approval]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      # release.yml runs in parallel on the same tag and its wheel matrix is
+      # slow, so poll rather than sample once. Prod must never document a
+      # version users cannot `pip install`.
+      - name: Await GitHub Release and PyPI availability
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          PYPI_VERSION="${VERSION#v}"
+          for attempt in $(seq 1 30); do
+            RELEASED=false
+            PUBLISHED=false
+            if gh release view "$VERSION" --repo "$REPO" >/dev/null 2>&1; then
+              RELEASED=true
+            fi
+            CODE=$(curl -fsS -o /dev/null -w '%{http_code}' \
+              "https://pypi.org/pypi/xy/${PYPI_VERSION}/json" 2>/dev/null || true)
+            if [[ "$CODE" == "200" ]]; then
+              PUBLISHED=true
+            fi
+            if [[ "$RELEASED" == true && "$PUBLISHED" == true ]]; then
+              echo "::notice::${VERSION} is on GitHub Releases and PyPI"
+              exit 0
+            fi
+            echo "attempt ${attempt}/30 — release=${RELEASED} pypi=${PUBLISHED}; retrying in 60s"
+            sleep 60
+          done
+          echo "::error::${VERSION} did not publish (GitHub Release and/or PyPI missing) — refusing to promote prod"
+          exit 1
 
   helm-pr-prod:
     name: Update Production Helm Values
-    needs: [prepare, await-prod-approval]
+    needs: [prepare, await-prod-approval, verify-library-release]
     permissions:
       contents: read
     uses: ./.github/workflows/_helm-docs-pr.yml


### PR DESCRIPTION
`deploy-docs-stg.yml` was the only workflow still keyed to the flexgen/helm-charts CalVer scheme (`2026.WW.N`). Every other workflow here runs on push/PR/dispatch, and `release.yml` runs on the library's `v*` tags. This aligns the docs deploy with that.

## Changes

- **Trigger:** `tags: ["20[0-9][0-9].[0-9]*"]` → `tags: ["v*"]` — the same tags `release.yml` publishes to PyPI from, so the docs site ships the version it documents.
- **Version guard:** `^20[0-9]{2}\.[0-9]+\.[0-9]+$` → `^v[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9.-]*$`. Accepts `v0.1.0`, `v1.20.3rc1`, `v0.1.0-beta.1`; rejects `v1.2` and PEP 440 local versions (`v1.2.3+local`) — `+` is not a legal Docker tag character and this value becomes the image tag.
- **`workflow_dispatch` input description** updated to match.
- **Removed the `Create GitHub Release` job**, rewiring `helm-pr-prod` off it.

## Why the release job had to go

On a `v*` tag, `release.yml`'s `publish-pyodide` already does `gh release create "$tag" --generate-notes`, gated on tag == pyproject == CHANGELOG. Leaving this workflow's release job in place meant two workflows racing to create the same release. The race is unlikely but not impossible — the docs job runs after prod approval, the wheel matrix is slow — and if the docs deploy won, the library release would permanently carry notes reading "Production deployment of XY docs" instead of generated changelog notes.

## Behavior change to weigh

Docs prod deploys are now coupled to library releases: cutting a CalVer tag no longer ships a docs-only prod update. The remaining paths are `workflow_dispatch` against an existing `v*` tag, and `deploy-docs-dev.yml`, which still tracks `main` on every push. If docs should keep shipping independently of PyPI releases, the fix is to keep both trigger patterns instead — say the word and I'll add the CalVer pattern back alongside `v*`.

## Verification

- `make check-ci` passes.
- Workflow YAML parses; job graph is `prepare → build → helm-pr-stg → await-prod-approval → helm-pr-prod` with no dangling `needs`.
- Version regex exercised against `v0.1.0`, `v0.0.2`, `v1.20.3rc1`, `v0.1.0-beta.1` (pass) and `2026.26.1`, `v1.2`, `v1.2.3+local`, `v1.2.3;rm` (reject).
- `pre-commit run --all-files`, `ruff check .`, `ruff format --check .` all clean.

Note: no `spec/` or `docs/` page documents the deploy tag scheme, so there was nothing to sync there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated documentation staging and production deployment to trigger only on semantic version `v*` release tags.
  * Enhanced version validation to reject unsupported tag formats and overly long versions.
  * Removed automatic GitHub Release creation from the docs deployment flow.
  * Improved production release safety by verifying the corresponding GitHub Release and package availability before promoting Helm/production updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->