### PR TITLE
Allow data: fonts in the standalone HTML CSP

### DIFF
--- a/docs/guides/serving-csp-and-offline-use.md
+++ b/docs/guides/serving-csp-and-offline-use.md
@@ -27,6 +27,11 @@ blocks external connections, objects, forms, and base-URL changes. Density
 refinement can start a worker from the bundled source, so the policy allows
 `worker-src blob:`; it does not allow an external worker script.
 
+Two `data:` allowances keep the file self-contained: `img-src data:` for
+embedded raster content, and `font-src data:` so a `custom_css` `@font-face`
+can carry a brand face inline. Neither permits a network origin, so a
+standalone chart still loads nothing from the network.
+
 Portable single-file output necessarily uses inline script and style blocks.
 Its policy therefore includes `script-src 'unsafe-inline'` and
 `style-src 'unsafe-inline'`. `custom_css=` is added to that inline author

--- a/docs/styling/themes-and-tokens.md
+++ b/docs/styling/themes-and-tokens.md
@@ -473,16 +473,26 @@ Standalone HTML and Chromium PNG accept the font declaration through
 `custom_css`. Embed the font as a data URL when the HTML file must remain fully
 portable; an ordinary URL still depends on that resource being reachable.
 
+Declare the face in `custom_css` and select it with `xy.theme(font_family=...)`.
+The chart root carries a computed `font` shorthand, which an ordinary
+`.xy { font-family: ... }` rule cannot outrank — the theme token writes that
+shorthand, so it is the reliable way to apply the family.
+
 ~~~python
 from xy import Engine
+import xy
 
 font_css = """
   @font-face {
     font-family: "Acme Sans";
     src: url("data:font/woff2;base64,...") format("woff2");
   }
-  .xy { font-family: "Acme Sans", system-ui, sans-serif; }
 """
+
+chart = xy.line_chart(
+    xy.line([1, 2, 3], [2, 5, 3]),
+    xy.theme(font_family='"Acme Sans", system-ui, sans-serif'),
+)
 
 chart.to_html("chart.html", custom_css=font_css)
 chart.to_png(

--- a/python/xy/export.py
+++ b/python/xy/export.py
@@ -85,6 +85,10 @@ _STANDALONE_CSP = (
     "script-src 'unsafe-inline'; "
     "style-src 'unsafe-inline'; "
     "img-src data:; "
+    # data: only — `custom_css` may embed a brand face as a data-URL
+    # `@font-face` (the documented portable-font recipe); no network origin
+    # is reachable, so a standalone file stays self-contained offline.
+    "font-src data:; "
     "connect-src 'none'; "
     # blob: only — the density re-bin worker boots from a Blob URL of its own
     # bundled source; no external worker script can ever load.

--- a/scripts/render_smoke_nonumpy.py
+++ b/scripts/render_smoke_nonumpy.py
@@ -238,7 +238,8 @@ def main() -> None:
     # same policy a real to_html export ships.
     csp = (
         "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; "
-        "img-src data:; connect-src 'none'; worker-src blob:; object-src 'none'; "
+        "img-src data:; font-src data:; connect-src 'none'; worker-src blob:; "
+        "object-src 'none'; "
         "base-uri 'none'; form-action 'none'"
     )
     page = f"""<!doctype html><html><head><meta charset=utf-8>

--- a/spec/process/security-audit-2026-07-06.md
+++ b/spec/process/security-audit-2026-07-06.md
@@ -42,6 +42,21 @@ directive listed above is unchanged. `tests/test_static_client_security.py`
 asserts the directive is exactly `worker-src blob:`, and
 `docs/guides/serving-csp-and-offline-use.md` documents it for host operators.
 
+#### Status as of 2026-07-24 (XY-SEC-2026-01)
+
+`font-src data:` was added. The policy previously declared no `font-src`, so it
+inherited `default-src 'none'` and blocked **every** font load — including the
+`data:` URL `@font-face` that `docs/styling/themes-and-tokens.md` documents as
+the portable brand-font recipe. A standalone export therefore fell back to
+`system-ui` with only a console CSP violation to explain it, and the same
+failure reached Chromium PNG, which renders that document.
+
+The new directive is exactly `data:`, so no network origin can serve a face and
+a standalone file stays self-contained offline — the property `default-src
+'none'` exists to protect. `img-src data:` already grants the same shape of
+access for images. `tests/test_static_client_security.py` asserts `font-src` is
+exactly `data:`.
+
 ### XY-SEC-2026-02: Legend swatches accepted raw CSS paint strings
 
 Severity: medium.

--- a/tests/test_static_client_security.py
+++ b/tests/test_static_client_security.py
@@ -871,6 +871,27 @@ def test_standalone_csp_allows_blob_workers_and_matches_smoke() -> None:
     assert smoke_csp == _STANDALONE_CSP, "smoke CSP diverged from export._STANDALONE_CSP"
 
 
+def test_standalone_csp_allows_data_url_fonts_only() -> None:
+    """`custom_css` may embed a brand face as a data-URL `@font-face` — the
+    portable-font recipe in docs/styling/themes-and-tokens.md. Without an
+    explicit `font-src`, `default-src 'none'` blocks every font load including
+    `data:`, so the documented recipe silently falls back to system-ui.
+
+    `data:` and nothing else: a standalone file must stay self-contained, so no
+    network origin may serve a face."""
+    from xy.export import _STANDALONE_CSP
+
+    directives = dict(
+        part.strip().split(" ", 1) for part in _STANDALONE_CSP.split(";") if part.strip()
+    )
+    assert directives.get("font-src") == "data:", (
+        "font-src must be exactly 'data:' — absent means default-src 'none' "
+        "blocks the documented data-URL @font-face recipe; anything wider "
+        "would let a standalone export reach the network for a font"
+    )
+    assert directives["default-src"] == "'none'"
+
+
 def test_client_supports_edge_to_edge_sparklines() -> None:
     """Dashboards need chrome-less, edge-to-edge charts: an explicit `padding`
     override collapses the label-aware margins, and tick_label_strategy="none"


### PR DESCRIPTION
## Problem

`_STANDALONE_CSP` declares no `font-src`, so font loads fall back to
`default-src 'none'` and **every** face is blocked — including the data-URL
`@font-face` that [`docs/styling/themes-and-tokens.md`](../blob/main/docs/styling/themes-and-tokens.md) documents as the portable brand-font recipe.

A standalone export silently rendered in `system-ui`, leaving only a console CSP
violation to explain it. Because `to_image(engine=Engine.chromium)` renders that
same document, the failure reached Chromium PNG too — the path the docs point at
precisely when font fidelity matters.

Captured live in a browser against a generated export:

```
securitypolicyviolation → { violatedDirective: "font-src", blockedURI: "data" }
document.fonts.check('12px "XY Audit Face"') → false
computed font-family → "system-ui, sans-serif"
```

## Before / after

Same script, same embedded face (Chalkduster as a `data:` URL under a custom
family name, so it can only come from the data URL — no local fallback can
satisfy it). Left: `origin/main`. Right: this branch.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/reflex-dev/xy/alek/customizability-evidence/evidence/csp-font-before.png) | ![after](https://raw.githubusercontent.com/reflex-dev/xy/alek/customizability-evidence/evidence/csp-font-after.png) |

After the fix: zero CSP violations, `document.fonts.check(...)` → `true`.

## Fix

Add `font-src data:` beside the existing `img-src data:`. Exactly `data:` — no
network origin can serve a face, so a standalone file stays self-contained
offline, which is the property `default-src 'none'` exists to protect.

The recipe had a **second** blocker, also fixed here in docs: the chart root
carries a computed `font` shorthand that an ordinary `.xy { font-family: ... }`
rule cannot outrank. The docs now use `xy.theme(font_family=...)`, which writes
that shorthand — verified in the screenshot above.

## Notes

- The CSP string is duplicated in `scripts/render_smoke_nonumpy.py` and asserted
  equal by an existing test, so both move together.
- The new test asserts `font-src` is exactly `data:`. Existing coverage only
  checked the `worker-src` substring and self-consistency, which is why this
  went unnoticed.
- `spec/process/security-audit-2026-07-06.md` gets a status entry, matching how
  the `worker-src` relaxation was recorded.

Found during a customizability audit of the styling surface.
