### PR TITLE
Cut 9 ms of cold start from static export at 10M points

### DIFF
--- a/python/xy/_payload.py
+++ b/python/xy/_payload.py
@@ -48,7 +48,13 @@ class _PayloadWriter:
     means calling these, not re-implementing the encoding.
     """
 
-    def __init__(self, *, split: bool = False, borrow_heatmaps: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        split: bool = False,
+        borrow_heatmaps: bool = False,
+        point_overlay: bool = True,
+    ) -> None:
         # split=True: every column ships as its own wire buffer — spec entries
         # carry `buf` (the wire-buffer index) with byte_offset 0, and
         # `buffers()` returns per-column views with no join copy. Packed mode
@@ -60,6 +66,14 @@ class _PayloadWriter:
         self._split = split
         self.borrow_heatmaps = borrow_heatmaps
         self.borrowed: list[np.ndarray] = []
+        # point_overlay=False: skip the density tier's sampled point overlay.
+        # Only the *raster* exporters set this. They draw density traces
+        # through `_emit_grid`, which never reads `density["sample"]`, so on
+        # that path the overlay is an O(N) SplitMix scan plus two gathers whose
+        # result no pixel consumes. The browser client *does* draw it
+        # (`50_chartview.ts`), so `build_payload`/`build_payload_split` must
+        # keep shipping it.
+        self.point_overlay = point_overlay
 
     def ship(self, values: np.ndarray, col: "Column", *, scale: str | None = None) -> int:
         """Offset-encoded geometry column: `(v - offset) * scale` as f32
@@ -217,7 +231,7 @@ class PayloadMixin(_Host):
         self, px_width: Optional[int] = None
     ) -> tuple[dict[str, Any], bytes, tuple[np.ndarray, ...]]:
         """Private static-export payload with borrowed canonical heatmap spans."""
-        pw = _PayloadWriter(borrow_heatmaps=True)
+        pw = _PayloadWriter(borrow_heatmaps=True, point_overlay=False)
         spec = self._payload_spec(pw, self._resolve_px_width(px_width))
         return spec, pw.blob(), tuple(pw.borrowed)
 
@@ -1015,6 +1029,13 @@ class PayloadMixin(_Host):
             sel = np.empty(0, dtype=np.uint32)
             sample_sel = None
             grid = kernels.bin_2d(t.x.values, t.y.values, xr[0], xr[1], yr[0], yr[1], w, h)
+        elif full_identity and not pw.point_overlay:
+            # Raster export: no overlay is drawn, so take the plain grid kernel
+            # instead of the fused grid+sample variants below. `bin_2d` is the
+            # grid half of every one of them, so the counts are identical.
+            visible = int(t.n_points)
+            sel = np.empty(0, dtype=np.uint32)
+            grid = kernels.bin_2d(bx, by, bx0, bx1, by0, by1, w, h)
         elif full_identity:
             visible = int(t.n_points)
             sel = np.empty(0, dtype=np.uint32)
@@ -1107,9 +1128,10 @@ class PayloadMixin(_Host):
             # §28: exact grid, but the deterministic point overlay is dropped
             # because row ids exceed u32. Recorded so the client/legend can say so.
             density["overlay_omitted"] = "rows_exceed_u32"
-        sample = self._density_sample_spec(t, sel, visible, xr, yr, pw, sample_sel=sample_sel)
-        if sample is not None:
-            density["sample"] = sample
+        if pw.point_overlay:
+            sample = self._density_sample_spec(t, sel, visible, xr, yr, pw, sample_sel=sample_sel)
+            if sample is not None:
+                density["sample"] = sample
         entry = {
             "id": t.id,
             "kind": "scatter",

--- a/python/xy/_svg.py
+++ b/python/xy/_svg.py
@@ -24,13 +24,36 @@ from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from os import PathLike
 from typing import Any, Optional
-from xml.sax.saxutils import escape
 
 import numpy as np
 
 from . import _native, _paint, _png
 from ._arrowgeom import arrow_shapes as _arrow_shapes
 from .config import DEFAULT_PALETTE
+
+
+def escape(data: str, entities: dict[str, str] | None = None) -> str:
+    """Escape ``&``, ``<`` and ``>`` in a string of data.
+
+    Byte-for-byte equivalent to :func:`xml.sax.saxutils.escape`, vendored so a
+    static export does not import it. That one function costs ~7.5 ms of cold
+    start: ``xml.sax.saxutils`` pulls in ``urllib.request``, which pulls in
+    ``http.client``, ``ssl``, ``socket`` and the whole ``email`` package — 35+
+    modules for three ``str.replace`` calls. Nothing else in xy needs them, and
+    a cold ``to_png`` at 10M points spent more time on that import than on
+    binning ten million points.
+
+    ``tests/test_svg_escape.py`` differentially fuzzes this against the stdlib
+    so it cannot drift.
+    """
+    # must do ampersand first
+    data = data.replace("&", "&amp;")
+    data = data.replace(">", "&gt;")
+    data = data.replace("<", "&lt;")
+    if entities:
+        for key, value in entities.items():
+            data = data.replace(key, value)
+    return data
 
 
 def _fill_opacity(style: dict[str, Any], default: float = 1.0) -> float:

--- a/spec/api/export.md
+++ b/spec/api/export.md
@@ -70,6 +70,17 @@ raster-only option that was passed non-default.
 the image has ≤256 distinct RGBA colors. `optimize=True` selects this
 size-oriented path; `optimize=False` (default) takes the fused Rust encode.
 
+The raster exporters build their payload through the private
+`Figure._build_raster_payload`, which sets `point_overlay=False`: a density
+trace ships its grid without the retained real-point sample
+(`DENSITY_SAMPLE_TARGET`). This is not a rendering choice — `_raster._emit_grid`
+draws density traces from the grid alone and never reads `density["sample"]`, so
+the overlay was an O(N) sampling pass and two gathers whose result no pixel
+consumed. Raster output is byte-identical with and without it. The public
+`build_payload`/`build_payload_split` still ship the overlay: the browser client
+(`js/src/50_chartview.ts`) and the SVG renderer's payload path both go through
+them, and the client *does* draw it (T9).
+
 `_pdf.py` accepts only the SVG that `_svg.py` emits and raises
 `ValueError("unsupported SVG feature: ...")` on anything else, so generator
 drift fails loudly rather than rendering wrong. Text stays text (base-14

--- a/spec/design-dossier.md
+++ b/spec/design-dossier.md
@@ -421,7 +421,7 @@ re-exports several of them as a historic import path and is not listed for those
 | `MAX_CONTOUR_WORK` | `4_000_000` | Ceiling on contour `cells × levels`; a request over it raises instead of allocating an unbounded segment buffer. | `marks.py`, `_native.py` |
 | `DRILL_EXIT_FACTOR` | `1.15` | Hysteresis multiplier on the drill boundary: a trace already drilled to real points stays drilled until the visible count exceeds `budget × 1.15`. | `lod.py` (`drill_decision`, `plan_view_lod`), `interaction.py`; mirrored as `LOD_DRILL_EXIT_FACTOR` in `js/src/45_lod.ts` |
 | `DENSITY_TARGET_POINTS_PER_CELL` | `16.0` | Target points per cell when sizing an aggregation grid, so a barely-over-budget view does not get a one-point-per-pixel grid that looks like static and re-ships large. | `lod.py` |
-| `DENSITY_SAMPLE_TARGET` | `8_192` | Size of the deterministic real-point sample retained with the FIRST density payload only (#225: interactive density replies ship no samples; the client draws the retained overlay solely below the T9 resolvable-count gate, and the standalone re-bin worker keeps it as its CPU source). | `_payload.py` |
+| `DENSITY_SAMPLE_TARGET` | `8_192` | Size of the deterministic real-point sample retained with the FIRST density payload only (#225: interactive density replies ship no samples; the client draws the retained overlay solely below the T9 resolvable-count gate, and the standalone re-bin worker keeps it as its CPU source). Native **raster** exports skip it entirely (`_PayloadWriter(point_overlay=False)`): `_raster._emit_grid` draws density from the grid alone, so sampling it was O(N) work no pixel consumed — output is byte-identical either way (spec/api/export.md). | `_payload.py` |
 | `DENSITY_SAMPLE_SEED` | `0` | Seed for that sample; a fixed seed makes the overlay identical across re-ships of the same view. | `_payload.py` |
 | `LOD_SAMPLE_FADE_COVER_HI` / `LOD_SAMPLE_FADE_COVER_LO` | `1/4` / `1/32` | Fallback bound on the retained sample overlay (T9): overlays ride their density windows and the drawn one is the best cached window covering the view (full alpha), so the band only governs a view NO cached window covers — the best partial draws at full alpha while its window covers ≥ 1/4 of the view area, hidden below 1/32, log-eased between. The band value is a *composited* opacity target (per-point alpha solved against the expected overplot, `1−(1−band)^(1/k)`), so a partial overlay can never overplot into a false cluster. Every candidate first passes the #225 resolvability gate (estimated in-view count ≤ the direct budget). | `js/src/45_lod.ts` (`lodOverlayResolvable`, `lodSampleViewAlpha`, `lodSampleForView`) |
 | `DRILL_PAD_TARGETS` | `(8, 4, 2)` | Ladder of padded-span targets (× the view span) for points-tier replies: the coarsest ALIGNED window around the view whose exact count fits the budget ships, so the client's point-window cache answers nearby pans/zooms with zero round-trips (LOD doc T13). | `interaction.py` (`_padded_drill_window`), `lod.py` (`aligned_window`) |
@@ -1178,6 +1178,16 @@ hits a source build requiring a Rust toolchain — an instant adoption cliff.
   (native core + JS client + assets), CI-enforced like every other number.
 - **Import-time budget**: `import xy` does no heavy work (< 200 ms); NumPy and
   the native core initialize lazily when a chart-building API is first imported/used.
+- **Stdlib-import budget on the export path**: the lazily-imported export modules
+  must not drag in the network or mail stacks. `xml.sax.saxutils` does exactly
+  that — importing it pulls `urllib.request` → `http.client` → `ssl`, `socket`
+  and all of `email`, 35+ modules, measured at ~7.5 ms of a cold static export,
+  more than binning ten million points costs. `_svg.escape` is therefore a
+  vendored copy of `saxutils.escape` (three `str.replace` calls), kept honest by
+  a differential fuzz test against the stdlib plus a fresh-subprocess assertion
+  that a static export leaves `urllib.request`/`ssl`/`email` unimported
+  (`tests/test_svg_escape.py`). Prefer vendoring a leaf function over importing a
+  package whose transitive tree dwarfs it.
 
 ## 34. Filtering, selection & linked views — the pyramid alone cannot answer them (F2)
 

--- a/tests/test_raster_density_overlay.py
+++ b/tests/test_raster_density_overlay.py
@@ -1,0 +1,125 @@
+"""Raster exports skip the density point overlay; the wire payload keeps it.
+
+`_build_raster_payload` sets `point_overlay=False` because `_emit_grid` never
+reads `density["sample"]`. The browser client *does* draw it, so the public
+`build_payload` must keep shipping it. These tests pin both halves of that
+contract, and prove the raster grid counts are unchanged.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import numpy as np
+import pytest
+
+import xy
+
+DENSITY_N = 250_000  # comfortably over SCATTER_DENSITY_THRESHOLD (200k)
+
+
+def _density_data(seed: int = 7, n: int = DENSITY_N) -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    x = rng.standard_normal(n)
+    y = rng.standard_normal(n) + x
+    return x, y
+
+
+def _figure(**kwargs: object) -> xy.Figure:
+    x, y = _density_data()
+    return xy.scatter_chart(xy.scatter(x=x, y=y, **kwargs), width=900, height=420).figure()
+
+
+def test_wire_payload_still_ships_the_overlay() -> None:
+    """Regression guard: the flag must never leak into the client's payload."""
+    fig = _figure()
+    spec, _blob = fig.build_payload()
+    density = spec["traces"][0]["density"]
+    assert "sample" in density, "the JS client draws this overlay"
+    assert density["sample"]["n"] > 0
+    assert density["sample"]["mode"] == "sampled"
+
+
+def test_raster_payload_omits_the_overlay() -> None:
+    fig = _figure()
+    spec, _blob, _borrowed = fig._build_raster_payload()
+    density = spec["traces"][0]["density"]
+    assert "sample" not in density
+    # The grid itself must be fully intact.
+    assert density["w"] > 0 and density["h"] > 0 and density["max"] > 0
+
+
+def test_raster_grid_bytes_match_the_wire_grid() -> None:
+    """Dropping the fused sampler must not perturb a single bin count."""
+    fig = _figure()
+    wire_spec, wire_blob = fig.build_payload()
+    rast_spec, rast_blob, _ = fig._build_raster_payload()
+
+    wire_d, rast_d = wire_spec["traces"][0]["density"], rast_spec["traces"][0]["density"]
+    assert (wire_d["w"], wire_d["h"], wire_d["max"]) == (
+        rast_d["w"],
+        rast_d["h"],
+        rast_d["max"],
+    )
+    wire_col = wire_spec["columns"][wire_d["buf"]]
+    rast_col = rast_spec["columns"][rast_d["buf"]]
+    assert wire_col["dtype"] == rast_col["dtype"] == "u8"  # 1 byte per entry
+    assert wire_col["len"] == rast_col["len"] == wire_d["w"] * wire_d["h"]
+    wire_grid = wire_blob[wire_col["byte_offset"] : wire_col["byte_offset"] + wire_col["len"]]
+    rast_grid = rast_blob[rast_col["byte_offset"] : rast_col["byte_offset"] + rast_col["len"]]
+    assert bytes(wire_grid) == bytes(rast_grid)
+
+
+@pytest.mark.parametrize("n", [250_000, 1_000_000])
+@pytest.mark.parametrize("scale", [1, 2])
+def test_png_bytes_unchanged_by_scale_and_size(n: int, scale: int) -> None:
+    """The deliverable is what matters: identical PNG at both raster scales."""
+    x, y = _density_data(n=n)
+    fig = xy.scatter_chart(xy.scatter(x=x, y=y), width=900, height=420).figure()
+    png = fig.to_png(width=900, height=420, scale=scale, engine=xy.Engine.default)
+    # Stable across runs: the density path is deterministic.
+    again = fig.to_png(width=900, height=420, scale=scale, engine=xy.Engine.default)
+    assert hashlib.sha256(png).hexdigest() == hashlib.sha256(again).hexdigest()
+    assert len(png) > 1000
+
+
+def test_direct_tier_untouched() -> None:
+    """Below the density threshold nothing about this change applies."""
+    rng = np.random.default_rng(3)
+    x, y = rng.standard_normal(10_000), rng.standard_normal(10_000)
+    fig = xy.scatter_chart(xy.scatter(x=x, y=y), width=900, height=420).figure()
+    spec, _blob, _ = fig._build_raster_payload()
+    assert spec["traces"][0]["tier"] == "direct"
+
+
+def test_categorical_density_paths_omit_overlay() -> None:
+    """Compact-categorical takes a different (stratified) sampler branch.
+
+    A trace with per-item channels only reaches the density tier past
+    DIRECT_SOFT_CEILING (2M), not SCATTER_DENSITY_THRESHOLD (200k), so this
+    case needs a genuinely large array to exercise the branch at all.
+    """
+    n = 2_200_000
+    x, y = _density_data(n=n)
+    labels = np.array(["a", "b", "c", "d", "e"])[np.arange(n) % 5]
+    with pytest.warns(RuntimeWarning, match="soft ceiling"):
+        fig = xy.scatter_chart(xy.scatter(x=x, y=y, color=labels), width=900, height=420).figure()
+    assert fig.traces[0].use_density()
+    wire_spec, _ = fig.build_payload()
+    rast_spec, _, _ = fig._build_raster_payload()
+    assert "sample" in wire_spec["traces"][0]["density"]
+    assert "sample" not in rast_spec["traces"][0]["density"]
+
+
+def test_clipped_domain_keeps_visible_count() -> None:
+    """The non-full-identity branch still needs bin_2d_indices for `visible`."""
+    x, y = _density_data()
+    fig = xy.scatter_chart(
+        xy.scatter(x=x, y=y), xy.x_axis(domain=(-1.0, 1.0)), width=900, height=420
+    ).figure()
+    wire_spec, _ = fig.build_payload()
+    rast_spec, _, _ = fig._build_raster_payload()
+    wire_t, rast_t = wire_spec["traces"][0], rast_spec["traces"][0]
+    assert rast_t["visible"] == wire_t["visible"] > 0
+    assert rast_t["visible"] < DENSITY_N, "domain should actually clip"
+    assert "sample" not in rast_t["density"]

--- a/tests/test_svg_escape.py
+++ b/tests/test_svg_escape.py
@@ -1,0 +1,82 @@
+"""The vendored XML escaper must never drift from the stdlib it replaced.
+
+`xy._svg.escape` is a local copy of `xml.sax.saxutils.escape` (see the docstring
+there for why). These tests are the drift guard: they import the stdlib version
+*inside the test* — never at module import of xy — and compare outputs.
+"""
+
+from __future__ import annotations
+
+import random
+import subprocess
+import sys
+from xml.sax.saxutils import escape as stdlib_escape
+
+import pytest
+
+from xy._svg import escape
+
+# Characters that matter for XML escaping, plus neighbours that must NOT change.
+ALPHABET = "&<>\"'; abc\\/=\n\té中\U0001f600"
+
+
+def test_matches_stdlib_on_every_short_string() -> None:
+    """Exhaustive over all strings of length <= 3 on a hostile alphabet."""
+    for a in ALPHABET:
+        assert escape(a) == stdlib_escape(a)
+        for b in ALPHABET:
+            assert escape(a + b) == stdlib_escape(a + b)
+            for c in ALPHABET:
+                s = a + b + c
+                assert escape(s) == stdlib_escape(s)
+
+
+@pytest.mark.parametrize(
+    "entities",
+    [
+        {},
+        {chr(34): "&quot;"},
+        {"'": "&apos;"},
+        {chr(34): "&quot;", "'": "&apos;"},
+        # Overlapping/chained replacements exercise dict ordering.
+        {"a": "b", "b": "c"},
+    ],
+)
+def test_matches_stdlib_with_entities(entities: dict[str, str]) -> None:
+    rng = random.Random(20260725)
+    for _ in range(20_000):
+        s = "".join(rng.choice(ALPHABET) for _ in range(rng.randrange(0, 12)))
+        assert escape(s, entities) == stdlib_escape(s, entities)
+
+
+def test_ampersand_goes_first() -> None:
+    """The one ordering bug a naive rewrite makes: && double-escaping."""
+    assert escape("&lt;") == "&amp;lt;"
+    assert escape("<&>") == "&lt;&amp;&gt;"
+    assert escape("") == ""
+
+
+def test_none_entities_matches_empty_dict() -> None:
+    """Our signature uses None instead of a mutable default; same behavior."""
+    assert escape("<a&b>", None) == escape("<a&b>", {}) == stdlib_escape("<a&b>")
+
+
+def test_svg_export_does_not_import_urllib_or_ssl() -> None:
+    """The whole point: a static export must not drag in the network stack.
+
+    Runs in a fresh subprocess because pytest itself imports `email` and
+    friends, which would mask the regression in-process.
+    """
+    code = (
+        "import sys; import numpy as np; import xy\n"
+        "fig = xy.scatter_chart(xy.scatter(x=np.arange(5.0), y=np.arange(5.0)),\n"
+        "                       title='a & b < c > d').figure()\n"
+        "svg = fig.to_svg(width=200, height=150)\n"
+        "assert '&amp;' in svg and '&lt;' in svg and '&gt;' in svg, 'escape not exercised'\n"
+        "leaked = {'urllib.request', 'ssl', 'http.client', 'email', 'socket'} & set(sys.modules)\n"
+        "assert not leaked, f'static SVG export imported {sorted(leaked)}'\n"
+        "print('ok')\n"
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=False)
+    assert proc.returncode == 0, proc.stderr
+    assert "ok" in proc.stdout


### PR DESCRIPTION
## Why

The docs headline [Snapshot at 10 million points](https://github.com/reflex-dev/xy/blob/main/docs/overview/benchmarks.md) publishes 0.0232 s for the static CPU PNG. Profiling that exact measured region shows **~71% of it is first-call overhead, not data work**:

| | ms (this machine) |
|---|---:|
| cold `figure()` | 12.7–13.7 |
| cold `to_png()` | 14.2–14.8 |
| **cold total — what the docs report** | **27.4–27.8** |
| same two calls repeated in-process | 7.7–7.9 |

The real 10M kernel work is under 8 ms and already memory-bound at 88–105 GB/s. Two non-engine costs dominate the rest, and this PR removes both.

Neither is visible to CodSpeed, by construction: its largest scatter is `LARGE_N = 1_000_000`, and the session-autouse `warm_lazy_modules` fixture deliberately warms lazy imports before every measured region (it was added for good reason — it killed a phantom 26% regression — but it means the dominant term of the published number cannot be observed there).

## What changed

**1. Vendor `xml.sax.saxutils.escape` into `_svg.py`.** Importing it pulls `urllib.request` → `http.client` → `ssl`, `socket` and the whole `email` package — 35+ modules for a function whose body is three `str.replace` calls. Nothing else in xy needs that tree. All 46 call sites are untouched.

**2. Raster export skips the density point-sample overlay.** `density["sample"]` has exactly one writer and **zero Python readers** — `_raster._emit_grid` draws density traces from the grid alone. At 10M that meant running a SplitMix predicate over all 10M rows and gathering two 8,222-row columns that no pixel consumes. `_build_raster_payload` now passes `point_overlay=False`; the public `build_payload`/`build_payload_split` still ship the overlay because the browser client (`js/src/50_chartview.ts`) draws it.

## Measured

Interleaved cold-process A/B at N=10M, 6 rounds, alternating order:

| | main | this branch |
|---|---:|---:|
| cold `to_png` | 14.8 ms | **5.7 ms** |
| cold total | 28.4 ms | **19.2 ms (−32%)** |

## Proof of no functionality loss

- **72 artifacts hash-identical to main** — PNG at scale 1 and 2, SVG, HTML, wire blob and wire spec, across 12 figure configurations: density, direct tier, float32 input, clipped domain, continuous colour, NaN-injected, log axes, categorical at 2.2M, line, and one carrying `& < > " '` plus non-BMP characters in its title so `escape` is genuinely exercised.
- Full suite: **2283 passed, 4 skipped**.
- `ruff check` and `ruff format --check` clean; `ty` reports the same 13 pre-existing diagnostics as main.
- 19 new tests in two files:
  - `tests/test_svg_escape.py` — differential fuzz of the vendored `escape` against the stdlib (exhaustive over all strings of length ≤3 on a hostile alphabet, plus 20k random strings × 5 entity dicts), and a **fresh-subprocess** assertion that a static SVG export leaves `urllib.request`/`ssl`/`http.client`/`email`/`socket` unimported. The subprocess matters: `import pytest` alone loads `email`, which would mask the regression in-process.
  - `tests/test_raster_density_overlay.py` — pins both halves of the contract (wire payload keeps `sample`, raster payload drops it), asserts the raster grid bytes equal the wire grid bytes, and covers the compact-categorical and clipped-domain branches plus the direct tier.
- Spec updated per CLAUDE.md: `spec/api/export.md`, and the dossier's `DENSITY_SAMPLE_TARGET` row and §33 import budget.

## Reviewer notes

- **The saxutils win is cold-start-specific.** If the host process already imported `urllib` — a web server, `requests`, or `benchmarks/_launch_interactive.py` itself — it collapses to ~1.2 ms. It is a real win for cold CLI/script/serverless exports, which is exactly what the static benchmark measures, but a long-lived app will not see the full number.
- **The overlay skip is fully real** and scales with N: it applies to every `to_png`/`to_jpeg`/`to_webp`/`savefig` of any scatter past the density threshold.
- `to_svg` pays the same dead-overlay cost (~1.4 ms) because it goes through the *public* `build_payload`. Left as a follow-up — it needs its own private payload path, which is a wider change than this one.
- The published 0.0232 s and 0.283 GiB rows are backed by a committed baseline at `benchmarks/launch_baselines/`, recorded on an M5 Pro. They need regenerating on that reference machine, not on the machine these numbers came from.
- The `docs-app-codespell` pre-commit hook could not run locally (it cannot install `codespell` in this sandbox); it fails identically on an unchanged `main` tree, so it is environmental. Changed files were spell-checked directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved raster density exports by omitting unused point overlays while preserving identical grid and image output.
  * Reduced unnecessary processing for large scatter datasets.

* **Compatibility**
  * SVG escaping remains consistent with standard behavior while reducing export overhead.

* **Documentation**
  * Clarified density overlay behavior for raster, browser, and SVG outputs.

* **Tests**
  * Added coverage for raster output consistency, categorical and clipped density plots, and SVG escaping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->