### PR TITLE
Shrink README image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="spec/assets/xy-sdf-binned-scatter.png" alt="XY-shaped probability field shown as a binned scatter chart." width="694">
+  <img src="spec/assets/xy-sdf-binned-scatter.png" alt="XY-shaped probability field shown as a binned scatter chart." width="521">
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Reduce the displayed width of the lead README image from 694 px to 521 px, approximately 75% of its original size.

## Impact

The README hero image takes up less space while preserving its aspect ratio and source asset quality.

## Validation

- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Adjusted the README banner image width for improved display and layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->