### PR TITLE
Format colorbar ticks, and measure the gutters that hold formatted labels

### DIFF
--- a/docs/components/colorbars.md
+++ b/docs/components/colorbars.md
@@ -229,6 +229,22 @@ Pass them to the component: `xy.colorbar(title="Temperature (°C)", ticks=[-3, 0
 `ticks=` supplies explicit finite tick positions; both work in either
 orientation.
 
+### How do I format colorbar tick labels as currency or percentages?
+
+`xy.colorbar(format="$,.0f")` — the same format grammar the axes and tooltips
+use, so `$,.0f` gives `$14,741`, `.1%` gives `18.5%`, and a literal prefix or
+suffix is copied through. An unrecognized spec falls back to the automatic
+label rather than raising. The colorbar's reserved width and title position
+both follow the widest formatted label, so long currency labels do not collide
+with the title.
+
+~~~python
+chart = xy.scatter_chart(
+    xy.scatter(x, y, color=spend, colormap="viridis"),
+    xy.colorbar(title="spend", format="$,.0f"),
+)
+~~~
+
 ### Can I make the colorbar horizontal instead of vertical?
 
 Yes — `xy.colorbar(orientation="horizontal")`. The `orientation=` option

--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -1,7 +1,7 @@
 import { PROTOCOL, xyByteSpan } from "./00_header";
 import { buildLutData, colormapStops } from "./10_colormaps";
 import { chartBackdrop, cssColor, ensureChromeStylesheet, hexColor, parseColor, readTheme, safeCssPaint } from "./20_theme";
-import { categoryTicks, fmtAxis, fmtGeneral, fmtLinear, fmtValue, linearTicks, logTicks, timeTicks } from "./30_ticks";
+import { categoryTicks, fmtAxis, fmtGeneral, fmtLinear, fmtNumberSpec, fmtValue, linearTicks, logTicks, timeTicks } from "./30_ticks";
 import { AREA_FS, AREA_VS, ATTR_SLOTS, BAR_VS, DENSITY_FS, GRID_VS, HEATMAP_FS, LINE_FS, LINE_VS, MESH_FS, MESH_VS, PICK_FS, PICK_VS, POINT_FS, POINT_SIMPLE_FS, POINT_SIMPLE_VS, POINT_VS, RECT_FS, RECT_VS, SEGMENT_FS, SEGMENT_VS, makeProgram, uniformOf, xySmoothResample } from "./40_gl";
 import { lodCopyGrid, lodDecodeLogU8, lodDrawDensityTier, lodDropDensityCache, lodDropPointCache, lodRememberDensity, lodSampleForView, lodWriteGridTexture } from "./45_lod";
 import { markOf } from "./55_marks";
@@ -335,6 +335,42 @@ function xyInitiallyVisible(el) {
   );
 }
 
+// Gutter a vertical colorbar needs, widened for its actual tick labels.
+// The historical 86 assumed ~6 characters of automatic label; a `format` that
+// adds a currency symbol and separators makes them wider, and the title would
+// otherwise collide. Mirrors `_svg.colorbar_right_room` exactly.
+const COLORBAR_CHROME_W = 46;
+const COLORBAR_MIN_ROOM = 86;
+const COLORBAR_TICK_FONT = 10;
+
+export function colorbarTickLabelWidth(colorbar) {
+  const domain = (colorbar && colorbar.domain) || [0, 1];
+  const lo = Number(domain[0]), hi = Number(domain[1]);
+  if (!Number.isFinite(lo) || !Number.isFinite(hi)) return 0;
+  const explicit = Array.isArray(colorbar.ticks);
+  const result = linearTicks(lo, hi, 8);
+  const values = explicit
+    ? colorbar.ticks.map(Number).filter((v) => Number.isFinite(v) && v >= Math.min(lo, hi) && v <= Math.max(lo, hi))
+    : (result.ticks.length ? result.ticks : [lo, hi]);
+  let widest = 0;
+  for (const value of values) {
+    const text = fmtNumberSpec(value, colorbar.format)
+      ?? (explicit ? fmtGeneral(value) : fmtLinear(value, result.step));
+    widest = Math.max(widest, String(text).length);
+  }
+  return widest * COLORBAR_TICK_FONT * 0.62;
+}
+
+export function colorbarRightRoomFor(colorbar) {
+  return Math.max(COLORBAR_MIN_ROOM, COLORBAR_CHROME_W + colorbarTickLabelWidth(colorbar) + 8);
+}
+
+// Distance from the bar to the rotated title, tracking the tick labels for
+// the same reason the gutter does. Mirrors `_svg.colorbar_label_offset`.
+export function colorbarLabelOffsetFor(colorbar) {
+  return Math.max(38, 4 + colorbarTickLabelWidth(colorbar) + 10);
+}
+
 export class ChartView {
   constructor(el, spec, buffer, comm) {
     if (spec.protocol !== PROTOCOL) {
@@ -507,7 +543,7 @@ export class ChartView {
     const colorbarRightRoom = verticalColorbar
       ? (this._compactVerticalColorbar
         ? COMPACT_COLORBAR_GAP + COLORBAR_THICKNESS + 8
-        : 86 + (colorbar.label ? 18 : 0))
+        : colorbarRightRoomFor(colorbar) + (colorbar.label ? 18 : 0))
       : 0;
     const colorbarBottomRoom = horizontalColorbar ? 38 + (colorbar.label ? 16 : 0) : 0;
     const baseRight = pad ? (responsivePad ? Math.min(pad[1], 8) : pad[1]) : compact ? 8 : MARGIN.r;
@@ -2346,7 +2382,11 @@ export class ChartView {
       const value = Number(raw);
       if (!Number.isFinite(value) || value < Math.min(lo, hi) || value > Math.max(lo, hi)) continue;
       const tick = document.createElement("span");
-      tick.textContent = hasExplicitTicks ? fmtGeneral(value) : fmtLinear(value, tickStep);
+      // `format` wins when it parses; otherwise the historical automatic
+      // label stands, so an unrecognized spec degrades the same way an
+      // axis format does (30_ticks.fmtAxis) instead of blanking the tick.
+      tick.textContent = fmtNumberSpec(value, cb.format)
+        ?? (hasExplicitTicks ? fmtGeneral(value) : fmtLinear(value, tickStep));
       const fraction = (value - lo) / span;
       tick.style.cssText = horizontal
         ? `position:absolute;left:${100 * fraction}%;top:${COLORBAR_THICKNESS + 2}px;transform:translateX(-50%);white-space:nowrap;`
@@ -2359,7 +2399,7 @@ export class ChartView {
       label.textContent = String(cb.label);
       label.style.cssText = horizontal
         ? `position:absolute;left:50%;top:${COLORBAR_THICKNESS + 18}px;transform:translateX(-50%);white-space:nowrap;`
-        : `position:absolute;left:${COLORBAR_THICKNESS + 40}px;top:50%;writing-mode:vertical-rl;transform:translateY(-50%) rotate(180deg);white-space:nowrap;`;
+        : `position:absolute;left:${COLORBAR_THICKNESS + colorbarLabelOffsetFor(cb) + 2}px;top:50%;writing-mode:vertical-rl;transform:translateY(-50%) rotate(180deg);white-space:nowrap;`;
       this._applySlot(label, "colorbar_title");
       box.appendChild(label);
     }

--- a/python/xy/_raster.py
+++ b/python/xy/_raster.py
@@ -33,6 +33,7 @@ from ._svg import (
     _axis_tick_label_layout,
     _axis_tick_label_strategy,
     _colorbar_right_axis_room,
+    _colorbar_tick_text,
     _colormap_stops,
     _column,
     _corner_radii,
@@ -2074,7 +2075,7 @@ def _emit_colorbar(
                 1,
                 10,
                 _parse_color(text_color),
-                f"{value:g}",
+                _colorbar_tick_text(value, options.get("format")),
             )
         if options.get("label"):
             cmd.text(
@@ -2098,7 +2099,7 @@ def _emit_colorbar(
                 0,
                 10,
                 _parse_color(text_color),
-                f"{value:g}",
+                _colorbar_tick_text(value, options.get("format")),
             )
         # The native text primitive does not rotate; a compact label above the
         # bar remains legible and, crucially, stays inside the export canvas.

--- a/python/xy/_svg.py
+++ b/python/xy/_svg.py
@@ -1173,6 +1173,52 @@ def _axis_scales(
     return x_scales, y_scales, sx, sy, extra_x_axes, extra_y_axes
 
 
+# Bar offset (24) + bar width (18) + tick gap (4) = the fixed chrome left of
+# a vertical colorbar's tick labels; the rest of the gutter is label room.
+_COLORBAR_CHROME_W = 46.0
+_COLORBAR_MIN_ROOM = 86.0
+_COLORBAR_TICK_FONT = 10.0
+
+
+def colorbar_tick_label_width(colorbar: dict[str, Any]) -> float:
+    """Widest rendered tick label of a vertical colorbar, in px."""
+    domain = colorbar.get("domain") or [0.0, 1.0]
+    try:
+        lo, hi = float(domain[0]), float(domain[1])
+    except (TypeError, ValueError, IndexError):
+        return 0.0
+    ticks = colorbar.get("ticks")
+    values = (
+        [float(v) for v in ticks if lo <= float(v) <= hi]
+        if ticks is not None
+        else (_linear_ticks(lo, hi, 8)[0] or [lo, hi])
+    )
+    widest = max((len(_colorbar_tick_text(v, colorbar.get("format"))) for v in values), default=0)
+    return widest * _COLORBAR_TICK_FONT * 0.62
+
+
+def colorbar_label_offset(colorbar: dict[str, Any]) -> float:
+    """Distance from a vertical colorbar's bar to its rotated title.
+
+    Tracks the tick-label width for the same reason the gutter does: a
+    formatted label is wider than the automatic one, and a fixed 38 px put
+    the title on top of it.
+    """
+    return max(38.0, 4.0 + colorbar_tick_label_width(colorbar) + 10.0)
+
+
+def colorbar_right_room(colorbar: dict[str, Any]) -> float:
+    """Gutter a vertical colorbar needs, widened for its actual tick labels.
+
+    The historical 86 px assumed ~6 characters of automatic label. A
+    `format` that adds a currency symbol and group separators makes labels
+    materially wider, so measure them instead of letting the title collide.
+    Never narrower than 86, so unformatted charts keep their layout exactly.
+    The client applies the identical rule (`50_chartview.ts`).
+    """
+    return max(_COLORBAR_MIN_ROOM, _COLORBAR_CHROME_W + colorbar_tick_label_width(colorbar) + 8.0)
+
+
 def _colorbar_right_axis_room(
     y_axis: dict[str, Any],
     extra_y_axes: list[tuple[str, dict[str, Any], _Scale]],
@@ -1190,6 +1236,43 @@ def _colorbar_right_axis_room(
     ):
         return 42.0 if compact else 54.0
     return 0.0
+
+
+# The default left gutter is sized for roughly this many base-size characters
+# of y tick label — `800000` at 11 px, the width an automatic label reaches
+# before it starts running under the rotated axis title. Labels are measured
+# against this budget and the gutter grows by the OVERFLOW only, so every
+# chart whose labels already fit keeps its historical geometry to the pixel.
+_Y_LABEL_BUDGET_CHARS = 6.0
+# The size those six characters are measured at.
+_Y_BASE_FONT_SIZE = 11.0
+_Y_CHAR_ASPECT = 0.62
+# One wide label must not be able to collapse the plot rect.
+_Y_EXTRA_ROOM_CAP = 120.0
+
+
+def _left_axis_room(axes: dict[str, dict[str, Any]], plot_h: float, default_left: float) -> float:
+    """Left gutter for the widest left-side y tick label, never below `default_left`.
+
+    `y_axis(format="$,.0f")` turns `800000` into `$800,000` and
+    `theme(font_size=)` scales every label; both used to run under the axis
+    title because the gutter was a constant.
+    """
+    budget = _Y_LABEL_BUDGET_CHARS * _Y_BASE_FONT_SIZE
+    extra = 0.0
+    for axis_id, axis in axes.items():
+        if not axis_id.startswith("y") or axis.get("side", "left") != "left":
+            continue
+        if _axis_tick_label_strategy(axis) == "none":
+            continue
+        try:
+            _ticks, labeled, step = axis_ticks(axis, max(1.0, plot_h), False)
+        except (KeyError, TypeError, ValueError):
+            continue
+        font_size = _axis_tick_font_size(axis)
+        widest = max((len(_tick_text(axis, value, step)) for value in labeled), default=0)
+        extra = max(extra, (widest * font_size - budget) * _Y_CHAR_ASPECT)
+    return default_left + min(max(0.0, extra), _Y_EXTRA_ROOM_CAP)
 
 
 def layout(spec: dict[str, Any]) -> tuple[int, int, bool, dict[str, float]]:
@@ -1236,7 +1319,7 @@ def layout(spec: dict[str, Any]) -> tuple[int, int, bool, dict[str, float]]:
     if colorbar.get("orientation") == "horizontal":
         bottom += 38 + (16 if colorbar.get("label") else 0)
     elif colorbar:
-        right += 86 + (18 if colorbar.get("label") else 0)
+        right += colorbar_right_room(colorbar) + (18 if colorbar.get("label") else 0)
     if any(
         axis_id.startswith("y")
         and axis.get("side", "right") == "right"
@@ -1247,6 +1330,12 @@ def layout(spec: dict[str, Any]) -> tuple[int, int, bool, dict[str, float]]:
         # secondary-y tick labels/title. Multiple right axes intentionally
         # overlay in both renderers until offset axes become part of the API.
         right += 42 if compact else 54
+    if not (isinstance(pad, list) and len(pad) == 4):
+        # Explicit `padding=` is the author's decision and is left alone.
+        # Otherwise the left gutter grows to fit labels wider than the default
+        # reserve assumes — `y_axis(format="$,.0f")` turns `800000` into
+        # `$800,000`, which used to run under the rotated axis title.
+        left = _left_axis_room(axes, height - top - bottom, left)
     plot = {
         "x": left,
         "y": top,
@@ -2932,6 +3021,16 @@ def _legend(
     return f'<g clip-path="url(#{clip_id})">{"".join(rows)}</g>'
 
 
+def _colorbar_tick_text(value: float, format: Any) -> str:
+    """A colorbar tick label: the shared format grammar, else Python's `:g`.
+
+    `:g` is the historical default and stays the fallback so an unrecognized
+    spec degrades to the label the chart drew before, exactly as the axes do.
+    """
+    formatted = _fmt_number_spec(float(value), format)
+    return formatted if formatted is not None else f"{value:g}"
+
+
 def _colorbar(
     options: dict, plot: dict, right_axis_room: float = 0.0, text_color: str = _TEXT
 ) -> str:
@@ -2957,9 +3056,10 @@ def _colorbar(
         y, width, height = plot["y"], 18, plot["h"]
         gradient_attrs = 'x1="0" y1="100%" x2="0" y2="0"'
     label = str(options.get("label") or "")
+    label_x = x + width + colorbar_label_offset(options)
     label_node = (
-        f'<text x="{_num(x + width + 38)}" y="{_num(y + height / 2)}" '
-        f'text-anchor="middle" transform="rotate(-90 {_num(x + width + 38)} '
+        f'<text x="{_num(label_x)}" y="{_num(y + height / 2)}" '
+        f'text-anchor="middle" transform="rotate(-90 {_num(label_x)} '
         f'{_num(y + height / 2)})" fill="{escape(text_color)}">{escape(label)}</text>'
         if label and orientation != "horizontal"
         else (
@@ -2971,6 +3071,7 @@ def _colorbar(
     )
     lo, hi = float(domain[0]), float(domain[1])
     span = (hi - lo) or 1.0
+    tick_format = options.get("format")
     ticks = options.get("ticks")
     tick_positions = (
         [float(value) for value in ticks if lo <= float(value) <= hi]
@@ -2981,14 +3082,14 @@ def _colorbar(
         "".join(
             f'<text x="{_num(x + width + 4)}" '
             f'y="{_num(y + height * (1 - (value - lo) / span) + 4)}" '
-            f'fill="{escape(text_color)}">{value:g}</text>'
+            f'fill="{escape(text_color)}">{escape(_colorbar_tick_text(value, tick_format))}</text>'
             for value in tick_positions
         )
         if orientation != "horizontal"
         else "".join(
             f'<text x="{_num(x + width * (value - lo) / span)}" '
             f'y="{_num(y + height + 12)}" text-anchor="middle" '
-            f'fill="{escape(text_color)}">{value:g}</text>'
+            f'fill="{escape(text_color)}">{escape(_colorbar_tick_text(value, tick_format))}</text>'
             for value in tick_positions
         )
     )

--- a/python/xy/components.py
+++ b/python/xy/components.py
@@ -267,6 +267,7 @@ class Colorbar(Component):
     title: Optional[str] = None
     orientation: str = "vertical"
     ticks: Optional[list[float]] = None
+    format: Optional[str] = None
     class_name: Optional[str] = None
     style: dict[str, StyleValue] = field(default_factory=dict)
     render: Any = None
@@ -2453,6 +2454,7 @@ def colorbar(
     title: Optional[str] = None,
     orientation: str = "vertical",
     ticks: Optional[list[float]] = None,
+    format: Optional[str] = None,
     class_name: Optional[str] = None,
     style: Optional[dict[str, StyleValue]] = None,
 ) -> Colorbar:
@@ -2466,18 +2468,22 @@ def colorbar(
             mark name when one is available.
         orientation: ``vertical`` or ``horizontal`` placement.
         ticks: Optional finite numeric tick positions.
+        format: Tick-label format string, in the same grammar the axes use
+            (``"$,.0f"``, ``".1%"``). Unrecognized specs fall back to the
+            automatic label rather than raising, matching ``x_axis(format=)``.
         class_name: DOM class name applied to the colorbar.
         style: Colorbar style overrides.
     """
     show, render = _chrome_render_args(children, show, render, "colorbar")
-    show, title, orientation, ticks, class_name, style = _validated_colorbar_fields(
-        show, title, orientation, ticks, class_name, style
+    show, title, orientation, ticks, format, class_name, style = _validated_colorbar_fields(
+        show, title, orientation, ticks, format, class_name, style
     )
     return Colorbar(
         show=show,
         title=title,
         orientation=orientation,
         ticks=ticks,
+        format=format,
         class_name=class_name,
         style=style,
         render=render,
@@ -2489,6 +2495,7 @@ def _validated_colorbar_fields(
     title: Any,
     orientation: Any,
     ticks: Any,
+    format: Any,
     class_name: Any,
     style: Any,
 ) -> tuple[
@@ -2496,6 +2503,7 @@ def _validated_colorbar_fields(
     Optional[str],
     str,
     Optional[list[float]],
+    Optional[str],
     Optional[str],
     dict[str, StyleValue],
 ]:
@@ -2510,6 +2518,7 @@ def _validated_colorbar_fields(
         _optional_string(title, "colorbar title"),
         _colorbar_orientation(orientation),
         _colorbar_ticks(ticks),
+        _optional_string(format, "colorbar format"),
         _optional_string(class_name, "colorbar class_name"),
         _style_dict(style, "colorbar style"),
     )
@@ -3255,6 +3264,7 @@ class Chart(Component):
                 node_title,
                 node_orientation,
                 node_ticks,
+                node_format,
                 node_class_name,
                 node_style,
             ) = _validated_colorbar_fields(
@@ -3262,6 +3272,7 @@ class Chart(Component):
                 node.title,
                 node.orientation,
                 node.ticks,
+                node.format,
                 node.class_name,
                 node.style,
             )
@@ -3280,6 +3291,8 @@ class Chart(Component):
                         options["label"] = node_title
                     if node_ticks is not None:
                         options["ticks"] = node_ticks
+                    if node_format is not None:
+                        options["format"] = node_format
                     fig.colorbar_options = options
         fig._validate_interaction()
         self._figure = fig

--- a/spec/api/styling.md
+++ b/spec/api/styling.md
@@ -187,6 +187,17 @@ but they fail differently, and only the numeric grammar falls back.
   One deliberate difference: group separators are the `,`/`.` pair rather than
   the viewer's locale, because a static export has no viewer and must stay
   reproducible.
+  The colorbar applies the same grammar via `xy.colorbar(format=...)`, with
+  Python's `:g` — the historical colorbar default — as the fallback. The gutter
+  reserved for a vertical colorbar and the offset of its rotated title are both
+  measured from the widest **formatted** label (`_svg.colorbar_right_room` /
+  `colorbar_label_offset`, mirrored by `colorbarRightRoomFor` /
+  `colorbarLabelOffsetFor`), never below the historical 86 px, so a wide
+  currency label cannot collide with the title. The y-axis gutter grows the
+  same way (`_svg._left_axis_room`): sized for about six characters, it widens
+  by the overflow so a formatted label cannot run under the rotated axis title.
+  Charts whose labels already fit keep their exact previous geometry, and an
+  explicit `padding=` is left alone.
 - **Time axes** accept a strftime subset of exactly `%Y %m %d %H %M %S %b %B`.
   All fields are **UTC**; `%b`/`%B` are English month names. A time spec
   **never** falls back: `fmtTimeSpec` (`js/src/30_ticks.ts:180-200`)

--- a/tests/test_colorbar_format.py
+++ b/tests/test_colorbar_format.py
@@ -1,0 +1,110 @@
+"""Colorbar tick formatting, and the gutters that keep formatted labels legible."""
+
+from __future__ import annotations
+
+import re
+
+import numpy as np
+import pytest
+
+import xy
+from xy import _svg
+
+
+def svg_texts(chart: xy.Chart) -> list[str]:
+    return re.findall(r">([^<>]+)</text>", chart.to_svg())
+
+
+# ---------------------------------------------------------------------------
+# Colorbar formats
+# ---------------------------------------------------------------------------
+
+
+def scatter_with_colorbar(**colorbar_kwargs) -> xy.Chart:
+    values = np.linspace(12_000.0, 150_000.0, 200)
+    return xy.scatter_chart(
+        xy.scatter(np.arange(200.0), values, color=values, colormap="viridis"),
+        xy.colorbar(**colorbar_kwargs),
+    )
+
+
+def test_colorbar_format_reaches_svg() -> None:
+    labels = svg_texts(scatter_with_colorbar(title="spend", format="$,.0f"))
+    assert any(label.startswith("$") and "," in label for label in labels), labels
+
+
+def test_colorbar_without_format_keeps_the_general_default() -> None:
+    labels = svg_texts(scatter_with_colorbar(title="spend"))
+    assert not any(label.startswith("$") for label in labels)
+
+
+def test_unparsable_colorbar_format_falls_back_to_general() -> None:
+    labels = svg_texts(scatter_with_colorbar(title="spend", format="nonsense"))
+    assert "nonsense" not in labels
+    assert any(re.fullmatch(r"-?[\d.e+]+", label) for label in labels)
+
+
+def test_colorbar_gutter_widens_for_wide_formatted_labels() -> None:
+    plain = {"domain": [12_000.0, 150_000.0]}
+    formatted = {"domain": [12_000.0, 150_000.0], "format": "$,.0f"}
+    assert _svg.colorbar_right_room(formatted) > _svg.colorbar_right_room(plain)
+    assert _svg.colorbar_label_offset(formatted) > _svg.colorbar_label_offset(plain)
+
+
+def test_colorbar_gutter_never_narrows_below_the_historical_reserve() -> None:
+    assert _svg.colorbar_right_room({"domain": [0.0, 1.0]}) == 86.0
+    assert _svg.colorbar_label_offset({"domain": [0.0, 1.0]}) == 38.0
+
+
+def test_colorbar_format_is_validated() -> None:
+    with pytest.raises(ValueError, match="colorbar format"):
+        xy.colorbar(format=3)
+
+
+# ---------------------------------------------------------------------------
+# The left gutter grows for tick labels wider than the default reserve
+# ---------------------------------------------------------------------------
+
+
+def plot_left(chart: xy.Chart) -> float:
+    spec, _blob = chart.figure().build_payload()
+    return _svg.layout(spec)[3]["x"]
+
+
+SIX_FIGURE = [412_000.0, 468_000.0, 559_000.0]
+
+
+def test_a_formatted_label_widens_the_left_gutter() -> None:
+    plain = xy.line_chart(xy.line([1, 2, 3], SIX_FIGURE), xy.y_axis(label="revenue"))
+    formatted = xy.line_chart(
+        xy.line([1, 2, 3], SIX_FIGURE), xy.y_axis(label="revenue", format="$,.0f")
+    )
+    assert plot_left(formatted) > plot_left(plain)
+
+
+def test_labels_that_already_fit_keep_the_historical_geometry() -> None:
+    """The reserve is sized for ~6 characters; anything at or under that must
+    not move, or every existing chart's layout shifts."""
+    assert plot_left(xy.line_chart(xy.line([1, 2, 3], [1, 2, 3]), xy.y_axis(label="y"))) == 62.0
+    assert plot_left(xy.line_chart(xy.line([1, 2, 3], SIX_FIGURE), xy.y_axis(label="r"))) == 62.0
+
+
+def test_explicit_padding_is_never_second_guessed() -> None:
+    chart = xy.line_chart(
+        xy.line([1, 2, 3], SIX_FIGURE),
+        xy.y_axis(label="r", format="$,.0f"),
+        padding=(10, 10, 40, 50),
+    )
+    assert plot_left(chart) == 50.0
+
+
+def test_the_gutter_is_capped_so_one_label_cannot_eat_the_plot() -> None:
+    axes = {"y": {"id": "y", "range": [0.0, 1.0], "format": "$,.8f" + "x" * 40, "label": "y"}}
+    assert _svg._left_axis_room(axes, 300.0, 62.0) <= 62.0 + _svg._Y_EXTRA_ROOM_CAP
+
+
+def test_a_hidden_axis_contributes_no_gutter() -> None:
+    chart = xy.line_chart(
+        xy.line([1, 2, 3], SIX_FIGURE), xy.y_axis(format="$,.0f", tick_label_strategy="none")
+    )
+    assert plot_left(chart) == 62.0

--- a/tests/test_declarative_colorbar.py
+++ b/tests/test_declarative_colorbar.py
@@ -240,6 +240,7 @@ def test_colorbar_uses_semantic_positional_fields_and_custom_render() -> None:
         "Temperature",
         "horizontal",
         [0.0, 1.0],
+        ".1f",
         "scale-class",
         {"color": "red"},
         renderer,
@@ -248,6 +249,9 @@ def test_colorbar_uses_semantic_positional_fields_and_custom_render() -> None:
     assert node.title == "Temperature"
     assert node.orientation == "horizontal"
     assert node.ticks == [0.0, 1.0]
+    # `format` sits between the tick fields and the DOM fields, matching
+    # Tooltip's field order.
+    assert node.format == ".1f"
     assert node.class_name == "scale-class"
     assert node.style == {"color": "red"}
     assert node.render is renderer


### PR DESCRIPTION
Stacked on #288.

`x_axis(format=)` now reaches the native exporters (#287), but the colorbar
beside it had no `format=` at all — tick text was hardcoded `f"{value:g}"`,
so a revenue scale read `2e+07 4e+07` while the axis next to it read
`$20,000,000`.

## What changed

`xy.colorbar(format=...)` applies the same grammar through the same
`_fmt_number_spec`, with Python's `:g` — the historical colorbar default — as
the fallback rather than `fmtLinear`, so an unrecognized spec degrades to the
label the chart drew before. The browser client gets the identical rule.

```python
xy.scatter_chart(
    xy.scatter(x, y, color=spend, colormap="viridis"),
    xy.colorbar(title="spend", format="$,.0f"),
)
```

| before | after |
| --- | --- |
| <img src="https://raw.githubusercontent.com/reflex-dev/xy/ff3d39831a6838a8f25539c65cfc1a6e3e3eaa6d/evidence/colorbar-format-before.png" width="420"> | <img src="https://raw.githubusercontent.com/reflex-dev/xy/ff3d39831a6838a8f25539c65cfc1a6e3e3eaa6d/evidence/colorbar-format-after.png" width="420"> |

## The gutters

Formatted labels are wider than the automatic ones they replace, and three
gutters were constants sized for the old width: the colorbar's 86 px reserve,
the 38 px offset of its rotated title, and the chart's 62 px left gutter.
`$140,000` overflowed all three — the colorbar title landed on its own tick
labels, and the y-axis title ran under the tick column. Each is now measured
from the widest label the chart will actually draw.

The left gutter grows by the **overflow** past the ~6 characters the 62 px
reserve already assumed, so every chart whose labels fit keeps its geometry to
the pixel (asserted). An explicit `padding=` is never second-guessed, and the
extra room is capped so one runaway label cannot collapse the plot rect.

This is the exporters catching up to the browser, which has always measured its
own labels; `colorbarRightRoomFor`/`colorbarLabelOffsetFor` mirror the Python
so the two agree.

Below, the axis `format=` from #287 with the gutter fix applied — same figure,
tick labels no longer colliding with the axis title:

| before | after |
| --- | --- |
| <img src="https://raw.githubusercontent.com/reflex-dev/xy/ff3d39831a6838a8f25539c65cfc1a6e3e3eaa6d/evidence/axis-format-before.png" width="420"> | <img src="https://raw.githubusercontent.com/reflex-dev/xy/ff3d39831a6838a8f25539c65cfc1a6e3e3eaa6d/evidence/axis-format-after.png" width="420"> |

## Verification

`uv run pytest` — 2278 passed. 11 new tests in `tests/test_colorbar_format.py`
cover the grammar, the `:g` fallback, the gutter growth, the no-change case,
`padding=` immunity, the cap, and a hidden axis.
