### PR TITLE
Remove shallow nonfunctional tests

### DIFF
--- a/tests/pyplot/test_axes_charts.py
+++ b/tests/pyplot/test_axes_charts.py
@@ -133,29 +133,6 @@ def test_imshow_flips_origin_upper() -> None:
     assert fig.traces[0].kind == "heatmap"
 
 
-def test_twinx_targets_second_axis() -> None:
-    _fig, ax = plt.subplots()
-    ax.plot([0, 1], [1, 2])
-    ax2 = ax.twinx()
-    ax2.plot([0, 1], [10, 20])
-    chart = ax._build_chart(640, 480)
-    fig = chart.figure()
-    assert len(fig.traces) == 2
-    html = chart.to_html()
-    assert html.startswith("<!doctype html>")
-
-
-def test_log_scale_and_invert() -> None:
-    _fig, ax = plt.subplots()
-    ax.plot([1, 10, 100], [1, 2, 3])
-    ax.set_xscale("log")
-    ax.invert_yaxis()
-    fig = ax._build_chart(640, 480).figure()
-    assert fig.axis_options["x"].get("type") == "log" or True  # spec-level check below
-    html = ax._build_chart(640, 480).to_html()
-    assert html  # builds cleanly with log+reverse
-
-
 def test_labels_title_reach_the_chart() -> None:
     _fig, ax = plt.subplots()
     ax.plot([0, 1], [1, 2])

--- a/tests/reflex_adapter/test_component.py
+++ b/tests/reflex_adapter/test_component.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import pathlib
 
 import pytest
@@ -144,32 +143,3 @@ def test_static_facet_chart_compiles_as_grid_of_panel_payloads(app_cwd):
 def test_live_chart_does_not_claim_runtime_classes_are_compile_time_known(app_cwd):
     rendered = str(reflex_xy.chart("xyfig-runtime"))
     assert "tailwindClassTokens" not in rendered
-
-
-def test_component_creation_does_not_touch_repo_root():
-    """Outside an app cwd nothing has leaked assets/ into the repo."""
-    repo_root = pathlib.Path(reflex_xy.__file__).resolve().parents[3]
-    assert not (repo_root / "assets").exists(), (
-        "importing/creating reflex_xy components must not scatter asset "
-        "symlinks outside an app directory"
-    )
-    assert os.getcwd() != str(repo_root) or True
-
-
-def test_semantic_event_wrapper_contracts_are_present():
-    source = (
-        pathlib.Path(__file__).parents[2] / "python/reflex-xy/reflex_xy/assets/XYChart.jsx"
-    ).read_text()
-    assert 'm.type === "select_polygon"' in source
-    assert 'lastSelect?.type === "select_polygon" ? lastSelect.points : null' in source
-    assert "interaction.click = true" in source
-    assert "interaction.view_change = true" in source
-    assert "include_rows: true" in source
-    assert "HOVER_THROTTLE_MS = 120" in source
-    assert "VIEW_THROTTLE_MS = 120" in source
-    assert "envelope.v = payloadVersion" in source
-    assert "restoreSelectionSeqs.delete(message.seq)" in source
-    assert "restoringSelection" not in source
-    assert 'pointEnvelope("point_click"' in source
-    assert 'type: "select_end"' in source
-    assert 'type: "view_change"' in source

--- a/tests/test_custom_ramps_and_palette.py
+++ b/tests/test_custom_ramps_and_palette.py
@@ -419,12 +419,3 @@ def test_text_switch_does_not_collide_with_tick_labels():
     axis = xy.x_axis(tick_values=(0.0, 1.0), tick_labels=("lo", "hi"), text=False)
     assert axis.tick_labels == ["lo", "hi"]
     assert axis.style["tick_label_color"] == "#00000000"
-
-
-def test_hidden_axes_render_in_every_static_renderer():
-    x, y = _xy(100)
-    chart = xy.scatter_chart(
-        xy.scatter(x, y), xy.x_axis(show=False), xy.y_axis(show=False, grid=True)
-    )
-    assert chart.to_svg().startswith("<?xml") or chart.to_svg().startswith("<svg")
-    assert chart.to_png().startswith(b"\x89PNG")

--- a/tests/test_static_client_security.py
+++ b/tests/test_static_client_security.py
@@ -36,7 +36,6 @@ _STANDALONE = ("static/standalone.js", _read(_STATIC / "standalone.js"))
 CLIENT_FILES = (_CLIENT_SRC,)
 BUNDLES = (_INDEX, _STANDALONE)
 FORMATTER_FILES = (("js/src/30_ticks.ts", _read(ROOT / "js/src/30_ticks.ts")),)
-LOD_FILES = (("js/src/45_lod.ts", _read(ROOT / "js/src/45_lod.ts")),)
 # The chrome default stylesheet lives in the theme part; its rules are string
 # literals, so the bundle-level test re-asserts them in both built bundles.
 THEME_FILES = (("js/src/20_theme.ts", _read(ROOT / "js/src/20_theme.ts")),)
@@ -565,42 +564,6 @@ def test_client_refreshes_theme_when_framework_theme_classes_change() -> None:
     for path, text in CLIENT_FILES:
         for marker in required:
             assert marker in text, f"{path} lost host-driven theme refresh {marker!r}"
-
-
-def test_client_lod_layer_stays_chart_agnostic_and_renderer_delegated() -> None:
-    source_lod = (ROOT / "js/src/45_lod.ts").read_text(encoding="utf-8")
-    assert "trace.kind" not in source_lod
-    assert "markOf(" not in source_lod
-
-    # The intent comment is a source-only assertion — the built bundles are
-    # compacted (comments stripped), so only code markers are checked there.
-    assert "future heatmap/histogram tier reuses it instead of copy-pasting" in source_lod
-
-    lod_required = (
-        "function lodApplyDrill(view, g, upd, buffers)",
-        "function lodApplyDensityUpdate(view, g, upd, buffers)",
-        "function lodDrawDensityTier(view, g, x0, x1, y0, y1)",
-        "lodRememberDensity(view, g, g.density);",
-        "view._drawDensity(g, density",
-        "view._drawPoints(",
-        "lodDropDrill(view, g)",
-    )
-    for path, text in LOD_FILES:
-        for marker in lod_required:
-            assert marker in text, f"{path} no longer preserves shared LOD marker {marker!r}"
-
-    chartview_required = (
-        "lodDrawDensityTier(this, g",
-        "markOf(g.trace.kind).draw(this, g",
-        'if (upd.mode === "points") { this._applyDrill(g, upd, buffers); continue; }',
-        "lodApplyDensityUpdate(this, g, upd, buffers);",
-        "lodApplyDrill(this, g, upd, buffers);",
-        "lodDropDrill(this, g);",
-        'markOf(t.trace.kind).pointPick && (t.tier !== "density" || t.drill)',
-    )
-    for path, text in CLIENT_FILES:
-        for marker in chartview_required:
-            assert marker in text, f"{path} no longer delegates shared LOD marker {marker!r}"
 
 
 def test_client_coalesces_wheel_zoom_without_animation_lag() -> None:

--- a/tests/test_viewport_bounds.py
+++ b/tests/test_viewport_bounds.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 import xy
-
-ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_explicit_axis_bounds_ship_separately_from_initial_domain() -> None:
@@ -46,13 +42,3 @@ def test_axis_bounds_validation(factory) -> None:
         factory(bounds="everything")
     with pytest.raises(ValueError, match="positive"):
         xy.line_chart(xy.line([1, 2], [1, 2]), factory(type_="log", bounds=(-1, 10))).figure()
-
-
-def test_client_clamps_pan_zoom_and_reversed_log_ranges() -> None:
-    source = (ROOT / "js/src/53_interaction.ts").read_text(encoding="utf-8")
-
-    assert "_clampAxisRange(axisId, lo, hi, anchorFrac = 0.5)" in source
-    assert "const reverse = c1 < c0" in source
-    assert "const target = this._clampView(" in source
-    assert 'source: "pan_drag"' in source
-    assert "opts.anchors?.[axisId] ?? 0.5" in source


### PR DESCRIPTION
## Summary

- remove seven tests that contained tautological assertions, checked only output signatures, or inspected source text without exercising the named behavior
- remove imports and constants that became unused with those tests
- leave production code unchanged

## Why

These tests overstated behavioral coverage and could remain green while the functionality named by the test was broken. The clearest cases included unconditional `or True` assertions; the remaining cases were source-shape or smoke checks labeled as feature tests.

Removing them makes the suite's signal more honest. Behavioral replacements can be added separately when they exercise actual runtime outcomes.

## Impact

No runtime or public API behavior changes. The test suite loses seven misleading checks across five files and avoids false confidence from nonfunctional coverage.

## Validation

- `uv run --with pre-commit pre-commit run --all-files`
- `uv run ruff check .`
- `uv run ruff format --check .`
- Python syntax compilation for the edited files
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated chart wrapper coverage to verify that live chart output excludes Tailwind class tokens.
  * Removed several outdated or implementation-specific tests covering axis behavior, static rendering, client security, and viewport clamping.
  * Simplified test setup by removing unused imports and obsolete fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->