### PR TITLE
Publish PyEmscripten wheel to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,8 @@ jobs:
   wasm:
     name: Wheel PyEmscripten (runtime verified)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,11 +127,12 @@ jobs:
           name: dist-${{ matrix.plat }}
           path: dist/*.whl
 
-  # Pyodide / Emscripten WASM wheel for in-browser CPython. Pyodide's platform
-  # ABI is compiler-sensitive, so keep Rust, Emscripten, the wheel tag, and the
-  # runtime probe pinned as one tested set (see spec/process/production-readiness.md).
+  # PyEmscripten WASM wheel for in-browser CPython. The platform ABI is
+  # compiler-sensitive, so keep Rust, Emscripten, cibuildwheel, the wheel tag,
+  # and the runtime probe pinned as one tested set
+  # (see spec/process/production-readiness.md).
   wasm:
-    name: Wheel Pyodide (runtime verified)
+    name: Wheel PyEmscripten (runtime verified)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -143,52 +144,48 @@ jobs:
         with:
           toolchain: 1.97.0
           targets: wasm32-unknown-emscripten
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          enable-cache: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
-      - uses: emscripten-core/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
-        with:
-          # Pyodide 0.29.x / pyodide_2025_0 ABI compiler version.
-          version: "4.0.9"
       - name: Install JS build toolchain
         run: npm ci
-      - name: Cross-compile the native core (emscripten)
+      # cibuildwheel installs the Pyodide 314 cross-environment and its patched
+      # Emscripten 5.0.3 toolchain before CIBW_BEFORE_BUILD_PYODIDE runs. Build
+      # the standalone Rust cdylib there, then tell the Hatch hook to package
+      # that prebuilt artifact rather than invoke Cargo a second time.
+      - name: Build the PyEmscripten wheel
+        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         env:
-          # Unwinding imports a __cpp_exception WebAssembly tag that Pyodide's
-          # main module does not provide. Abort keeps the C ABI side module
-          # exception-free and was runtime-verified against Pyodide 0.29.4.
-          RUSTFLAGS: "-C panic=abort"
-        run: cargo build --release --target wasm32-unknown-emscripten
-      - name: Build the Pyodide wheel
-        shell: bash
-        env:
-          XY_REQUIRE_CARGO: "1"
-          XY_SKIP_CARGO: "1"
-          XY_CARGO_TARGET: wasm32-unknown-emscripten
-          XY_WHEEL_PLATFORM: pyodide_2025_0_wasm32
-        run: uv build --wheel
+          CIBW_PLATFORM: pyodide
+          CIBW_BUILD: cp314-pyodide_wasm32
+          CIBW_PYODIDE_VERSION: "314.0.0"
+          CIBW_BEFORE_BUILD_PYODIDE: >-
+            cargo build --release --target wasm32-unknown-emscripten
+          CIBW_ENVIRONMENT_PYODIDE: >-
+            XY_REQUIRE_CARGO=1
+            XY_SKIP_CARGO=1
+            XY_CARGO_TARGET=wasm32-unknown-emscripten
+            XY_WHEEL_PLATFORM=pyemscripten_2026_0_wasm32
+            RUSTFLAGS="-C panic=abort"
       - name: Verify wheel contents
         shell: bash
         run: |
-          whl=$(ls dist/*.whl)
+          whl=$(ls wheelhouse/*.whl)
           python scripts/verify_wheel.py "$whl" --expect-native
-      # "Builds" is not "loads": install the exact wheel in a real Pyodide
+      # "Builds" is not "loads": install the exact wheel in a real Pyodide 314
       # runtime and call both the C ABI version function and a native kernel.
-      - name: Pyodide runtime load probe
+      - name: PyEmscripten runtime load probe
         run: |
-          npm i --no-save pyodide@0.29.4
-          whl=$(ls dist/*.whl)
+          npm i --no-save pyodide@314.0.0
+          whl=$(ls wheelhouse/*.whl)
           python scripts/pyodide_load_smoke.py "$whl"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          # Keep this outside the dist-* namespace: PyPI rejects Pyodide's
-          # pyodide_* platform tags, so this wheel is retained as a workflow
-          # artifact but must not enter the PyPI upload directory.
-          name: pyodide-wheel
-          path: dist/*.whl
+          # PEP 783 makes pyemscripten_* a standard PyPI platform tag. Keeping
+          # this in the dist-* namespace includes it in the trusted-publishing
+          # batch alongside the native wheels and sdist.
+          name: dist-pyemscripten
+          path: wheelhouse/*.whl
 
   sdist:
     name: sdist
@@ -251,9 +248,9 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    # Publishing still requires the runtime-verified Pyodide job to pass, but
-    # only native wheels and the sdist use dist-* artifact names. PyPI does not
-    # accept Pyodide platform tags, so its wheel remains a separate artifact.
+    # Publishing requires the runtime-verified PyEmscripten job to pass. Its
+    # PEP 783 wheel uses a standard PyPI platform tag and joins the same
+    # trusted-publishing batch as the native wheels and sdist.
     needs: [wheels, sdist, wasm]
     runs-on: ubuntu-latest
     environment: pypi
@@ -295,63 +292,3 @@ jobs:
           # A failed upload can leave a partial release on immutable PyPI.
           # Retrying the same tag should skip files that were already accepted.
           skip-existing: true
-
-  publish-pyodide:
-    name: Publish Pyodide wheel
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true'
-    needs: [wheels, sdist, wasm]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          # Full history and tags: the distribution version is derived
-          # from the latest `v*` tag, and a shallow clone has none.
-          fetch-depth: 0
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "22"
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: pyodide-wheel
-          path: dist-pyodide
-      # PyPI rejects Pyodide platform tags. Publish the runtime-verified wheel
-      # as a release asset instead; micropip supports installing binary WASM
-      # wheels directly from HTTPS URLs.
-      - name: Upload Pyodide wheel to GitHub Release
-        id: publish
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          REF_NAME: ${{ github.ref_name }}
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          # The release asset hangs off the tag itself. On a tag push that is
-          # the ref; a manual dry run has no tag, so fall back to the newest
-          # release tag (the same one the version was derived from) rather than
-          # inventing one from a version that no longer lives in pyproject.
-          if [[ "$EVENT_NAME" == "push" ]]; then
-            tag="$REF_NAME"
-          else
-            tag=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*')
-          fi
-          test -n "$tag"
-          python3 scripts/check_release_version.py --tag "$tag"
-          wheel=$(find dist-pyodide -maxdepth 1 -name '*.whl' -print -quit)
-          test -n "$wheel"
-          if gh release view "$tag" >/dev/null 2>&1; then
-            gh release upload "$tag" "$wheel" --clobber
-          else
-            gh release create "$tag" "$wheel" --verify-tag --generate-notes --title "$tag"
-          fi
-          url="https://github.com/${GH_REPO}/releases/download/${tag}/$(basename "$wheel")"
-          echo "wheel_url=$url" >> "$GITHUB_OUTPUT"
-          echo "Pyodide wheel: $url"
-      - name: Verify published Pyodide wheel from its HTTPS URL
-        env:
-          WHEEL_URL: ${{ steps.publish.outputs.wheel_url }}
-        run: |
-          npm i --no-save pyodide@0.29.4
-          python3 scripts/pyodide_load_smoke.py "$WHEEL_URL"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ adheres to [Semantic Versioning](https://semver.org/) once `1.0.0` ships;
 pre-1.0, minor versions may contain breaking changes (see the stability table
 in the README).
 
+## Unreleased
+
+### Changed
+- The runtime-verified WebAssembly wheel now targets the standardized PEP 783
+  `pyemscripten_2026_0_wasm32` platform with Pyodide 314, Emscripten 5.0.3,
+  and cibuildwheel 4.1.0. It is published directly to PyPI through the existing
+  trusted-publishing release job, so browser users can install `xy` by package
+  name with `micropip` instead of downloading a GitHub Release asset URL.
+
+### Fixed
+- Emscripten cross-builds always package the Rust side module as
+  `libxy_core.so`, the filename Pyodide's dynamic loader expects, even when
+  cibuildwheel runs on a macOS host.
+
 ## [0.0.2] - 2026-07-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ core. End users do not need Rust, Node, npm, or a CDN.
 
 In Pyodide 314:
 
+First load `micropip` in the Pyodide JavaScript runtime:
+
+```javascript
+await pyodide.loadPackage("micropip");
+```
+
 ```python
 import micropip
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ uv add xy
 Published wheels contain the Python package, JavaScript client, and native Rust
 core. End users do not need Rust, Node, npm, or a CDN.
 
+In Pyodide 314:
+
+```python
+import micropip
+
+await micropip.install("xy")
+```
+
 ## Getting started
 
 Create a small business chart:

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -69,7 +69,13 @@ from typing import Any, Optional
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 
-def _lib_filename() -> str:
+def _lib_filename(target: Optional[str] = None) -> str:
+    # Cargo emits an Emscripten cdylib as `.wasm`, but Pyodide's dynamic loader
+    # follows the Unix extension-module convention and ctypes looks for `.so`.
+    # Choose that wheel-internal destination from the *target*, not the build
+    # host (cibuildwheel supports both Linux and macOS hosts).
+    if target == "wasm32-unknown-emscripten":
+        return "libxy_core.so"
     if sys.platform == "win32":
         return "xy_core.dll"
     if sys.platform == "darwin":
@@ -159,7 +165,7 @@ class CustomBuildHook(BuildHookInterface):
         if self.target_name != "wheel":
             return
 
-        lib_name = _lib_filename()
+        lib_name = _lib_filename(_cargo_target())
         dest_dir = root / "python" / "xy" / "_native_lib"
         dest = dest_dir / lib_name
         require = os.environ.get("XY_REQUIRE_CARGO") == "1"

--- a/scripts/verify_ci_workflow.py
+++ b/scripts/verify_ci_workflow.py
@@ -714,6 +714,8 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
         "wasm",
         "release",
         "runtime-verified, PyPI-published PyEmscripten WASM wheel",
+        "permissions:",
+        "contents: read",
         "toolchain: 1.97.0",
         "wasm32-unknown-emscripten",
         'RUSTFLAGS="-C panic=abort"',

--- a/scripts/verify_ci_workflow.py
+++ b/scripts/verify_ci_workflow.py
@@ -33,7 +33,7 @@ REQUIRED_CI_JOBS = {
     "install_without_rust",
 }
 REQUIRED_CODSPEED_JOBS = {"benchmarks"}
-REQUIRED_RELEASE_JOBS = {"wheels", "sdist", "publish", "publish-pyodide", "wasm"}
+REQUIRED_RELEASE_JOBS = {"wheels", "sdist", "publish", "wasm"}
 
 
 def _job_blocks(text: str) -> dict[str, str]:
@@ -713,18 +713,23 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
         jobs,
         "wasm",
         "release",
-        "runtime-verified Pyodide/Emscripten WASM wheel",
+        "runtime-verified, PyPI-published PyEmscripten WASM wheel",
         "toolchain: 1.97.0",
         "wasm32-unknown-emscripten",
-        "setup-emsdk",
-        'version: "4.0.9"',
-        'RUSTFLAGS: "-C panic=abort"',
-        "pyodide_2025_0_wasm32",
-        "pyodide@0.29.4",
+        'RUSTFLAGS="-C panic=abort"',
+        "pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55",
+        "CIBW_PLATFORM: pyodide",
+        "CIBW_BUILD: cp314-pyodide_wasm32",
+        'CIBW_PYODIDE_VERSION: "314.0.0"',
+        "CIBW_BEFORE_BUILD_PYODIDE",
+        "CIBW_ENVIRONMENT_PYODIDE",
+        "pyemscripten_2026_0_wasm32",
+        "pyodide@314.0.0",
         "scripts/pyodide_load_smoke.py",
         "scripts/verify_wheel.py",
         "--expect-native",
-        "name: pyodide-wheel",
+        "wheelhouse/*.whl",
+        "name: dist-pyemscripten",
     )
     wasm_job = jobs.get("wasm", "")
     if "continue-on-error:" in wasm_job:
@@ -776,30 +781,6 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
         "type: boolean",
         "default: true",
     )
-    _require_job_contains(
-        errors,
-        jobs,
-        "publish-pyodide",
-        "release",
-        "GitHub Release publication of the runtime-verified Pyodide wheel",
-        "needs: [wheels, sdist, wasm]",
-        "contents: write",
-        "actions/setup-node@",
-        'node-version: "22"',
-        "actions/download-artifact@",
-        "name: pyodide-wheel",
-        "dry_run",
-        "scripts/check_release_version.py",
-        "GH_TOKEN",
-        "gh release upload",
-        "--clobber",
-        "gh release create",
-        "--verify-tag",
-        "steps.publish.outputs.wheel_url",
-        "pyodide@0.29.4",
-        "scripts/pyodide_load_smoke.py",
-    )
-
     publish = jobs.get("publish", "")
     if "password:" in publish or "api-token" in publish:
         errors.append("release publish job should use trusted publishing, not a PyPI token")

--- a/spec/process/production-readiness.md
+++ b/spec/process/production-readiness.md
@@ -361,16 +361,16 @@ Before tagging a release:
   arm64).
 - Confirm the Pyodide/Emscripten wheel passes its runtime load gate, not only
   its structural wheel check. The tested toolchain is Rust 1.97.0 with
-  `panic=abort`, Emscripten 4.0.9, the `pyodide_2025_0` wheel ABI, and Pyodide
-  0.29.4. The abort strategy is required: the previous unwind build imported a
-  `__cpp_exception` WebAssembly tag that Pyodide's main module did not provide.
-  `scripts/pyodide_load_smoke.py` installs the built artifact with micropip,
-  loads the C ABI through `ctypes`, verifies `xy_abi_version`, and calls the
-  native `min_max` kernel. PyPI does not accept Pyodide platform tags, so the
-  release workflow publishes this wheel as a GitHub Release asset and repeats
-  the same runtime smoke against its public HTTPS URL. The wasm job is
-  release-blocking so an ABI or toolchain drift cannot silently ship a
-  build-only, unloadable artifact.
+  `panic=abort`, Emscripten 5.0.3, cibuildwheel 4.1.0, the PEP 783
+  `pyemscripten_2026_0` wheel ABI, and Pyodide 314.0.0. The abort strategy keeps
+  Rust panics from unwinding across the Python/`ctypes` C ABI boundary.
+  `scripts/pyodide_load_smoke.py` installs the exact built artifact with
+  micropip, loads the C ABI through `ctypes`, verifies `xy_abi_version`, and
+  calls the native `min_max` kernel. PEP 783 platform tags are accepted by
+  PyPI, so the runtime-verified wheel joins the same trusted-publishing batch
+  as the native wheels and sdist; Pyodide 314 users can install it with
+  `await micropip.install("xy")`. The wasm job is release-blocking so an ABI or
+  toolchain drift cannot silently ship a build-only, unloadable artifact.
 - Confirm the no-Rust install job passed (it must build, install, and then
   raise a clear ImportError on first compute — never a silent fallback).
 - Confirm the sdist verifier passed and the source archive contains the expected

--- a/tests/test_hatch_build.py
+++ b/tests/test_hatch_build.py
@@ -45,6 +45,14 @@ def _load_hatch_build():
 hb = _load_hatch_build()
 
 
+def test_emscripten_destination_uses_pyodide_loader_suffix(monkeypatch) -> None:
+    # The wheel must contain libxy_core.so even when cibuildwheel runs on macOS;
+    # Pyodide's ctypes loader does not look for the build host's `.dylib`.
+    monkeypatch.setattr(hb.sys, "platform", "darwin")
+    assert hb._lib_filename("wasm32-unknown-emscripten") == "libxy_core.so"
+    assert hb._lib_filename() == "libxy_core.dylib"
+
+
 def _release_dir(base: Path, triple: str) -> Path:
     d = base / "target" / triple / "release"
     d.mkdir(parents=True)

--- a/tests/test_pyodide_load_smoke.py
+++ b/tests/test_pyodide_load_smoke.py
@@ -21,8 +21,8 @@ pyodide_load_smoke = _load_smoke_module()
 
 def test_remote_wheel_url_is_installed_directly(monkeypatch, tmp_path: Path) -> None:
     url = (
-        "https://github.com/reflex-dev/xy/releases/download/v0.0.1/"
-        "xy-0.0.1-py3-none-pyodide_2025_0_wasm32.whl"
+        "https://files.pythonhosted.org/packages/example/"
+        "xy-0.0.3-py3-none-pyemscripten_2026_0_wasm32.whl"
     )
     observed: dict[str, object] = {}
 

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -604,16 +604,29 @@ def test_release_workflow_rejects_unpinned_pyodide_runtime_contract(
     workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
     path = tmp_path / "release.yml"
     path.write_text(
-        workflow.replace('          RUSTFLAGS: "-C panic=abort"\n', "")
-        .replace('          version: "4.0.9"\n', "")
-        .replace("          npm i --no-save pyodide@0.29.4\n", ""),
+        workflow.replace('            RUSTFLAGS="-C panic=abort"\n', "")
+        .replace("          CIBW_BUILD: cp314-pyodide_wasm32\n", "")
+        .replace('          CIBW_PYODIDE_VERSION: "314.0.0"\n', "")
+        .replace(
+            "          CIBW_BEFORE_BUILD_PYODIDE: >-\n"
+            "            cargo build --release --target wasm32-unknown-emscripten\n",
+            "",
+        )
+        .replace(
+            "        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0\n",
+            "",
+        )
+        .replace("          npm i --no-save pyodide@314.0.0\n", ""),
         encoding="utf-8",
     )
 
     errors = verify_ci_workflow.validate_release_workflow(path)
 
     assert any(
-        "release wasm job" in error and "panic=abort" in error and "pyodide@0.29.4" in error
+        "release wasm job" in error
+        and "panic=abort" in error
+        and "cibuildwheel" in error
+        and "pyodide@314.0.0" in error
         for error in errors
     )
 
@@ -635,30 +648,21 @@ def test_release_workflow_rejects_nonblocking_pyodide_probe(tmp_path: Path) -> N
     assert any("wasm job must block publishing" in error for error in errors)
 
 
-def test_release_workflow_rejects_pyodide_artifact_in_pypi_batch(tmp_path: Path) -> None:
+def test_release_workflow_rejects_pyemscripten_artifact_outside_pypi_batch(
+    tmp_path: Path,
+) -> None:
     workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
     path = tmp_path / "release.yml"
     path.write_text(
-        workflow.replace("          name: pyodide-wheel\n", "          name: dist-pyodide\n"),
+        workflow.replace(
+            "          name: dist-pyemscripten\n", "          name: pyemscripten-wheel\n"
+        ),
         encoding="utf-8",
     )
 
     errors = verify_ci_workflow.validate_release_workflow(path)
 
-    assert any("release wasm job" in error and "pyodide-wheel" in error for error in errors)
-
-
-def test_release_workflow_rejects_missing_pyodide_release_publisher(tmp_path: Path) -> None:
-    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
-    path = tmp_path / "release.yml"
-    path.write_text(
-        workflow.replace("  publish-pyodide:\n", "  publish-pyodide-removed:\n"),
-        encoding="utf-8",
-    )
-
-    errors = verify_ci_workflow.validate_release_workflow(path)
-
-    assert any("missing required release job 'publish-pyodide'" in error for error in errors)
+    assert any("release wasm job" in error and "dist-pyemscripten" in error for error in errors)
 
 
 def test_release_workflow_rejects_missing_sdist_norust_smoke(tmp_path: Path) -> None:

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -648,6 +648,23 @@ def test_release_workflow_rejects_nonblocking_pyodide_probe(tmp_path: Path) -> N
     assert any("wasm job must block publishing" in error for error in errors)
 
 
+def test_release_workflow_rejects_broad_wasm_permissions(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(
+            "    permissions:\n      contents: read\n    steps:\n",
+            "    steps:\n",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("release wasm job" in error and "contents: read" in error for error in errors)
+
+
 def test_release_workflow_rejects_pyemscripten_artifact_outside_pypi_batch(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What changed

- Build the browser wheel with pinned `cibuildwheel` 4.1.0 for `cp314-pyodide_wasm32` / Pyodide 314.0.0.
- Target the standardized PEP 783 `pyemscripten_2026_0_wasm32` platform and publish the runtime-verified wheel through the existing trusted-PyPI artifact batch.
- Remove the separate GitHub Release asset publishing path; Pyodide users can now install with `await micropip.install("xy")`.
- Make the Hatch build hook package Emscripten cdylibs as `libxy_core.so` based on the target rather than the build host, so cibuildwheel works from both Linux and macOS.
- Update release guardrails, regression tests, README installation guidance, production-readiness notes, and the changelog.

## Why

PEP 783 and Pyodide 314 make `pyemscripten_*` a standard PyPI wheel platform. The previous `pyodide_2025_0_wasm32` wheel could not be uploaded to PyPI and had to be installed from a GitHub Release URL.

A production-equivalent macOS build also exposed that the build hook derived the packaged library suffix from the host. That produced `libxy_core.dylib`, while Pyodide's dynamic loader expects `libxy_core.so`; the target-aware destination fixes that masked cross-host bug.

## Impact

The next tagged release will publish a Pyodide 314-compatible WASM wheel alongside the native wheels and sdist. Browser users get normal package-name installation through `micropip`, while the existing ABI/version/content/runtime gates remain release-blocking.

## Validation

- `make check` — 2,189 passed, 68 skipped; all 8 gates passed (the existing `ty` findings remain advisory)
- Focused packaging/workflow tests — 58 passed
- Real cibuildwheel 4.1.0 build produced `xy-0.0.2-py3-none-pyemscripten_2026_0_wasm32.whl`
- `scripts/verify_wheel.py --expect-native` passed on that artifact
- Real Pyodide 314.0.0 runtime probe passed: `backend=native`, ABI 41, `min_max=(1,3)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebAssembly wheels now target the standardized **PEP 783 PyEmscripten** platform and are published directly to **PyPI** via trusted publishing.
  * Added **Pyodide 314** installation instructions for installing `xy` in the browser using **micropip**.
* **Bug Fixes**
  * Cross-compiling WebAssembly now consistently packages the shared library as **`libxy_core.so`** for Pyodide’s loader expectations.
* **Documentation**
  * Updated the README and production release checklist/changelog to reflect the new PyEmscripten distribution and Pyodide install flow.
* **Tests / CI**
  * Updated CI/release workflow verification to remove the legacy Pyodide publishing path and add stricter wasm-job permission and artifact placement checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->