### PR TITLE
Record why the raster payload omits the density overlay

### DIFF
--- a/python/xy/_payload.py
+++ b/python/xy/_payload.py
@@ -1132,6 +1132,11 @@ class PayloadMixin(_Host):
             sample = self._density_sample_spec(t, sel, visible, xr, yr, pw, sample_sel=sample_sel)
             if sample is not None:
                 density["sample"] = sample
+        elif "overlay_omitted" not in density:
+            # §28: no representation is dropped silently. `oversized` above may
+            # have already recorded the more fundamental u32 reason; that one
+            # wins, so only claim the field when nothing else has.
+            density["overlay_omitted"] = "static_raster"
         entry = {
             "id": t.id,
             "kind": "scatter",

--- a/spec/api/export.md
+++ b/spec/api/export.md
@@ -76,7 +76,10 @@ trace ships its grid without the retained real-point sample
 (`DENSITY_SAMPLE_TARGET`). This is not a rendering choice — `_raster._emit_grid`
 draws density traces from the grid alone and never reads `density["sample"]`, so
 the overlay was an O(N) sampling pass and two gathers whose result no pixel
-consumed. Raster output is byte-identical with and without it. The public
+consumed. Raster output is byte-identical with and without it. The omission is
+recorded as `density["overlay_omitted"] = "static_raster"` so a raster payload
+still explains itself (§28); the `rows_exceed_u32` reason takes precedence when
+both apply. The public
 `build_payload`/`build_payload_split` still ship the overlay: the browser client
 (`js/src/50_chartview.ts`) and the SVG renderer's payload path both go through
 them, and the client *does* draw it (T9).

--- a/tests/test_raster_density_overlay.py
+++ b/tests/test_raster_density_overlay.py
@@ -38,6 +38,7 @@ def test_wire_payload_still_ships_the_overlay() -> None:
     assert "sample" in density, "the JS client draws this overlay"
     assert density["sample"]["n"] > 0
     assert density["sample"]["mode"] == "sampled"
+    assert "overlay_omitted" not in density, "the raster-only reason must not reach the wire"
 
 
 def test_raster_payload_omits_the_overlay() -> None:
@@ -45,6 +46,8 @@ def test_raster_payload_omits_the_overlay() -> None:
     spec, _blob, _borrowed = fig._build_raster_payload()
     density = spec["traces"][0]["density"]
     assert "sample" not in density
+    # §28: the omission is recorded, not silent.
+    assert density["overlay_omitted"] == "static_raster"
     # The grid itself must be fully intact.
     assert density["w"] > 0 and density["h"] > 0 and density["max"] > 0
 

--- a/tests/test_svg_escape.py
+++ b/tests/test_svg_escape.py
@@ -65,15 +65,23 @@ def test_svg_export_does_not_import_urllib_or_ssl() -> None:
     """The whole point: a static export must not drag in the network stack.
 
     Runs in a fresh subprocess because pytest itself imports `email` and
-    friends, which would mask the regression in-process.
+    friends, which would mask the regression in-process. The module set is
+    sampled *after* NumPy so nothing NumPy pulls in is blamed on xy, and
+    `xml.sax.saxutils` is checked directly rather than only the urllib/ssl/email
+    tree it happens to drag in today — otherwise a future slimmer saxutils would
+    let the removed import creep back without failing this guard.
     """
     code = (
-        "import sys; import numpy as np; import xy\n"
+        "import sys; import numpy as np\n"
+        "before = set(sys.modules)\n"
+        "import xy\n"
         "fig = xy.scatter_chart(xy.scatter(x=np.arange(5.0), y=np.arange(5.0)),\n"
         "                       title='a & b < c > d').figure()\n"
         "svg = fig.to_svg(width=200, height=150)\n"
         "assert '&amp;' in svg and '&lt;' in svg and '&gt;' in svg, 'escape not exercised'\n"
-        "leaked = {'urllib.request', 'ssl', 'http.client', 'email', 'socket'} & set(sys.modules)\n"
+        "forbidden = {'xml.sax.saxutils', 'urllib.request', 'ssl',\n"
+        "             'http.client', 'email', 'socket'}\n"
+        "leaked = forbidden & (set(sys.modules) - before)\n"
         "assert not leaked, f'static SVG export imported {sorted(leaked)}'\n"
         "print('ok')\n"
     )


### PR DESCRIPTION
Follow-up to #284, addressing its review.

## The finding

#284 made the raster exporters skip the density point-sample overlay, because
`_raster._emit_grid` never reads `density["sample"]`. But it dropped that
representation without recording anything, which contradicts a stated invariant:

> Every decimation/tier decision is recorded in the spec, never silent (§28).

The neighbouring branch already honours this — it sets
`density["overlay_omitted"] = "rows_exceed_u32"` when row ids exceed u32. The new
raster case had no equivalent, so a raster payload dump showed an absent `sample`
with no explanation.

## What changed

`density["overlay_omitted"] = "static_raster"` on the raster path, guarded with
`if "overlay_omitted" not in density` so it cannot mask the more fundamental
`rows_exceed_u32` reason when a trace hits both.

Tests pin **both** halves: the field is present on the raster payload, and absent
from `build_payload`, so the raster-only flag can never leak to the client.

Also tightens the import guard added in #284:

- the module set is sampled *after* NumPy, so nothing NumPy pulls in is attributed to xy
- `xml.sax.saxutils` joins the forbidden set directly, rather than the guard relying
  on the urllib/ssl/email tree that import happens to drag in today — a future
  slimmer `saxutils` would otherwise let the removed import creep back without
  failing the test named for it

## Verification

`overlay_omitted` is written only into the private raster spec, which no renderer
reads, so this is observably inert:

- **all 72 artifact hashes unchanged** — PNG at scale 1 and 2, SVG, HTML, wire blob
  and wire spec, across 12 figure configurations (density, direct, f32, clipped,
  continuous colour, NaN-injected, log axes, categorical at 2.2M, line, and one
  with `& < > " '` plus non-BMP characters in the title)
- full suite **2283 passed, 4 skipped**
- `ruff check` and `ruff format --check` clean

Spec updated in `spec/api/export.md` alongside the code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Static raster density payloads now consistently indicate when the point overlay is omitted.
  - Omission reasons are reported clearly, with oversized row IDs taking precedence when applicable.
  - Wire payloads continue to exclude overlay metadata when it is not shipped.

- **Documentation**
  - Updated static raster export documentation to describe overlay omission reporting and reason precedence.

- **Tests**
  - Added regression coverage for payload omission markers and SVG export behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->