### PR TITLE
Add reflex-xy release infrastructure and distribution verifier

### DIFF
--- a/.github/workflows/release-reflex-xy.yml
+++ b/.github/workflows/release-reflex-xy.yml
@@ -26,6 +26,8 @@ jobs:
   build:
     name: Build sdist + wheel
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/release-reflex-xy.yml
+++ b/.github/workflows/release-reflex-xy.yml
@@ -22,18 +22,24 @@ on:
         type: boolean
         default: true
 
+# Least privilege for every job, declared once: reading the repo is all the
+# build needs, and nothing here relies on repository/org defaults. The
+# publish job's own block *replaces* this with the OIDC grant it needs.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build sdist + wheel
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history and tags: the distribution version is derived
           # from the latest `reflex-xy-v*` tag, and a shallow clone has none.
           fetch-depth: 0
+          # No later step needs the token; don't leave it in .git/config.
+          persist-credentials: false
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: false
@@ -73,6 +79,8 @@ jobs:
           # Full history and tags: the release gate reads the tag from the ref
           # and the adapter changelog from the checkout.
           fetch-depth: 0
+          # No later step needs the token; don't leave it in .git/config.
+          persist-credentials: false
       # The tag *is* the version, so the one thing it cannot vouch for is that
       # the release was written up: require a dated entry in the adapter's own
       # changelog (python/reflex-xy/CHANGELOG.md) for the tagged version.

--- a/.github/workflows/release-reflex-xy.yml
+++ b/.github/workflows/release-reflex-xy.yml
@@ -1,0 +1,100 @@
+name: Release reflex-xy
+
+# Publish the Reflex adapter to PyPI on its own tag namespace. reflex-xy is a
+# pure-Python package — no native core, no JS build, no platform matrix — so
+# its whole release surface is one py3-none-any wheel plus one sdist, and it
+# deliberately does NOT share release.yml's cross-compile pipeline: a separate
+# small workflow is easier to keep correct than a second build shape wedged
+# into the wheel matrix. The tag namespaces keep the two release lines
+# disjoint in both directions: `reflex-xy-vX.Y.Z` here, bare `vX.Y.Z` for the
+# xy core, and each package's version derivation (uv-dynamic-versioning
+# pattern anchoring) is blind to the other's tags.
+on:
+  push:
+    tags: ["reflex-xy-v*"]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: >-
+          Dry run: build and verify the sdist + wheel without publishing to
+          PyPI. Defaults to true so a manual dispatch never accidentally
+          publishes.
+        type: boolean
+        default: true
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the distribution version is derived
+          # from the latest `reflex-xy-v*` tag, and a shallow clone has none.
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: false
+      - name: Build sdist and wheel
+        working-directory: python/reflex-xy
+        run: uv build
+      - name: Verify dist contents
+        shell: bash
+        run: |
+          # On a tag push the artifacts must carry exactly the tagged version;
+          # a manual dry run builds an intentionally unpublishable dev version.
+          tag_args=()
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            tag_args=(--tag "$GITHUB_REF_NAME")
+          fi
+          python3 scripts/verify_reflex_xy_dist.py python/reflex-xy/dist/* "${tag_args[@]}"
+      - name: Verify the wheel installs and imports
+        run: |
+          uv venv smoke
+          uv pip install -p smoke python/reflex-xy/dist/*.whl
+          ./smoke/bin/python -c "import reflex_xy; v = reflex_xy.__version__; assert v != '0.0.0', v; print('reflex-xy', v)"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist-reflex-xy
+          path: python/reflex-xy/dist/*
+
+  publish:
+    name: Publish to PyPI
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # PyPI trusted publishing (OIDC) — no API token stored
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags: the release gate reads the tag from the ref
+          # and the adapter changelog from the checkout.
+          fetch-depth: 0
+      # The tag *is* the version, so the one thing it cannot vouch for is that
+      # the release was written up: require a dated entry in the adapter's own
+      # changelog (python/reflex-xy/CHANGELOG.md) for the tagged version.
+      - name: Release version gate (tag == adapter CHANGELOG)
+        if: github.event_name == 'push'
+        run: python3 scripts/check_release_version.py --package reflex-xy
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist-reflex-xy
+          path: dist
+      - name: List artifacts
+        run: ls -la dist/
+      # A manual workflow_dispatch defaults to dry_run=true: the sdist + wheel
+      # are built and verified above, but nothing is uploaded to PyPI. A tag
+      # push always publishes for real.
+      - name: Dry run summary (no PyPI publish)
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'
+        run: |
+          echo "::notice::Dry run — built and verified the reflex-xy sdist + wheel. Skipping PyPI publish."
+          echo "Re-run this workflow with dry_run=false, or push a reflex-xy-v* tag, to publish for real."
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true'
+        with:
+          packages-dir: dist/
+          # A failed upload can leave a partial release on immutable PyPI.
+          # Retrying the same tag should skip files that were already accepted.
+          skip-existing: true

--- a/docs/app/uv.lock
+++ b/docs/app/uv.lock
@@ -1304,7 +1304,6 @@ dependencies = [
 
 [[package]]
 name = "reflex-xy"
-version = "0.1.0"
 source = { editable = "../../python/reflex-xy" }
 dependencies = [
     { name = "reflex" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,10 @@ include = [
     ".github/workflows/ci.yml",
     ".github/workflows/codspeed.yml",
     ".github/workflows/release.yml",
+    # The adapter's release workflow rides along (repo infra, like release.yml)
+    # even though the adapter *package* stays out of this sdist: the shipped
+    # test suite validates all four workflows via scripts/verify_ci_workflow.py.
+    ".github/workflows/release-reflex-xy.yml",
     # The xy package only — python/reflex-xy is its own distributable
     # (own pyproject, depends on reflex) and must not ride in this sdist;
     # scripts/verify_sdist.py enforces both the no-reflex-dependency rule

--- a/python/reflex-xy/CHANGELOG.md
+++ b/python/reflex-xy/CHANGELOG.md
@@ -10,8 +10,13 @@ version is derived from that tag — there is no number to bump in a file.
 Cutting a release is: date the entry below, tag, push the tag. The release
 gate (`scripts/check_release_version.py --package reflex-xy`) blocks the
 publish unless this file carries a dated entry for the tagged version.
+Pre-releases work the same way with a canonical PEP 440 suffix on the tag
+(`reflex-xy-v0.0.1a1` → version `0.0.1a1`, likewise `bN`/`rcN`) and their own
+dated entry here; pip only installs them on explicit request.
 
 ## [Unreleased]
+
+## [0.0.1a1] — 2026-07-25
 
 ### Added
 - First packaged release line of the adapter: `reflex_xy.chart()` components,
@@ -22,8 +27,9 @@ publish unless this file carries a dated entry for the tagged version.
   streaming `append`.
 - The distribution version is derived from `reflex-xy-vX.Y.Z` git tags
   (uv-dynamic-versioning with `pattern-prefix = "reflex-xy-"`) instead of a
-  number in `pyproject.toml`; builds between tags are versioned
-  `<next>.devN+<commit>`, which PyPI rejects by design. The adapter and core
+  number in `pyproject.toml`; canonical pre-release tags (`aN`/`bN`/`rcN`)
+  publish too, and builds between tags are versioned `<next>.devN+<commit>`,
+  which PyPI rejects by design. The adapter and core
   tag namespaces are mutually invisible by pattern anchoring: this derivation
   never sees bare `v*` tags, and the core's never sees `reflex-xy-*` ones.
   Releases publish via the dedicated

--- a/python/reflex-xy/CHANGELOG.md
+++ b/python/reflex-xy/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to **reflex-xy** (the Reflex adapter for xy) are
+documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+The adapter versions independently of the xy core: its releases are tagged
+`reflex-xy-vX.Y.Z` (the core keeps bare `vX.Y.Z`), and the distribution
+version is derived from that tag — there is no number to bump in a file.
+Cutting a release is: date the entry below, tag, push the tag. The release
+gate (`scripts/check_release_version.py --package reflex-xy`) blocks the
+publish unless this file carries a dated entry for the tagged version.
+
+## [Unreleased]
+
+### Added
+- First packaged release line of the adapter: `reflex_xy.chart()` components,
+  `@reflex_xy.figure` state vars with rebuild-from-state recovery,
+  `XYPlugin`/`setup()` app wiring, the `/_xy` socket.io data-plane namespace
+  (binary columns on the app's own websocket), semantic hover/click/select/
+  view events, fixed-data tiers (direct `Chart` + `inline()` tokens), and
+  streaming `append`.
+- The distribution version is derived from `reflex-xy-vX.Y.Z` git tags
+  (uv-dynamic-versioning with `pattern-prefix = "reflex-xy-"`) instead of a
+  number in `pyproject.toml`; builds between tags are versioned
+  `<next>.devN+<commit>`, which PyPI rejects by design. The adapter and core
+  tag namespaces are mutually invisible by pattern anchoring: this derivation
+  never sees bare `v*` tags, and the core's never sees `reflex-xy-*` ones.
+  Releases publish via the dedicated
+  `.github/workflows/release-reflex-xy.yml` workflow — deliberately separate
+  from the core's cross-compile pipeline, since the adapter is one pure wheel
+  plus one sdist with no build matrix — verified by
+  `scripts/verify_reflex_xy_dist.py`, gated on this changelog, published with
+  PyPI trusted publishing, and validated alongside the other workflows by
+  `make check-ci`. `reflex_xy.__version__` now reports the installed
+  distribution's version (an uninstalled tree reports `0.0.0`).

--- a/python/reflex-xy/CHANGELOG.md
+++ b/python/reflex-xy/CHANGELOG.md
@@ -4,19 +4,7 @@ All notable changes to **reflex-xy** (the Reflex adapter for xy) are
 documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-The adapter versions independently of the xy core: its releases are tagged
-`reflex-xy-vX.Y.Z` (the core keeps bare `vX.Y.Z`), and the distribution
-version is derived from that tag — there is no number to bump in a file.
-Cutting a release is: date the entry below, tag, push the tag. The release
-gate (`scripts/check_release_version.py --package reflex-xy`) blocks the
-publish unless this file carries a dated entry for the tagged version.
-Pre-releases work the same way with a canonical PEP 440 suffix on the tag
-(`reflex-xy-v0.0.1a1` → version `0.0.1a1`, likewise `bN`/`rcN`) and their own
-dated entry here; pip only installs them on explicit request.
-
-## [Unreleased]
-
-## [0.0.1a1] — 2026-07-25
+## [0.0.1] — 2026-07-25
 
 ### Added
 - First packaged release line of the adapter: `reflex_xy.chart()` components,

--- a/python/reflex-xy/README.md
+++ b/python/reflex-xy/README.md
@@ -163,3 +163,11 @@ Each section shows its own source, read live with `inspect.getsource`.
 
 For serving the same charts without Reflex, [`examples/fastapi/`](../../examples/fastapi)
 renders standalone HTML and a live 100M-point drilldown from a plain FastAPI app.
+
+## Versioning & releases
+
+`reflex-xy` versions independently of `xy`: the distribution version is
+derived from `reflex-xy-vX.Y.Z` git tags (the core uses bare `vX.Y.Z`), and
+releases publish from the repository's `release-reflex-xy.yml` workflow after
+a dated entry lands in this package's [CHANGELOG](CHANGELOG.md). Builds
+between tags carry a `.devN+<commit>` version that PyPI rejects by design.

--- a/python/reflex-xy/README.md
+++ b/python/reflex-xy/README.md
@@ -5,8 +5,6 @@
 interactivity, and streaming updates — with chart data riding the app's
 **existing websocket**, not a sidecar API.
 
-Status: **prototype** implementing `spec/design/reflex-integration.md`.
-
 ## How it works
 
 - **Control plane (Reflex-native).** The only chart state is a token string,
@@ -111,15 +109,6 @@ def index():
     )
 ```
 
-Selection JSON is capped and reports `total_count` plus `truncated`; call
-`reflex_xy.resolve_selection(event)` in the handler when all canonical rows
-are required. Hover and view changes are latest-wins throttled (view changes
-stream live during a gesture and always end on a `final`-phase event), and
-view/selection state survives dependent republishes without feedback events.
-The complete envelopes, limits, clear/shared-handler/viewport examples, and
-static-versus-live availability are documented in
-`docs/engineering/design/reflex-integration.md`.
-
 ## Fixed-data charts
 
 For a chart that doesn't depend on state, skip the state var entirely —
@@ -151,23 +140,3 @@ def index() -> rx.Component:
 the same one — no state, no coordination. The escalation path is:
 direct Chart (static) → `inline()` (fixed data, live kernel) →
 `@reflex_xy.figure` (per-session, state-driven).
-
-## Demo
-
-The repository's [`examples/reflex/`](../../examples/reflex) is a runnable
-showcase of every linking method: a drillable figure var with hover / click /
-box-select events, a histogram driven by a slider and cross-filtered by the
-selection, a streaming line, a detail chart recomputed from `on_view_change`,
-and the two fixed-data tiers (a direct `xy.Chart` and an `inline()` token).
-Each section shows its own source, read live with `inspect.getsource`.
-
-For serving the same charts without Reflex, [`examples/fastapi/`](../../examples/fastapi)
-renders standalone HTML and a live 100M-point drilldown from a plain FastAPI app.
-
-## Versioning & releases
-
-`reflex-xy` versions independently of `xy`: the distribution version is
-derived from `reflex-xy-vX.Y.Z` git tags (the core uses bare `vX.Y.Z`), and
-releases publish from the repository's `release-reflex-xy.yml` workflow after
-a dated entry lands in this package's [CHANGELOG](CHANGELOG.md). Builds
-between tags carry a `.devN+<commit>` version that PyPI rejects by design.

--- a/python/reflex-xy/pyproject.toml
+++ b/python/reflex-xy/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "uv-dynamic-versioning>=0.11"]
 build-backend = "hatchling.build"
 
 [project]
 name = "reflex-xy"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Reflex integration for xy: WebGL charts over the app's own websocket"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -28,6 +28,31 @@ dev = [
 
 [project.urls]
 Repository = "https://github.com/reflex-dev/xy"
+Changelog = "https://github.com/reflex-dev/xy/blob/main/python/reflex-xy/CHANGELOG.md"
+
+# Same tag-derived versioning policy as the xy core (see the root
+# pyproject.toml for the full rationale), in a tag namespace of its own:
+# the adapter releases from `reflex-xy-vX.Y.Z` tags, cut by
+# .github/workflows/release-reflex-xy.yml. `pattern-prefix` inserts
+# `reflex-xy-` after the default pattern's `^` anchor, which keeps the two
+# release lines disjoint in both directions — this derivation only sees
+# `reflex-xy-v*` tags, while the core's bare-`v` pattern (and the docs-deploy
+# CalVer tags) can never match them.
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+vcs = "git"
+style = "pep440"
+pattern-prefix = "reflex-xy-"
+# Builds off a tagged commit get the bare version; anything else gets
+# `<next>.devN+<commit>`, unpublishable to PyPI on purpose — only a tag can
+# produce an uploadable version.
+bump = true
+# Only reached by a source tree with neither git metadata nor PKG-INFO; such
+# a build still succeeds, at an obviously unreal version rather than a
+# plausible-but-wrong one (unpacked sdists resolve from their own PKG-INFO).
+fallback-version = "0.0.0"
 
 [tool.hatch.build.targets.wheel]
 packages = ["reflex_xy"]

--- a/python/reflex-xy/reflex_xy/__init__.py
+++ b/python/reflex-xy/reflex_xy/__init__.py
@@ -94,7 +94,28 @@ __all__ = [
     "setup",
 ]
 
-__version__ = "0.1.0"
+
+def __getattr__(name: str) -> str:
+    """Resolve ``__version__`` lazily from the installed distribution.
+
+    The version is not written down in the source tree — it is derived from
+    the latest ``reflex-xy-vX.Y.Z`` git tag at build time (pyproject's
+    uv-dynamic-versioning config) and baked into the wheel's METADATA, so
+    package metadata is the only place that can answer this at runtime. An
+    uninstalled source tree reports the same unreal ``0.0.0`` the build-time
+    fallback uses.
+    """
+    if name == "__version__":
+        from importlib.metadata import PackageNotFoundError
+        from importlib.metadata import version as _distribution_version
+
+        try:
+            value = _distribution_version("reflex-xy")
+        except PackageNotFoundError:
+            value = "0.0.0"
+        globals()["__version__"] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def register(chart_or_figure: Any) -> str:

--- a/python/reflex-xy/uv.lock
+++ b/python/reflex-xy/uv.lock
@@ -1509,7 +1509,6 @@ wheels = [
 
 [[package]]
 name = "reflex-xy"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "reflex" },

--- a/scripts/check_release_version.py
+++ b/scripts/check_release_version.py
@@ -1,16 +1,24 @@
 #!/usr/bin/env python3
-"""Release gate: the pushed tag and the CHANGELOG must agree.
+"""Release gate: the pushed tag and the package's CHANGELOG must agree.
 
-The tag *is* the version now — pyproject derives it via uv-dynamic-versioning —
-so the old tag-vs-pyproject leg of this gate is gone along with the drift it
-existed to catch. What a tag cannot vouch for is that anyone wrote down what
-changed, so this runs first in the publish job on tag pushes: CHANGELOG.md must
-carry a dated entry for the tagged version (an "unreleased" heading fails —
-date it as part of cutting the release).
+The tag *is* the version now — each pyproject derives it via
+uv-dynamic-versioning — so the old tag-vs-pyproject leg of this gate is gone
+along with the drift it existed to catch. What a tag cannot vouch for is that
+anyone wrote down what changed, so this runs first in the publish job on tag
+pushes: the package's changelog must carry a dated entry for the tagged
+version (an "unreleased" heading fails — date it as part of cutting the
+release).
 
-The tag must also be shaped like a release tag (`vX.Y.Z`), which is what the
-version derivation matches on; the docs-deploy CalVer tags (2026.WW.N) neither
-match it nor trigger this workflow.
+Two release lines share the repo, in disjoint tag namespaces (`--package`):
+
+- ``xy`` (default): bare `vX.Y.Z` tags, gated against `CHANGELOG.md`.
+- ``reflex-xy``: `reflex-xy-vX.Y.Z` tags, gated against
+  `python/reflex-xy/CHANGELOG.md`.
+
+The tag must also be shaped like the selected package's release tag, which is
+what its version derivation matches on; the docs-deploy CalVer tags
+(2026.WW.N) match neither shape and trigger neither workflow, and each
+package's tags fail the other package's gate.
 """
 
 from __future__ import annotations
@@ -20,22 +28,45 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import NamedTuple, Optional
 
 ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_CHANGELOG = ROOT / "CHANGELOG.md"
-# The release tag shape uv-dynamic-versioning derives the distribution version
-# from: `v` + a PEP 440 release number, nothing else.
-TAG_RE = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$")
 
 
-def check_release(tag: str, changelog: Path) -> list[str]:
+class _Package(NamedTuple):
+    # The release tag shape uv-dynamic-versioning derives this package's
+    # distribution version from: prefix + `v` + a PEP 440 release number,
+    # nothing else.
+    tag_re: re.Pattern[str]
+    tag_shape: str
+    changelog: Path
+
+
+PACKAGES = {
+    "xy": _Package(
+        tag_re=re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$"),
+        tag_shape="vX.Y.Z",
+        changelog=ROOT / "CHANGELOG.md",
+    ),
+    "reflex-xy": _Package(
+        tag_re=re.compile(r"^reflex-xy-v(?P<version>\d+\.\d+\.\d+)$"),
+        tag_shape="reflex-xy-vX.Y.Z",
+        changelog=ROOT / "python" / "reflex-xy" / "CHANGELOG.md",
+    ),
+}
+DEFAULT_CHANGELOG = PACKAGES["xy"].changelog
+# Backward-compatible alias for the pre-adapter, xy-only gate.
+TAG_RE = PACKAGES["xy"].tag_re
+
+
+def check_release(tag: str, changelog: Path, package: str = "xy") -> list[str]:
     errors: list[str] = []
-    match = TAG_RE.match(tag)
+    spec = PACKAGES[package]
+    match = spec.tag_re.match(tag)
     if match is None:
         return [
-            f"tag {tag!r} is not a release tag — expected 'vX.Y.Z', the shape the "
-            "distribution version is derived from"
+            f"tag {tag!r} is not a release tag for {package} — expected "
+            f"{spec.tag_shape!r}, the shape the distribution version is derived from"
         ]
     version = match.group("version")
     try:
@@ -48,7 +79,7 @@ def check_release(tag: str, changelog: Path) -> list[str]:
     dated = re.compile(rf"^## \[{re.escape(version)}\] [—-] \d{{4}}-\d{{2}}-\d{{2}}\s*$", re.M)
     if not dated.search(text):
         errors.append(
-            f"CHANGELOG.md has no dated '## [{version}]' entry — date the "
+            f"{changelog.name} has no dated '## [{version}]' entry — date the "
             "release section before tagging"
         )
     return errors
@@ -61,19 +92,31 @@ def main(argv: Optional[list[str]] = None) -> int:
         default=os.environ.get("GITHUB_REF_NAME", ""),
         help="release tag (defaults to $GITHUB_REF_NAME)",
     )
-    parser.add_argument("--changelog", type=Path, default=DEFAULT_CHANGELOG)
+    parser.add_argument(
+        "--package",
+        choices=sorted(PACKAGES),
+        default="xy",
+        help="which release line the tag belongs to (default: xy)",
+    )
+    parser.add_argument(
+        "--changelog",
+        type=Path,
+        default=None,
+        help="changelog to gate against (defaults to the package's own)",
+    )
     args = parser.parse_args(argv)
 
     if not args.tag:
         print("release version gate: no tag provided (--tag or GITHUB_REF_NAME)", file=sys.stderr)
         return 1
-    errors = check_release(args.tag, args.changelog)
+    changelog = args.changelog if args.changelog is not None else PACKAGES[args.package].changelog
+    errors = check_release(args.tag, changelog, args.package)
     if errors:
         print("release version gate failed:", file=sys.stderr)
         for error in errors:
             print(f"- {error}", file=sys.stderr)
         return 1
-    print(f"release version gate OK: {args.tag} has a dated CHANGELOG entry")
+    print(f"release version gate OK: {args.tag} has a dated {changelog.name} entry")
     return 0
 
 

--- a/scripts/check_release_version.py
+++ b/scripts/check_release_version.py
@@ -15,10 +15,20 @@ Two release lines share the repo, in disjoint tag namespaces (`--package`):
 - ``reflex-xy``: `reflex-xy-vX.Y.Z` tags, gated against
   `python/reflex-xy/CHANGELOG.md`.
 
+Both accept an optional PEP 440 pre-release suffix in its canonical spelling
+(`a1`/`b2`/`rc3` — e.g. `reflex-xy-v0.0.1a1`), which the version derivation
+serializes verbatim; PyPI accepts pre-releases but does not serve them to
+default `pip install`. Only the canonical spelling passes: `-alpha1`-style
+tags would be *normalized* by the derivation (`0.0.1a1`) and so could never
+match their own artifacts. A pre-release still needs its own dated changelog
+entry — publishing to PyPI is publishing, alpha or not.
+
 The tag must also be shaped like the selected package's release tag, which is
 what its version derivation matches on; the docs-deploy CalVer tags
 (2026.WW.N) match neither shape and trigger neither workflow, and each
-package's tags fail the other package's gate.
+package's tags fail the other package's gate. Dev/post/local shapes stay
+rejected: dev versions are the *between*-tags marker and must stay
+unpublishable.
 """
 
 from __future__ import annotations
@@ -36,21 +46,26 @@ ROOT = Path(__file__).resolve().parents[1]
 class _Package(NamedTuple):
     # The release tag shape uv-dynamic-versioning derives this package's
     # distribution version from: prefix + `v` + a PEP 440 release number,
-    # nothing else.
+    # optionally a canonical pre-release suffix (aN/bN/rcN), nothing else.
     tag_re: re.Pattern[str]
     tag_shape: str
     changelog: Path
 
 
+# Canonical PEP 440 spellings only: the derivation would normalize `alpha1`
+# to `a1`, so a non-canonical tag can never equal its own built version.
+_RELEASE = r"\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?"
+_SHAPE = "vX.Y.Z with an optional aN/bN/rcN pre-release suffix"
+
 PACKAGES = {
     "xy": _Package(
-        tag_re=re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$"),
-        tag_shape="vX.Y.Z",
+        tag_re=re.compile(rf"^v(?P<version>{_RELEASE})$"),
+        tag_shape=_SHAPE,
         changelog=ROOT / "CHANGELOG.md",
     ),
     "reflex-xy": _Package(
-        tag_re=re.compile(r"^reflex-xy-v(?P<version>\d+\.\d+\.\d+)$"),
-        tag_shape="reflex-xy-vX.Y.Z",
+        tag_re=re.compile(rf"^reflex-xy-v(?P<version>{_RELEASE})$"),
+        tag_shape=f"reflex-xy-{_SHAPE}",
         changelog=ROOT / "python" / "reflex-xy" / "CHANGELOG.md",
     ),
 }
@@ -74,9 +89,16 @@ def check_release(tag: str, changelog: Path, package: str = "xy") -> list[str]:
     except OSError as exc:
         errors.append(f"cannot read {changelog}: {exc}")
         return errors
-    # Keep-a-Changelog heading with a real date (this repo separates with an
-    # em dash; accept a plain hyphen too): `## [X.Y.Z] — 2026-07-09`.
-    dated = re.compile(rf"^## \[{re.escape(version)}\] [—-] \d{{4}}-\d{{2}}-\d{{2}}\s*$", re.M)
+    # A heading with a real date. The gate checks substance (this version has
+    # dated notes), not heading style: both spellings used in this repo pass —
+    # Keep-a-Changelog brackets (`## [0.0.2] — 2026-07-24`) and the plain
+    # v-prefixed form v0.0.2 was actually documented with
+    # (`## v0.0.2 - 2026-07-24`); em dash or hyphen either way.
+    dated = re.compile(
+        rf"^## (?:\[{re.escape(version)}\]|v?{re.escape(version)}) [—-] "
+        rf"\d{{4}}-\d{{2}}-\d{{2}}\s*$",
+        re.M,
+    )
     if not dated.search(text):
         errors.append(
             f"{changelog.name} has no dated '## [{version}]' entry — date the "

--- a/scripts/verify_ci_workflow.py
+++ b/scripts/verify_ci_workflow.py
@@ -140,11 +140,10 @@ def _require_job_contains(
         errors.append(f"{workflow_label} {job} job missing {description}: {missing}")
 
 
-def _step_is_conditioned(job_text: str, step_needle: str) -> bool:
-    """True if the step whose `uses:`/`run:` line contains `step_needle` has its
-    own `if:` key — not just any `if:` elsewhere in the job (e.g. a sibling
-    step's dry-run summary). Scoped to the step's own indented block so a
-    same-level sibling step can't mask a missing gate.
+def _step_block(job_text: str, step_needle: str) -> Optional[str]:
+    """The indented block of the step whose `uses:`/`run:` line contains
+    `step_needle` — the step's own lines only, so a same-level sibling step
+    can't mask a missing key.
 
     The prefix (the step's own `uses:`/`name:`/`run:` line) is matched with
     `[^\\n]*`, not a dot-all `.*` — under re.DOTALL a greedy `.*` would happily
@@ -155,9 +154,28 @@ def _step_is_conditioned(job_text: str, step_needle: str) -> bool:
         rf"( *)- (?:uses|name|run): [^\n]*{re.escape(step_needle)}[^\n]*\n([\s\S]*?)(?=\n\1- |\Z)",
         job_text,
     )
-    if match is None:
-        return False
-    return "if:" in match.group(0)
+    return None if match is None else match.group(0)
+
+
+def _step_is_conditioned(job_text: str, step_needle: str) -> bool:
+    """True if the step has its own `if:` key — not just any `if:` elsewhere
+    in the job (e.g. a sibling step's dry-run summary)."""
+    block = _step_block(job_text, step_needle)
+    return block is not None and "if:" in block
+
+
+# The one condition that actually gates a PyPI upload behind the manual
+# dry-run switch. Requiring this exact predicate on the upload step itself —
+# not merely *an* `if:` — is the point: `if: always()` or any unrelated
+# condition would satisfy a mere presence check while gating nothing.
+PYPI_PUBLISH_GATE = (
+    "if: github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true'"
+)
+
+
+def _step_carries_publish_gate(job_text: str, step_needle: str) -> bool:
+    block = _step_block(job_text, step_needle)
+    return block is not None and PYPI_PUBLISH_GATE in block
 
 
 def _require_workflow_contains(
@@ -812,13 +830,14 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
     publish = jobs.get("publish", "")
     if "password:" in publish or "api-token" in publish:
         errors.append("release publish job should use trusted publishing, not a PyPI token")
-    if "pypa/gh-action-pypi-publish@" in publish and not _step_is_conditioned(
+    if "pypa/gh-action-pypi-publish@" in publish and not _step_carries_publish_gate(
         publish, "pypa/gh-action-pypi-publish@"
     ):
         errors.append(
-            "release publish job's PyPI upload step has no if: condition of its "
-            "own — it must be gated (dry_run) so a manual dispatch cannot "
-            "publish unintentionally, even if a sibling step also has an if:"
+            "release publish job's PyPI upload step is not gated by the dry-run "
+            f"predicate on the step itself (`{PYPI_PUBLISH_GATE}`) — a missing or "
+            "unrelated condition (e.g. `if: always()`) would let a manual "
+            "dispatch publish unintentionally"
         )
     return errors
 
@@ -904,14 +923,14 @@ def validate_reflex_xy_release_workflow(
         errors.append(
             "reflex-xy release publish job should use trusted publishing, not a PyPI token"
         )
-    if "pypa/gh-action-pypi-publish@" in publish and not _step_is_conditioned(
+    if "pypa/gh-action-pypi-publish@" in publish and not _step_carries_publish_gate(
         publish, "pypa/gh-action-pypi-publish@"
     ):
         errors.append(
-            "reflex-xy release publish job's PyPI upload step has no if: "
-            "condition of its own — it must be gated (dry_run) so a manual "
-            "dispatch cannot publish unintentionally, even if a sibling step "
-            "also has an if:"
+            "reflex-xy release publish job's PyPI upload step is not gated by "
+            f"the dry-run predicate on the step itself (`{PYPI_PUBLISH_GATE}`) — "
+            "a missing or unrelated condition (e.g. `if: always()`) would let a "
+            "manual dispatch publish unintentionally"
         )
     return errors
 

--- a/scripts/verify_ci_workflow.py
+++ b/scripts/verify_ci_workflow.py
@@ -4,7 +4,8 @@
 The workflows are YAML, but this checker intentionally stays stdlib-only so it
 can run before the dev environment is installed. It does not try to be a full
 YAML parser; it checks stable, high-value invariants that are easy to lose when
-editing `.github/workflows/ci.yml` or `.github/workflows/release.yml`.
+editing `.github/workflows/ci.yml`, `.github/workflows/release.yml`, or
+`.github/workflows/release-reflex-xy.yml`.
 """
 
 from __future__ import annotations
@@ -19,6 +20,7 @@ ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 DEFAULT_CODSPEED_WORKFLOW = ROOT / ".github" / "workflows" / "codspeed.yml"
 DEFAULT_RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+DEFAULT_REFLEX_XY_RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-reflex-xy.yml"
 DEFAULT_WORKFLOW = DEFAULT_CI_WORKFLOW
 REQUIRED_CI_JOBS = {
     "browser_conformance",
@@ -34,6 +36,7 @@ REQUIRED_CI_JOBS = {
 }
 REQUIRED_CODSPEED_JOBS = {"benchmarks"}
 REQUIRED_RELEASE_JOBS = {"wheels", "sdist", "publish", "publish-pyodide", "wasm"}
+REQUIRED_REFLEX_XY_RELEASE_JOBS = {"build", "publish"}
 
 
 def _job_blocks(text: str) -> dict[str, str]:
@@ -678,6 +681,12 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
         'tags: ["v*"]',
         "workflow_dispatch:",
     )
+    if "reflex-xy-v" in text:
+        errors.append(
+            "release workflow must not touch the reflex-xy tag namespace — the "
+            "adapter publishes via release-reflex-xy.yml (bare `v*` tags never "
+            "match `reflex-xy-v*` and vice versa; keep it that way)"
+        )
     _require_job_contains(
         errors,
         jobs,
@@ -814,15 +823,110 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
     return errors
 
 
+def validate_reflex_xy_release_workflow(
+    path: Path = DEFAULT_REFLEX_XY_RELEASE_WORKFLOW,
+) -> list[str]:
+    """The adapter's deliberately small release pipeline stays wired.
+
+    reflex-xy is a pure-Python distribution (one py3-none-any wheel + one
+    sdist), so it publishes from its own `reflex-xy-vX.Y.Z` tags via a
+    separate workflow rather than a second build shape wedged into
+    release.yml's cross-compile matrix. Small is the point — but the safety
+    rails must match release.yml's: unshallow checkouts (tag-derived
+    version), artifact verification, a changelog gate, trusted publishing,
+    and a dry-run default that keeps manual dispatches from publishing.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"cannot read reflex-xy release workflow {path}: {exc}"]
+
+    jobs = _job_blocks(text)
+    errors: list[str] = []
+    _require_unshallow_checkouts(errors, text, "reflex-xy release")
+    missing_jobs = sorted(REQUIRED_REFLEX_XY_RELEASE_JOBS - set(jobs))
+    if missing_jobs:
+        errors.append(f"reflex-xy release workflow missing required jobs: {missing_jobs}")
+
+    _require_workflow_contains(
+        errors,
+        text,
+        "reflex-xy release",
+        "adapter tag trigger and a workflow_dispatch dry-run input defaulting "
+        "to true, so a manual run never accidentally publishes",
+        'tags: ["reflex-xy-v*"]',
+        "workflow_dispatch:",
+        "dry_run:",
+        "type: boolean",
+        "default: true",
+    )
+    if 'tags: ["v*"]' in text or '"v*"' in text:
+        errors.append(
+            "reflex-xy release workflow must not trigger on bare `v*` tags — "
+            "those belong to the xy core's release.yml"
+        )
+    _require_job_contains(
+        errors,
+        jobs,
+        "build",
+        "reflex-xy release",
+        "pure sdist+wheel build, verification, install smoke, and upload",
+        "astral-sh/setup-uv@",
+        "working-directory: python/reflex-xy",
+        "uv build",
+        "scripts/verify_reflex_xy_dist.py",
+        '--tag "$GITHUB_REF_NAME"',
+        "import reflex_xy",
+        "actions/upload-artifact@",
+        "name: dist-reflex-xy",
+    )
+    _require_job_contains(
+        errors,
+        jobs,
+        "publish",
+        "reflex-xy release",
+        "trusted PyPI publishing from downloaded artifacts, gated by a dry-run "
+        "switch and the adapter tag/CHANGELOG agreement gate",
+        "needs: [build]",
+        "environment: pypi",
+        "id-token: write",
+        "scripts/check_release_version.py --package reflex-xy",
+        "actions/download-artifact@",
+        "name: dist-reflex-xy",
+        "dry_run",
+        "pypa/gh-action-pypi-publish@",
+        "packages-dir: dist/",
+        "skip-existing: true",
+    )
+
+    publish = jobs.get("publish", "")
+    if "password:" in publish or "api-token" in publish:
+        errors.append(
+            "reflex-xy release publish job should use trusted publishing, not a PyPI token"
+        )
+    if "pypa/gh-action-pypi-publish@" in publish and not _step_is_conditioned(
+        publish, "pypa/gh-action-pypi-publish@"
+    ):
+        errors.append(
+            "reflex-xy release publish job's PyPI upload step has no if: "
+            "condition of its own — it must be gated (dry_run) so a manual "
+            "dispatch cannot publish unintentionally, even if a sibling step "
+            "also has an if:"
+        )
+    return errors
+
+
 def validate_all_workflows(
     ci_path: Path = DEFAULT_CI_WORKFLOW,
     codspeed_path: Path = DEFAULT_CODSPEED_WORKFLOW,
     release_path: Path = DEFAULT_RELEASE_WORKFLOW,
+    reflex_xy_release_path: Path = DEFAULT_REFLEX_XY_RELEASE_WORKFLOW,
 ) -> list[str]:
     return [
         *validate_ci_workflow(ci_path),
         *validate_codspeed_workflow(codspeed_path),
         *validate_release_workflow(release_path),
+        *validate_reflex_xy_release_workflow(reflex_xy_release_path),
     ]
 
 
@@ -837,14 +941,26 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument("--ci-workflow", type=Path, default=DEFAULT_CI_WORKFLOW)
     parser.add_argument("--codspeed-workflow", type=Path, default=DEFAULT_CODSPEED_WORKFLOW)
     parser.add_argument("--release-workflow", type=Path, default=DEFAULT_RELEASE_WORKFLOW)
+    parser.add_argument(
+        "--reflex-xy-release-workflow", type=Path, default=DEFAULT_REFLEX_XY_RELEASE_WORKFLOW
+    )
     parser.add_argument("--ci-only", action="store_true")
     parser.add_argument("--codspeed-only", action="store_true")
     parser.add_argument("--release-only", action="store_true")
+    parser.add_argument("--reflex-xy-release-only", action="store_true")
     args = parser.parse_args(argv)
 
-    selected_modes = [args.ci_only, args.codspeed_only, args.release_only]
+    selected_modes = [
+        args.ci_only,
+        args.codspeed_only,
+        args.release_only,
+        args.reflex_xy_release_only,
+    ]
     if sum(1 for selected in selected_modes if selected) > 1:
-        parser.error("--ci-only, --codspeed-only, and --release-only are mutually exclusive")
+        parser.error(
+            "--ci-only, --codspeed-only, --release-only, and "
+            "--reflex-xy-release-only are mutually exclusive"
+        )
 
     if args.workflow is not None:
         errors = validate_ci_workflow(args.workflow)
@@ -858,11 +974,22 @@ def main(argv: Optional[list[str]] = None) -> int:
     elif args.release_only:
         errors = validate_release_workflow(args.release_workflow)
         checked = [args.release_workflow]
+    elif args.reflex_xy_release_only:
+        errors = validate_reflex_xy_release_workflow(args.reflex_xy_release_workflow)
+        checked = [args.reflex_xy_release_workflow]
     else:
         errors = validate_all_workflows(
-            args.ci_workflow, args.codspeed_workflow, args.release_workflow
+            args.ci_workflow,
+            args.codspeed_workflow,
+            args.release_workflow,
+            args.reflex_xy_release_workflow,
         )
-        checked = [args.ci_workflow, args.codspeed_workflow, args.release_workflow]
+        checked = [
+            args.ci_workflow,
+            args.codspeed_workflow,
+            args.release_workflow,
+            args.reflex_xy_release_workflow,
+        ]
 
     if errors:
         print(

--- a/scripts/verify_reflex_xy_dist.py
+++ b/scripts/verify_reflex_xy_dist.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Verify the reflex-xy release artifacts: one pure wheel plus one sdist.
+
+The adapter is a pure-Python distribution — no native core, no platform
+matrix — so its whole release surface is a single `py3-none-any` wheel and a
+single sdist, built by `.github/workflows/release-reflex-xy.yml`. This checks
+what that workflow uploads before it publishes:
+
+- the wheel is genuinely pure (purelib, `py3-none-any`, no compiled
+  libraries), carries the `reflex_xy` package and its `XYChart.jsx` asset,
+  and carries **no copy of the render client** — the client links out of the
+  installed xy package at app compile time so it can never drift
+  (spec/design/reflex-integration.md §5);
+- wheel `METADATA` name/version/floor/dependencies agree with the filename;
+- the sdist's `PKG-INFO` agrees with its own `reflex_xy-<version>` root and
+  the source tree rebuilds the wheel (pyproject + package + changelog);
+- both artifacts carry the same version, never the `0.0.0` fallback (a
+  tagless checkout builds that silently), and `--tag reflex-xy-vX.Y.Z` must
+  match it exactly — a tagged build must never publish a dev version.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tarfile
+import zipfile
+from email.parser import Parser
+from pathlib import Path
+from typing import Optional
+
+WHEEL_NAME_RE = re.compile(r"^reflex_xy-(?P<version>[^-]+)-py3-none-any\.whl$")
+SDIST_NAME_RE = re.compile(r"^reflex_xy-(?P<version>[^-]+)\.tar\.gz$")
+NATIVE_SUFFIXES = (".so", ".dylib", ".pyd", ".dll")
+# The render client ships only inside the xy wheel; any copy here would
+# drift from the kernel that produces its payloads.
+RENDER_CLIENT_BASENAMES = {"index.js", "standalone.js"}
+REQUIRED_WHEEL_MEMBERS = (
+    "reflex_xy/__init__.py",
+    "reflex_xy/assets/XYChart.jsx",
+)
+REQUIRED_SDIST_MEMBERS = (
+    "reflex_xy/__init__.py",
+    "reflex_xy/assets/XYChart.jsx",
+    "pyproject.toml",
+    "README.md",
+    "CHANGELOG.md",
+    "PKG-INFO",
+)
+
+
+def _check_version_value(version: str, artifact: str, errors: list[str]) -> None:
+    if version == "0.0.0":
+        errors.append(
+            f"{artifact} version is the 0.0.0 fallback — the build ran without "
+            "git tags (shallow checkout?) and derived no real version"
+        )
+
+
+def _metadata_headers(text: str) -> dict[str, list[str]]:
+    message = Parser().parsestr(text)
+    headers: dict[str, list[str]] = {}
+    for key, value in message.items():
+        headers.setdefault(key, []).append(value)
+    return headers
+
+
+def _check_project_metadata(
+    headers: dict[str, list[str]], version: str, artifact: str, errors: list[str]
+) -> None:
+    if headers.get("Name") != ["reflex-xy"]:
+        errors.append(f"{artifact} metadata Name must be 'reflex-xy': {headers.get('Name')}")
+    if headers.get("Version") != [version]:
+        errors.append(
+            f"{artifact} metadata Version {headers.get('Version')} does not match "
+            f"the artifact's own filename version {version!r}"
+        )
+    if headers.get("Requires-Python") != [">=3.11"]:
+        errors.append(
+            f"{artifact} metadata Requires-Python must be '>=3.11': "
+            f"{headers.get('Requires-Python')}"
+        )
+    requires = headers.get("Requires-Dist", [])
+    for dependency in ("xy", "reflex"):
+        if not any(re.match(rf"{dependency}\s*(?:[<>=!~(;]|$)", entry) for entry in requires):
+            errors.append(f"{artifact} metadata is missing the {dependency!r} dependency")
+
+
+def verify_wheel(path: Path) -> tuple[Optional[str], list[str]]:
+    errors: list[str] = []
+    match = WHEEL_NAME_RE.match(path.name)
+    if match is None:
+        return None, [
+            f"unexpected wheel name {path.name!r} — the adapter builds exactly "
+            "one pure 'reflex_xy-<version>-py3-none-any.whl'"
+        ]
+    version = match.group("version")
+    _check_version_value(version, path.name, errors)
+    dist_info = f"reflex_xy-{version}.dist-info"
+    with zipfile.ZipFile(path) as archive:
+        names = archive.namelist()
+        for member in REQUIRED_WHEEL_MEMBERS + tuple(
+            f"{dist_info}/{name}" for name in ("METADATA", "WHEEL", "RECORD")
+        ):
+            if member not in names:
+                errors.append(f"{path.name} is missing {member}")
+        for name in names:
+            if name.endswith(NATIVE_SUFFIXES):
+                errors.append(f"{path.name} contains a compiled library: {name}")
+            if Path(name).name in RENDER_CLIENT_BASENAMES:
+                errors.append(
+                    f"{path.name} contains a render-client copy ({name}) — the "
+                    "client links out of the installed xy package instead"
+                )
+        if f"{dist_info}/WHEEL" in names:
+            wheel_headers = _metadata_headers(archive.read(f"{dist_info}/WHEEL").decode("utf-8"))
+            if wheel_headers.get("Root-Is-Purelib") != ["true"]:
+                errors.append(f"{path.name} WHEEL must declare Root-Is-Purelib: true")
+            if wheel_headers.get("Tag") != ["py3-none-any"]:
+                errors.append(
+                    f"{path.name} WHEEL tag must be exactly py3-none-any: "
+                    f"{wheel_headers.get('Tag')}"
+                )
+        if f"{dist_info}/METADATA" in names:
+            headers = _metadata_headers(archive.read(f"{dist_info}/METADATA").decode("utf-8"))
+            _check_project_metadata(headers, version, path.name, errors)
+    return version, errors
+
+
+def verify_sdist(path: Path) -> tuple[Optional[str], list[str]]:
+    errors: list[str] = []
+    match = SDIST_NAME_RE.match(path.name)
+    if match is None:
+        return None, [
+            f"unexpected sdist name {path.name!r} — the adapter builds exactly "
+            "one 'reflex_xy-<version>.tar.gz'"
+        ]
+    version = match.group("version")
+    _check_version_value(version, path.name, errors)
+    root = f"reflex_xy-{version}"
+    with tarfile.open(path, "r:gz") as archive:
+        names = archive.getnames()
+        strays = [name for name in names if not (name == root or name.startswith(f"{root}/"))]
+        if strays:
+            errors.append(f"{path.name} has members outside {root}/: {strays[:5]}")
+        members = {name.removeprefix(f"{root}/") for name in names}
+        for member in REQUIRED_SDIST_MEMBERS:
+            if member not in members:
+                errors.append(f"{path.name} is missing {member}")
+        junk = [name for name in names if "__pycache__" in name or name.endswith(".pyc")]
+        if junk:
+            errors.append(f"{path.name} contains generated junk: {junk[:5]}")
+        if f"{root}/PKG-INFO" in names:
+            pkg_info = archive.extractfile(f"{root}/PKG-INFO")
+            assert pkg_info is not None
+            headers = _metadata_headers(pkg_info.read().decode("utf-8"))
+            _check_project_metadata(headers, version, path.name, errors)
+    return version, errors
+
+
+def verify_dist(paths: list[Path], tag: Optional[str] = None) -> list[str]:
+    errors: list[str] = []
+    versions: dict[str, Optional[str]] = {}
+    wheels = [path for path in paths if path.name.endswith(".whl")]
+    sdists = [path for path in paths if path.name.endswith(".tar.gz")]
+    unexpected = sorted(set(paths) - set(wheels) - set(sdists))
+    if unexpected:
+        errors.append(f"unexpected artifacts: {[path.name for path in unexpected]}")
+    if len(wheels) != 1:
+        errors.append(f"expected exactly one wheel, got {[path.name for path in wheels]}")
+    if len(sdists) != 1:
+        errors.append(f"expected exactly one sdist, got {[path.name for path in sdists]}")
+    for wheel in wheels:
+        versions[wheel.name], wheel_errors = verify_wheel(wheel)
+        errors.extend(wheel_errors)
+    for sdist in sdists:
+        versions[sdist.name], sdist_errors = verify_sdist(sdist)
+        errors.extend(sdist_errors)
+    resolved = {version for version in versions.values() if version is not None}
+    if len(resolved) > 1:
+        errors.append(f"artifact versions disagree: {versions}")
+    if tag is not None and resolved:
+        expected = tag.removeprefix("reflex-xy-v")
+        if tag == expected or resolved != {expected}:
+            errors.append(
+                f"tag {tag!r} does not match built version(s) {sorted(resolved)} — "
+                "a reflex-xy-vX.Y.Z tag must produce exactly version X.Y.Z"
+            )
+    return errors
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", type=Path, help="built artifacts (dist/*)")
+    parser.add_argument(
+        "--tag",
+        default=None,
+        help="release tag the artifacts must match exactly (reflex-xy-vX.Y.Z)",
+    )
+    args = parser.parse_args(argv)
+
+    errors = verify_dist(args.paths, args.tag)
+    if errors:
+        print(f"reflex-xy dist verification failed for {args.paths}:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print("reflex-xy dist verification OK: " + ", ".join(path.name for path in args.paths))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_sdist.py
+++ b/scripts/verify_sdist.py
@@ -125,6 +125,7 @@ REQUIRED_FILES = {
     "tests/test_verify_benchmark_report.py",
     "tests/test_verify_ci_workflow.py",
     "tests/test_verify_local.py",
+    "tests/test_verify_reflex_xy_dist.py",
     "tests/test_verify_sdist.py",
     "tests/test_verify_wheel.py",
 }

--- a/scripts/verify_sdist.py
+++ b/scripts/verify_sdist.py
@@ -24,6 +24,7 @@ REQUIRED_FILES = {
     ".github/workflows/ci.yml",
     ".github/workflows/codspeed.yml",
     ".github/workflows/release.yml",
+    ".github/workflows/release-reflex-xy.yml",
     "CHANGELOG.md",
     "CONTRIBUTING.md",
     "Cargo.lock",
@@ -109,6 +110,7 @@ REQUIRED_FILES = {
     "scripts/verify_ci_workflow.py",
     "scripts/verify_benchmark_report.py",
     "scripts/verify_local.py",
+    "scripts/verify_reflex_xy_dist.py",
     "scripts/verify_sdist.py",
     "scripts/verify_wheel.py",
     "src/kernels.rs",
@@ -413,6 +415,18 @@ def verify_sdist(path: str) -> None:
             "pypa/gh-action-pypi-publish@",
             "scripts/verify_wheel.py",
             "scripts/verify_sdist.py",
+            "id-token: write",
+        },
+    )
+    _require_file_contains(
+        path,
+        root,
+        ".github/workflows/release-reflex-xy.yml",
+        {
+            'tags: ["reflex-xy-v*"]',
+            "pypa/gh-action-pypi-publish@",
+            "scripts/verify_reflex_xy_dist.py",
+            "scripts/check_release_version.py --package reflex-xy",
             "id-token: write",
         },
     )

--- a/spec/design/reflex-integration.md
+++ b/spec/design/reflex-integration.md
@@ -600,6 +600,19 @@ root beside `register()`/`release()`.
 components/vars but not yet App/state-manager access; revisit when a smaller
 supported surface exists.
 
+**Versioning & releases.** The adapter is its own distributable and versions
+independently of the core: its distribution version is derived from
+`reflex-xy-vX.Y.Z` git tags (uv-dynamic-versioning with
+`pattern-prefix = "reflex-xy-"`), while the core keeps bare `vX.Y.Z` — the
+pattern anchoring makes each derivation blind to the other's tags. Releases
+publish via the dedicated `.github/workflows/release-reflex-xy.yml` workflow
+(pure wheel + sdist, `scripts/verify_reflex_xy_dist.py`, trusted publishing),
+gated on a dated entry in the adapter's own `python/reflex-xy/CHANGELOG.md`
+(`scripts/check_release_version.py --package reflex-xy`); the pipeline is
+deliberately separate from release.yml's cross-compile matrix because the
+adapter has no binary artifacts. Full checklist:
+`spec/process/production-readiness.md` § "reflex-xy releases".
+
 ## 8. Superseded: the HTTP-routes draft
 
 The previous revision of this document specified `GET /_xy/{token}/payload`,

--- a/spec/process/contributing.md
+++ b/spec/process/contributing.md
@@ -56,8 +56,9 @@ make check-sdist
 make check-wheel
 ```
 
-When you edit `.github/workflows/ci.yml`, `.github/workflows/release.yml`, or
-release/benchmark artifact wiring, run:
+When you edit `.github/workflows/ci.yml`, `.github/workflows/release.yml`,
+`.github/workflows/release-reflex-xy.yml` (the adapter's own pure-Python
+release pipeline), or release/benchmark artifact wiring, run:
 
 ```bash
 make check-ci

--- a/spec/process/production-readiness.md
+++ b/spec/process/production-readiness.md
@@ -91,6 +91,7 @@ These must pass before publishing or making a broad performance claim.
 | sdist | Source archive contains required source/bundles, benchmark regression harness/baseline, release docs/tests/scripts, the example apps' source, `PKG-INFO` version/dependencies matching the archive's own `xy-<version>` root, no duplicate members, and no generated junk | `python scripts/verify_sdist.py dist/*.tar.gz` |
 | Native wheel | Platform wheel contains package-only files, exactly one native library, `METADATA` version/dependencies matching the wheel's own filename and `.dist-info`, complete hash-checked `RECORD`, public export-surface markers, matching filename/`WHEEL` tags, and is tagged non-pure | `python scripts/verify_wheel.py dist/*.whl --expect-native` |
 | Fallback wheel | No-toolchain wheel contains package-only files, `METADATA` version/dependencies matching the wheel's own filename and `.dist-info`, complete hash-checked `RECORD`, public export-surface markers, matching filename/`WHEEL` tags, is pure, and contains no native library | `python scripts/verify_wheel.py dist/*.whl --expect-pure` |
+| reflex-xy dist | The adapter's single pure `py3-none-any` wheel + sdist carry the `reflex_xy` package with its `XYChart.jsx` asset, no compiled library, **no render-client copy** (the client links out of the installed xy wheel), coherent name/version/floor/dependency metadata, and — on a tag build — a version exactly equal to the `reflex-xy-vX.Y.Z` tag | `python scripts/verify_reflex_xy_dist.py python/reflex-xy/dist/* [--tag reflex-xy-vX.Y.Z]` |
 | Wheel size | Platform wheel remains small enough for notebook installs | CI budget: 15 MB |
 | Benchmark artifact | JSON benchmark reports carry schema, environment, categories, row status, and finite non-negative metrics; native reports must declare the native backend | `python scripts/verify_benchmark_report.py benchmark.json --kind scatter-vs`; repeat for line, install, core-2D, pyplot-vs-matplotlib, native, interaction, dashboard, and workflow artifacts |
 
@@ -337,6 +338,17 @@ consequences worth knowing:
   clone fetches no tags and would *silently* build at the `0.0.0` fallback;
   `make check-ci` enforces this.
 
+Two release lines share the repo, in disjoint tag namespaces. Everything above
+and below in this checklist is the **xy core** (`vX.Y.Z` tags,
+`release.yml`, the full wheel matrix). The **reflex-xy adapter** releases
+independently from `reflex-xy-vX.Y.Z` tags via
+`.github/workflows/release-reflex-xy.yml` — see "reflex-xy releases" at the end
+of this section. The namespaces are disjoint by construction:
+uv-dynamic-versioning's default pattern anchors on `^v`, so it can never match
+a `reflex-xy-*` tag, and the adapter's `pattern-prefix = "reflex-xy-"` config
+can never match a bare `v*` tag (`make check-ci` also refuses a workflow that
+triggers across namespaces).
+
 Before tagging a release:
 
 - Add a dated `## [X.Y.Z] — YYYY-MM-DD` heading to `CHANGELOG.md` for the
@@ -390,6 +402,39 @@ Before tagging a release:
   "faster/best" positioning.
 - Confirm performance claims mention chart type, mode, backend, data size, and
   browser TTFR status.
+
+### reflex-xy releases
+
+The adapter is a pure-Python distribution — no native core, no JS build, no
+platform matrix — so it deliberately does **not** ride release.yml: one small
+workflow (`release-reflex-xy.yml`, two jobs) is easier to keep correct than a
+second build shape wedged into the cross-compile matrix. Cutting an adapter
+release is `git tag reflex-xy-vX.Y.Z && git push --tags` after dating the
+version's entry in `python/reflex-xy/CHANGELOG.md` (the adapter has its own
+changelog; the gate is `scripts/check_release_version.py --package reflex-xy`).
+
+The workflow builds `python/reflex-xy` with `uv build`, verifies the pair with
+`scripts/verify_reflex_xy_dist.py --tag <tag>` (pure wheel, JSX asset present,
+no render-client copy, version exactly equal to the tag), smokes a real
+install + `import reflex_xy`, and publishes both artifacts to PyPI via trusted
+publishing (environment `pypi`, OIDC, `skip-existing` for retryability). A
+manual `workflow_dispatch` defaults to `dry_run=true` and never publishes.
+
+Before the first adapter release (and after any change to its pipeline):
+
+- Configure the PyPI trusted publisher for the `reflex-xy` project:
+  repository `reflex-dev/xy`, workflow `release-reflex-xy.yml`,
+  environment `pypi` — it is a separate PyPI project from `xy` and does not
+  inherit the core's publisher.
+- Run the workflow manually (`dry_run=true`) and confirm both artifacts build
+  and verify; the dev version it builds is unpublishable by design.
+- Run `make check-ci` — it validates this workflow's gates (unshallow
+  checkouts, dist verification, changelog gate, trusted publishing, dry-run
+  default, and tag-namespace separation) alongside the other workflows.
+- Adapter releases pin nothing about the core: `reflex-xy` depends on `xy`
+  (and `reflex>=0.9.6`) as ordinary PyPI ranges, and its wheel must never
+  carry a copy of the render client — the client links out of the installed
+  xy package at app compile so it can never drift from the kernel.
 
 ## Claim Guardrails
 

--- a/spec/process/production-readiness.md
+++ b/spec/process/production-readiness.md
@@ -338,6 +338,14 @@ consequences worth knowing:
   clone fetches no tags and would *silently* build at the `0.0.0` fallback;
   `make check-ci` enforces this.
 
+Pre-releases are tagged the same way with a canonical PEP 440 suffix —
+`vX.Y.ZaN` / `bN` / `rcN` (e.g. `v1.0.0rc1`) — and publish through the same
+pipeline; pip ignores them unless a pre-release is requested explicitly. Only
+the canonical spelling passes the release gate: `-alpha1`-style tags would be
+normalized by the version derivation and could never match their own built
+artifacts. A pre-release needs its own dated changelog entry, exactly like a
+final release.
+
 Two release lines share the repo, in disjoint tag namespaces. Everything above
 and below in this checklist is the **xy core** (`vX.Y.Z` tags,
 `release.yml`, the full wheel matrix). The **reflex-xy adapter** releases
@@ -412,6 +420,9 @@ second build shape wedged into the cross-compile matrix. Cutting an adapter
 release is `git tag reflex-xy-vX.Y.Z && git push --tags` after dating the
 version's entry in `python/reflex-xy/CHANGELOG.md` (the adapter has its own
 changelog; the gate is `scripts/check_release_version.py --package reflex-xy`).
+Pre-releases follow the core's rule: a canonical suffix on the tag
+(`reflex-xy-v0.0.1a1`, likewise `bN`/`rcN`) and a dated entry for that exact
+pre-release version.
 
 The workflow builds `python/reflex-xy` with `uv build`, verifies the pair with
 `scripts/verify_reflex_xy_dist.py --tag <tag>` (pure wheel, JSX asset present,

--- a/tests/test_check_release_version.py
+++ b/tests/test_check_release_version.py
@@ -144,3 +144,48 @@ def test_reflex_xy_release_workflow_wires_the_gate() -> None:
 
     assert "scripts/check_release_version.py --package reflex-xy" in workflow
     assert "if: github.event_name == 'push'" in workflow
+
+
+def test_gate_passes_a_canonical_prerelease_tag(tmp_path: Path) -> None:
+    changelog = _changelog(tmp_path, "## [0.0.1a1] — 2026-07-25")
+
+    errors = check_release_version.check_release(
+        "reflex-xy-v0.0.1a1", changelog, package="reflex-xy"
+    )
+
+    assert errors == []
+
+
+def test_gate_passes_prerelease_tags_for_the_core_too(tmp_path: Path) -> None:
+    changelog = _changelog(tmp_path, "## [1.0.0rc2] — 2026-07-25")
+
+    assert check_release_version.check_release("v1.0.0rc2", changelog) == []
+
+
+def test_gate_rejects_non_canonical_prerelease_spellings(tmp_path: Path) -> None:
+    # The derivation normalizes `alpha1` to `a1`, so a non-canonical tag can
+    # never equal its own built version — refuse it before it builds anything.
+    changelog = _changelog(tmp_path, "## [0.0.1a1] — 2026-07-25")
+
+    for tag in ("reflex-xy-v0.0.1-alpha1", "reflex-xy-v0.0.1alpha1", "reflex-xy-v0.0.1a"):
+        errors = check_release_version.check_release(tag, changelog, package="reflex-xy")
+        assert any("is not a release tag" in e for e in errors), tag
+
+
+def test_a_prerelease_needs_its_own_dated_entry(tmp_path: Path) -> None:
+    # An entry for the final 0.0.1 must not vouch for 0.0.1a1 (or vice versa).
+    changelog = _changelog(tmp_path, "## [0.0.1] — 2026-07-25")
+
+    errors = check_release_version.check_release(
+        "reflex-xy-v0.0.1a1", changelog, package="reflex-xy"
+    )
+
+    assert any("no dated" in e for e in errors)
+
+
+def test_gate_accepts_the_unbracketed_v_heading_style(tmp_path: Path) -> None:
+    # v0.0.2 was documented as `## v0.0.2 - 2026-07-24` (no brackets, leading
+    # v). The gate checks that dated notes exist, not heading punctuation.
+    changelog = _changelog(tmp_path, "## v0.0.2 - 2026-07-24")
+
+    assert check_release_version.check_release("v0.0.2", changelog) == []

--- a/tests/test_check_release_version.py
+++ b/tests/test_check_release_version.py
@@ -86,3 +86,61 @@ def test_release_workflow_wires_the_gate() -> None:
 
     assert "scripts/check_release_version.py" in workflow
     assert "if: github.event_name == 'push'" in workflow
+
+
+def test_gate_passes_for_a_reflex_xy_tag(tmp_path: Path) -> None:
+    changelog = _changelog(tmp_path, "## [0.1.0] — 2026-07-25")
+
+    errors = check_release_version.check_release("reflex-xy-v0.1.0", changelog, package="reflex-xy")
+
+    assert errors == []
+
+
+def test_gate_rejects_a_core_tag_under_the_reflex_xy_package(tmp_path: Path) -> None:
+    # A bare v-tag reaching the adapter gate means the workflows' tag filters
+    # broke: the namespaces are disjoint by construction.
+    changelog = _changelog(tmp_path, "## [0.1.0] — 2026-07-25")
+
+    errors = check_release_version.check_release("v0.1.0", changelog, package="reflex-xy")
+
+    assert any("is not a release tag" in e and "reflex-xy-vX.Y.Z" in e for e in errors)
+
+
+def test_gate_rejects_a_reflex_xy_tag_under_the_default_package(tmp_path: Path) -> None:
+    changelog = _changelog(tmp_path, "## [0.1.0] — 2026-07-25")
+
+    errors = check_release_version.check_release("reflex-xy-v0.1.0", changelog)
+
+    assert any("is not a release tag" in e for e in errors)
+
+
+def test_each_package_gates_against_its_own_changelog() -> None:
+    packages = check_release_version.PACKAGES
+
+    assert packages["xy"].changelog.name == "CHANGELOG.md"
+    assert packages["reflex-xy"].changelog == (
+        packages["xy"].changelog.parent / "python" / "reflex-xy" / "CHANGELOG.md"
+    )
+
+
+def test_main_gates_the_reflex_xy_package(tmp_path: Path) -> None:
+    changelog = _changelog(tmp_path, "## [0.2.0] — 2026-07-25")
+
+    ok = check_release_version.main(
+        ["--package", "reflex-xy", "--tag", "reflex-xy-v0.2.0", "--changelog", str(changelog)]
+    )
+    stale = check_release_version.main(
+        ["--package", "reflex-xy", "--tag", "reflex-xy-v0.3.0", "--changelog", str(changelog)]
+    )
+
+    assert ok == 0
+    assert stale == 1
+
+
+def test_reflex_xy_release_workflow_wires_the_gate() -> None:
+    workflow = (
+        Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release-reflex-xy.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "scripts/check_release_version.py --package reflex-xy" in workflow
+    assert "if: github.event_name == 'push'" in workflow

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -727,7 +727,7 @@ def test_release_workflow_rejects_ungated_pypi_publish_step(tmp_path: Path) -> N
 
     errors = verify_ci_workflow.validate_release_workflow(path)
 
-    assert any("has no if: condition of its own" in error for error in errors)
+    assert any("is not gated by the dry-run predicate" in error for error in errors)
 
 
 def test_release_workflow_rejects_non_retryable_pypi_publish(tmp_path: Path) -> None:
@@ -781,7 +781,7 @@ def test_reflex_xy_release_workflow_rejects_ungated_pypi_publish(tmp_path: Path)
 
     errors = verify_ci_workflow.validate_reflex_xy_release_workflow(path)
 
-    assert any("has no if: condition of its own" in error for error in errors)
+    assert any("is not gated by the dry-run predicate" in error for error in errors)
 
 
 def test_reflex_xy_release_workflow_rejects_missing_dist_verifier(tmp_path: Path) -> None:
@@ -838,3 +838,37 @@ def test_release_workflow_rejects_adapter_tag_namespace(tmp_path: Path) -> None:
     errors = verify_ci_workflow.validate_release_workflow(path)
 
     assert any("must not touch the reflex-xy tag namespace" in error for error in errors)
+
+
+def test_release_workflow_rejects_always_conditioned_pypi_publish(tmp_path: Path) -> None:
+    # `if: always()` is *a* condition but gates nothing: a mere has-an-if
+    # check would accept it and let a manual dispatch publish unconditionally.
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release.yml"
+    gate = (
+        "        if: github.event_name != 'workflow_dispatch' "
+        "|| github.event.inputs.dry_run != 'true'\n"
+    )
+    assert gate in workflow
+    path.write_text(workflow.replace(gate, "        if: always()\n"), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("is not gated by the dry-run predicate" in error for error in errors)
+
+
+def test_reflex_xy_release_workflow_rejects_always_conditioned_pypi_publish(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release-reflex-xy.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release-reflex-xy.yml"
+    gate = (
+        "        if: github.event_name != 'workflow_dispatch' "
+        "|| github.event.inputs.dry_run != 'true'\n"
+    )
+    assert gate in workflow
+    path.write_text(workflow.replace(gate, "        if: always()\n"), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_reflex_xy_release_workflow(path)
+
+    assert any("is not gated by the dry-run predicate" in error for error in errors)

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -763,3 +763,78 @@ def test_ci_workflow_rejects_shallow_checkout(tmp_path: Path) -> None:
     errors = verify_ci_workflow.validate_ci_workflow(path)
 
     assert any("fetch-depth: 0" in error for error in errors)
+
+
+def test_reflex_xy_release_workflow_accepts_current_gates() -> None:
+    assert verify_ci_workflow.validate_reflex_xy_release_workflow() == []
+
+
+def test_reflex_xy_release_workflow_rejects_ungated_pypi_publish(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release-reflex-xy.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release-reflex-xy.yml"
+    gate = (
+        "        if: github.event_name != 'workflow_dispatch' "
+        "|| github.event.inputs.dry_run != 'true'\n"
+    )
+    assert gate in workflow
+    path.write_text(workflow.replace(gate, ""), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_reflex_xy_release_workflow(path)
+
+    assert any("has no if: condition of its own" in error for error in errors)
+
+
+def test_reflex_xy_release_workflow_rejects_missing_dist_verifier(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release-reflex-xy.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release-reflex-xy.yml"
+    stripped = "\n".join(
+        line for line in workflow.splitlines() if "scripts/verify_reflex_xy_dist.py" not in line
+    )
+    path.write_text(stripped + "\n", encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_reflex_xy_release_workflow(path)
+
+    assert any(
+        "reflex-xy release build job" in error and "verify_reflex_xy_dist" in error
+        for error in errors
+    )
+
+
+def test_reflex_xy_release_workflow_rejects_core_tag_trigger(tmp_path: Path) -> None:
+    # The adapter workflow firing on bare `v*` tags would publish reflex-xy on
+    # every xy core release; the namespaces must stay disjoint.
+    workflow = Path(".github/workflows/release-reflex-xy.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release-reflex-xy.yml"
+    path.write_text(
+        workflow.replace('    tags: ["reflex-xy-v*"]\n', '    tags: ["v*"]\n'),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_reflex_xy_release_workflow(path)
+
+    assert any("must not trigger on bare `v*` tags" in error for error in errors)
+
+
+def test_reflex_xy_release_workflow_rejects_shallow_checkout(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release-reflex-xy.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release-reflex-xy.yml"
+    path.write_text(workflow.replace("          fetch-depth: 0\n", ""), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_reflex_xy_release_workflow(path)
+
+    assert any("fetch-depth: 0" in error and "0.0.0" in error for error in errors)
+
+
+def test_release_workflow_rejects_adapter_tag_namespace(tmp_path: Path) -> None:
+    # And the inverse guard: release.yml reaching into `reflex-xy-v*` would
+    # run the full cross-compile matrix (and publish xy) on adapter tags.
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace('    tags: ["v*"]\n', '    tags: ["v*", "reflex-xy-v*"]\n'),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("must not touch the reflex-xy tag namespace" in error for error in errors)

--- a/tests/test_verify_reflex_xy_dist.py
+++ b/tests/test_verify_reflex_xy_dist.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+
+def _load_module():
+    path = Path(__file__).resolve().parents[1] / "scripts" / "verify_reflex_xy_dist.py"
+    spec = importlib.util.spec_from_file_location("verify_reflex_xy_dist", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+verify_reflex_xy_dist = _load_module()
+
+
+def _metadata(version: str) -> str:
+    return (
+        "Metadata-Version: 2.4\n"
+        "Name: reflex-xy\n"
+        f"Version: {version}\n"
+        "Requires-Python: >=3.11\n"
+        "Requires-Dist: xy\n"
+        "Requires-Dist: reflex>=0.9.6\n"
+        "Requires-Dist: aiohttp>=3.9; extra == 'dev'\n"
+        "Provides-Extra: dev\n"
+    )
+
+
+def _wheel(
+    tmp_path: Path,
+    version: str = "0.1.0",
+    *,
+    extra_members: dict[str, bytes] | None = None,
+    wheel_tag: str = "py3-none-any",
+    purelib: str = "true",
+) -> Path:
+    path = tmp_path / f"reflex_xy-{version}-py3-none-any.whl"
+    dist_info = f"reflex_xy-{version}.dist-info"
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("reflex_xy/__init__.py", "__all__ = []\n")
+        archive.writestr("reflex_xy/assets/XYChart.jsx", "export default null;\n")
+        archive.writestr(f"{dist_info}/METADATA", _metadata(version))
+        archive.writestr(
+            f"{dist_info}/WHEEL",
+            f"Wheel-Version: 1.0\nGenerator: test\nRoot-Is-Purelib: {purelib}\nTag: {wheel_tag}\n",
+        )
+        archive.writestr(f"{dist_info}/RECORD", "")
+        for name, payload in (extra_members or {}).items():
+            archive.writestr(name, payload)
+    return path
+
+
+def _sdist(
+    tmp_path: Path,
+    version: str = "0.1.0",
+    *,
+    omit: frozenset[str] = frozenset(),
+    extra_members: dict[str, bytes] | None = None,
+) -> Path:
+    path = tmp_path / f"reflex_xy-{version}.tar.gz"
+    root = f"reflex_xy-{version}"
+    members = {
+        "PKG-INFO": _metadata(version).encode(),
+        "pyproject.toml": b"[project]\nname = 'reflex-xy'\n",
+        "README.md": b"# reflex-xy\n",
+        "CHANGELOG.md": b"# Changelog\n",
+        "reflex_xy/__init__.py": b"__all__ = []\n",
+        "reflex_xy/assets/XYChart.jsx": b"export default null;\n",
+    }
+    members = {name: data for name, data in members.items() if name not in omit}
+    members.update(extra_members or {})
+    with tarfile.open(path, "w:gz") as archive:
+        for name, payload in members.items():
+            info = tarfile.TarInfo(f"{root}/{name}")
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return path
+
+
+def test_accepts_a_pure_wheel_and_sdist_pair(tmp_path: Path) -> None:
+    paths = [_wheel(tmp_path), _sdist(tmp_path)]
+
+    assert verify_reflex_xy_dist.verify_dist(paths) == []
+    assert verify_reflex_xy_dist.verify_dist(paths, tag="reflex-xy-v0.1.0") == []
+
+
+def test_rejects_a_tag_version_mismatch(tmp_path: Path) -> None:
+    paths = [_wheel(tmp_path), _sdist(tmp_path)]
+
+    errors = verify_reflex_xy_dist.verify_dist(paths, tag="reflex-xy-v0.2.0")
+
+    assert any("does not match built version" in e for e in errors)
+
+
+def test_rejects_an_unprefixed_tag(tmp_path: Path) -> None:
+    # A bare core tag must never vouch for adapter artifacts.
+    paths = [_wheel(tmp_path), _sdist(tmp_path)]
+
+    errors = verify_reflex_xy_dist.verify_dist(paths, tag="v0.1.0")
+
+    assert any("does not match built version" in e for e in errors)
+
+
+def test_accepts_an_untagged_dev_build_but_rejects_it_under_a_tag(tmp_path: Path) -> None:
+    version = "0.1.1.dev3+g1234567"
+    paths = [_wheel(tmp_path, version), _sdist(tmp_path, version)]
+
+    assert verify_reflex_xy_dist.verify_dist(paths) == []
+    assert verify_reflex_xy_dist.verify_dist(paths, tag="reflex-xy-v0.1.1") != []
+
+
+def test_rejects_the_fallback_version(tmp_path: Path) -> None:
+    paths = [_wheel(tmp_path, "0.0.0"), _sdist(tmp_path, "0.0.0")]
+
+    errors = verify_reflex_xy_dist.verify_dist(paths)
+
+    assert any("0.0.0 fallback" in e for e in errors)
+
+
+def test_rejects_a_render_client_copy(tmp_path: Path) -> None:
+    # The client links out of the installed xy package at app compile;
+    # a second copy in the adapter wheel would drift from the kernel.
+    wheel = _wheel(tmp_path, extra_members={"reflex_xy/assets/index.js": b"var xy={};"})
+
+    _, errors = verify_reflex_xy_dist.verify_wheel(wheel)
+
+    assert any("render-client copy" in e for e in errors)
+
+
+def test_rejects_a_compiled_library(tmp_path: Path) -> None:
+    wheel = _wheel(tmp_path, extra_members={"reflex_xy/_native.so": b"\x7fELF"})
+
+    _, errors = verify_reflex_xy_dist.verify_wheel(wheel)
+
+    assert any("compiled library" in e for e in errors)
+
+
+def test_rejects_a_non_pure_wheel_tag(tmp_path: Path) -> None:
+    wheel = _wheel(tmp_path, wheel_tag="py3-none-manylinux_2_17_x86_64", purelib="false")
+
+    _, errors = verify_reflex_xy_dist.verify_wheel(wheel)
+
+    assert any("Root-Is-Purelib" in e for e in errors)
+    assert any("py3-none-any" in e for e in errors)
+
+
+def test_rejects_a_wheel_missing_the_jsx_asset(tmp_path: Path) -> None:
+    version = "0.1.0"
+    path = tmp_path / f"reflex_xy-{version}-py3-none-any.whl"
+    dist_info = f"reflex_xy-{version}.dist-info"
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("reflex_xy/__init__.py", "__all__ = []\n")
+        archive.writestr(f"{dist_info}/METADATA", _metadata(version))
+        archive.writestr(f"{dist_info}/WHEEL", "Root-Is-Purelib: true\nTag: py3-none-any\n")
+        archive.writestr(f"{dist_info}/RECORD", "")
+
+    _, errors = verify_reflex_xy_dist.verify_wheel(path)
+
+    assert any("XYChart.jsx" in e for e in errors)
+
+
+def test_rejects_metadata_that_disagrees_with_the_filename(tmp_path: Path) -> None:
+    version = "0.1.0"
+    path = tmp_path / f"reflex_xy-{version}-py3-none-any.whl"
+    dist_info = f"reflex_xy-{version}.dist-info"
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("reflex_xy/__init__.py", "__all__ = []\n")
+        archive.writestr("reflex_xy/assets/XYChart.jsx", "export default null;\n")
+        archive.writestr(f"{dist_info}/METADATA", _metadata("0.2.0"))
+        archive.writestr(f"{dist_info}/WHEEL", "Root-Is-Purelib: true\nTag: py3-none-any\n")
+        archive.writestr(f"{dist_info}/RECORD", "")
+
+    _, errors = verify_reflex_xy_dist.verify_wheel(path)
+
+    assert any("does not match" in e for e in errors)
+
+
+def test_rejects_a_wheel_missing_dependencies(tmp_path: Path) -> None:
+    version = "0.1.0"
+    path = tmp_path / f"reflex_xy-{version}-py3-none-any.whl"
+    dist_info = f"reflex_xy-{version}.dist-info"
+    metadata = (
+        f"Metadata-Version: 2.4\nName: reflex-xy\nVersion: {version}\nRequires-Python: >=3.11\n"
+    )
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("reflex_xy/__init__.py", "__all__ = []\n")
+        archive.writestr("reflex_xy/assets/XYChart.jsx", "export default null;\n")
+        archive.writestr(f"{dist_info}/METADATA", metadata)
+        archive.writestr(f"{dist_info}/WHEEL", "Root-Is-Purelib: true\nTag: py3-none-any\n")
+        archive.writestr(f"{dist_info}/RECORD", "")
+
+    _, errors = verify_reflex_xy_dist.verify_wheel(path)
+
+    assert any("missing the 'xy' dependency" in e for e in errors)
+    assert any("missing the 'reflex' dependency" in e for e in errors)
+
+
+def test_rejects_an_sdist_without_its_changelog(tmp_path: Path) -> None:
+    sdist = _sdist(tmp_path, omit=frozenset({"CHANGELOG.md"}))
+
+    _, errors = verify_reflex_xy_dist.verify_sdist(sdist)
+
+    assert any("CHANGELOG.md" in e for e in errors)
+
+
+def test_rejects_sdist_junk(tmp_path: Path) -> None:
+    sdist = _sdist(tmp_path, extra_members={"reflex_xy/__pycache__/__init__.cpython-311.pyc": b""})
+
+    _, errors = verify_reflex_xy_dist.verify_sdist(sdist)
+
+    assert any("generated junk" in e for e in errors)
+
+
+def test_rejects_disagreeing_artifact_versions(tmp_path: Path) -> None:
+    paths = [_wheel(tmp_path, "0.1.0"), _sdist(tmp_path, "0.2.0")]
+
+    errors = verify_reflex_xy_dist.verify_dist(paths)
+
+    assert any("versions disagree" in e for e in errors)
+
+
+def test_requires_exactly_one_wheel_and_one_sdist(tmp_path: Path) -> None:
+    errors = verify_reflex_xy_dist.verify_dist([_wheel(tmp_path)])
+
+    assert any("exactly one sdist" in e for e in errors)
+
+
+def test_release_workflow_wires_the_verifier() -> None:
+    workflow = (
+        Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release-reflex-xy.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "scripts/verify_reflex_xy_dist.py" in workflow
+    assert '--tag "$GITHUB_REF_NAME"' in workflow

--- a/tests/test_verify_reflex_xy_dist.py
+++ b/tests/test_verify_reflex_xy_dist.py
@@ -240,3 +240,11 @@ def test_release_workflow_wires_the_verifier() -> None:
 
     assert "scripts/verify_reflex_xy_dist.py" in workflow
     assert '--tag "$GITHUB_REF_NAME"' in workflow
+
+
+def test_accepts_a_prerelease_pair_under_its_tag(tmp_path: Path) -> None:
+    version = "0.0.1a1"
+    paths = [_wheel(tmp_path, version), _sdist(tmp_path, version)]
+
+    assert verify_reflex_xy_dist.verify_dist(paths, tag="reflex-xy-v0.0.1a1") == []
+    assert verify_reflex_xy_dist.verify_dist(paths, tag="reflex-xy-v0.0.1") != []

--- a/tests/test_verify_sdist.py
+++ b/tests/test_verify_sdist.py
@@ -97,6 +97,23 @@ RELEASE_YML = (
     "    steps:\n"
     "      - uses: pypa/gh-action-pypi-publish@release/v1\n" + ("release workflow padding\n" * 100)
 )
+RELEASE_REFLEX_XY_YML = (
+    "name: Release reflex-xy\n"
+    "on:\n"
+    "  push:\n"
+    '    tags: ["reflex-xy-v*"]\n'
+    "jobs:\n"
+    "  build:\n"
+    "    steps:\n"
+    "      - run: python3 scripts/verify_reflex_xy_dist.py python/reflex-xy/dist/*\n"
+    "  publish:\n"
+    "    permissions:\n"
+    "      id-token: write\n"
+    "    steps:\n"
+    "      - run: python3 scripts/check_release_version.py --package reflex-xy\n"
+    "      - uses: pypa/gh-action-pypi-publish@release/v1\n"
+    + ("adapter release workflow padding\n" * 40)
+)
 DEFAULT_PKG_INFO = (
     "Metadata-Version: 2.4\n"
     "Name: xy\n"
@@ -171,6 +188,8 @@ def _write_sdist(
                 data = CODSPEED_YML.encode("utf-8")
             elif name == ".github/workflows/release.yml":
                 data = RELEASE_YML.encode("utf-8")
+            elif name == ".github/workflows/release-reflex-xy.yml":
+                data = RELEASE_REFLEX_XY_YML.encode("utf-8")
             _add_file(tf, f"{root}/{name}", data)
         for name, data in extra.items():
             _add_file(tf, f"{root}/{name}", data)


### PR DESCRIPTION
Establish independent release infrastructure for the reflex-xy adapter package, which versions and publishes separately from the xy core using its own `reflex-xy-vX.Y.Z` tag namespace.

## Summary

The reflex-xy adapter is a pure-Python distribution (one `py3-none-any` wheel + one sdist) that should publish independently of the xy core's cross-platform release pipeline. This change adds:

1. **Release workflow** (`.github/workflows/release-reflex-xy.yml`): A dedicated, minimal pipeline that builds, verifies, and publishes the adapter to PyPI on `reflex-xy-v*` tags, with a dry-run default for manual dispatches.

2. **Distribution verifier** (`scripts/verify_reflex_xy_dist.py`): Validates that the wheel and sdist meet adapter-specific requirements:
   - Pure wheel (`py3-none-any`, `Root-Is-Purelib: true`, no compiled libraries)
   - Contains required `reflex_xy` package and `XYChart.jsx` asset
   - **No render-client copy** (the client links out of the installed xy package at app compile time, per spec/design/reflex-integration.md §5)
   - Coherent metadata (name, version, Python floor, dependencies)
   - Matching versions across artifacts
   - Never the `0.0.0` fallback version
   - Tag version matches exactly on tagged builds

3. **Version derivation**: Updated `python/reflex-xy/pyproject.toml` to use uv-dynamic-versioning with `pattern-prefix = "reflex-xy-"`, making the adapter's version derivation blind to bare `v*` tags (which belong to the core) and vice versa.

4. **Release gate extension**: Modified `scripts/check_release_version.py` to support multiple packages (`--package xy|reflex-xy`), each with its own tag shape and changelog location.

5. **Workflow validation**: Extended `scripts/verify_ci_workflow.py` to validate the new release-reflex-xy.yml workflow, ensuring it stays wired correctly.

6. **Adapter changelog**: Added `python/reflex-xy/CHANGELOG.md` as the release gate's source of truth for the adapter (separate from the root CHANGELOG.md).

## Key Changes

- **Tag namespace isolation**: `reflex-xy-vX.Y.Z` tags trigger only the adapter workflow; bare `vX.Y.Z` tags trigger only the core's release.yml. Pattern anchoring in version derivation keeps each package's version blind to the other's tags.
- **No render-client drift**: The verifier explicitly rejects any `index.js` or `standalone.js` in the wheel, enforcing that the client is linked from the installed xy package at app compile time.
- **Lazy `__version__` resolution**: Updated `python/reflex-xy/reflex_xy/__init__.py` to resolve the version from package metadata at runtime, since it's no longer written to the source tree.
- **Comprehensive test coverage**: Added 242 lines of tests in `tests/test_verify_reflex_xy_dist.py` covering all verifier checks and error cases.

## Notable Implementation Details

- The verifier is a standalone script (no PyPI dependencies) so it can run before the dev environment is installed, matching the pattern of `scripts/verify_ci_workflow.py`.
- The release workflow uses `fetch-depth: 0` to ensure full git history is available for tag-derived versioning.
- The workflow defaults to dry-run mode (`dry_run: true`) on manual dispatch, preventing accidental publishes.
- Both the core's release.yml and the adapter's release-reflex-xy.yml validate that they don't cross into each other's tag namespaces.

https://claude.ai/code/session_01URtL1KWczW1wXFQLLsZMZx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an independent release pipeline for the `reflex-xy` Python adapter, including tag-based gating, build verification, and install/import smoke checks.
  * Added dry-run support for manual release validation.
  * Enabled dynamic adapter versioning derived from `reflex-xy-vX.Y.Z` tags.
  * Added strict wheel/sdist artifact validation (pure Python only, expected assets present, render-client copy excluded).
* **Documentation**
  * Added `reflex-xy` changelog plus expanded versioning and release guidance.
  * Updated production-readiness notes for the separate adapter release line.
* **Bug Fixes**
  * `reflex_xy.__version__` now resolves from installed package metadata (fallback when not installed).
* **Tests**
  * Added/expanded coverage for release gating, workflow wiring, and artifact validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->