### PR TITLE
Correct the palette rule in the dossier and finish a half-edited sentence

### DIFF
--- a/spec/api/styling.md
+++ b/spec/api/styling.md
@@ -193,11 +193,11 @@ assigns to its categories. It must land before any mark applies — a trace bake
 its color at build — and rides the spec as `palette`, the indexed fallback the
 SVG and native renderers use for a trace with no style color. (The browser
 client never reads the chart-level key; it works from each channel's own
-resolved `palette`.) A palette entry is an ordinary paint color, so
-Entries obey the **same rule as colormap stops**, for the same reason: a
-palette is an indexed lookup consumed by four things with no DOM between them
-(the density plane, the SVG writer, the native rasterizer, and the client's own
-worker re-bin), so `var()`/`oklch()`/`color-mix()` are refused with that reason.
+resolved `palette`.) Entries obey the **same rule as colormap stops**, for the
+same reason: a palette is an indexed lookup consumed by four things with no DOM
+between them (the density plane, the SVG writer, the native rasterizer, and the
+client's own worker re-bin), so `var()`/`oklch()`/`color-mix()` are refused with
+that reason.
 The failure they would cause is worse than for a single mark — several such
 entries resolve to one fallback, collapsing distinct categories into one
 indistinguishable color. A single `color=`/`stroke`/`fill` is unaffected: one

--- a/spec/design-dossier.md
+++ b/spec/design-dossier.md
@@ -1335,7 +1335,17 @@ author expects.
   colors a categorical `color=` channel assigns to its categories. It lives on `Figure`
   before any mark applies (a trace bakes its color at build), rides the spec as
   `palette`, and is carried on each `ColorChannel` so ship / re-bin / legend / export all
-  read one source. Entries take any CSS color the paint props take, `var()` included.
+  read one source. Entries obey the same literal-color rule as ramp stops below, plus a
+  sharper reason of their own: a palette is an *indexed* lookup, so several browser-only
+  entries would land on one fallback and merge distinct categories into a single
+  indistinguishable color. They are **normalized to hex on the wire**, not merely
+  validated — the client's only cascade-free decode is `hexColor`, and anything else hits
+  a `getComputedStyle` probe that returns `""` on a root not yet in the document
+  (notebook webviews attach asynchronously), yielding black permanently, since a cached
+  palette LUT is rebuilt only on GL context loss. `channels.palette_rows_rgba8` is the one
+  place a palette becomes LUT rows — shared by the density plane and both static
+  exporters — and it substitutes the built-in color *at the same index*, never one shared
+  fallback, and warns (§28).
   `colormap=` likewise accepts a **custom ramp**: a sequence of 2–256 CSS colors,
   optionally `(position, color)` pairs, or a CSS `linear-gradient(...)`.
   `channels.resolve_colormap` normalizes every form to *evenly spaced 8-bit RGB stops* —


### PR DESCRIPTION
Two doc defects left behind by #298, both residue of the same edit: an earlier
draft let a `theme(palette=...)` entry be any CSS color, the shipped rule does
not, and two spots kept the old claim.

## The dossier says the opposite of what the code does

`spec/design-dossier.md` §36:

> Entries take any CSS color the paint props take, `var()` included.

They do not. `components._palette_list` runs every entry through
`_validate.resolved_hex_paint`, which refuses `var()`/`oklch()`/`color-mix()`
*naming that reason* and normalizes the rest to hex. Every other surface —
`spec/api/styling.md`, `docs/styling/customize.md`, the CHANGELOG, `theme()`'s
docstring, and `test_browser_only_palette_entries_are_refused_like_colormap_stops`
— states the strict rule. The dossier was the lone dissenter, and it is the file
the next change gets read against.

The replacement states the rule and the two reasons behind it, neither of which
was written down anywhere in the spec:

- A palette is an **indexed** lookup, so a browser-only entry does not merely
  mispaint one mark — several of them land on one fallback and merge distinct
  categories into a single indistinguishable color.
- Entries are **normalized to hex on the wire**, not merely validated, because
  the client's only cascade-free decode is `hexColor` and the `getComputedStyle`
  fallback returns `""` on a root not yet in the document (notebook webviews
  attach asynchronously) — black, permanently, since a cached palette LUT is
  rebuilt only on GL context loss.

It also records `channels.palette_rows_rgba8` as the one place a palette becomes
LUT rows, and that it substitutes **at the same index** rather than onto one
shared fallback. That invariant is the whole point of unifying the three
resolvers in #298, and it currently lives only in a docstring — exactly the kind
of thing that gets re-broken by a well-meaning refactor.

## A sentence that was edited in half

`spec/api/styling.md`:

> resolved `palette`.) A palette entry is an ordinary paint color, so
> Entries obey the **same rule as colormap stops**, …

The first clause is the permissive draft, the second is the strict rule that
replaced it. Dropped the clause and re-wrapped the paragraph.

## Verification

Docs only, no behavior change. `ruff check` / `ruff format --check` /
`pre-commit run --all-files` clean. Swept `spec/` and `docs/` for other
palette-vs-`var()` claims; these two were the only ones.