### PR TITLE
Name the theme tokens nothing reads instead of swallowing them

### DIFF
--- a/python/xy/components.py
+++ b/python/xy/components.py
@@ -4052,10 +4052,57 @@ _THEME_TOKEN_ALIASES = {
 }
 
 
+# Theme keys some renderer actually consumes. A `--*` custom property is
+# always allowed (the author defines its meaning and reads it back with
+# `var()`); a bare key has to be one of these or nothing will ever read it.
+_KNOWN_THEME_TOKENS = frozenset(
+    set(_THEME_TOKEN_ALIASES)
+    | set(_THEME_TOKEN_ALIASES.values())
+    | {
+        "background",
+        "color",
+        "font-family",
+        "font_family",
+        "font-size",
+        "font_size",
+        "font-weight",
+        "font_weight",
+        "font-style",
+        "font_style",
+    }
+)
+
+
+def _warn_unknown_theme_tokens(keys: list[str], label: str) -> None:
+    """Name theme tokens nothing will read (§28: allowed, but never silent).
+
+    A misspelled token — `text_colour`, `gridcolor` — validates as an unknown
+    CSS declaration and is then dropped by every renderer, so the chart comes
+    out unthemed with no diagnostic. Warn rather than raise: the browser
+    cascade can give meaning to a declaration the exporters do not know, so a
+    hard error would break charts that render correctly today.
+    """
+    unknown = [key for key in keys if not key.startswith("--") and key not in _KNOWN_THEME_TOKENS]
+    if not unknown:
+        return
+    import warnings
+
+    known = ", ".join(sorted(_THEME_TOKEN_ALIASES))
+    warnings.warn(
+        f"{label} got token(s) {unknown} that no XY renderer reads, so they will "
+        f"have no effect. Named tokens: {known}. Any `--custom-property` is also "
+        "accepted and readable back with var().",
+        RuntimeWarning,
+        stacklevel=4,
+    )
+
+
 def _theme_tokens(values: dict[str, Any], label: str) -> dict[str, StyleValue]:
     raw = {key: value for key, value in values.items() if value is not None}
     mapped = {_THEME_TOKEN_ALIASES.get(key, key): value for key, value in raw.items()}
-    return _style_dict(mapped, label)
+    compiled = _style_dict(mapped, label)
+    _warn_unknown_theme_tokens(list(compiled), label)
+    return compiled
 
 
 def _chrome_render_args(

--- a/tests/test_theme_token_hygiene.py
+++ b/tests/test_theme_token_hygiene.py
@@ -1,0 +1,37 @@
+"""Theme tokens nothing reads are named, not swallowed."""
+
+from __future__ import annotations
+
+import pytest
+
+import xy
+
+# ---------------------------------------------------------------------------
+# Unknown theme tokens are allowed but never silent (§28)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("token", ["text_colour", "gridcolor", "bogus_token"])
+def test_a_misspelled_theme_token_warns_instead_of_vanishing(token) -> None:
+    with pytest.warns(RuntimeWarning, match="no XY renderer reads"):
+        xy.theme(**{token: "#ff0000"})
+
+
+@pytest.mark.parametrize(
+    "tokens",
+    [
+        {"text_color": "#ff0000"},
+        {"background": "#ffffff"},
+        {"font_family": "Georgia, serif"},
+        {"--chart-tooltip-bg": "#000000"},
+        # An author's own custom property is theirs to define and read back.
+        {"--brand-accent": "#ff5c00"},
+    ],
+)
+def test_tokens_a_renderer_reads_do_not_warn(tokens) -> None:
+    import warnings
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        xy.theme(**tokens)
+    assert [str(record.message) for record in records] == []


### PR DESCRIPTION
Stacked on #293. Small hygiene fix; closes out the stack.

`theme(**tokens)` forwards anything through the CSS declaration check, which
passes unknown properties by design. So this:

```python
xy.theme(text_colour="#f00", gridcolor="#eee")   # both misspelled
```

was accepted, serialized, and read by no renderer. The chart came out unthemed
with no diagnostic and nothing to grep for — the failure mode `styles.py`
opens by saying XY avoids:

> Unsupported declarations fail before data ingestion rather than being
> silently ignored by one renderer.

That principle is enforced for mark and axis `style=` dicts and nowhere else.

## What changed

```
RuntimeWarning: theme tokens got token(s) ['text_colour'] that no XY renderer
reads, so they will have no effect. Named tokens: axis_color, crosshair_color,
grid_color, plot_background, selection_color, selection_fill, text_color. Any
`--custom-property` is also accepted and readable back with var().
```

A warning, not an error, on purpose: the browser cascade can give meaning to a
declaration the exporters do not know, so raising would break charts that
render correctly today. A `--custom-property` never warns — the author defines
it and reads it back with `var()`.

This is the cheapest slice of a broader finding: an audit of the styling
surface turned up ~20 inputs that are accepted, validated, and then discarded
without a word. The rest are separate work; this covers the theme surface.

## Verification

`uv run pytest` — 2321 passed. 8 new tests in
`tests/test_theme_token_hygiene.py`: three misspellings warn, and five valid
forms (named token, `background`, `font_family`, a documented `--chart-*`
token, and an author's own custom property) stay silent.
