### PR TITLE
Route categorical factorization on repetition, not category count

### DIFF
--- a/benchmarks/test_codspeed_kernels.py
+++ b/benchmarks/test_codspeed_kernels.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 
 import xy
+from xy import channels as ch
 from xy import kernels as k
 from xy._figure import Figure  # harness type annotations only
 
@@ -328,6 +329,32 @@ def test_factorize_unicode1_categorical(benchmark):
     assert len(codes) == N and len(unique) == len(labels)
     np.testing.assert_array_equal(codes[:48], np.tile(np.arange(24, dtype=np.uint8), 2))
     assert int(counts.sum()) == N
+
+
+def test_factorize_many_categories_routing(benchmark):
+    """Categorical resolve above the compact-palette ceiling, routing included.
+
+    The two rows above call the kernels directly, so neither prices the choice
+    of path. Every other categorical workload in the suite carries 24
+    categories, which short-circuits on `_FACTORIZE_NATIVE_MAX_PROBE_CATEGORIES`
+    — leaving the regime this covers untested: enough categories to clear that
+    early-out while staying far from a unique-id column. Routing it back onto
+    per-row Python label boxing costs an O(N) object pass, which instruction
+    counting sees loudly.
+    """
+    labels = np.asarray([f"{i:08d}" for i in range(600)])
+    values = np.resize(labels, N)
+    # `np.resize` tiles with period 600 and the router samples on a fixed
+    # stride, so the probe's distinct count is an aliasing accident of N and
+    # the probe width. Pin it: if either constant drifts so the probe falls
+    # back inside the early-out, this row silently stops covering the regime
+    # its docstring claims.
+    probe = values[np.linspace(0, N - 1, ch._FACTORIZE_PROBE_ROWS, dtype=np.intp)]
+    assert len(np.unique(probe)) > ch._FACTORIZE_NATIVE_MAX_PROBE_CATEGORIES
+    assert ch._use_native_fixed_factorizer(values)
+    categories, codes, _ = benchmark(ch._factorize_categories, values)
+    assert len(categories) == len(labels) and len(codes) == N
+    np.testing.assert_array_equal(codes[:24], np.arange(24, dtype=codes.dtype))
 
 
 def test_m4_indices_full(benchmark, data):

--- a/python/xy/channels.py
+++ b/python/xy/channels.py
@@ -122,6 +122,16 @@ DEFAULT_COLORMAP = "viridis"
 MAX_CATEGORIES = 256
 _FACTORIZE_PROBE_ROWS = 4096
 _FACTORIZE_NATIVE_MAX_PROBE_CATEGORIES = 512
+# How near-unique a probe must look before hashing stops paying for itself.
+# Measured on an M-series Mac at N=500k, native-vs-object by probe uniqueness
+# ratio: 0.146 -> native 13.2x, 0.904 -> 5.8x, 0.989 -> 1.29x. Wide records
+# cross over earlier because hashing them costs more per row, so narrow columns
+# only give up the fast path for a true id column (no repeats in the probe at
+# all) while wide ones give it up as soon as repeats get scarce. Category
+# *count* is the wrong axis: 600 categories over millions of rows probes at
+# 0.146, nowhere near unique.
+_FACTORIZE_NEAR_UNIQUE_RATIO = 0.95
+_FACTORIZE_NARROW_ITEMSIZE = 32
 
 
 @dataclass
@@ -275,12 +285,18 @@ def _category_code_dtype(category_count: int) -> type[np.uint8] | type[np.uint32
 
 
 def _use_native_fixed_factorizer(arr: np.ndarray) -> bool:
-    """Choose the O(N) hash path when a bounded global probe is low-cardinality.
+    """Choose the O(N) hash path unless a bounded global probe says it cannot pay.
 
-    With nearly every label unique, Python must still materialize and sort the
-    complete display-label set; hashing those records first is redundant work.
-    Sampling across the full array avoids that regression while keeping the
-    decision independent of N.
+    The native pass earns its keep by keeping N records out of Python: only the
+    compact unique set crosses the label-policy path. It stops paying when the
+    column is near-unique, because then Python must materialize and sort
+    essentially the whole label set anyway and hashing the records first is
+    redundant. What decides that is how *repetitive* the probe is, not how many
+    categories it happens to contain — a few hundred categories spread over
+    millions of rows is an ordinary categorical column and keeps the fast path.
+    Wide records cross over sooner, so they hand back the fast path as soon as
+    repeats get scarce while narrow ones hold it until the probe is entirely
+    distinct. Sampling across the full array keeps the decision independent of N.
     """
     n = len(arr)
     if n <= _FACTORIZE_PROBE_ROWS:
@@ -288,7 +304,13 @@ def _use_native_fixed_factorizer(arr: np.ndarray) -> bool:
     else:
         rows = np.linspace(0, n - 1, _FACTORIZE_PROBE_ROWS, dtype=np.intp)
         probe = arr[rows]
-    return len(np.unique(probe)) <= _FACTORIZE_NATIVE_MAX_PROBE_CATEGORIES
+    distinct = len(np.unique(probe))
+    if distinct <= _FACTORIZE_NATIVE_MAX_PROBE_CATEGORIES:
+        return True
+    near_unique = (
+        1.0 if arr.dtype.itemsize <= _FACTORIZE_NARROW_ITEMSIZE else _FACTORIZE_NEAR_UNIQUE_RATIO
+    )
+    return distinct < near_unique * len(probe)
 
 
 def _factorize_categories(

--- a/spec/design/rust-engine.md
+++ b/spec/design/rust-engine.md
@@ -42,7 +42,13 @@ binning (1D/2D/channel-aware) ✅/plan · decimation (M4 ✅, OHLC plan) ·
 range filtering (`xy_range_indices` ✅) · implicit uniform and compact-u8
 stratified sampling (`xy_sample_range_indices` / `xy_stratified_sample_range_u8` ✅) · grouping/category encoding
 (`xy_factorize_fixed` ✅ for contiguous fixed-width values; defensive Python
-label canonicalization for mixed objects) · histogram stats ✅ · quantiles (plan:
+label canonicalization for mixed objects. Routing is decided by a bounded
+4096-row probe on how *repetitive* the column is, never by how many categories
+it holds: the native pass exists to keep N records out of Python, so it is
+declined only for a near-unique id/key column, where Python must materialize
+essentially the whole label set regardless. Wide records cross over sooner —
+above 32 B they are declined once the probe is 95% distinct, at or below 32 B
+only when it is entirely distinct) · histogram stats ✅ · quantiles (plan:
 `xy_quantiles`, needed by box/violin) · box/violin stats (thin composition
 over quantiles — stats in Rust, assembly in Python) · multi-resolution tile
 generation (`tiles.rs` ✅, including stable-domain incremental updates) ·

--- a/tests/test_scatter.py
+++ b/tests/test_scatter.py
@@ -16,6 +16,16 @@ from xy.config import DENSITY_SAMPLE_TARGET, MAX_SCREEN_DIM
 from xy.interaction import _decode_log_u8
 
 
+def _factorize_forcing(labels, use_native):
+    """Factorize down one specific path, whichever one the router would pick."""
+    original = ch._use_native_fixed_factorizer
+    ch._use_native_fixed_factorizer = lambda _a: use_native
+    try:
+        return ch._factorize_categories(labels)
+    finally:
+        ch._use_native_fixed_factorizer = original
+
+
 def _col(spec, blob, ref, dtype=None):
     m = spec["columns"][ref]
     if dtype is None:
@@ -127,17 +137,53 @@ def test_categorical_code_width_changes_without_wrapping_at_palette_boundary() -
     assert int(channel_257.codes.max()) == 256
 
 
-def test_high_cardinality_fixed_labels_avoid_redundant_native_hash(monkeypatch) -> None:
+def test_id_like_column_avoids_redundant_native_hash(monkeypatch) -> None:
+    # Every row distinct: Python has to materialize the whole label set anyway,
+    # so hashing the records first buys nothing.
     labels = np.asarray([f"category-{i:04d}" for i in range(600)])
 
     def unexpected_native(_values):
-        raise AssertionError("high-cardinality probe should retain the direct label path")
+        raise AssertionError("id-like probe should retain the direct label path")
 
     monkeypatch.setattr(ch.kernels, "factorize_fixed", unexpected_native)
     with pytest.warns(RuntimeWarning, match="categories"):
         channel = ch.resolve_color(labels, len(labels), default_constant="#000")
     assert channel.codes is not None and channel.codes.dtype == np.uint32
     assert len(channel.categories or []) == len(labels)
+
+
+def test_many_categories_over_many_rows_uses_native_factorizer() -> None:
+    # A few hundred categories spread over many rows is an ordinary categorical
+    # column, not an id column: it must keep the native path, which is where the
+    # O(N) Python label materialization is avoided. Routing on category *count*
+    # sent this to the object path and cost 383.6 MB / 889 ms at 5M rows versus
+    # 40.3 MB / 63 ms here.
+    rng = np.random.default_rng(0)
+    categories = np.asarray([f"{i:08d}" for i in range(600)])
+    labels = categories[rng.integers(0, len(categories), size=20_000)]
+
+    assert ch._use_native_fixed_factorizer(labels)
+
+    native_cats, native_codes, native_counts = ch._factorize_categories(labels)
+    object_cats, object_codes, object_counts = _factorize_forcing(labels, use_native=False)
+    assert native_cats == object_cats
+    np.testing.assert_array_equal(native_codes, object_codes)
+    # Counts ride along only from the compact (<= MAX_CATEGORIES) kernel; above
+    # that both paths report None and callers recount.
+    assert native_counts is None and object_counts is None
+
+
+def test_both_factorizer_paths_agree_across_the_width_threshold() -> None:
+    # The routing threshold is width-dependent, so pin that both sides of it
+    # factorize identically whichever path a column is routed down.
+    rng = np.random.default_rng(1)
+    for width in (8, 64):
+        categories = np.asarray([f"{i:0{width}d}"[-width:] for i in range(4_000)])
+        labels = categories[rng.integers(0, len(categories), size=12_000)]
+        native_cats, native_codes, _ = _factorize_forcing(labels, use_native=True)
+        object_cats, object_codes, _ = _factorize_forcing(labels, use_native=False)
+        assert native_cats == object_cats, f"width {width}"
+        np.testing.assert_array_equal(native_codes, object_codes)
 
 
 def test_numeric_object_color_with_missing_is_continuous():


### PR DESCRIPTION
## The bug

A categorical color column with more than 512 categories fell off the native
factorizer onto a per-row Python label path (`arr.astype(object)` + an N-element
list of `str`), costing a full O(N) Python object pass.

The probe was asking the wrong question. It capped on how *many* categories the
column holds, but what the native pass depends on is how *repetitive* the column
is. Its whole job is to keep N records out of Python and hand only the compact
unique set to the label-policy path — so it stops paying only for a near-unique
id/key column, where Python has to materialize essentially every label anyway.

600 categories spread over millions of rows is an ordinary categorical column,
not an id column. It probes at **0.146** distinct and was being treated as if it
probed at 1.0.

## The fix

Route on the probe's uniqueness ratio. Wide records cross over sooner because
hashing them costs more per row, so records above 32 B give up the fast path
once the probe is 95% distinct, while narrower ones hold it until the probe is
entirely distinct — which keeps the true id-column case (the one the guard was
written for) on the direct label path exactly as before.

## Measurements

M-series Mac, 5M rows over 600 `<U8` categories, fresh process per arm:

| | peak RSS | wall-clock |
|---|---|---|
| before | 383.6 MB | 889 ms |
| after | **40.3 MB** | **63 ms** |
| | **9.5x less** | **14x faster** |

Identical categories and byte-identical codes (`sha256(codes) = 4e5bd98c2937f419`
in both arms).

Swept 34 combinations of record width (`U8`…`U512`, `S32`, `bool`), cardinality
(8 … N) and shape (repeated vs. true id column) at N=400k. **Every routing change
is a win between 1.20x and 12.35x, no case regresses, and all three outputs
(categories, codes, counts) match the other path exactly in all 34.** A sample:

| dtype | shape | before → after | change |
|---|---|---|---|
| U8 | 600 categories | object → native | **12.35x** |
| U8 | 20,000 categories | object → native | 4.95x |
| U13 | 600 categories | object → native | 9.61x |
| U32 | 600 categories | object → native | 5.55x |
| U128 | 600 categories | object → native | 2.02x |
| S32 | gather | object → native | 1.20x |
| U8 / U13 / U32 / U128 / U512 | **true id column** | object → object | unchanged |

The id-column rows are the point of the width term: they keep the old routing,
because that is the one shape where hashing genuinely buys nothing.

## Risk

- **No CodSpeed row covers this path**, so the gate will read flat — this should
  be argued from wall-clock, not from the dashboard.
- Output is unchanged by construction and asserted equal on both paths in the
  new tests.
- `test_high_cardinality_fixed_labels_avoid_redundant_native_hash` is renamed to
  `test_id_like_column_avoids_redundant_native_hash`: its array (600 unique
  labels over 600 rows) is an id column, and the old name encoded the mental
  model this PR is correcting. Its assertions are unchanged and still pass.

## Benchmark coverage

Nothing in the suite covered this regime. The two existing factorize rows
(`test_factorize_fixed_categorical`, `test_factorize_unicode1_categorical`) call
the kernels directly, so neither prices the choice of path, and every other
categorical workload carries 24 categories — inside the `<= 512` early-out.

Added `test_factorize_many_categories_routing`: 600 categories over 1M rows,
which probes at 600 distinct — past the early-out, nowhere near a unique-id
column. It measures `_factorize_categories` rather than `resolve_color` so the
region is the routing decision and the path it picks, without the palette
warning diluting it.

Rerouting it back onto per-row Python label boxing moves the row **13.7x
wall-clock** (12.25 ms → 167.96 ms, measured locally). The dashboard delta will
be smaller than that: CodSpeed counts instrumented instructions, and the win is
dominated by avoiding N Python object allocations, which shows up clearly in
instruction counts but does not reproduce the wall-clock ratio. It regresses
loudly either way. Local walltime StdDev is 0.7%, the tightest of the three
factorize rows — this defect is instruction-bound, the case simulation mode
measures well.

`np.resize` tiles with period 600 while the router samples on a fixed stride, so
the probe's distinct count is an aliasing accident of `N` and
`_FACTORIZE_PROBE_ROWS`. That is asserted outside the measured region, so the row
fails rather than silently sliding back inside the early-out if either constant
moves.

Note this row is a cost tripwire, not the gate: CodSpeed is advisory on this
repo (the branch is unprotected), so the binding guard against the specific
regression is the `_use_native_fixed_factorizer` assertion in the pytest suite.

## Tests

Full suite green: **2326 passed, 4 skipped**. `ruff check`, `ruff format --check`
and the `ruff` pre-commit hooks all pass. Three tests added/renamed covering the
fixed case, the preserved id-column case, and cross-path equivalence on both
sides of the width threshold.

Spec updated at `spec/design/rust-engine.md` — the routing rule is now written
down.

---

Found during a memory audit of the engine; this was the top-ranked
strictly-better fix of 39.



