### PR TITLE
Rerun the launch scatter benchmark and refresh every published number

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ chart = xy.line_chart(
   <img src="spec/assets/launch-benchmark-comparison.svg" alt="Cold-render time for a 10-million-point chart in XY, Matplotlib, and Plotly. Lower is better." width="1200">
 </p>
 
-In the recorded 10-million-point baseline, XY produced a static PNG in 0.023 s
-versus 2.8 s for Matplotlib and 9.6 s for Plotly, and reached first interactive
-render 16–20× sooner.
+In the recorded 10-million-point baseline, XY produced a static PNG in 0.018 s
+versus 2.7 s for Matplotlib and 9.6 s for Plotly, and reached first interactive
+render 16–18× sooner.
 
 That baseline is one proof point, not the finish line. XY is being built to
 outperform every competing charting library across small-data startup,
@@ -172,7 +172,7 @@ the project measures and proves that goal.
 
 The committed launch baseline uses identical seeded data, a 900×420 output,
 and three isolated cold runs. See the
-[launch report](benchmarks/launch_baselines/xy-0.1.0/macos-arm64-m5-pro/report.md),
+[launch report](benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/report.md),
 [benchmark runbook](benchmarks/README.md), and
 [competitive benchmark specification](spec/benchmarks/results.md) for the
 environment, methodology, raw results, and full evidence program.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -35,10 +35,12 @@ interactive CPU fallback through SwiftShader. Each successful cell is the mean
 of three complete cold-process runs; interactive samples also use a fresh
 browser. Terminal 1B failures are attempted once and are not averaged.
 
-Reproduce the 0.1.0 launch environment with its exact dependency versions:
+Reproduce the launch environment with its exact dependency versions. Both
+baseline directories carry the same competitor pins, so either one reproduces
+the comparison environment; use the newest for a fresh run:
 
 ```bash
-BASELINE=benchmarks/launch_baselines/xy-0.1.0/macos-arm64-m5-pro
+BASELINE=benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro
 uv sync --project "$BASELINE" --frozen --python 3.14.5
 ```
 
@@ -63,9 +65,17 @@ uv run --project "$BASELINE" --frozen python benchmarks/bench_launch_scatter.py 
 ```
 
 The immutable 0.1.0 launch baseline, report, and raw results live under
-`benchmarks/launch_baselines/xy-0.1.0/macos-arm64-m5-pro/`. Add a new
-version/environment directory for later launches; never overwrite an earlier
-launch baseline or mix hardware and SwiftShader rows.
+`benchmarks/launch_baselines/xy-0.1.0/macos-arm64-m5-pro/`. The 2026-07-26 rerun
+that the README and public benchmarks page quote lives under
+`benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/`; it repeats
+the same contracts against the same pinned competitor versions on the same
+machine. Add a new version/environment directory for later launches; never
+overwrite an earlier launch baseline or mix hardware and SwiftShader rows.
+
+Warm the checkout before a measured run. A first invocation in a fresh worktree
+pays for cold bytecode caches, Matplotlib's font cache, and Kaleido's browser
+download — measured at 13× the warm value for the `xy` 10k static row — so
+discard it rather than publishing it.
 
 ## CI Software GL
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -74,8 +74,9 @@ overwrite an earlier launch baseline or mix hardware and SwiftShader rows.
 
 Warm the checkout before a measured run. A first invocation in a fresh worktree
 pays for cold bytecode caches, Matplotlib's font cache, and Kaleido's browser
-download — measured at 13× the warm value for the `xy` 10k static row — so
-discard it rather than publishing it.
+download, which inflate every library's first row by an amount that is not part
+of any output contract. Run the suite once and discard it; publish the run after
+it.
 
 ## CI Software GL
 

--- a/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/cpu-fallback-results.json
+++ b/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/cpu-fallback-results.json
@@ -1,0 +1,1162 @@
+{
+  "generated_at_utc": "2026-07-27T02:37:15.458453Z",
+  "repetitions_requested": 3,
+  "aggregation": "arithmetic mean of successful fresh-process runs",
+  "sizes": [
+    10000,
+    100000,
+    1000000,
+    10000000,
+    1000000000
+  ],
+  "software_browser": true,
+  "static": [],
+  "interactive": [
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 10000,
+          "source_bytes": 80000,
+          "source_rss_bytes": 49561600,
+          "python_render_ms": 1.8725410336628556,
+          "output_bytes": 446199,
+          "mode": "direct",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 52117504,
+          "wall_ms": 129.46854205802083,
+          "browser_probe": {
+            "ready_ms": 975.2000000476837,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 14073,
+            "js_heap_bytes": 2696563,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1213726720,
+            "browser_wall_ms": 1351.2030830606818
+          },
+          "end_to_end_ttfr_ms": 977.0725410813466,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 10000,
+          "source_bytes": 80000,
+          "source_rss_bytes": 49627136,
+          "python_render_ms": 1.8726669950410724,
+          "output_bytes": 446199,
+          "mode": "direct",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 52166656,
+          "wall_ms": 134.754833066836,
+          "browser_probe": {
+            "ready_ms": 951.5,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 14073,
+            "js_heap_bytes": 2698107,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1170866176,
+            "browser_wall_ms": 1477.6160839246586
+          },
+          "end_to_end_ttfr_ms": 953.3726669950411,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 10000,
+          "source_bytes": 80000,
+          "source_rss_bytes": 49528832,
+          "python_render_ms": 1.91399990580976,
+          "output_bytes": 446199,
+          "mode": "direct",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 52084736,
+          "wall_ms": 129.87870804499835,
+          "browser_probe": {
+            "ready_ms": 963.6000000238419,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 14073,
+            "js_heap_bytes": 2703127,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1173520384,
+            "browser_wall_ms": 1268.9155840780586
+          },
+          "end_to_end_ttfr_ms": 965.5139999296516,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        }
+      ],
+      "mean_ms": 965.3197360020131,
+      "median_ms": 965.5139999296516,
+      "stdev_ms": 11.851131244816669,
+      "min_ms": 953.3726669950411,
+      "max_ms": 977.0725410813466,
+      "library": "xy",
+      "n": 10000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 10000,
+          "source_bytes": 80000,
+          "source_rss_bytes": 59244544,
+          "python_render_ms": 127.76441604364663,
+          "output_bytes": 4995805,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 128040960,
+          "wall_ms": 268.7966669909656,
+          "browser_probe": {
+            "ready_ms": 1163,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 15705,
+            "js_heap_bytes": 24721003,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1389445120,
+            "browser_wall_ms": 1456.892624963075
+          },
+          "end_to_end_ttfr_ms": 1290.7644160436466,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 10000,
+          "source_bytes": 80000,
+          "source_rss_bytes": 59375616,
+          "python_render_ms": 123.69670800399035,
+          "output_bytes": 4995805,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 134397952,
+          "wall_ms": 268.50470900535583,
+          "browser_probe": {
+            "ready_ms": 1214.1000000238419,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 15705,
+            "js_heap_bytes": 19707043,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1385971712,
+            "browser_wall_ms": 1451.299124979414
+          },
+          "end_to_end_ttfr_ms": 1337.7967080278322,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 10000,
+          "source_bytes": 80000,
+          "source_rss_bytes": 59359232,
+          "python_render_ms": 126.69437506701797,
+          "output_bytes": 4995805,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 128679936,
+          "wall_ms": 267.3736250726506,
+          "browser_probe": {
+            "ready_ms": 1228.6999999284744,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 15705,
+            "js_heap_bytes": 19718415,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1385627648,
+            "browser_wall_ms": 1511.9776669889688
+          },
+          "end_to_end_ttfr_ms": 1355.3943749954924,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        }
+      ],
+      "mean_ms": 1327.9851663556572,
+      "median_ms": 1337.7967080278322,
+      "stdev_ms": 33.41343533697095,
+      "min_ms": 1290.7644160436466,
+      "max_ms": 1355.3943749954924,
+      "library": "plotly",
+      "n": 10000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "n": 10000,
+          "source_bytes": 80000,
+          "source_rss_bytes": 76316672,
+          "build_ms": 21.27825003117323,
+          "mode": "interactive-webagg",
+          "offset_count": 10000,
+          "ready_ms": 1016.3999999761581,
+          "nonblank_samples": 836,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 2333513,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 93143040,
+          "browser_peak_rss_bytes": 1183662080,
+          "browser_wall_ms": 1286.2334999954328,
+          "end_to_end_ttfr_ms": 1037.6782500073314
+        },
+        {
+          "n": 10000,
+          "source_bytes": 80000,
+          "source_rss_bytes": 76349440,
+          "build_ms": 20.991583936847746,
+          "mode": "interactive-webagg",
+          "offset_count": 10000,
+          "ready_ms": 1173.6000000238419,
+          "nonblank_samples": 836,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 2333513,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 93192192,
+          "browser_peak_rss_bytes": 1167130624,
+          "browser_wall_ms": 1384.634750080295,
+          "end_to_end_ttfr_ms": 1194.5915839606896
+        },
+        {
+          "n": 10000,
+          "source_bytes": 80000,
+          "source_rss_bytes": 76677120,
+          "build_ms": 20.904292003251612,
+          "mode": "interactive-webagg",
+          "offset_count": 10000,
+          "ready_ms": 1025.5,
+          "nonblank_samples": 836,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 2333513,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 93241344,
+          "browser_peak_rss_bytes": 1115734016,
+          "browser_wall_ms": 1283.3977079717442,
+          "end_to_end_ttfr_ms": 1046.4042920032516
+        }
+      ],
+      "mean_ms": 1092.8913753237575,
+      "median_ms": 1046.4042920032516,
+      "stdev_ms": 88.182964793804,
+      "min_ms": 1037.6782500073314,
+      "max_ms": 1194.5915839606896,
+      "library": "matplotlib",
+      "n": 10000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 100000,
+          "source_bytes": 800000,
+          "source_rss_bytes": 49922048,
+          "python_render_ms": 4.493582993745804,
+          "output_bytes": 1406204,
+          "mode": "direct",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 62767104,
+          "wall_ms": 124.26937511190772,
+          "browser_probe": {
+            "ready_ms": 964.1000000238419,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16349,
+            "js_heap_bytes": 5335745,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1173651456,
+            "browser_wall_ms": 1333.0259580397978
+          },
+          "end_to_end_ttfr_ms": 968.5935830175877,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 100000,
+          "source_bytes": 800000,
+          "source_rss_bytes": 49872896,
+          "python_render_ms": 4.614833043888211,
+          "output_bytes": 1406204,
+          "mode": "direct",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 58441728,
+          "wall_ms": 134.32095805183053,
+          "browser_probe": {
+            "ready_ms": 958.7999999523163,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16349,
+            "js_heap_bytes": 5333805,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1175715840,
+            "browser_wall_ms": 1375.465041026473
+          },
+          "end_to_end_ttfr_ms": 963.4148329962045,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 100000,
+          "source_bytes": 800000,
+          "source_rss_bytes": 49840128,
+          "python_render_ms": 4.4401249615475535,
+          "output_bytes": 1406204,
+          "mode": "direct",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 58851328,
+          "wall_ms": 131.53354194946587,
+          "browser_probe": {
+            "ready_ms": 955.1000000238419,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16349,
+            "js_heap_bytes": 5341305,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1146765312,
+            "browser_wall_ms": 1326.1052500456572
+          },
+          "end_to_end_ttfr_ms": 959.5401249853894,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        }
+      ],
+      "mean_ms": 963.8495136663938,
+      "median_ms": 963.4148329962045,
+      "stdev_ms": 4.542354681106591,
+      "min_ms": 959.5401249853894,
+      "max_ms": 968.5935830175877,
+      "library": "xy",
+      "n": 100000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 100000,
+          "source_bytes": 800000,
+          "source_rss_bytes": 59359232,
+          "python_render_ms": 127.86283297464252,
+          "output_bytes": 6208625,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 128024576,
+          "wall_ms": 330.114166950807,
+          "browser_probe": {
+            "ready_ms": 1240.2999999523163,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 39964581,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1431142400,
+            "browser_wall_ms": 1546.5170830721036
+          },
+          "end_to_end_ttfr_ms": 1368.1628329269588,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 100000,
+          "source_bytes": 800000,
+          "source_rss_bytes": 59310080,
+          "python_render_ms": 127.0048749865964,
+          "output_bytes": 6208625,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 131514368,
+          "wall_ms": 267.78429199475795,
+          "browser_probe": {
+            "ready_ms": 1218.5,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 39449933,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1432518656,
+            "browser_wall_ms": 1506.842041038908
+          },
+          "end_to_end_ttfr_ms": 1345.5048749865964,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 100000,
+          "source_bytes": 800000,
+          "source_rss_bytes": 59260928,
+          "python_render_ms": 126.87849998474121,
+          "output_bytes": 6208625,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 132513792,
+          "wall_ms": 268.0399169912562,
+          "browser_probe": {
+            "ready_ms": 1209.9000000953674,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 39186577,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1428996096,
+            "browser_wall_ms": 1441.829124931246
+          },
+          "end_to_end_ttfr_ms": 1336.7785000801086,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        }
+      ],
+      "mean_ms": 1350.148735997888,
+      "median_ms": 1345.5048749865964,
+      "stdev_ms": 16.199326247705944,
+      "min_ms": 1336.7785000801086,
+      "max_ms": 1368.1628329269588,
+      "library": "plotly",
+      "n": 100000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "n": 100000,
+          "source_bytes": 800000,
+          "source_rss_bytes": 76808192,
+          "build_ms": 22.803458967246115,
+          "mode": "interactive-webagg",
+          "offset_count": 100000,
+          "ready_ms": 1125.6999999284744,
+          "nonblank_samples": 1071,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 3864255,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 98041856,
+          "browser_peak_rss_bytes": 1111785472,
+          "browser_wall_ms": 1380.4550420027226,
+          "end_to_end_ttfr_ms": 1148.5034588957205
+        },
+        {
+          "n": 100000,
+          "source_bytes": 800000,
+          "source_rss_bytes": 76611584,
+          "build_ms": 22.302875062450767,
+          "mode": "interactive-webagg",
+          "offset_count": 100000,
+          "ready_ms": 1025.8999999761581,
+          "nonblank_samples": 1071,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 3864319,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 96534528,
+          "browser_peak_rss_bytes": 1125318656,
+          "browser_wall_ms": 1237.2742090374231,
+          "end_to_end_ttfr_ms": 1048.202875038609
+        },
+        {
+          "n": 100000,
+          "source_bytes": 800000,
+          "source_rss_bytes": 76644352,
+          "build_ms": 22.336458903737366,
+          "mode": "interactive-webagg",
+          "offset_count": 100000,
+          "ready_ms": 1177.8000000715256,
+          "nonblank_samples": 1071,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 3864319,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 96649216,
+          "browser_peak_rss_bytes": 1171947520,
+          "browser_wall_ms": 1441.8471249518916,
+          "end_to_end_ttfr_ms": 1200.136458975263
+        }
+      ],
+      "mean_ms": 1132.2809309698641,
+      "median_ms": 1148.5034588957205,
+      "stdev_ms": 77.25497583449216,
+      "min_ms": 1048.202875038609,
+      "max_ms": 1200.136458975263,
+      "library": "matplotlib",
+      "n": 100000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 1000000,
+          "source_bytes": 8000000,
+          "source_rss_bytes": 57720832,
+          "python_render_ms": 4.837792017497122,
+          "output_bytes": 692682,
+          "mode": "density",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 57720832,
+          "wall_ms": 134.02820902410895,
+          "browser_probe": {
+            "ready_ms": 1078.2999999523163,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 6010280,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1182482432,
+            "browser_wall_ms": 1324.640833074227
+          },
+          "end_to_end_ttfr_ms": 1083.1377919698134,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 1000000,
+          "source_bytes": 8000000,
+          "source_rss_bytes": 57753600,
+          "python_render_ms": 5.054000066593289,
+          "output_bytes": 692682,
+          "mode": "density",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 50839552,
+          "wall_ms": 130.1507499301806,
+          "browser_probe": {
+            "ready_ms": 1068.2000000476837,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 5952164,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1149566976,
+            "browser_wall_ms": 1383.9554160367697
+          },
+          "end_to_end_ttfr_ms": 1073.254000114277,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 1000000,
+          "source_bytes": 8000000,
+          "source_rss_bytes": 57720832,
+          "python_render_ms": 4.786417004652321,
+          "output_bytes": 692682,
+          "mode": "density",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 57737216,
+          "wall_ms": 133.39458301197737,
+          "browser_probe": {
+            "ready_ms": 1089.5,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 5927164,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1146290176,
+            "browser_wall_ms": 1340.1952920248732
+          },
+          "end_to_end_ttfr_ms": 1094.2864170046523,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        }
+      ],
+      "mean_ms": 1083.5594030295808,
+      "median_ms": 1083.1377919698134,
+      "stdev_ms": 10.522545175808224,
+      "min_ms": 1073.254000114277,
+      "max_ms": 1094.2864170046523,
+      "library": "xy",
+      "n": 1000000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 1000000,
+          "source_bytes": 8000000,
+          "source_rss_bytes": 67469312,
+          "python_render_ms": 155.57699999772012,
+          "output_bytes": 18339740,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 342966272,
+          "wall_ms": 325.72866696864367,
+          "browser_probe": {
+            "ready_ms": 1770.2999999523163,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 253431939,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1716977664,
+            "browser_wall_ms": 2060.4360420256853
+          },
+          "end_to_end_ttfr_ms": 1925.8769999500364,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 1000000,
+          "source_bytes": 8000000,
+          "source_rss_bytes": 67485696,
+          "python_render_ms": 154.76762491744012,
+          "output_bytes": 18339740,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 342999040,
+          "wall_ms": 334.69875005539507,
+          "browser_probe": {
+            "ready_ms": 1772.6000000238419,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 253302643,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1715437568,
+            "browser_wall_ms": 2015.8297079615295
+          },
+          "end_to_end_ttfr_ms": 1927.367624941282,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 1000000,
+          "source_bytes": 8000000,
+          "source_rss_bytes": 67502080,
+          "python_render_ms": 157.00370899867266,
+          "output_bytes": 18339740,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 342966272,
+          "wall_ms": 331.3744160113856,
+          "browser_probe": {
+            "ready_ms": 1784.8999999761581,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 253278763,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1717026816,
+            "browser_wall_ms": 2075.9954580571502
+          },
+          "end_to_end_ttfr_ms": 1941.9037089748308,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        }
+      ],
+      "mean_ms": 1931.7161112887163,
+      "median_ms": 1927.367624941282,
+      "stdev_ms": 8.854143136222964,
+      "min_ms": 1925.8769999500364,
+      "max_ms": 1941.9037089748308,
+      "library": "plotly",
+      "n": 1000000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "n": 1000000,
+          "source_bytes": 8000000,
+          "source_rss_bytes": 84459520,
+          "build_ms": 34.786458942107856,
+          "mode": "interactive-webagg",
+          "offset_count": 1000000,
+          "ready_ms": 1197.3000000715256,
+          "nonblank_samples": 1114,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 13002260,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 167870464,
+          "browser_peak_rss_bytes": 1166573568,
+          "browser_wall_ms": 1430.2420410094783,
+          "end_to_end_ttfr_ms": 1232.0864590136334
+        },
+        {
+          "n": 1000000,
+          "source_bytes": 8000000,
+          "source_rss_bytes": 84426752,
+          "build_ms": 35.15179199166596,
+          "mode": "interactive-webagg",
+          "offset_count": 1000000,
+          "ready_ms": 1183.7000000476837,
+          "nonblank_samples": 1114,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 13002260,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 167706624,
+          "browser_peak_rss_bytes": 1132494848,
+          "browser_wall_ms": 1449.3936249054968,
+          "end_to_end_ttfr_ms": 1218.8517920393497
+        },
+        {
+          "n": 1000000,
+          "source_bytes": 8000000,
+          "source_rss_bytes": 84459520,
+          "build_ms": 35.32833291683346,
+          "mode": "interactive-webagg",
+          "offset_count": 1000000,
+          "ready_ms": 1212,
+          "nonblank_samples": 1114,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 13002844,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 167919616,
+          "browser_peak_rss_bytes": 1132625920,
+          "browser_wall_ms": 1429.9619159428403,
+          "end_to_end_ttfr_ms": 1247.3283329168335
+        }
+      ],
+      "mean_ms": 1232.7555279899389,
+      "median_ms": 1232.0864590136334,
+      "stdev_ms": 14.25005561596312,
+      "min_ms": 1218.8517920393497,
+      "max_ms": 1247.3283329168335,
+      "library": "matplotlib",
+      "n": 1000000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 10000000,
+          "source_bytes": 80000000,
+          "source_rss_bytes": 129630208,
+          "python_render_ms": 16.557374969124794,
+          "output_bytes": 690102,
+          "mode": "density",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 306479104,
+          "wall_ms": 200.79833292402327,
+          "browser_probe": {
+            "ready_ms": 1021.5,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 6067413,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1192280064,
+            "browser_wall_ms": 1311.4087090361863
+          },
+          "end_to_end_ttfr_ms": 1038.0573749691248,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 10000000,
+          "source_bytes": 80000000,
+          "source_rss_bytes": 129744896,
+          "python_render_ms": 16.85870799701661,
+          "output_bytes": 690102,
+          "mode": "density",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 306642944,
+          "wall_ms": 201.1575410142541,
+          "browser_probe": {
+            "ready_ms": 1023.9000000953674,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 5911677,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1174716416,
+            "browser_wall_ms": 1322.9892919771373
+          },
+          "end_to_end_ttfr_ms": 1040.758708092384,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 10000000,
+          "source_bytes": 80000000,
+          "source_rss_bytes": 129712128,
+          "python_render_ms": 17.022292013280094,
+          "output_bytes": 690102,
+          "mode": "density",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 305512448,
+          "wall_ms": 193.52916709613055,
+          "browser_probe": {
+            "ready_ms": 1009.7999999523163,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 5930017,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1176354816,
+            "browser_wall_ms": 1395.9190000314265
+          },
+          "end_to_end_ttfr_ms": 1026.8222919655964,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        }
+      ],
+      "mean_ms": 1035.2127916757017,
+      "median_ms": 1038.0573749691248,
+      "stdev_ms": 7.390850032280657,
+      "min_ms": 1026.8222919655964,
+      "max_ms": 1040.758708092384,
+      "library": "xy",
+      "n": 10000000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 10000000,
+          "source_bytes": 80000000,
+          "source_rss_bytes": 139280384,
+          "python_render_ms": 436.2220000475645,
+          "output_bytes": 139649110,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 1952890880,
+          "wall_ms": 661.399667034857,
+          "browser_probe": {
+            "ready_ms": 7637.100000023842,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 2513470235,
+            "status": "ok",
+            "browser_peak_rss_bytes": 4315561984,
+            "browser_wall_ms": 7884.096499998122
+          },
+          "end_to_end_ttfr_ms": 8073.322000071406,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 10000000,
+          "source_bytes": 80000000,
+          "source_rss_bytes": 139542528,
+          "python_render_ms": 443.33966600243,
+          "output_bytes": 139649110,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 1953103872,
+          "wall_ms": 657.8744170255959,
+          "browser_probe": {
+            "ready_ms": 7669.699999928474,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 2523976827,
+            "status": "ok",
+            "browser_peak_rss_bytes": 4330160128,
+            "browser_wall_ms": 7975.973916938528
+          },
+          "end_to_end_ttfr_ms": 8113.039665930904,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 10000000,
+          "source_bytes": 80000000,
+          "source_rss_bytes": 139296768,
+          "python_render_ms": 447.8023339761421,
+          "output_bytes": 139649110,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 1952956416,
+          "wall_ms": 670.2299999305978,
+          "browser_probe": {
+            "ready_ms": 7632.200000047684,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 2513647911,
+            "status": "ok",
+            "browser_peak_rss_bytes": 4314185728,
+            "browser_wall_ms": 7883.396917022765
+          },
+          "end_to_end_ttfr_ms": 8080.002334023826,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        }
+      ],
+      "mean_ms": 8088.7880000087125,
+      "median_ms": 8080.002334023826,
+      "stdev_ms": 21.26650395411002,
+      "min_ms": 8073.322000071406,
+      "max_ms": 8113.039665930904,
+      "library": "plotly",
+      "n": 10000000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "n": 10000000,
+          "source_bytes": 80000000,
+          "source_rss_bytes": 156565504,
+          "build_ms": 159.41641596145928,
+          "mode": "interactive-webagg",
+          "offset_count": 10000000,
+          "ready_ms": 3447.7999999523163,
+          "nonblank_samples": 1096,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 9823867,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 903102464,
+          "browser_peak_rss_bytes": 1459355648,
+          "browser_wall_ms": 3720.6797500839457,
+          "end_to_end_ttfr_ms": 3607.2164159137756
+        },
+        {
+          "n": 10000000,
+          "source_bytes": 80000000,
+          "source_rss_bytes": 156286976,
+          "build_ms": 155.84124997258186,
+          "mode": "interactive-webagg",
+          "offset_count": 10000000,
+          "ready_ms": 3470.7000000476837,
+          "nonblank_samples": 1096,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 9823867,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 903036928,
+          "browser_peak_rss_bytes": 1454424064,
+          "browser_wall_ms": 3686.843458097428,
+          "end_to_end_ttfr_ms": 3626.5412500202656
+        },
+        {
+          "n": 10000000,
+          "source_bytes": 80000000,
+          "source_rss_bytes": 156549120,
+          "build_ms": 155.8598750270903,
+          "mode": "interactive-webagg",
+          "offset_count": 10000000,
+          "ready_ms": 3446.7000000476837,
+          "nonblank_samples": 1096,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 12868179,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 903102464,
+          "browser_peak_rss_bytes": 1534492672,
+          "browser_wall_ms": 3717.438542051241,
+          "end_to_end_ttfr_ms": 3602.559875074774
+        }
+      ],
+      "mean_ms": 3612.1058470029384,
+      "median_ms": 3607.2164159137756,
+      "stdev_ms": 12.716386607476846,
+      "min_ms": 3602.559875074774,
+      "max_ms": 3626.5412500202656,
+      "library": "matplotlib",
+      "n": 10000000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 1000000000,
+          "source_bytes": 8000000000,
+          "source_rss_bytes": 8049606656,
+          "python_render_ms": 1091.401332989335,
+          "output_bytes": 690091,
+          "mode": "density",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 24069488640,
+          "wall_ms": 6298.97104203701,
+          "browser_probe": {
+            "ready_ms": 1025.2000000476837,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 6038716,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1174863872,
+            "browser_wall_ms": 1373.0688749346882
+          },
+          "end_to_end_ttfr_ms": 2116.601333037019,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 1000000000,
+          "source_bytes": 8000000000,
+          "source_rss_bytes": 8049754112,
+          "python_render_ms": 1104.2680419050157,
+          "output_bytes": 690091,
+          "mode": "density",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 24069439488,
+          "wall_ms": 6424.472708022222,
+          "browser_probe": {
+            "ready_ms": 1135.2999999523163,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 6031048,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1162199040,
+            "browser_wall_ms": 1406.2282919185236
+          },
+          "end_to_end_ttfr_ms": 2239.568041857332,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 1000000000,
+          "source_bytes": 8000000000,
+          "source_rss_bytes": 8049623040,
+          "python_render_ms": 1085.5401660082862,
+          "output_bytes": 690091,
+          "mode": "density",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 24069586944,
+          "wall_ms": 6798.109499970451,
+          "browser_probe": {
+            "ready_ms": 1088.2000000476837,
+            "renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 6168804,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1201471488,
+            "browser_wall_ms": 1351.1300419922918
+          },
+          "end_to_end_ttfr_ms": 2173.74016605597,
+          "browser_renderer": "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM 10.0.0) (0x0000C0DE)), SwiftShader driver)"
+        }
+      ],
+      "mean_ms": 2176.6365136501067,
+      "median_ms": 2173.74016605597,
+      "stdev_ms": 61.53449838557613,
+      "min_ms": 2116.601333037019,
+      "max_ms": 2239.568041857332,
+      "library": "xy",
+      "n": 1000000000
+    },
+    {
+      "attempted_runs": 1,
+      "successful_runs": 0,
+      "statuses": [
+        "memory_limit"
+      ],
+      "samples": [
+        {
+          "status": "memory_limit",
+          "library": "plotly",
+          "n": 1000000000,
+          "wall_ms": 7308.831875096075,
+          "python_peak_rss_bytes": 39544111104,
+          "stderr_tail": ""
+        }
+      ],
+      "library": "plotly",
+      "n": 1000000000
+    },
+    {
+      "attempted_runs": 1,
+      "successful_runs": 0,
+      "statuses": [
+        "memory_limit"
+      ],
+      "samples": [
+        {
+          "status": "memory_limit",
+          "n": 1000000000,
+          "python_peak_rss_bytes": 39186071552,
+          "phase": "figure-build"
+        }
+      ],
+      "library": "matplotlib",
+      "n": 1000000000
+    }
+  ]
+}

--- a/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/default-results.json
+++ b/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/default-results.json
@@ -1,0 +1,2021 @@
+{
+  "generated_at_utc": "2026-07-27T02:31:53.582057Z",
+  "repetitions_requested": 3,
+  "aggregation": "arithmetic mean of successful fresh-process runs",
+  "sizes": [
+    10000,
+    100000,
+    1000000,
+    10000000,
+    1000000000
+  ],
+  "software_browser": false,
+  "static": [
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 10000,
+          "mode": "direct",
+          "source_bytes": 80000,
+          "source_rss_bytes": 44613632,
+          "render_ms": 3.570833010599017,
+          "png_bytes": 218839,
+          "nonblank_pixels": 77705,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 54886400,
+          "wall_ms": 125.32737501896918
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 10000,
+          "mode": "direct",
+          "source_bytes": 80000,
+          "source_rss_bytes": 44597248,
+          "render_ms": 3.5467910347506404,
+          "png_bytes": 218839,
+          "nonblank_pixels": 77705,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 53575680,
+          "wall_ms": 126.26383302267641
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 10000,
+          "mode": "direct",
+          "source_bytes": 80000,
+          "source_rss_bytes": 44662784,
+          "render_ms": 3.597834031097591,
+          "png_bytes": 218839,
+          "nonblank_pixels": 77705,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 51707904,
+          "wall_ms": 127.97962501645088
+        }
+      ],
+      "mean_ms": 3.5718193588157496,
+      "median_ms": 3.570833010599017,
+      "stdev_ms": 0.025535789220664195,
+      "min_ms": 3.5467910347506404,
+      "max_ms": 3.597834031097591,
+      "library": "xy",
+      "n": 10000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 10000,
+          "mode": "scattergl",
+          "source_bytes": 80000,
+          "source_rss_bytes": 56721408,
+          "render_ms": 2016.4285000646487,
+          "png_bytes": 69429,
+          "nonblank_pixels": 207017,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 1540505600,
+          "wall_ms": 2242.448417004198
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 10000,
+          "mode": "scattergl",
+          "source_bytes": 80000,
+          "source_rss_bytes": 56672256,
+          "render_ms": 2025.2173750195652,
+          "png_bytes": 69429,
+          "nonblank_pixels": 207017,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 1511882752,
+          "wall_ms": 2239.72562502604
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 10000,
+          "mode": "scattergl",
+          "source_bytes": 80000,
+          "source_rss_bytes": 56770560,
+          "render_ms": 2027.7224590536207,
+          "png_bytes": 69429,
+          "nonblank_pixels": 207017,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 1539424256,
+          "wall_ms": 2260.8470839913934
+        }
+      ],
+      "mean_ms": 2023.1227780459449,
+      "median_ms": 2025.2173750195652,
+      "stdev_ms": 5.931178615803951,
+      "min_ms": 2016.4285000646487,
+      "max_ms": 2027.7224590536207,
+      "library": "plotly",
+      "n": 10000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "matplotlib",
+          "n": 10000,
+          "mode": "static-agg",
+          "source_bytes": 80000,
+          "source_rss_bytes": 74317824,
+          "render_ms": 22.36287505365908,
+          "png_bytes": 29381,
+          "nonblank_pixels": 79681,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 84983808,
+          "wall_ms": 255.96983404830098
+        },
+        {
+          "status": "ok",
+          "library": "matplotlib",
+          "n": 10000,
+          "mode": "static-agg",
+          "source_bytes": 80000,
+          "source_rss_bytes": 74334208,
+          "render_ms": 22.465708083473146,
+          "png_bytes": 29381,
+          "nonblank_pixels": 79681,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 84983808,
+          "wall_ms": 252.03783402685076
+        },
+        {
+          "status": "ok",
+          "library": "matplotlib",
+          "n": 10000,
+          "mode": "static-agg",
+          "source_bytes": 80000,
+          "source_rss_bytes": 74268672,
+          "render_ms": 22.30570896063,
+          "png_bytes": 29381,
+          "nonblank_pixels": 79681,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 84918272,
+          "wall_ms": 255.3527499549091
+        }
+      ],
+      "mean_ms": 22.37809736592074,
+      "median_ms": 22.36287505365908,
+      "stdev_ms": 0.08107847384224552,
+      "min_ms": 22.30570896063,
+      "max_ms": 22.465708083473146,
+      "library": "matplotlib",
+      "n": 10000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 100000,
+          "mode": "direct",
+          "source_bytes": 800000,
+          "source_rss_bytes": 44924928,
+          "render_ms": 6.144708022475243,
+          "png_bytes": 190460,
+          "nonblank_pixels": 111251,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 52527104,
+          "wall_ms": 124.47437504306436
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 100000,
+          "mode": "direct",
+          "source_bytes": 800000,
+          "source_rss_bytes": 44974080,
+          "render_ms": 5.654958076775074,
+          "png_bytes": 190460,
+          "nonblank_pixels": 111251,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 55164928,
+          "wall_ms": 128.15916701219976
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 100000,
+          "mode": "direct",
+          "source_bytes": 800000,
+          "source_rss_bytes": 45023232,
+          "render_ms": 6.08650001231581,
+          "png_bytes": 190460,
+          "nonblank_pixels": 111251,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 54525952,
+          "wall_ms": 127.31795804575086
+        }
+      ],
+      "mean_ms": 5.962055370522042,
+      "median_ms": 6.08650001231581,
+      "stdev_ms": 0.2675417798806644,
+      "min_ms": 5.654958076775074,
+      "max_ms": 6.144708022475243,
+      "library": "xy",
+      "n": 100000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 100000,
+          "mode": "scattergl",
+          "source_bytes": 800000,
+          "source_rss_bytes": 56737792,
+          "render_ms": 2109.6693750005215,
+          "png_bytes": 64131,
+          "nonblank_pixels": 207673,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 1531396096,
+          "wall_ms": 2322.6912079844624
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 100000,
+          "mode": "scattergl",
+          "source_bytes": 800000,
+          "source_rss_bytes": 56705024,
+          "render_ms": 2109.8288340726867,
+          "png_bytes": 64131,
+          "nonblank_pixels": 207673,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 1534836736,
+          "wall_ms": 2318.4815000277013
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 100000,
+          "mode": "scattergl",
+          "source_bytes": 800000,
+          "source_rss_bytes": 56803328,
+          "render_ms": 2110.618457896635,
+          "png_bytes": 64131,
+          "nonblank_pixels": 207673,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 1566457856,
+          "wall_ms": 2326.44137495663
+        }
+      ],
+      "mean_ms": 2110.0388889899477,
+      "median_ms": 2109.8288340726867,
+      "stdev_ms": 0.5082144105816887,
+      "min_ms": 2109.6693750005215,
+      "max_ms": 2110.618457896635,
+      "library": "plotly",
+      "n": 100000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "matplotlib",
+          "n": 100000,
+          "mode": "static-agg",
+          "source_bytes": 800000,
+          "source_rss_bytes": 74547200,
+          "render_ms": 45.329582993872464,
+          "png_bytes": 27421,
+          "nonblank_pixels": 99990,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 85426176,
+          "wall_ms": 255.02570800017565
+        },
+        {
+          "status": "ok",
+          "library": "matplotlib",
+          "n": 100000,
+          "mode": "static-agg",
+          "source_bytes": 800000,
+          "source_rss_bytes": 74563584,
+          "render_ms": 45.34595797304064,
+          "png_bytes": 27421,
+          "nonblank_pixels": 99990,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 85557248,
+          "wall_ms": 251.37887499295175
+        },
+        {
+          "status": "ok",
+          "library": "matplotlib",
+          "n": 100000,
+          "mode": "static-agg",
+          "source_bytes": 800000,
+          "source_rss_bytes": 74579968,
+          "render_ms": 46.0294159129262,
+          "png_bytes": 27421,
+          "nonblank_pixels": 99990,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 84901888,
+          "wall_ms": 251.7653750255704
+        }
+      ],
+      "mean_ms": 45.56831895994643,
+      "median_ms": 45.34595797304064,
+      "stdev_ms": 0.39940560214036325,
+      "min_ms": 45.329582993872464,
+      "max_ms": 46.0294159129262,
+      "library": "matplotlib",
+      "n": 100000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 1000000,
+          "mode": "density",
+          "source_bytes": 8000000,
+          "source_rss_bytes": 52609024,
+          "render_ms": 5.757666076533496,
+          "png_bytes": 174467,
+          "nonblank_pixels": 91381,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 76808192,
+          "wall_ms": 127.53049994353205
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 1000000,
+          "mode": "density",
+          "source_bytes": 8000000,
+          "source_rss_bytes": 52707328,
+          "render_ms": 5.862958030775189,
+          "png_bytes": 174467,
+          "nonblank_pixels": 91381,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 76955648,
+          "wall_ms": 127.89508292917162
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 1000000,
+          "mode": "density",
+          "source_bytes": 8000000,
+          "source_rss_bytes": 52707328,
+          "render_ms": 5.757958977483213,
+          "png_bytes": 174467,
+          "nonblank_pixels": 91381,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 76775424,
+          "wall_ms": 128.23891604784876
+        }
+      ],
+      "mean_ms": 5.7928610282639665,
+      "median_ms": 5.757958977483213,
+      "stdev_ms": 0.06070596155679774,
+      "min_ms": 5.757666076533496,
+      "max_ms": 5.862958030775189,
+      "library": "xy",
+      "n": 1000000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 1000000,
+          "mode": "scattergl",
+          "source_bytes": 8000000,
+          "source_rss_bytes": 64765952,
+          "render_ms": 2793.7417500652373,
+          "png_bytes": 50232,
+          "nonblank_pixels": 207166,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 1991868416,
+          "wall_ms": 3026.11174993217
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 1000000,
+          "mode": "scattergl",
+          "source_bytes": 8000000,
+          "source_rss_bytes": 64946176,
+          "render_ms": 2857.1659999433905,
+          "png_bytes": 50232,
+          "nonblank_pixels": 207166,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 1939341312,
+          "wall_ms": 3070.256083039567
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 1000000,
+          "mode": "scattergl",
+          "source_bytes": 8000000,
+          "source_rss_bytes": 64733184,
+          "render_ms": 2775.0252089463174,
+          "png_bytes": 50232,
+          "nonblank_pixels": 207166,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 1973092352,
+          "wall_ms": 2967.899417039007
+        }
+      ],
+      "mean_ms": 2808.6443196516484,
+      "median_ms": 2793.7417500652373,
+      "stdev_ms": 43.05046250174995,
+      "min_ms": 2775.0252089463174,
+      "max_ms": 2857.1659999433905,
+      "library": "plotly",
+      "n": 1000000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "matplotlib",
+          "n": 1000000,
+          "mode": "static-agg",
+          "source_bytes": 8000000,
+          "source_rss_bytes": 82280448,
+          "render_ms": 285.45729198958725,
+          "png_bytes": 23447,
+          "nonblank_pixels": 104373,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 159531008,
+          "wall_ms": 505.90433401521295
+        },
+        {
+          "status": "ok",
+          "library": "matplotlib",
+          "n": 1000000,
+          "mode": "static-agg",
+          "source_bytes": 8000000,
+          "source_rss_bytes": 82231296,
+          "render_ms": 286.5363750606775,
+          "png_bytes": 23447,
+          "nonblank_pixels": 104373,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 159531008,
+          "wall_ms": 506.2768750358373
+        },
+        {
+          "status": "ok",
+          "library": "matplotlib",
+          "n": 1000000,
+          "mode": "static-agg",
+          "source_bytes": 8000000,
+          "source_rss_bytes": 82231296,
+          "render_ms": 285.4614579118788,
+          "png_bytes": 23447,
+          "nonblank_pixels": 104373,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 159547392,
+          "wall_ms": 503.01079102791846
+        }
+      ],
+      "mean_ms": 285.8183749873812,
+      "median_ms": 285.4614579118788,
+      "stdev_ms": 0.6218097921931469,
+      "min_ms": 285.45729198958725,
+      "max_ms": 286.5363750606775,
+      "library": "matplotlib",
+      "n": 1000000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 10000000,
+          "mode": "density",
+          "source_bytes": 80000000,
+          "source_rss_bytes": 124649472,
+          "render_ms": 18.434457946568727,
+          "png_bytes": 111986,
+          "nonblank_pixels": 73043,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 307019776,
+          "wall_ms": 191.30549998953938
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 10000000,
+          "mode": "density",
+          "source_bytes": 80000000,
+          "source_rss_bytes": 124698624,
+          "render_ms": 18.464166088961065,
+          "png_bytes": 111986,
+          "nonblank_pixels": 73043,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 307625984,
+          "wall_ms": 191.64008309599012
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 10000000,
+          "mode": "density",
+          "source_bytes": 80000000,
+          "source_rss_bytes": 124567552,
+          "render_ms": 18.429749994538724,
+          "png_bytes": 111986,
+          "nonblank_pixels": 73043,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 307740672,
+          "wall_ms": 191.93783402442932
+        }
+      ],
+      "mean_ms": 18.442791343356173,
+      "median_ms": 18.434457946568727,
+      "stdev_ms": 0.01866014510486476,
+      "min_ms": 18.429749994538724,
+      "max_ms": 18.464166088961065,
+      "library": "xy",
+      "n": 10000000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 10000000,
+          "mode": "scattergl",
+          "source_bytes": 80000000,
+          "source_rss_bytes": 136839168,
+          "render_ms": 9635.618250002153,
+          "png_bytes": 44250,
+          "nonblank_pixels": 207132,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 5167366144,
+          "wall_ms": 9889.443124993704
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 10000000,
+          "mode": "scattergl",
+          "source_bytes": 80000000,
+          "source_rss_bytes": 136773632,
+          "render_ms": 9675.327916978858,
+          "png_bytes": 44250,
+          "nonblank_pixels": 207132,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 5865553920,
+          "wall_ms": 9912.571708089672
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 10000000,
+          "mode": "scattergl",
+          "source_bytes": 80000000,
+          "source_rss_bytes": 136822784,
+          "render_ms": 9619.011500035413,
+          "png_bytes": 44250,
+          "nonblank_pixels": 207132,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 6031523840,
+          "wall_ms": 9888.900790945627
+        }
+      ],
+      "mean_ms": 9643.319222338809,
+      "median_ms": 9635.618250002153,
+      "stdev_ms": 28.937232686185627,
+      "min_ms": 9619.011500035413,
+      "max_ms": 9675.327916978858,
+      "library": "plotly",
+      "n": 10000000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "matplotlib",
+          "n": 10000000,
+          "mode": "static-agg",
+          "source_bytes": 80000000,
+          "source_rss_bytes": 154337280,
+          "render_ms": 2746.2725420482457,
+          "png_bytes": 19889,
+          "nonblank_pixels": 101884,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 895090688,
+          "wall_ms": 3036.4136249991134
+        },
+        {
+          "status": "ok",
+          "library": "matplotlib",
+          "n": 10000000,
+          "mode": "static-agg",
+          "source_bytes": 80000000,
+          "source_rss_bytes": 154370048,
+          "render_ms": 2747.428791015409,
+          "png_bytes": 19889,
+          "nonblank_pixels": 101884,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 895090688,
+          "wall_ms": 3037.5287079950795
+        },
+        {
+          "status": "ok",
+          "library": "matplotlib",
+          "n": 10000000,
+          "mode": "static-agg",
+          "source_bytes": 80000000,
+          "source_rss_bytes": 154353664,
+          "render_ms": 2736.023291014135,
+          "png_bytes": 19889,
+          "nonblank_pixels": 101884,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 887668736,
+          "wall_ms": 3034.7135830670595
+        }
+      ],
+      "mean_ms": 2743.241541359263,
+      "median_ms": 2746.2725420482457,
+      "stdev_ms": 6.277864402185261,
+      "min_ms": 2736.023291014135,
+      "max_ms": 2747.428791015409,
+      "library": "matplotlib",
+      "n": 10000000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 1000000000,
+          "mode": "density",
+          "source_bytes": 8000000000,
+          "source_rss_bytes": 8044675072,
+          "render_ms": 1236.2582919886336,
+          "png_bytes": 90148,
+          "nonblank_pixels": 61762,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 24066162688,
+          "wall_ms": 6458.238041959703
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 1000000000,
+          "mode": "density",
+          "source_bytes": 8000000000,
+          "source_rss_bytes": 8044658688,
+          "render_ms": 1079.0227090474218,
+          "png_bytes": 90148,
+          "nonblank_pixels": 61762,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 24065900544,
+          "wall_ms": 6402.758041978814
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 1000000000,
+          "mode": "density",
+          "source_bytes": 8000000000,
+          "source_rss_bytes": 8044724224,
+          "render_ms": 1071.0358748910949,
+          "png_bytes": 90148,
+          "nonblank_pixels": 61762,
+          "width": 900,
+          "height": 420,
+          "peak_rss_bytes": 24065933312,
+          "wall_ms": 6391.729374998249
+        }
+      ],
+      "mean_ms": 1128.7722919757168,
+      "median_ms": 1079.0227090474218,
+      "stdev_ms": 93.17122693751936,
+      "min_ms": 1071.0358748910949,
+      "max_ms": 1236.2582919886336,
+      "library": "xy",
+      "n": 1000000000
+    },
+    {
+      "attempted_runs": 1,
+      "successful_runs": 0,
+      "statuses": [
+        "failed(exit=1)"
+      ],
+      "samples": [
+        {
+          "status": "failed(exit=1)",
+          "library": "plotly",
+          "n": 1000000000,
+          "peak_rss_bytes": 28016345088,
+          "wall_ms": 122100.63737502787,
+          "stdout_tail": "",
+          "stderr_tail": "lib/python3.14/asyncio/runners.py\", line 127, in run\n    return self._loop.run_until_complete(task)\n           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^\n  File \"/Users/alek/.local/share/uv/python/cpython-3.14.5-macos-aarch64-none/lib/python3.14/asyncio/base_events.py\", line 719, in run_until_complete\n    return future.result()\n           ~~~~~~~~~~~~~^^\n  File \"/Users/alek/Desktop/xy-bench/benchmarks/launch_baselines/xy-0.1.0/macos-arm64-m5-pro/.venv/lib/python3.14/site-packages/kaleido/__init__.py\", line 104, in calc_fig\n    return await k.calc_fig(\n           ^^^^^^^^^^^^^^^^^\n    ...<3 lines>...\n    )\n    ^\n  File \"/Users/alek/Desktop/xy-bench/benchmarks/launch_baselines/xy-0.1.0/macos-arm64-m5-pro/.venv/lib/python3.14/site-packages/kaleido/kaleido.py\", line 618, in calc_fig\n    return await self.write_fig_from_object(  # type: ignore[reportCallIssue]\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    ...<4 lines>...\n    )\n    ^\n  File \"/Users/alek/Desktop/xy-bench/benchmarks/launch_baselines/xy-0.1.0/macos-arm64-m5-pro/.venv/lib/python3.14/site-packages/kaleido/kaleido.py\", line 493, in write_fig_from_object\n    res = await asyncio.gather(*tasks, return_exceptions=not cancel_on_error)\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/alek/Desktop/xy-bench/benchmarks/launch_baselines/xy-0.1.0/macos-arm64-m5-pro/.venv/lib/python3.14/site-packages/kaleido/kaleido.py\", line 358, in _render_task\n    img_bytes = await asyncio.wait_for(\n                ^^^^^^^^^^^^^^^^^^^^^^^\n    ...<7 lines>...\n    )\n    ^\n  File \"/Users/alek/.local/share/uv/python/cpython-3.14.5-macos-aarch64-none/lib/python3.14/asyncio/tasks.py\", line 487, in wait_for\n    async with timeouts.timeout(timeout):\n               ~~~~~~~~~~~~~~~~^^^^^^^^^\n  File \"/Users/alek/.local/share/uv/python/cpython-3.14.5-macos-aarch64-none/lib/python3.14/asyncio/timeouts.py\", line 114, in __aexit__\n    raise TimeoutError from exc_val\nTimeoutError\n"
+        }
+      ],
+      "library": "plotly",
+      "n": 1000000000
+    },
+    {
+      "attempted_runs": 1,
+      "successful_runs": 0,
+      "statuses": [
+        "memory_limit"
+      ],
+      "samples": [
+        {
+          "status": "memory_limit",
+          "library": "matplotlib",
+          "n": 1000000000,
+          "peak_rss_bytes": 38668255232,
+          "wall_ms": 7794.159165932797,
+          "stderr_tail": ""
+        }
+      ],
+      "library": "matplotlib",
+      "n": 1000000000
+    }
+  ],
+  "interactive": [
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 10000,
+          "source_bytes": 80000,
+          "source_rss_bytes": 49627136,
+          "python_render_ms": 2.9283330077305436,
+          "output_bytes": 446199,
+          "mode": "direct",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 46448640,
+          "wall_ms": 124.02216694317758,
+          "browser_probe": {
+            "ready_ms": 166.20000004768372,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 14080,
+            "js_heap_bytes": 2703113,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1049051136,
+            "browser_wall_ms": 683.2498330622911
+          },
+          "end_to_end_ttfr_ms": 169.12833305541426,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 10000,
+          "source_bytes": 80000,
+          "source_rss_bytes": 49643520,
+          "python_render_ms": 1.8704580143094063,
+          "output_bytes": 446199,
+          "mode": "direct",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 49233920,
+          "wall_ms": 119.71979204099625,
+          "browser_probe": {
+            "ready_ms": 160.29999995231628,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 14080,
+            "js_heap_bytes": 2693013,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1048461312,
+            "browser_wall_ms": 406.9967499235645
+          },
+          "end_to_end_ttfr_ms": 162.1704579666257,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 10000,
+          "source_bytes": 80000,
+          "source_rss_bytes": 49643520,
+          "python_render_ms": 1.9021659391000867,
+          "output_bytes": 446199,
+          "mode": "direct",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 52002816,
+          "wall_ms": 123.93812509253621,
+          "browser_probe": {
+            "ready_ms": 159.60000002384186,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 14080,
+            "js_heap_bytes": 2698385,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1048231936,
+            "browser_wall_ms": 455.24099993053824
+          },
+          "end_to_end_ttfr_ms": 161.50216596294194,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        }
+      ],
+      "mean_ms": 164.26698566166064,
+      "median_ms": 162.1704579666257,
+      "stdev_ms": 4.223289880248963,
+      "min_ms": 161.50216596294194,
+      "max_ms": 169.12833305541426,
+      "library": "xy",
+      "n": 10000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 10000,
+          "source_bytes": 80000,
+          "source_rss_bytes": 59408384,
+          "python_render_ms": 184.23074996098876,
+          "output_bytes": 4995805,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 183828480,
+          "wall_ms": 372.1375829773024,
+          "browser_probe": {
+            "ready_ms": 381.6999999284744,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 15707,
+            "js_heap_bytes": 24792981,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1144586240,
+            "browser_wall_ms": 623.1179999886081
+          },
+          "end_to_end_ttfr_ms": 565.9307498894632,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 10000,
+          "source_bytes": 80000,
+          "source_rss_bytes": 59293696,
+          "python_render_ms": 123.53370792698115,
+          "output_bytes": 4995805,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 183812096,
+          "wall_ms": 309.66949998401105,
+          "browser_probe": {
+            "ready_ms": 394.60000002384186,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 15707,
+            "js_heap_bytes": 24486533,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1145143296,
+            "browser_wall_ms": 697.8430410381407
+          },
+          "end_to_end_ttfr_ms": 518.133707950823,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 10000,
+          "source_bytes": 80000,
+          "source_rss_bytes": 59211776,
+          "python_render_ms": 128.55187500827014,
+          "output_bytes": 4995805,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 183664640,
+          "wall_ms": 303.4502500668168,
+          "browser_probe": {
+            "ready_ms": 379.60000002384186,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 15707,
+            "js_heap_bytes": 24823589,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1147322368,
+            "browser_wall_ms": 623.8847499480471
+          },
+          "end_to_end_ttfr_ms": 508.151875032112,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        }
+      ],
+      "mean_ms": 530.7387776241327,
+      "median_ms": 518.133707950823,
+      "stdev_ms": 30.883092964389213,
+      "min_ms": 508.151875032112,
+      "max_ms": 565.9307498894632,
+      "library": "plotly",
+      "n": 10000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "n": 10000,
+          "source_bytes": 80000,
+          "source_rss_bytes": 76234752,
+          "build_ms": 31.57679201103747,
+          "mode": "interactive-webagg",
+          "offset_count": 10000,
+          "ready_ms": 192.80000007152557,
+          "nonblank_samples": 836,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 2333905,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 92913664,
+          "browser_peak_rss_bytes": 1040842752,
+          "browser_wall_ms": 466.3972909329459,
+          "end_to_end_ttfr_ms": 224.37679208256304
+        },
+        {
+          "n": 10000,
+          "source_bytes": 80000,
+          "source_rss_bytes": 76398592,
+          "build_ms": 20.94191696960479,
+          "mode": "interactive-webagg",
+          "offset_count": 10000,
+          "ready_ms": 186.10000002384186,
+          "nonblank_samples": 836,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 2333905,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 96092160,
+          "browser_peak_rss_bytes": 1039466496,
+          "browser_wall_ms": 397.3079159623012,
+          "end_to_end_ttfr_ms": 207.04191699344665
+        },
+        {
+          "n": 10000,
+          "source_bytes": 80000,
+          "source_rss_bytes": 76365824,
+          "build_ms": 21.247791941277683,
+          "mode": "interactive-webagg",
+          "offset_count": 10000,
+          "ready_ms": 192.80000007152557,
+          "nonblank_samples": 836,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 2333905,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 96649216,
+          "browser_peak_rss_bytes": 1040515072,
+          "browser_wall_ms": 451.55479200184345,
+          "end_to_end_ttfr_ms": 214.04779201280326
+        }
+      ],
+      "mean_ms": 215.15550036293766,
+      "median_ms": 214.04779201280326,
+      "stdev_ms": 8.720363348538587,
+      "min_ms": 207.04191699344665,
+      "max_ms": 224.37679208256304,
+      "library": "matplotlib",
+      "n": 10000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 100000,
+          "source_bytes": 800000,
+          "source_rss_bytes": 49938432,
+          "python_render_ms": 4.6652499586343765,
+          "output_bytes": 1406204,
+          "mode": "direct",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 48676864,
+          "wall_ms": 123.86616691946983,
+          "browser_probe": {
+            "ready_ms": 166.10000002384186,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16350,
+            "js_heap_bytes": 5333647,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1004830720,
+            "browser_wall_ms": 388.1134999683127
+          },
+          "end_to_end_ttfr_ms": 170.76524998247623,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 100000,
+          "source_bytes": 800000,
+          "source_rss_bytes": 49954816,
+          "python_render_ms": 4.375542048364878,
+          "output_bytes": 1406204,
+          "mode": "direct",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 54149120,
+          "wall_ms": 124.18162496760488,
+          "browser_probe": {
+            "ready_ms": 158.40000009536743,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16350,
+            "js_heap_bytes": 5333523,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1052917760,
+            "browser_wall_ms": 449.03916597831994
+          },
+          "end_to_end_ttfr_ms": 162.7755421437323,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 100000,
+          "source_bytes": 800000,
+          "source_rss_bytes": 49807360,
+          "python_render_ms": 4.256291897036135,
+          "output_bytes": 1406204,
+          "mode": "direct",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 54018048,
+          "wall_ms": 124.02995803859085,
+          "browser_probe": {
+            "ready_ms": 166.10000002384186,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16350,
+            "js_heap_bytes": 5333523,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1054851072,
+            "browser_wall_ms": 454.63991700671613
+          },
+          "end_to_end_ttfr_ms": 170.356291920878,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        }
+      ],
+      "mean_ms": 167.96569468236217,
+      "median_ms": 170.356291920878,
+      "stdev_ms": 4.499452656126199,
+      "min_ms": 162.7755421437323,
+      "max_ms": 170.76524998247623,
+      "library": "xy",
+      "n": 100000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 100000,
+          "source_bytes": 800000,
+          "source_rss_bytes": 59195392,
+          "python_render_ms": 129.2391250608489,
+          "output_bytes": 6208625,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 196935680,
+          "wall_ms": 309.364499989897,
+          "browser_probe": {
+            "ready_ms": 408.10000002384186,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 48636199,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1186775040,
+            "browser_wall_ms": 646.0361659992486
+          },
+          "end_to_end_ttfr_ms": 537.3391250846907,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 100000,
+          "source_bytes": 800000,
+          "source_rss_bytes": 59310080,
+          "python_render_ms": 128.0293749878183,
+          "output_bytes": 6208625,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 197066752,
+          "wall_ms": 304.7909589949995,
+          "browser_probe": {
+            "ready_ms": 410.10000002384186,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 31667375,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1185611776,
+            "browser_wall_ms": 705.6096660671756
+          },
+          "end_to_end_ttfr_ms": 538.1293750116602,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 100000,
+          "source_bytes": 800000,
+          "source_rss_bytes": 59211776,
+          "python_render_ms": 129.40212502144277,
+          "output_bytes": 6208625,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 197001216,
+          "wall_ms": 309.64566697366536,
+          "browser_probe": {
+            "ready_ms": 412.10000002384186,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 41157263,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1189953536,
+            "browser_wall_ms": 654.1090829996392
+          },
+          "end_to_end_ttfr_ms": 541.5021250452846,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        }
+      ],
+      "mean_ms": 538.9902083805451,
+      "median_ms": 538.1293750116602,
+      "stdev_ms": 2.210976647256956,
+      "min_ms": 537.3391250846907,
+      "max_ms": 541.5021250452846,
+      "library": "plotly",
+      "n": 100000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "n": 100000,
+          "source_bytes": 800000,
+          "source_rss_bytes": 76677120,
+          "build_ms": 22.644959040917456,
+          "mode": "interactive-webagg",
+          "offset_count": 100000,
+          "ready_ms": 189.10000002384186,
+          "nonblank_samples": 3788,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 2334255,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 95895552,
+          "browser_peak_rss_bytes": 1034387456,
+          "browser_wall_ms": 464.19683296699077,
+          "end_to_end_ttfr_ms": 211.7449590647593
+        },
+        {
+          "n": 100000,
+          "source_bytes": 800000,
+          "source_rss_bytes": 76595200,
+          "build_ms": 22.510915994644165,
+          "mode": "interactive-webagg",
+          "offset_count": 100000,
+          "ready_ms": 219.70000004768372,
+          "nonblank_samples": 1071,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 5386147,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 96485376,
+          "browser_peak_rss_bytes": 1049165824,
+          "browser_wall_ms": 437.40912491921335,
+          "end_to_end_ttfr_ms": 242.21091604232788
+        },
+        {
+          "n": 100000,
+          "source_bytes": 800000,
+          "source_rss_bytes": 76709888,
+          "build_ms": 22.4263749551028,
+          "mode": "interactive-webagg",
+          "offset_count": 100000,
+          "ready_ms": 222.60000002384186,
+          "nonblank_samples": 1071,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 3864057,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 96681984,
+          "browser_peak_rss_bytes": 1045364736,
+          "browser_wall_ms": 486.0460410127416,
+          "end_to_end_ttfr_ms": 245.02637497894466
+        }
+      ],
+      "mean_ms": 232.99408336201063,
+      "median_ms": 242.21091604232788,
+      "stdev_ms": 18.456046835819706,
+      "min_ms": 211.7449590647593,
+      "max_ms": 245.02637497894466,
+      "library": "matplotlib",
+      "n": 100000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 1000000,
+          "source_bytes": 8000000,
+          "source_rss_bytes": 57720832,
+          "python_render_ms": 5.800958024337888,
+          "output_bytes": 692682,
+          "mode": "density",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 50626560,
+          "wall_ms": 123.90437501017004,
+          "browser_probe": {
+            "ready_ms": 171.70000004768372,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 6024182,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1055080448,
+            "browser_wall_ms": 405.20958392880857
+          },
+          "end_to_end_ttfr_ms": 177.5009580720216,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 1000000,
+          "source_bytes": 8000000,
+          "source_rss_bytes": 57753600,
+          "python_render_ms": 4.84887498896569,
+          "output_bytes": 692682,
+          "mode": "density",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 47923200,
+          "wall_ms": 120.71716599166393,
+          "browser_probe": {
+            "ready_ms": 171,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 5901378,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1055391744,
+            "browser_wall_ms": 459.4600419513881
+          },
+          "end_to_end_ttfr_ms": 175.8488749889657,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 1000000,
+          "source_bytes": 8000000,
+          "source_rss_bytes": 57655296,
+          "python_render_ms": 4.729124950245023,
+          "output_bytes": 692682,
+          "mode": "density",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 51068928,
+          "wall_ms": 121.85404205229133,
+          "browser_probe": {
+            "ready_ms": 170.5,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 6026078,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1055440896,
+            "browser_wall_ms": 462.0088749798015
+          },
+          "end_to_end_ttfr_ms": 175.22912495024502,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        }
+      ],
+      "mean_ms": 176.1929860037441,
+      "median_ms": 175.8488749889657,
+      "stdev_ms": 1.1743575801982777,
+      "min_ms": 175.22912495024502,
+      "max_ms": 177.5009580720216,
+      "library": "xy",
+      "n": 1000000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 1000000,
+          "source_bytes": 8000000,
+          "source_rss_bytes": 67354624,
+          "python_render_ms": 159.8507920280099,
+          "output_bytes": 18339740,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 334692352,
+          "wall_ms": 309.7945839399472,
+          "browser_probe": {
+            "ready_ms": 612.6000000238419,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 253210693,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1477541888,
+            "browser_wall_ms": 856.7212919006124
+          },
+          "end_to_end_ttfr_ms": 772.4507920518517,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 1000000,
+          "source_bytes": 8000000,
+          "source_rss_bytes": 67485696,
+          "python_render_ms": 154.83133296947926,
+          "output_bytes": 18339740,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 342933504,
+          "wall_ms": 309.3794999876991,
+          "browser_probe": {
+            "ready_ms": 615.3000000715256,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 253145521,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1477525504,
+            "browser_wall_ms": 917.4471669830382
+          },
+          "end_to_end_ttfr_ms": 770.1313330410048,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 1000000,
+          "source_bytes": 8000000,
+          "source_rss_bytes": 67338240,
+          "python_render_ms": 155.28629103209823,
+          "output_bytes": 18339740,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 342851584,
+          "wall_ms": 305.6408748961985,
+          "browser_probe": {
+            "ready_ms": 615.1000000238419,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 253209177,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1477279744,
+            "browser_wall_ms": 869.333624956198
+          },
+          "end_to_end_ttfr_ms": 770.3862910559401,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        }
+      ],
+      "mean_ms": 770.9894720495989,
+      "median_ms": 770.3862910559401,
+      "stdev_ms": 1.2719445778347218,
+      "min_ms": 770.1313330410048,
+      "max_ms": 772.4507920518517,
+      "library": "plotly",
+      "n": 1000000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "n": 1000000,
+          "source_bytes": 8000000,
+          "source_rss_bytes": 84361216,
+          "build_ms": 34.79220799636096,
+          "mode": "interactive-webagg",
+          "offset_count": 1000000,
+          "ready_ms": 463.8000000715256,
+          "nonblank_samples": 1114,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 13003240,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 167739392,
+          "browser_peak_rss_bytes": 1057357824,
+          "browser_wall_ms": 736.011500004679,
+          "end_to_end_ttfr_ms": 498.59220806788653
+        },
+        {
+          "n": 1000000,
+          "source_bytes": 8000000,
+          "source_rss_bytes": 84459520,
+          "build_ms": 37.19029203057289,
+          "mode": "interactive-webagg",
+          "offset_count": 1000000,
+          "ready_ms": 458,
+          "nonblank_samples": 1114,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 14524384,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 167624704,
+          "browser_peak_rss_bytes": 1058471936,
+          "browser_wall_ms": 728.8144999183714,
+          "end_to_end_ttfr_ms": 495.1902920305729
+        },
+        {
+          "n": 1000000,
+          "source_bytes": 8000000,
+          "source_rss_bytes": 85245952,
+          "build_ms": 34.9511670647189,
+          "mode": "interactive-webagg",
+          "offset_count": 1000000,
+          "ready_ms": 451.3000000715256,
+          "nonblank_samples": 1114,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 13003240,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 168329216,
+          "browser_peak_rss_bytes": 1058684928,
+          "browser_wall_ms": 718.3966670418158,
+          "end_to_end_ttfr_ms": 486.2511671362445
+        }
+      ],
+      "mean_ms": 493.3445557449013,
+      "median_ms": 495.1902920305729,
+      "stdev_ms": 6.374196392197194,
+      "min_ms": 486.2511671362445,
+      "max_ms": 498.59220806788653,
+      "library": "matplotlib",
+      "n": 1000000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 10000000,
+          "source_bytes": 80000000,
+          "source_rss_bytes": 129744896,
+          "python_render_ms": 21.955834003165364,
+          "output_bytes": 690102,
+          "mode": "density",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 286474240,
+          "wall_ms": 181.85920803807676,
+          "browser_probe": {
+            "ready_ms": 168.60000002384186,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 5992511,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1057292288,
+            "browser_wall_ms": 466.89812501426786
+          },
+          "end_to_end_ttfr_ms": 190.55583402700722,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 10000000,
+          "source_bytes": 80000000,
+          "source_rss_bytes": 129695744,
+          "python_render_ms": 16.71679096762091,
+          "output_bytes": 690102,
+          "mode": "density",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 305889280,
+          "wall_ms": 186.2629579845816,
+          "browser_probe": {
+            "ready_ms": 167.10000002384186,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 6070235,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1055031296,
+            "browser_wall_ms": 463.0943749798462
+          },
+          "end_to_end_ttfr_ms": 183.81679099146277,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 10000000,
+          "source_bytes": 80000000,
+          "source_rss_bytes": 129744896,
+          "python_render_ms": 16.566166072152555,
+          "output_bytes": 690102,
+          "mode": "density",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 305987584,
+          "wall_ms": 187.11387505754828,
+          "browser_probe": {
+            "ready_ms": 171.60000002384186,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 6088543,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1055129600,
+            "browser_wall_ms": 405.79479199368507
+          },
+          "end_to_end_ttfr_ms": 188.1661660959944,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        }
+      ],
+      "mean_ms": 187.51293037148812,
+      "median_ms": 188.1661660959944,
+      "stdev_ms": 3.4166815687971988,
+      "min_ms": 183.81679099146277,
+      "max_ms": 190.55583402700722,
+      "library": "xy",
+      "n": 10000000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 10000000,
+          "source_bytes": 80000000,
+          "source_rss_bytes": 139296768,
+          "python_render_ms": 436.63229199592024,
+          "output_bytes": 139649110,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 1937145856,
+          "wall_ms": 680.0784170627594,
+          "browser_probe": {
+            "ready_ms": 2933.2000000476837,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 2513609689,
+            "status": "ok",
+            "browser_peak_rss_bytes": 4074029056,
+            "browser_wall_ms": 3521.567458054051
+          },
+          "end_to_end_ttfr_ms": 3369.832292043604,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 10000000,
+          "source_bytes": 80000000,
+          "source_rss_bytes": 139460608,
+          "python_render_ms": 434.471582993865,
+          "output_bytes": 139649110,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 1952071680,
+          "wall_ms": 679.6923340298235,
+          "browser_probe": {
+            "ready_ms": 2924.7000000476837,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 2513514865,
+            "status": "ok",
+            "browser_peak_rss_bytes": 4070965248,
+            "browser_wall_ms": 3437.348666950129
+          },
+          "end_to_end_ttfr_ms": 3359.1715830415487,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        },
+        {
+          "status": "ok",
+          "library": "plotly",
+          "n": 10000000,
+          "source_bytes": 80000000,
+          "source_rss_bytes": 139395072,
+          "python_render_ms": 437.9285000031814,
+          "output_bytes": 139649110,
+          "mode": "scattergl",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 1938948096,
+          "wall_ms": 681.4318329561502,
+          "browser_probe": {
+            "ready_ms": 2951.899999976158,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 2523959013,
+            "status": "ok",
+            "browser_peak_rss_bytes": 4086595584,
+            "browser_wall_ms": 3550.3390409285203
+          },
+          "end_to_end_ttfr_ms": 3389.8284999793395,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        }
+      ],
+      "mean_ms": 3372.9441250214973,
+      "median_ms": 3369.832292043604,
+      "stdev_ms": 15.563555743928834,
+      "min_ms": 3359.1715830415487,
+      "max_ms": 3389.8284999793395,
+      "library": "plotly",
+      "n": 10000000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "n": 10000000,
+          "source_bytes": 80000000,
+          "source_rss_bytes": 156434432,
+          "build_ms": 157.162707997486,
+          "mode": "interactive-webagg",
+          "offset_count": 10000000,
+          "ready_ms": 2832.7999999523163,
+          "nonblank_samples": 1096,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 17444087,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 903020544,
+          "browser_peak_rss_bytes": 1463304192,
+          "browser_wall_ms": 3065.5464590527117,
+          "end_to_end_ttfr_ms": 2989.9627079498023
+        },
+        {
+          "n": 10000000,
+          "source_bytes": 80000000,
+          "source_rss_bytes": 156434432,
+          "build_ms": 151.4822089811787,
+          "mode": "interactive-webagg",
+          "offset_count": 10000000,
+          "ready_ms": 2835,
+          "nonblank_samples": 1096,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 17443755,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 903168000,
+          "browser_peak_rss_bytes": 1470251008,
+          "browser_wall_ms": 3108.2792080705985,
+          "end_to_end_ttfr_ms": 2986.4822089811787
+        },
+        {
+          "n": 10000000,
+          "source_bytes": 80000000,
+          "source_rss_bytes": 156450816,
+          "build_ms": 151.48941590450704,
+          "mode": "interactive-webagg",
+          "offset_count": 10000000,
+          "ready_ms": 2824.7999999523163,
+          "nonblank_samples": 1096,
+          "canvas_width": 900,
+          "canvas_height": 420,
+          "js_heap_bytes": 14392111,
+          "status": "ok",
+          "library": "matplotlib-webagg",
+          "python_peak_rss_bytes": 903168000,
+          "browser_peak_rss_bytes": 1435566080,
+          "browser_wall_ms": 3043.1484170258045,
+          "end_to_end_ttfr_ms": 2976.2894158568233
+        }
+      ],
+      "mean_ms": 2984.244777595935,
+      "median_ms": 2986.4822089811787,
+      "stdev_ms": 7.10593439089724,
+      "min_ms": 2976.2894158568233,
+      "max_ms": 2989.9627079498023,
+      "library": "matplotlib",
+      "n": 10000000
+    },
+    {
+      "attempted_runs": 3,
+      "successful_runs": 3,
+      "statuses": [
+        "ok",
+        "ok",
+        "ok"
+      ],
+      "samples": [
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 1000000000,
+          "source_bytes": 8000000000,
+          "source_rss_bytes": 8049672192,
+          "python_render_ms": 1097.6947080343962,
+          "output_bytes": 690091,
+          "mode": "density",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 24069652480,
+          "wall_ms": 6363.252791925333,
+          "browser_probe": {
+            "ready_ms": 168.10000002384186,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 6132566,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1057800192,
+            "browser_wall_ms": 484.33316603768617
+          },
+          "end_to_end_ttfr_ms": 1265.794708058238,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 1000000000,
+          "source_bytes": 8000000000,
+          "source_rss_bytes": 8049655808,
+          "python_render_ms": 1068.0549589451402,
+          "output_bytes": 690091,
+          "mode": "density",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 24069210112,
+          "wall_ms": 6272.771374904551,
+          "browser_probe": {
+            "ready_ms": 164.30000007152557,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 6135390,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1055358976,
+            "browser_wall_ms": 433.0932500306517
+          },
+          "end_to_end_ttfr_ms": 1232.3549590166658,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        },
+        {
+          "status": "ok",
+          "library": "xy",
+          "n": 1000000000,
+          "source_bytes": 8000000000,
+          "source_rss_bytes": 8049672192,
+          "python_render_ms": 1068.0818340042606,
+          "output_bytes": 690091,
+          "mode": "density",
+          "nonblank_pixels": null,
+          "python_peak_rss_bytes": 24069439488,
+          "wall_ms": 6264.4416249822825,
+          "browser_probe": {
+            "ready_ms": 159.39999997615814,
+            "renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)",
+            "nonblank_pixels": 16384,
+            "js_heap_bytes": 6170518,
+            "status": "ok",
+            "browser_peak_rss_bytes": 1055555584,
+            "browser_wall_ms": 472.57291700225323
+          },
+          "end_to_end_ttfr_ms": 1227.4818339804187,
+          "browser_renderer": "ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro, Unspecified Version)"
+        }
+      ],
+      "mean_ms": 1241.8771670184408,
+      "median_ms": 1232.3549590166658,
+      "stdev_ms": 20.8560162530506,
+      "min_ms": 1227.4818339804187,
+      "max_ms": 1265.794708058238,
+      "library": "xy",
+      "n": 1000000000
+    },
+    {
+      "attempted_runs": 1,
+      "successful_runs": 0,
+      "statuses": [
+        "memory_limit"
+      ],
+      "samples": [
+        {
+          "status": "memory_limit",
+          "library": "plotly",
+          "n": 1000000000,
+          "wall_ms": 7133.988916990347,
+          "python_peak_rss_bytes": 39128449024,
+          "stderr_tail": ""
+        }
+      ],
+      "library": "plotly",
+      "n": 1000000000
+    },
+    {
+      "attempted_runs": 1,
+      "successful_runs": 0,
+      "statuses": [
+        "memory_limit"
+      ],
+      "samples": [
+        {
+          "status": "memory_limit",
+          "n": 1000000000,
+          "python_peak_rss_bytes": 39205928960,
+          "phase": "figure-build"
+        }
+      ],
+      "library": "matplotlib",
+      "n": 1000000000
+    }
+  ]
+}

--- a/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/environment.json
+++ b/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/environment.json
@@ -1,0 +1,24 @@
+{
+  "source": {
+    "repository": "https://github.com/reflex-dev/xy",
+    "xy_version": "0.0.4.dev27+76047753",
+    "xy_commit": "7604775372979a7a76188c964c8cc6fb6e7d08db"
+  },
+  "runtime": {
+    "python": "3.14.5",
+    "rustc": "1.96.1 (31fca3adb 2026-06-26)",
+    "cargo": "1.96.1 (356927216 2026-06-26)",
+    "node": "26.0.0",
+    "chrome": "150.0.7871.186"
+  },
+  "hardware": {
+    "machine": "Apple M5 Pro",
+    "cpu_cores": 18,
+    "gpu_cores": 20,
+    "memory_gib": 64,
+    "architecture": "arm64"
+  },
+  "operating_system": "macOS 26.5.2",
+  "uv_project": "pyproject.toml",
+  "uv_lock": "uv.lock"
+}

--- a/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/manifest.json
+++ b/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/manifest.json
@@ -1,0 +1,61 @@
+{
+  "baseline": "xy-main-2026-07-26-launch-scatter",
+  "status": "refresh-of-xy-0.1.0-launch-baseline",
+  "supersedes_for_docs": "xy-0.1.0/macos-arm64-m5-pro",
+  "date": "2026-07-26",
+  "sizes": [
+    10000,
+    100000,
+    1000000,
+    10000000,
+    1000000000
+  ],
+  "viewport": [
+    900,
+    420
+  ],
+  "successful_repetitions": 3,
+  "aggregation": "arithmetic mean with sample standard deviation",
+  "limits": {
+    "seconds_per_phase": 180,
+    "gib_per_process_tree": 36
+  },
+  "contracts": {
+    "static_cpu": "validated PNG; default public APIs; CPU render paths",
+    "interactive_default": "validated first browser render; hardware WebGL or WebAgg default",
+    "interactive_cpu_fallback": "validated first browser render; forced ANGLE SwiftShader"
+  },
+  "xy_mean_seconds": {
+    "static_cpu": {
+      "10000": 0.0035718194,
+      "100000": 0.0059620554,
+      "1000000": 0.005792861,
+      "10000000": 0.0184427913,
+      "1000000000": 1.128772292
+    },
+    "interactive_default": {
+      "10000": 0.1642669857,
+      "100000": 0.1679656947,
+      "1000000": 0.176192986,
+      "10000000": 0.1875129304,
+      "1000000000": 1.241877167
+    },
+    "interactive_cpu_fallback": {
+      "10000": 0.965319736,
+      "100000": 0.9638495137,
+      "1000000": 1.083559403,
+      "10000000": 1.0352127917,
+      "1000000000": 2.1766365137
+    }
+  },
+  "raw_results": {
+    "default": "default-results.json",
+    "cpu_fallback": "cpu-fallback-results.json"
+  },
+  "reproduction": {
+    "environment": "environment.json",
+    "uv_project": "pyproject.toml",
+    "uv_lock": "uv.lock"
+  },
+  "comparison_rule": "Competitor dependency versions are pinned to the xy-0.1.0 lock so the only intended variables are the xy revision and the Chrome patch version. Preserve contracts and environment metadata; do not overwrite an earlier baseline."
+}

--- a/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/pyproject.toml
+++ b/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "xy-launch-scatter-baseline"
+version = "0.1.0"
+requires-python = "==3.14.*"
+dependencies = [
+    "xy",
+    "kaleido==1.3.0",
+    "matplotlib==3.11.0",
+    "numpy==2.5.1",
+    "pandas==3.0.3",
+    "pillow==12.3.0",
+    "plotly==6.9.0",
+    "psutil==7.2.2",
+    "tornado==6.5.7",
+    "websocket-client==1.9.0",
+]
+
+[tool.uv.sources]
+xy = { path = "../../../..", editable = true }

--- a/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/report.md
+++ b/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/report.md
@@ -1,0 +1,320 @@
+# Launch scatter benchmark refresh: static and interactive comparisons
+
+**Status:** current published baseline for the README and the public benchmarks
+page. This is a controlled rerun of the canonical `xy` 0.1.0 launch baseline
+(`../../xy-0.1.0/macos-arm64-m5-pro/`), which remains committed and unchanged.
+
+Run on 2026-07-26 with the same seeded `float32` x/y arrays at **10k, 100k, 1M,
+10M, and 1B points**, the same 900×420 output contracts, the same 180-second
+and 36 GiB guardrails, and the same reference machine.
+
+The competitor dependency set is pinned to the 0.1.0 lock file
+(`uv.lock`, copied verbatim), so the intended variables between the two runs
+are the `xy` revision and a Chrome patch bump:
+
+| | 0.1.0 baseline | this refresh |
+|---|---|---|
+| `xy` | 0.1.0, commit `7228f99` | `0.0.4.dev27+76047753`, commit `7604775` |
+| Chrome | 150.0.7871.115 | 150.0.7871.186 |
+| Python / NumPy / Plotly / Kaleido / Matplotlib / Tornado | 3.14.5 / 2.5.1 / 6.9.0 / 1.3.0 / 3.11.0 / 6.5.7 | identical |
+| Machine / OS | Apple M5 Pro, macOS 26.5.2 | identical |
+
+Across the 24 successful Plotly and Matplotlib timing cells, reproduction
+against the recorded 0.1.0 values has a median absolute deviation of 3.2%, with
+16 of 24 within 5% and all 24 within 10%. The largest deviations sit on the rows
+dominated by cold browser startup rather than by chart work: Kaleido's small-`N`
+static rows are 6–8% slower and the small-`N` SwiftShader rows are 3–10% faster,
+both consistent with the Chrome patch bump. The competitor side is therefore
+stable enough that the `xy` movement below — up to 2.37× on rows whose
+competitors barely moved — is a real change in `xy` rather than machine drift.
+
+The benchmark is split by output contract:
+
+1. **Static:** validated 900×420 PNG from every library.
+2. **Interactive:** validated first browser render from every library.
+
+No static result is mixed into the interactive table.
+
+## Metrics tracked
+
+| Benchmark | Tracked result | Render path |
+|---|---|---|
+| A | Static PNG time and peak process-tree RSS | CPU: `xy` native, Kaleido default, Matplotlib Agg |
+| B | Interactive TTFR and Python/browser peak RSS | Default hardware WebGL; Matplotlib WebAgg |
+| B-CPU | Interactive TTFR under browser CPU fallback | Forced ANGLE SwiftShader; Matplotlib remains Agg/WebAgg |
+
+Successful cells use three complete cold runs. Comparisons must retain the same
+900×420 viewport, seeded float32 data, nonblank render oracle, 180-second limit,
+36 GiB process-tree limit, and default library behavior. Any changed contract
+must be reported as a new benchmark rather than appended to these tables.
+
+## Benchmark A: static 900×420 PNG (CPU-rendered)
+
+Percentage faster is calculated as `(competitor time / xy time - 1) × 100`.
+Times are arithmetic mean ± sample standard deviation across three complete,
+isolated cold runs.
+
+| Points | `xy` native PNG | Plotly/Kaleido PNG | `xy` faster vs Plotly | Matplotlib/Agg PNG | `xy` faster vs Matplotlib | `xy` mode |
+|---:|---:|---:|---:|---:|---:|---|
+| 10k | **0.0036 ± 0.0000 s** | 2.0231 ± 0.0059 s | **566.41× (56,541.2%)** | 0.0224 ± 0.0001 s | **6.27× (526.5%)** | direct |
+| 100k | **0.0060 ± 0.0003 s** | 2.1100 ± 0.0005 s | **353.91× (35,291.1%)** | 0.0456 ± 0.0004 s | **7.64× (664.3%)** | direct |
+| 1M | **0.0058 ± 0.0001 s** | 2.8086 ± 0.0431 s | **484.85× (48,384.6%)** | 0.2858 ± 0.0006 s | **49.34× (4,834.0%)** | density |
+| 10M | **0.0184 ± 0.0000 s** | 9.6433 ± 0.0289 s | **522.88× (52,187.7%)** | 2.7432 ± 0.0063 s | **148.74× (14,774.3%)** | density |
+| 1B | **1.1288 ± 0.0932 s** | **failed on first guarded attempt** | — | **memory limit** | — | density |
+
+### Movement against the 0.1.0 baseline
+
+`xy` static render time, same contract, same machine:
+
+| Points | 0.1.0 | 2026-07-26 | change |
+|---:|---:|---:|---:|
+| 10k | 0.0085 s | 0.0036 s | **2.37× faster** |
+| 100k | 0.0108 s | 0.0060 s | **1.80× faster** |
+| 1M | 0.0114 s | 0.0058 s | **1.97× faster** |
+| 10M | 0.0232 s | 0.0184 s | **1.26× faster** |
+| 1B | 1.1452 s | 1.1288 s | 1.01× faster (within run-to-run spread) |
+
+The small-to-medium rows moved the most because they are dominated by
+fixed per-call overhead rather than by N-dependent kernel work; the 1B row is
+dominated by ingesting eight gigabytes of source columns and did not move.
+
+### Static peak process-tree RSS
+
+Plotly includes the Kaleido/Chrome processes required for its static export.
+
+| Points | `xy` | Plotly/Kaleido | Matplotlib/Agg |
+|---:|---:|---:|---:|
+| 10k | 0.050 GiB | 1.425 GiB | 0.079 GiB |
+| 100k | 0.050 GiB | 1.438 GiB | 0.079 GiB |
+| 1M | 0.072 GiB | 1.833 GiB | 0.149 GiB |
+| 10M | 0.286 GiB | 5.298 GiB | 0.831 GiB |
+| 1B | 22.413 GiB | 26.092 GiB observed; failed | >36 GiB; terminated |
+
+RSS values are arithmetic means of successful runs. Failure cells have no
+successful-run mean and report the highest observed value before termination.
+
+### Static interpretation
+
+- Matplotlib/Agg rasterizes every scatter offset. It does not sample this
+  `PathCollection`.
+- Plotly Express chooses `scattergl`, then Kaleido starts Chrome and renders the
+  complete trace to PNG. The cold Chrome startup dominates small rows.
+- `xy` switches to a density representation at 1M and its native rasterizer
+  paints that bounded representation. The 1B row does **not** draw one billion
+  individual markers; it ingests one billion rows and produces a density image.
+- All successful files decoded to exactly 900×420 and passed a nonblank-pixel
+  oracle.
+
+At 1B, Kaleido raised its internal render timeout after 122.1 seconds with
+26.09 GiB observed RSS, and its Python process exited non-zero without writing a
+PNG. Matplotlib crossed the 36 GiB safety ceiling. Neither produced an image.
+
+## Benchmark B: interactive first render (default GPU path)
+
+Times are arithmetic mean ± sample standard deviation across three complete,
+isolated cold Python + fresh-browser runs. Every successful WebGL sample on this
+path recorded the renderer `ANGLE (Apple, ANGLE Metal Renderer: Apple M5 Pro,
+Unspecified Version)`, confirming these are hardware-GPU rows and must never be
+merged with the SwiftShader table below.
+
+| Points | `xy` standalone | Plotly standalone | `xy` faster vs Plotly | Matplotlib WebAgg | `xy` faster vs Matplotlib | `xy` mode |
+|---:|---:|---:|---:|---:|---:|---|
+| 10k | **0.1643 ± 0.0042 s** | 0.5307 ± 0.0309 s | **3.23× (223.1%)** | 0.2152 ± 0.0087 s | **1.31× (31.0%)** | direct |
+| 100k | **0.1680 ± 0.0045 s** | 0.5390 ± 0.0022 s | **3.21× (220.9%)** | 0.2330 ± 0.0185 s | **1.39× (38.7%)** | direct |
+| 1M | **0.1762 ± 0.0012 s** | 0.7710 ± 0.0013 s | **4.38× (337.6%)** | 0.4933 ± 0.0064 s | **2.80× (180.0%)** | density + sample |
+| 10M | **0.1875 ± 0.0034 s** | 3.3729 ± 0.0156 s | **17.99× (1,698.8%)** | 2.9842 ± 0.0071 s | **15.91× (1,491.5%)** | density + sample |
+| 1B | **1.2419 ± 0.0209 s** | **memory limit** | — | **memory limit** | — | density + sample |
+
+Interactive TTFR definitions:
+
+- **`xy`:** figure construction + standalone HTML + fresh Chrome + WebGL draw
+  + two animation frames + GPU fence + nonblank readback.
+- **Plotly:** figure construction + standalone HTML + fresh Chrome + Plotly
+  ready + two animation frames + GPU fence + nonblank readback.
+- **Matplotlib WebAgg:** figure construction + built-in live WebAgg server +
+  fresh Chrome + Python Agg draw + WebSocket image delivery + nonblank
+  900×420 browser canvas.
+
+### Interactive peak RSS
+
+Python and browser process trees are separate columns. Chrome has an observed
+baseline near 0.97 GiB on this machine.
+
+| Points | `xy` Python | `xy` browser | Plotly Python | Plotly browser | WebAgg Python | WebAgg browser |
+|---:|---:|---:|---:|---:|---:|---:|
+| 10k | 0.046 | 0.977 | 0.171 | 1.067 | 0.089 | 0.969 |
+| 100k | 0.049 | 0.966 | 0.183 | 1.106 | 0.090 | 0.971 |
+| 1M | 0.046 | 0.983 | 0.317 | 1.376 | 0.156 | 0.985 |
+| 10M | 0.279 | 0.983 | 1.809 | 3.797 | 0.841 | 1.356 |
+| 1B | 22.416 | 0.984 | >36 observed | — | >36 observed | — |
+
+Values are GiB. Failure-row values are the highest observed before termination,
+not successful steady-state peaks. Successful values are means across runs.
+
+## Benchmark B-CPU: interactive first render with software rendering
+
+Chrome was forced to ANGLE SwiftShader (`--use-angle=swiftshader` and
+`--enable-unsafe-swiftshader`). Every successful `xy` and Plotly sample recorded
+the renderer string `ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (LLVM
+10.0.0) (0x0000C0DE)), SwiftShader driver)`, so the fallback is verified per
+sample rather than assumed from the flags. Matplotlib WebAgg reports no WebGL
+renderer because it delivers a server-rendered image canvas. This is the
+interactive CPU-fallback test; it still starts a fresh browser for every sample.
+
+| Points | `xy` software | Plotly software | `xy` faster vs Plotly | Matplotlib WebAgg software-browser | `xy` faster vs Matplotlib | `xy` mode |
+|---:|---:|---:|---:|---:|---:|---|
+| 10k | **0.9653 ± 0.0119 s** | 1.3280 ± 0.0334 s | **1.38× (37.6%)** | 1.0929 ± 0.0882 s | **1.13× (13.2%)** | direct |
+| 100k | **0.9638 ± 0.0045 s** | 1.3501 ± 0.0162 s | **1.40× (40.1%)** | 1.1323 ± 0.0773 s | **1.17× (17.5%)** | direct |
+| 1M | **1.0836 ± 0.0105 s** | 1.9317 ± 0.0089 s | **1.78× (78.3%)** | 1.2328 ± 0.0143 s | **1.14× (13.8%)** | density + sample |
+| 10M | **1.0352 ± 0.0074 s** | 8.0888 ± 0.0213 s | **7.81× (681.4%)** | 3.6121 ± 0.0127 s | **3.49× (248.9%)** | density + sample |
+| 1B | **2.1766 ± 0.0615 s** | **memory limit** | — | **memory limit** | — | density + sample |
+
+### Interactive CPU-fallback peak RSS
+
+| Points | `xy` Python | `xy` browser | Plotly Python | Plotly browser | WebAgg Python | WebAgg browser |
+|---:|---:|---:|---:|---:|---:|---:|
+| 10k | 0.049 | 1.105 | 0.121 | 1.292 | 0.087 | 1.076 |
+| 100k | 0.056 | 1.085 | 0.122 | 1.333 | 0.090 | 1.058 |
+| 1M | 0.052 | 1.080 | 0.319 | 1.599 | 0.156 | 1.065 |
+| 10M | 0.285 | 1.100 | 1.819 | 4.023 | 0.841 | 1.381 |
+| 1B | 22.416 | 1.099 | >36 observed | — | >36 observed | — |
+
+There is no separate static CPU-fallback table because Benchmark A already is
+the CPU path: `xy` uses its native CPU rasterizer, Matplotlib uses Agg, and the
+installed Kaleido/Choreographer configuration disables GPU by default. Repeating
+it under another “CPU” label would duplicate Benchmark A.
+
+### Interactive interpretation
+
+- Matplotlib really is interactive here: the built-in WebAgg backend supplies
+  pan/zoom controls through a live Python server and browser canvas.
+- WebAgg still retains every point. At 1B it crossed the 36 GiB process-tree
+  ceiling before delivering a first frame.
+- Plotly sends all points into its browser figure. It completed through 10M; its
+  1B Python process crossed the same ceiling at 36.44 GiB observed on the
+  default path and 36.83 GiB under software rendering.
+- `xy` keeps exact source data in Python, but its overview browser payload is
+  density + a stable sample. At deep zoom it can request exact visible points.
+  This changes the scaling regime and is the default feature under test.
+- Small non-monotonic steps remain visible — the 10M CPU-fallback mean is
+  slightly below the 1M mean, a 0.05 s gap against 0.007–0.011 s sample
+  deviations. Read those as flat within noise, not as larger data being faster.
+
+## What “default” means here
+
+| Library | Static path | Interactive path | Large-scatter reduction |
+|---|---|---|---|
+| `xy` | Native `to_png()` | Standalone WebGL | Automatic density + stable overlay + exact drilldown |
+| Plotly | `to_image()` through Kaleido | Standalone Plotly HTML | None; `px.scatter` auto-selects WebGL but retains all rows |
+| Matplotlib | Agg `savefig()` | Built-in WebAgg | None; rerenders the full `PathCollection` |
+
+Plotly documents that `px.scatter(render_mode="auto")` automatically selects
+WebGL above 1,000 rows; this changes the renderer, not the number of rows.
+[Plotly performance guide](https://plotly.com/python/performance/)
+
+Matplotlib documents WebAgg as an interactive browser backend built on Agg.
+[Matplotlib WebAgg documentation](https://matplotlib.org/stable/api/backend_webagg_core_api.html)
+
+## Shared methodology
+
+- Input: identical seeded correlated-Gaussian `float32` x/y arrays; 8 bytes per
+  source row.
+- Data generation and library imports excluded from elapsed render time; their
+  resident memory remains included.
+- Chart target: 900×420 pixels/CSS pixels.
+- Three complete isolated cold runs per successful library/size cell; each
+  interactive run also starts a fresh browser.
+- Tables report arithmetic mean ± sample standard deviation. Memory tables
+  report arithmetic mean peak RSS across successful runs.
+- A terminal 1B failure is attempted once and not averaged; repeating an
+  OOM/timeout cannot produce a successful timing distribution.
+- Guardrail: 180 seconds and 36 GiB per process tree.
+- RSS sampled from complete process trees every 50 ms; very brief peaks may be
+  missed.
+- Successful static rows require a decodable, nonblank 900×420 PNG.
+- Successful interactive rows require a visible, nonblank 900×420 chart surface
+  in fresh Chrome.
+- The environment was warmed before the measured suites: bytecode caches,
+  Matplotlib's font cache, and Kaleido's browser download all inflate a first
+  invocation in a fresh checkout and are not part of any published cell.
+
+## Environment
+
+- Apple M5 Pro: 18-core CPU, 20-core GPU, 64 GB RAM
+- macOS 26.5.2 arm64
+- Google Chrome 150.0.7871.186
+- Python 3.14.5
+- NumPy 2.5.1
+- `xy` 0.0.4.dev27+76047753, commit `7604775372979a7a76188c964c8cc6fb6e7d08db`
+- Plotly 6.9.0
+- Kaleido 1.3.0
+- Matplotlib 3.11.0
+- Tornado 6.5.7 for WebAgg
+- Seed `20260713`
+
+## Conclusions
+
+Static and interactive workloads lead to different decisions:
+
+- **Static:** Matplotlib is a strong exact brute-force baseline, but `xy`'s
+  native density-aware export scales much further. Plotly's cold Kaleido path
+  carries a large browser-startup cost.
+- **Interactive through 10M:** all three complete. `xy` remains near browser
+  startup cost because its automatic LOD bounds the representation; Plotly and
+  WebAgg scale with the complete point count.
+- **Interactive at 1B:** only `xy` reaches first render within the limits, by
+  rendering an aggregate overview while retaining source data for drilldown.
+- **CPU fallback:** forcing SwiftShader adds roughly 0.8 seconds of cold-browser
+  overhead to `xy`, but its bounded large-data representation still keeps 1M
+  and 10M near one second. Plotly's software path rises to 8.09 seconds at 10M;
+  WebAgg reaches 3.61 seconds.
+- **Against the previous baseline:** the static path is 1.26–2.37× faster on the
+  same hardware with unchanged competitor versions; interactive TTFR is
+  unchanged within noise, because it is bounded by cold browser startup rather
+  than by `xy`.
+
+The defensible headline is not “`xy` draws 1B markers.” It is:
+
+> `xy` ingested 1B points and produced both a validated static density PNG in
+> 1.129 s mean and a validated interactive density overview in 1.242 s mean,
+> while the default exact-point Plotly and Matplotlib paths did not complete at
+> that size within the 36 GiB/180-second limits.
+
+## Limitations
+
+- One machine, platform, and browser; three runs quantify local repeatability
+  but do not establish cross-machine performance.
+- `xy` aggregate output and Plotly/Matplotlib exact-point rendering are
+  intentionally different default product semantics.
+- WebAgg requires a live Python/Tornado server and is not self-contained HTML.
+- Plotly/Kaleido startup can be amortized in a persistent export service; these
+  are isolated cold exports.
+- Browser RSS includes Chrome overhead and does not measure GPU memory.
+- Timeout/memory-limit results are local guarded outcomes, not universal hard
+  limits.
+- Chrome moved by one patch release between the two runs; it is held constant
+  within this run but is not pinned across runs.
+
+## Reproduce
+
+```bash
+BASELINE=benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro
+uv sync --project "$BASELINE" --frozen --python 3.14.5
+export CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+
+# Repeated static + default interactive benchmarks
+uv run --project "$BASELINE" --frozen python benchmarks/bench_launch_scatter.py \
+  --sizes 10000,100000,1000000,10000000,1000000000 \
+  --repetitions 3 --timeout 180 --memory-gib 36 \
+  --chrome "$CHROME" --out launch-scatter-default.json
+
+# Repeated interactive CPU/software fallback
+uv run --project "$BASELINE" --frozen python benchmarks/bench_launch_scatter.py \
+  --sizes 10000,100000,1000000,10000000,1000000000 \
+  --repetitions 3 --timeout 180 --memory-gib 36 \
+  --interactive-only --software \
+  --chrome "$CHROME" --out launch-scatter-cpu-fallback.json
+```
+
+Discard a first invocation made in a fresh checkout: it measures cold bytecode
+and font caches, not the contract under test.

--- a/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/uv.lock
+++ b/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/uv.lock
@@ -1,0 +1,772 @@
+version = 1
+revision = 3
+requires-python = "==3.14.*"
+resolution-markers = [
+    "sys_platform == 'win32'",
+    "sys_platform == 'emscripten'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "anywidget"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ipywidgets" },
+    { name = "psygnal" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/31/0491d707c674b34267f55d96d6a7148e55e7b6718a271686232cf295fbe2/anywidget-0.11.0.tar.gz", hash = "sha256:6695fbef9449cf8c27f421b96c5837aa37f909ec1f60cfa33add333e1b70b169", size = 426999, upload-time = "2026-04-27T23:42:09.576Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/c2/8fec8e8e2eb920cc2280f569144080cd58622a2eda83bfa4c0c354a63264/anywidget-0.11.0-py3-none-any.whl", hash = "sha256:c574d9acc6503ad27b37a9acea48f957a8ba7c9c9876cfcb37898931c098ce9d", size = 317341, upload-time = "2026-04-27T23:42:08.356Z" },
+]
+
+[[package]]
+name = "asttokens"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/1e/faf0f247f6f881b98fc4d6d07e14085cb89d13665084e6d6ac1dc2c03d0b/asttokens-3.0.2.tar.gz", hash = "sha256:3ecdbd8f2cc195f53ccada3a613538bb5f9ef6f6869129f13e03c30a677b8fe2", size = 63136, upload-time = "2026-07-12T03:31:49.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/2b/04b8a15f3a1c77bc79ddf5c73875327f34b4fa75982df2b76e45e402d364/asttokens-3.0.2-py3-none-any.whl", hash = "sha256:9da13157f5b28becde0bd374fc677dcd3c290614264eff096f167c469cd9f933", size = 28702, upload-time = "2026-07-12T03:31:47.542Z" },
+]
+
+[[package]]
+name = "choreographer"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "logistro" },
+    { name = "platformdirs" },
+    { name = "simplejson" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/69/3058cd4f16d6b75c80e8f95e5b713d930526353ce294df9a7887453ba215/choreographer-1.3.0.tar.gz", hash = "sha256:6c44a0e48e9b37977344d40bfa5a9ed88575fe4bc0fd836771bf702bc24d6884", size = 48291, upload-time = "2026-04-28T22:57:45.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/6c/ff8bf52315064dbeb55cb5067e191120a5b2e58bb648d0d34cf7969dc2c2/choreographer-1.3.0-py3-none-any.whl", hash = "sha256:cea4cb739e4f61625e4b53888a8d3fa1d3bf73948b56753e460ab44da7d8d44f", size = 52622, upload-time = "2026-04-28T22:57:44.015Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "comm"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
+]
+
+[[package]]
+name = "contourpy"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/8b/4546f3ab60f78c514ffb7d01a0bd743f90de36f0019d1be84d0a708a580a/contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fde6c716d51c04b1c25d0b90364d0be954624a0ee9d60e23e850e8d48353d07a", size = 292189, upload-time = "2025-07-26T12:02:16.095Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e1/3542a9cb596cadd76fcef413f19c79216e002623158befe6daa03dbfa88c/contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cbedb772ed74ff5be440fa8eee9bd49f64f6e3fc09436d9c7d8f1c287b121d77", size = 273251, upload-time = "2025-07-26T12:02:17.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/71/f93e1e9471d189f79d0ce2497007731c1e6bf9ef6d1d61b911430c3db4e5/contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22e9b1bd7a9b1d652cd77388465dc358dafcd2e217d35552424aa4f996f524f5", size = 335810, upload-time = "2025-07-26T12:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/91/f9/e35f4c1c93f9275d4e38681a80506b5510e9327350c51f8d4a5a724d178c/contourpy-1.3.3-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a22738912262aa3e254e4f3cb079a95a67132fc5a063890e224393596902f5a4", size = 382871, upload-time = "2025-07-26T12:02:20.418Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/71/47b512f936f66a0a900d81c396a7e60d73419868fba959c61efed7a8ab46/contourpy-1.3.3-cp314-cp314-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:afe5a512f31ee6bd7d0dda52ec9864c984ca3d66664444f2d72e0dc4eb832e36", size = 386264, upload-time = "2025-07-26T12:02:21.916Z" },
+    { url = "https://files.pythonhosted.org/packages/04/5f/9ff93450ba96b09c7c2b3f81c94de31c89f92292f1380261bd7195bea4ea/contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f64836de09927cba6f79dcd00fdd7d5329f3fccc633468507079c829ca4db4e3", size = 363819, upload-time = "2025-07-26T12:02:23.759Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/a6/0b185d4cc480ee494945cde102cb0149ae830b5fa17bf855b95f2e70ad13/contourpy-1.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1fd43c3be4c8e5fd6e4f2baeae35ae18176cf2e5cced681cca908addf1cdd53b", size = 1333650, upload-time = "2025-07-26T12:02:26.181Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d7/afdc95580ca56f30fbcd3060250f66cedbde69b4547028863abd8aa3b47e/contourpy-1.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6afc576f7b33cf00996e5c1102dc2a8f7cc89e39c0b55df93a0b78c1bd992b36", size = 1404833, upload-time = "2025-07-26T12:02:28.782Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e2/366af18a6d386f41132a48f033cbd2102e9b0cf6345d35ff0826cd984566/contourpy-1.3.3-cp314-cp314-win32.whl", hash = "sha256:66c8a43a4f7b8df8b71ee1840e4211a3c8d93b214b213f590e18a1beca458f7d", size = 189692, upload-time = "2025-07-26T12:02:30.128Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:cf9022ef053f2694e31d630feaacb21ea24224be1c3ad0520b13d844274614fd", size = 232424, upload-time = "2025-07-26T12:02:31.395Z" },
+    { url = "https://files.pythonhosted.org/packages/18/79/a9416650df9b525737ab521aa181ccc42d56016d2123ddcb7b58e926a42c/contourpy-1.3.3-cp314-cp314-win_arm64.whl", hash = "sha256:95b181891b4c71de4bb404c6621e7e2390745f887f2a026b2d99e92c17892339", size = 198300, upload-time = "2025-07-26T12:02:32.956Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/42/38c159a7d0f2b7b9c04c64ab317042bb6952b713ba875c1681529a2932fe/contourpy-1.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:33c82d0138c0a062380332c861387650c82e4cf1747aaa6938b9b6516762e772", size = 306769, upload-time = "2025-07-26T12:02:34.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6c/26a8205f24bca10974e77460de68d3d7c63e282e23782f1239f226fcae6f/contourpy-1.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ea37e7b45949df430fe649e5de8351c423430046a2af20b1c1961cae3afcda77", size = 287892, upload-time = "2025-07-26T12:02:35.807Z" },
+    { url = "https://files.pythonhosted.org/packages/66/06/8a475c8ab718ebfd7925661747dbb3c3ee9c82ac834ccb3570be49d129f4/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d304906ecc71672e9c89e87c4675dc5c2645e1f4269a5063b99b0bb29f232d13", size = 326748, upload-time = "2025-07-26T12:02:37.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a3/c5ca9f010a44c223f098fccd8b158bb1cb287378a31ac141f04730dc49be/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ca658cd1a680a5c9ea96dc61cdbae1e85c8f25849843aa799dfd3cb370ad4fbe", size = 375554, upload-time = "2025-07-26T12:02:38.894Z" },
+    { url = "https://files.pythonhosted.org/packages/80/5b/68bd33ae63fac658a4145088c1e894405e07584a316738710b636c6d0333/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ab2fd90904c503739a75b7c8c5c01160130ba67944a7b77bbf36ef8054576e7f", size = 388118, upload-time = "2025-07-26T12:02:40.642Z" },
+    { url = "https://files.pythonhosted.org/packages/40/52/4c285a6435940ae25d7410a6c36bda5145839bc3f0beb20c707cda18b9d2/contourpy-1.3.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b7301b89040075c30e5768810bc96a8e8d78085b47d8be6e4c3f5a0b4ed478a0", size = 352555, upload-time = "2025-07-26T12:02:42.25Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ee/3e81e1dd174f5c7fefe50e85d0892de05ca4e26ef1c9a59c2a57e43b865a/contourpy-1.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2a2a8b627d5cc6b7c41a4beff6c5ad5eb848c88255fda4a8745f7e901b32d8e4", size = 1322295, upload-time = "2025-07-26T12:02:44.668Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b2/6d913d4d04e14379de429057cd169e5e00f6c2af3bb13e1710bcbdb5da12/contourpy-1.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fd6ec6be509c787f1caf6b247f0b1ca598bef13f4ddeaa126b7658215529ba0f", size = 1391027, upload-time = "2025-07-26T12:02:47.09Z" },
+    { url = "https://files.pythonhosted.org/packages/93/8a/68a4ec5c55a2971213d29a9374913f7e9f18581945a7a31d1a39b5d2dfe5/contourpy-1.3.3-cp314-cp314t-win32.whl", hash = "sha256:e74a9a0f5e3fff48fb5a7f2fd2b9b70a3fe014a67522f79b7cca4c0c7e43c9ae", size = 202428, upload-time = "2025-07-26T12:02:48.691Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/96/fd9f641ffedc4fa3ace923af73b9d07e869496c9cc7a459103e6e978992f/contourpy-1.3.3-cp314-cp314t-win_amd64.whl", hash = "sha256:13b68d6a62db8eafaebb8039218921399baf6e47bf85006fd8529f2a08ef33fc", size = 250331, upload-time = "2025-07-26T12:02:50.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8c/469afb6465b853afff216f9528ffda78a915ff880ed58813ba4faf4ba0b6/contourpy-1.3.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b7448cb5a725bb1e35ce88771b86fba35ef418952474492cf7c764059933ff8b", size = 203831, upload-time = "2025-07-26T12:02:51.449Z" },
+]
+
+[[package]]
+name = "cycler"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "decorator"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/8b/32f9823da46cde7df2087faa08cd98d01b908f8dcab982cdba9c84e85355/decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82", size = 58084, upload-time = "2026-05-18T06:03:28.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c", size = 10365, upload-time = "2026-05-18T06:03:26.517Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.63.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/69/c97f2c18e0db87d2c7b15da1974dace76ae938f1cfa22e2727a648b7ed43/fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0", size = 3597189, upload-time = "2026-05-14T12:04:30.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/d2/23d25e3f247b328be58d04a4c9f894178a0d1eda7d42867cfb388adaf416/fonttools-4.63.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fd1e3094f42d806d3d7c79162fc59e5910fcbe3a7360c385b8da969bc4493745", size = 2875338, upload-time = "2026-05-14T12:03:50.052Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/58/7dfa0c761cb3b2964e2a84c4dc986c926a87de0cb9fb60d5b28ded3f2914/fonttools-4.63.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6e528da43bc3791085f8cb6141b1d13e459226790240340fcbb4625649238b03", size = 2422661, upload-time = "2026-05-14T12:03:52.154Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/87/64cfa18a7a1621d17b7f4502b2b0ed8a135a90c3db51ea590ee99043e76b/fonttools-4.63.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b2248c5decb223562f7902ff6325077a073f608ee8e33e88ad88db734eb9f49", size = 5010526, upload-time = "2026-05-14T12:03:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e1/a8933a72c45a87177fbde2696e0d0755c8c9062f8c077a961c6215fa27b1/fonttools-4.63.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:308f957cdeaf8abe4e5f2f124902ef405448af92c90f80e302a3b771c2e6116b", size = 4923946, upload-time = "2026-05-14T12:03:56.984Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/872e6e233b8c5e8b41413796ff18b7fe479661bd40147e071b450dfad7a1/fonttools-4.63.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bf00f21eb5fb721dbaf73d1e9da6d02a1af7768f2ebcf9798be98beab8ba90f6", size = 4962489, upload-time = "2026-05-14T12:03:59.443Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c4/83c24f2ec38b90cfda84bf4b1a1f49df80e84a1db4e7ac6e0d41bf23bc39/fonttools-4.63.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c1aaa4b9c75798400ac043ce04d74e7830376c85095a5a6ed7cba2f17a266bf4", size = 5071870, upload-time = "2026-05-14T12:04:02.122Z" },
+    { url = "https://files.pythonhosted.org/packages/de/40/3ae22b60ff1d41ce0bd044b31238cdc72cef99f28b976f1e128ebd618c9b/fonttools-4.63.0-cp314-cp314-win32.whl", hash = "sha256:22693918177bd9ceabec4736d338045f357769416fc6b0b2508eefef75b08616", size = 2295026, upload-time = "2026-05-14T12:04:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d4/98078064ccc76b45cb0f6c002452011e93c4bd26f6850344f0951cc1fe89/fonttools-4.63.0-cp314-cp314-win_amd64.whl", hash = "sha256:7d782fac32985914c351556f68ac0855391572bcd87de50e05970d3cd4c96fc5", size = 2347454, upload-time = "2026-05-14T12:04:06.752Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4e/652d1580c5f4e39f7d103b0c793e4773129ad633dce4addd0cf4dfebde02/fonttools-4.63.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6db5140a60a5d731d21ec076745b40a310607731b0a565b50776393188649001", size = 2958152, upload-time = "2026-05-14T12:04:08.706Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/55/ad864c9a9b219f552eb46b32cd7906c466e5a578ba0c3abfcc0fe7413eb6/fonttools-4.63.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d76edbff9014094dbf03bd2d074709dfa6ec7aba13d838c937a2b33d2d6a86e", size = 2460809, upload-time = "2026-05-14T12:04:10.783Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2b/0aa8db70f18cf52e49b4ed5ecec68547f981160bf5ded3b5aed6faa0a6f9/fonttools-4.63.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0eac00b9118c3c2f87d272e45341871c5b3066baa3c86897fa634a7c3fb59096", size = 5148649, upload-time = "2026-05-14T12:04:12.747Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/63/18e4369c25043096f1048e0c9915951adc4f842bd81c6b18155824d6fa99/fonttools-4.63.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51394295f1a51de8b5f30bdb1e1b9a4231536c7064ef5c6e211eec19fa36036f", size = 4932147, upload-time = "2026-05-14T12:04:14.806Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/3f/67f3eac2ffd8a98446c5022f8ed3864eac878a5ff7af8df4c8286dba16cc/fonttools-4.63.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9e12f105d2b6342c559c298afb674006bb2893afc7102dcf8a1b55b0486b4e40", size = 5027237, upload-time = "2026-05-14T12:04:17.675Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ba/4e6214cb38a7b04779e97bb7636de9a5c7f20af7018d03dee0b64c08510a/fonttools-4.63.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:796f27556dbe094c4824f75ca85267e4df776c79036c8441469a4df37038c196", size = 5053933, upload-time = "2026-05-14T12:04:20.818Z" },
+    { url = "https://files.pythonhosted.org/packages/34/3b/214dcc19ee31d3d38fb5ad2755c11ef0514e5dc300bbaf41c0b69f393799/fonttools-4.63.0-cp314-cp314t-win32.whl", hash = "sha256:948428a275741f0b64b113c955425a953314f4b9ab9997f73a72c83e68e569c8", size = 2359326, upload-time = "2026-05-14T12:04:24.22Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/1e/3ff1a9b523058c2eeb6a9d50f5574e2a738200d0d94107d5bc4105e8da3f/fonttools-4.63.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6d4741eb179121cab9eea4cb2393d24492373a260d7945006358c08cfbf45419", size = 2425829, upload-time = "2026-05-14T12:04:26.829Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/47/c99d5268f354002ce80f8d029cd9d7d872969da1de8b93d32de4dc56d6f4/fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d", size = 1164562, upload-time = "2026-05-14T12:04:29.092Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "9.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/59/165d3b4d75cc34add3122c4417ecb229085140ac573103c223cd01dde96f/ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756", size = 4442580, upload-time = "2026-06-26T11:03:35.913Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/3a/948263ca3b9d65bb2b1b0c521b3a49fad5d59ada58724bd87d2bd5ff3f36/ipython-9.15.0-py3-none-any.whl", hash = "sha256:515ad9c3cdf0c932a5a9f6245419e8aba706b7bd03c3e1d3a1c83d9351d6aa6e", size = 630895, upload-time = "2026-06-26T11:03:33.809Z" },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "ipywidgets"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "comm" },
+    { name = "ipython" },
+    { name = "jupyterlab-widgets" },
+    { name = "traitlets" },
+    { name = "widgetsnbextension" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/ae/c5ce1edc1afe042eadb445e95b0671b03cee61895264357956e61c0d2ac0/ipywidgets-8.1.8.tar.gz", hash = "sha256:61f969306b95f85fba6b6986b7fe45d73124d1d9e3023a8068710d47a22ea668", size = 116739, upload-time = "2025-11-01T21:18:12.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl", hash = "sha256:ecaca67aed704a338f88f67b1181b58f821ab5dc89c1f0f5ef99db43c1c2921e", size = 139808, upload-time = "2025-11-01T21:18:10.956Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67", size = 4884812, upload-time = "2026-05-01T23:38:43.919Z" },
+]
+
+[[package]]
+name = "jupyterlab-widgets"
+version = "3.0.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/2d/ef58fed122b268c69c0aa099da20bc67657cdfb2e222688d5731bd5b971d/jupyterlab_widgets-3.0.16.tar.gz", hash = "sha256:423da05071d55cf27a9e602216d35a3a65a3e41cdf9c5d3b643b814ce38c19e0", size = 897423, upload-time = "2025-11-01T21:11:29.724Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl", hash = "sha256:45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8", size = 914926, upload-time = "2025-11-01T21:11:28.008Z" },
+]
+
+[[package]]
+name = "kaleido"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "choreographer" },
+    { name = "logistro" },
+    { name = "orjson" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/64/53eac73d31dbfc3310ee2e87bcac1ae7417427f0fbe3dd800eaf676db324/kaleido-1.3.0.tar.gz", hash = "sha256:5e0378a7475e98852773deeb6483dee91f8aa7b364dde7b5f2b3622cb468a3e6", size = 68938, upload-time = "2026-05-04T19:45:28.932Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/b9/a6d8bb7d228940f01885bd9f327ab7f9d366a9be775c4bf366bf9d9477ae/kaleido-1.3.0-py3-none-any.whl", hash = "sha256:52714dfd38e8f2a114831826200c40bb10d0ca0c11d4272f3f48ad499cd8f8ea", size = 55580, upload-time = "2026-05-04T19:45:27.483Z" },
+]
+
+[[package]]
+name = "kiwisolver"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a", size = 103482, upload-time = "2026-03-09T13:15:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d7/060f45052f2a01ad5762c8fdecd6d7a752b43400dc29ff75cd47225a40fd/kiwisolver-1.5.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8df31fe574b8b3993cc61764f40941111b25c2d9fea13d3ce24a49907cd2d615", size = 123231, upload-time = "2026-03-09T13:14:41.323Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a7/78da680eadd06ff35edef6ef68a1ad273bad3e2a0936c9a885103230aece/kiwisolver-1.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1d49a49ac4cbfb7c1375301cd1ec90169dfeae55ff84710d782260ce77a75a02", size = 66489, upload-time = "2026-03-09T13:14:42.534Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b2/97980f3ad4fae37dd7fe31626e2bf75fbf8bdf5d303950ec1fab39a12da8/kiwisolver-1.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0cbe94b69b819209a62cb27bdfa5dc2a8977d8de2f89dfd97ba4f53ed3af754e", size = 64063, upload-time = "2026-03-09T13:14:44.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f9/b06c934a6aa8bc91f566bd2a214fd04c30506c2d9e2b6b171953216a65b6/kiwisolver-1.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80aa065ffd378ff784822a6d7c3212f2d5f5e9c3589614b5c228b311fd3063ac", size = 1475913, upload-time = "2026-03-09T13:14:46.247Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f0/f768ae564a710135630672981231320bc403cf9152b5596ec5289de0f106/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e7f886f47ab881692f278ae901039a234e4025a68e6dfab514263a0b1c4ae05", size = 1282782, upload-time = "2026-03-09T13:14:48.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9f/1de7aad00697325f05238a5f2eafbd487fb637cc27a558b5367a5f37fb7f/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5060731cc3ed12ca3a8b57acd4aeca5bbc2f49216dd0bec1650a1acd89486bcd", size = 1300815, upload-time = "2026-03-09T13:14:50.721Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/c2/297f25141d2e468e0ce7f7a7b92e0cf8918143a0cbd3422c1ad627e85a06/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7a4aa69609f40fce3cbc3f87b2061f042eee32f94b8f11db707b66a26461591a", size = 1347925, upload-time = "2026-03-09T13:14:52.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d3/f4c73a02eb41520c47610207b21afa8cdd18fdbf64ffd94674ae21c4812d/kiwisolver-1.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:d168fda2dbff7b9b5f38e693182d792a938c31db4dac3a80a4888de603c99554", size = 991322, upload-time = "2026-03-09T13:14:54.637Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/46/d3f2efef7732fcda98d22bf4ad5d3d71d545167a852ca710a494f4c15343/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:413b820229730d358efd838ecbab79902fe97094565fdc80ddb6b0a18c18a581", size = 2232857, upload-time = "2026-03-09T13:14:56.471Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ec/2d9756bf2b6d26ae4349b8d3662fb3993f16d80c1f971c179ce862b9dbae/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5124d1ea754509b09e53738ec185584cc609aae4a3b510aaf4ed6aa047ef9303", size = 2329376, upload-time = "2026-03-09T13:14:58.072Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/9f/876a0a0f2260f1bde92e002b3019a5fabc35e0939c7d945e0fa66185eb20/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e4415a8db000bf49a6dd1c478bf70062eaacff0f462b92b0ba68791a905861f9", size = 1982549, upload-time = "2026-03-09T13:14:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/4f/ba3624dfac23a64d54ac4179832860cb537c1b0af06024936e82ca4154a0/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d618fd27420381a4f6044faa71f46d8bfd911bd077c555f7138ed88729bfbe79", size = 2494680, upload-time = "2026-03-09T13:15:01.364Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b7/97716b190ab98911b20d10bf92eca469121ec483b8ce0edd314f51bc85af/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5092eb5b1172947f57d6ea7d89b2f29650414e4293c47707eb499ec07a0ac796", size = 2297905, upload-time = "2026-03-09T13:15:03.925Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/36/4e551e8aa55c9188bca9abb5096805edbf7431072b76e2298e34fd3a3008/kiwisolver-1.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:d76e2d8c75051d58177e762164d2e9ab92886534e3a12e795f103524f221dd8e", size = 75086, upload-time = "2026-03-09T13:15:07.775Z" },
+    { url = "https://files.pythonhosted.org/packages/70/15/9b90f7df0e31a003c71649cf66ef61c3c1b862f48c81007fa2383c8bd8d7/kiwisolver-1.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:fa6248cd194edff41d7ea9425ced8ca3a6f838bfb295f6f1d6e6bb694a8518df", size = 66577, upload-time = "2026-03-09T13:15:09.139Z" },
+    { url = "https://files.pythonhosted.org/packages/17/01/7dc8c5443ff42b38e72731643ed7cf1ed9bf01691ae5cdca98501999ed83/kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d1ffeb80b5676463d7a7d56acbe8e37a20ce725570e09549fe738e02ca6b7e1e", size = 125794, upload-time = "2026-03-09T13:15:10.525Z" },
+    { url = "https://files.pythonhosted.org/packages/46/8a/b4ebe46ebaac6a303417fab10c2e165c557ddaff558f9699d302b256bc53/kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bc4d8e252f532ab46a1de9349e2d27b91fce46736a9eedaa37beaca66f574ed4", size = 67646, upload-time = "2026-03-09T13:15:12.016Z" },
+    { url = "https://files.pythonhosted.org/packages/60/35/10a844afc5f19d6f567359bf4789e26661755a2f36200d5d1ed8ad0126e5/kiwisolver-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6783e069732715ad0c3ce96dbf21dbc2235ab0593f2baf6338101f70371f4028", size = 65511, upload-time = "2026-03-09T13:15:13.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/8a/685b297052dd041dcebce8e8787b58923b6e78acc6115a0dc9189011c44b/kiwisolver-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7c4c09a490dc4d4a7f8cbee56c606a320f9dc28cf92a7157a39d1ce7676a657", size = 1584858, upload-time = "2026-03-09T13:15:15.103Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/80/04865e3d4638ac5bddec28908916df4a3075b8c6cc101786a96803188b96/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a075bd7bd19c70cf67c8badfa36cf7c5d8de3c9ddb8420c51e10d9c50e94920", size = 1392539, upload-time = "2026-03-09T13:15:16.661Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/01/77a19cacc0893fa13fafa46d1bba06fb4dc2360b3292baf4b56d8e067b24/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bdd3e53429ff02aa319ba59dfe4ceeec345bf46cf180ec2cf6fd5b942e7975e9", size = 1405310, upload-time = "2026-03-09T13:15:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/53/39/bcaf5d0cca50e604cfa9b4e3ae1d64b50ca1ae5b754122396084599ef903/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cdcb35dc9d807259c981a85531048ede628eabcffb3239adf3d17463518992d", size = 1456244, upload-time = "2026-03-09T13:15:20.444Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7a/72c187abc6975f6978c3e39b7cf67aeb8b3c0a8f9790aa7fd412855e9e1f/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:70d593af6a6ca332d1df73d519fddb5148edb15cd90d5f0155e3746a6d4fcc65", size = 1073154, upload-time = "2026-03-09T13:15:22.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ca/cf5b25783ebbd59143b4371ed0c8428a278abe68d6d0104b01865b1bbd0f/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:377815a8616074cabbf3f53354e1d040c35815a134e01d7614b7692e4bf8acfa", size = 2334377, upload-time = "2026-03-09T13:15:23.741Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e5/b1f492adc516796e88751282276745340e2a72dcd0d36cf7173e0daf3210/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0255a027391d52944eae1dbb5d4cc5903f57092f3674e8e544cdd2622826b3f0", size = 2425288, upload-time = "2026-03-09T13:15:25.789Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/e5/9b21fbe91a61b8f409d74a26498706e97a48008bfcd1864373d32a6ba31c/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:012b1eb16e28718fa782b5e61dc6f2da1f0792ca73bd05d54de6cb9561665fc9", size = 2063158, upload-time = "2026-03-09T13:15:27.63Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/02/83f47986138310f95ea95531f851b2a62227c11cbc3e690ae1374fe49f0f/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e3aafb33aed7479377e5e9a82e9d4bf87063741fc99fc7ae48b0f16e32bdd6f", size = 2597260, upload-time = "2026-03-09T13:15:29.421Z" },
+    { url = "https://files.pythonhosted.org/packages/07/18/43a5f24608d8c313dd189cf838c8e68d75b115567c6279de7796197cfb6a/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7a116ae737f0000343218c4edf5bd45893bfeaff0993c0b215d7124c9f77646", size = 2394403, upload-time = "2026-03-09T13:15:31.517Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b5/98222136d839b8afabcaa943b09bd05888c2d36355b7e448550211d1fca4/kiwisolver-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1dd9b0b119a350976a6d781e7278ec7aca0b201e1a9e2d23d9804afecb6ca681", size = 79687, upload-time = "2026-03-09T13:15:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a2/ca7dc962848040befed12732dff6acae7fb3c4f6fc4272b3f6c9a30b8713/kiwisolver-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:58f812017cd2985c21fbffb4864d59174d4903dd66fa23815e74bbc7a0e2dd57", size = 70032, upload-time = "2026-03-09T13:15:34.411Z" },
+]
+
+[[package]]
+name = "logistro"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/90/bfd7a6fab22bdfafe48ed3c4831713cb77b4779d18ade5e248d5dbc0ca22/logistro-2.0.1.tar.gz", hash = "sha256:8446affc82bab2577eb02bfcbcae196ae03129287557287b6a070f70c1985047", size = 8398, upload-time = "2025-11-01T02:41:18.81Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/6aa79ba3570bddd1bf7e951c6123f806751e58e8cce736bad77b2cf348d7/logistro-2.0.1-py3-none-any.whl", hash = "sha256:06ffa127b9fb4ac8b1972ae6b2a9d7fde57598bf5939cd708f43ec5bba2d31eb", size = 8555, upload-time = "2025-11-01T02:41:17.587Z" },
+]
+
+[[package]]
+name = "matplotlib"
+version = "3.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "contourpy" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/24/080c99d223d158d3a8902769269ab6da5b50f7a0e6e072513907e02b7a6c/matplotlib-3.11.0.tar.gz", hash = "sha256:68c0c7be01b30dcca3638934f7f591df73401235cbdbf0d1ab1c71e7db7f8b57", size = 33251176, upload-time = "2026-06-12T02:29:15.508Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/52/a94102ac99eb78e2fe9b826674f9ef9ee23327110ea6ab4776c1b4eb6209/matplotlib-3.11.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3338e3e3de128cf50d0d2fb92a122815daf9c755bd882a474343c05f8fd7ec79", size = 9452137, upload-time = "2026-06-12T02:28:37.93Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/03/b8cdb625a21f710dfa11bbca1f48fb4057d2c0286975f8b415bf80942c99/matplotlib-3.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:25c2e5455efd8d99f41fb79871a31feb7d301569642e332ec58d72cfe9282bc3", size = 9281514, upload-time = "2026-06-12T02:28:40.028Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/2d/4e1240ea82ee197dfb3851e71f71c87eeeb975f1753b56a0588e4e80739a/matplotlib-3.11.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9695457a467ff86d23f35037a43deb6f1134dd6d3e2ac8ce1e2087cff09ffb9", size = 10843005, upload-time = "2026-06-12T02:28:42.39Z" },
+    { url = "https://files.pythonhosted.org/packages/29/dc/6377ecfaa5fef79430f74a1a16638b4e2aa30d4692bae2c19f9d76fe3b01/matplotlib-3.11.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19c16c61dea63b3582918503e6b294193961261d9daa806d4ae2151f1ad05430", size = 11127459, upload-time = "2026-06-12T02:28:44.483Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/41/795c405aa7560443a3b01309424cde4a1113b85c90b8a63417444a749617/matplotlib-3.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2d72ea8b7924f3cb955e61518d21e43b3df1e6c8a793b480a0c1214f185d30ba", size = 10925160, upload-time = "2026-06-12T02:28:46.564Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/f7/3a9e6389a7cfaeff76c56e40c2dabcb13110e21e82f837228c834ebe748c/matplotlib-3.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:1c02da0a629dfa9debf52725ea06866b74c1fb70a895bae05e4493d34074f9f2", size = 9485186, upload-time = "2026-06-12T02:28:49.344Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/c0/396478ee7cf2091d182db8b4a8695f6a37f1ddb978989cf9dbb84cd5c123/matplotlib-3.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aa55d73b3117d4b07f959cd9eb6f69b375d8df3414139c479388e551aa5d999d", size = 9160349, upload-time = "2026-06-12T02:28:51.382Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6f/1c3bd51bb2b34eaacdcf3c3d859dbb357f952fc8020c617dc118ad7c9e38/matplotlib-3.11.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a9d8c6e7cd2f0ddf11d8d92e520dd1d9d2abb0cf6ac8831e338666c81e905847", size = 9500921, upload-time = "2026-06-12T02:28:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/4d861d0121840cb1a3fd4a10deb211efd6fccd481ed23e553f31f4f4da4a/matplotlib-3.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:be050fcf32f729eda99f7f75a80bf67612ce16ab9ac1c23a387dcaede95cb70e", size = 9332190, upload-time = "2026-06-12T02:28:55.623Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/cb/22f6bc35711a0b5639a784e74e653e77c86210bd4304449dd399a482f74e/matplotlib-3.11.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfabef0230d0697aa0d717385194dd41162e00207a68bf4abf94c2bf4c27dca0", size = 10854181, upload-time = "2026-06-12T02:28:57.856Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/7e/9a9eaca731a2939589da520f0ebe8fd8753d0f51fca98c7d20af6dbe261a/matplotlib-3.11.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1644db30e759199443493ac5e5caec24fdb775a8f6123021f85ba47c4133c3cb", size = 11137715, upload-time = "2026-06-12T02:29:00.555Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f9/9b030b6088354acb0296871bb624b25befc1c42509d3c6cd17420c83a5b8/matplotlib-3.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:15b0d160079cb10699a0e98b5989c70677b2df7cacdc62af67c30f2facec46d9", size = 10939427, upload-time = "2026-06-12T02:29:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/59/94/6b273eaee4ee250863567d100865da61a5c1527fa67f527b7ed22e0dd29c/matplotlib-3.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:446307e6b04b57b1f1239e228a1ec2af0d589a1008cebc3dfa3f5441d095cfb6", size = 9535809, upload-time = "2026-06-12T02:29:04.994Z" },
+    { url = "https://files.pythonhosted.org/packages/60/95/1d36bddf2b7e2692c1540e78a6e5bc88bc1496b137e3e35a611f91b65ac3/matplotlib-3.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:652fb5696271d4c50f196d22a5ff4f8e4444c74f847423570d7dc0aa2bbd0159", size = 9209226, upload-time = "2026-06-12T02:29:07.033Z" },
+]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6", size = 9534, upload-time = "2026-05-08T17:33:32.055Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.24.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/1d/58946e5aab18393e793bd4add6985b95d0e01c3a2d832f38f54468b10dcd/narwhals-2.24.0.tar.gz", hash = "sha256:b5c0f684ccd9d7475b564111e319a4964abcf2baf79d3cf6b1003d06ac9b828d", size = 661143, upload-time = "2026-07-13T10:49:19.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/85/a5bfaebfd305ac18b57b0854d74e37e586809061a91fda62f0bd50c8518e/narwhals-2.24.0-py3-none-any.whl", hash = "sha256:42fdedf44e5b2ca7505630d45b4ac3058f38d8485cba9fe1652ca23152df7489", size = 461030, upload-time = "2026-07-13T10:49:17.571Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/f4/731b6085a83faf6ca843394cbd5e217280c214399f7e8b21b9f552af0ae2/numpy-2.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7c786fe9a5bbe360022e584c5a34cf6b54265c71bd7ec8ac3d8fec38968071f8", size = 16795063, upload-time = "2026-07-04T17:07:07.374Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/64/0e215f2048dd11a55bb989ed41b3585ef57452404e638d703a211a3e4157/numpy-2.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32985c896d897419ef8da6917872d80b78ad0ea26d85b23245c7366ffde76d75", size = 11776652, upload-time = "2026-07-04T17:07:09.907Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/59/2b844c7a6e9deff69b404a66221e1542937734f65d5e6e39411876053862/numpy-2.5.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:efd736408cc97c79b9e6917338dfc8f06013b2274f992e96b1d9a81a71e2a2c2", size = 5335944, upload-time = "2026-07-04T17:07:12.227Z" },
+    { url = "https://files.pythonhosted.org/packages/86/51/9bf7cb2cabcebc9e017e4ec7e6322b378317a542c08b4cb68479c1efc716/numpy-2.5.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:ab84dc6b074fa881cae55bea94cc4f68e285181ba7f32497bf7dee6b1496165b", size = 6656266, upload-time = "2026-07-04T17:07:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/83/3e/fb7615b211b82a32f44d5180a6d421b61f84d4fadd578b48ba4ac34e189f/numpy-2.5.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caf3e317d33d60c37986b452613f4ab51246d0691350c03d0cb4a898627f4a95", size = 15179720, upload-time = "2026-07-04T17:07:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/0f992cb24560673496c5d68de61913b57166ce530ffda07c1f280e0cc464/numpy-2.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54ad769f17bc2d833b620851989f62054fb9ab93c969d9e1dc3c8e3d56beea21", size = 16664835, upload-time = "2026-07-04T17:07:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2f/97d6475ee91afe2587797d09446f9d3e475ad4cb681662d824809327b75a/numpy-2.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c12afb53450fa976d4c681c50a7423729a4c51c0465ed9f32b8a9cabbc472373", size = 16539135, upload-time = "2026-07-04T17:07:22.015Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5b/4db81e4ba0be7e2776b1de68c82aa862c7f8ec27e1b4927d4ae075e20678/numpy-2.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e8c11c405efc5ff6816d5983c96cdfa215bab3428961243af3ff59b228490438", size = 18426684, upload-time = "2026-07-04T17:07:24.941Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/64/c0ba2d90724d450279a7df8f32057241070250a26a7e2b5337d77347f481/numpy-2.5.1-cp314-cp314-win32.whl", hash = "sha256:f2479a47f8d5932d1718168a681ad6e536a9df484c83cfcf9de365e164537ace", size = 6116103, upload-time = "2026-07-04T17:07:27.622Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1a/837f9ed7405adcd7a40538792eb169eddd8fa5630c16a1ef49dae71a30f4/numpy-2.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:24d0eb82c0541d3415a33425db64ae439dffccd7b4dbcb30e7c35120205c506a", size = 12562177, upload-time = "2026-07-04T17:07:29.887Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/49707938b6dd0a78a9178dd93227dc89e4c11af47f5c798d70366e8d0483/numpy-2.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:5a4c988b38d261deeeaad9954e3deb091ad905c94e8bb6708654ef1d97f286b0", size = 10627739, upload-time = "2026-07-04T17:07:32.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/bb4b882cfe7f299cbc8b66e42e7dd78cf9d14e40f9469fc5e3db7e15b3bd/numpy-2.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a33276be12fa045805f477f22482088b66bb758ffbe89a9d21457de863a32e22", size = 11894709, upload-time = "2026-07-04T17:07:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/40/3f/5af7f4a7f6224aef48017aa82bb6174c7a659d724be0c75017b7e64a55b4/numpy-2.5.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f089d7b00756190aacf1f5d34bdf38c3c430ac82b4f868f8cede73380460fce7", size = 5453810, upload-time = "2026-07-04T17:07:37.495Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c9/3474309bc94d634d3f9c3eddf03250ecb8c22cd948ef16fef69a77cc5d7b/numpy-2.5.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:09e9bfd8d2cf479c7d174804fb3811c53a8e9f20a37444008606b57d6b7a826d", size = 6761189, upload-time = "2026-07-04T17:07:39.563Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8a/558ae39fdd55d7e7f7fef9a84a6e964ac6b23edbd2a07e52bb084500507d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e68d8dd1e7eba712948f2053a29ec86917bc70ba1358df869d9f06649ef9cf09", size = 15225039, upload-time = "2026-07-04T17:07:41.682Z" },
+    { url = "https://files.pythonhosted.org/packages/63/27/ca7392b2d030277bdf0273e7d23255b3ee57d57a7c170a6f4fb3981e1e5d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:99d5095fa265a0c4152e7bb12759e14381ef5496152f1ce58f44bdf55c44beb4", size = 16701306, upload-time = "2026-07-04T17:07:44.611Z" },
+    { url = "https://files.pythonhosted.org/packages/02/42/03d53ae7996c44d4374a8262e9dc41671fd56cbb98f7d47ef85cf5da4c6b/numpy-2.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ab87a91b3cc3382b8956095bd8f95e00cf679bb81554339be1a2ba404a1473c1", size = 16589955, upload-time = "2026-07-04T17:07:47.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/15/6c1784ae469640e65db111e9a34b3d0f14d91e8a38b9ce34810ced370dbb/numpy-2.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:224ca51130ef7da85bea2191625181cb4f337f9cb64b471f10c1a12aa8b60077", size = 18464252, upload-time = "2026-07-04T17:07:50.684Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a8/f98e50356cf167df656c526c2dfeec2d7dde182f2a3da4b458a5938e2776/numpy-2.5.1-cp314-cp314t-win32.whl", hash = "sha256:6eab239876581b2b3c5a242281b6007bbdbcd1c7085d7709bb57c5929b11e6bf", size = 6263298, upload-time = "2026-07-04T17:07:53.445Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ac/96ae880cdecad0b3275d9359fcec72667b49a4863c9f12942e43679dda02/numpy-2.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:83ce9c80d5b521b0d77ddcbe5447c218d247929b6cc056ca5351342accfff0af", size = 12748623, upload-time = "2026-07-04T17:07:55.384Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5a/4d2b1601df3602dba7a14f3348ba9bfe94a18adb428e693df6154c293831/numpy-2.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:5a6db61f9aaa57e369905c67d852045d3c4f7126405b29d09b19dec118e9c9cb", size = 10697674, upload-time = "2026-07-04T17:07:58.506Z" },
+]
+
+[[package]]
+name = "orjson"
+version = "3.11.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/0c/964746fcafbd16f8ff53219ad9f6b412b34f345c75f384ad434ceaadb538/orjson-3.11.9.tar.gz", hash = "sha256:4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f", size = 5599163, upload-time = "2026-05-06T15:11:08.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/eb/5da01e356015aee6ecfa1187ced87aef51364e306f5e695dd52719bf0e78/orjson-3.11.9-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:b6ef1979adc4bc243523f1a2ba91418030a8e29b0a99cbe7e0e2d6807d4dce6e", size = 228465, upload-time = "2026-05-06T15:10:44.097Z" },
+    { url = "https://files.pythonhosted.org/packages/64/62/3e0e0c14c957133bcd855395c62b55ed4e3b0af23ffea11b032cb1dcbdb1/orjson-3.11.9-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:f36b7f32c7c0db4a719f1fc5824db4a9c6f8bd1a354debb91faf26ebf3a4c71e", size = 128364, upload-time = "2026-05-06T15:10:45.839Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5a/07d8aa117211a8ed7630bda80c8c0b14d04e0f8dcf99bcf49656e4a710eb/orjson-3.11.9-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08f4d8ebb44925c794e535b2bebc507cebf32209df81de22ae285fb0d8d66de0", size = 132063, upload-time = "2026-05-06T15:10:47.267Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ec/4acaf21483e18aa945be74a474c74b434f284b549f275a0a39b9f98956e9/orjson-3.11.9-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6cc7923789694fd58f001cbcac7e47abc13af4d560ebbfcf3b41a8b1a0748124", size = 122356, upload-time = "2026-05-06T15:10:48.765Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d8/5f0555e7638801323b7a75850f92e7dfa891bc84fe27a1ba4449170d1200/orjson-3.11.9-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea5c46eb2d3af39e806b986f4b09d5c2706a1f5afde3cbf7544ce6616127173c", size = 129592, upload-time = "2026-05-06T15:10:50.13Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/30/ed9860412a3603ceb3c5955bfd72d28b9d0e7ba6ed81add14f83d7114236/orjson-3.11.9-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f5d89a2ed90731df3be64bab0aa44f78bff39fdc9d71c291f4a8023aa46425b7", size = 140491, upload-time = "2026-05-06T15:10:51.582Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/17/adc514dea7ac7c505527febf884934b815d34f0c7b8693c1a8b39c5c4a57/orjson-3.11.9-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:25e4aed0312d292c09f61af25bba34e0b2c88546041472b09088c39a4d828af1", size = 127309, upload-time = "2026-05-06T15:10:53.329Z" },
+    { url = "https://files.pythonhosted.org/packages/76/3e/c0b690253f0b82d86e99949af13533363acfb5432ecb5d53dd5b3bce9c34/orjson-3.11.9-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aaea64f3f467d22e70eeed68bdccb3bc4f83f650446c4a03c59f2cba28a108db", size = 134030, upload-time = "2026-05-06T15:10:54.988Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/7a/bc82a0bb25e9faaf92dc4d9ef002732efc09737706af83e346788641d4a7/orjson-3.11.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a028425d1b440c5d92a6be1e1a020739dfe67ea87d96c6dbe828c1b30041728b", size = 141482, upload-time = "2026-05-06T15:10:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/01/55/e69188b939f77d5d32a9833745ace31ea5ccae3ab613a1ec185d3cd2c4fb/orjson-3.11.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5b192c6cf397e4455b11523c5cf2b18ed084c1bbd61b6c0926344d2129481972", size = 415178, upload-time = "2026-05-06T15:10:58.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/b8a5a7ac527e80b9cb11d51e3f6689b709279183264b9ec5c7bc680bb8b5/orjson-3.11.9-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea407d4ccf5891d667d045fecae97a7a1e5e87b3b97f97ae1803c2e741130be0", size = 148089, upload-time = "2026-05-06T15:11:00.441Z" },
+    { url = "https://files.pythonhosted.org/packages/97/4e/00503f64204bf859b37213a63927028f30fb6268cd8677fb0a5ad48155e1/orjson-3.11.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f63aaf97afd9f6dec5b1a68e1b8da12bfccb4cb9a9a65c3e0b6c847849e7586", size = 136921, upload-time = "2026-05-06T15:11:02.176Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ba/a23b82a0a8d0ed7bed4e5f5035aae751cad4ff6a1e8d2ecd14d8860f5929/orjson-3.11.9-cp314-cp314-win32.whl", hash = "sha256:e30ab17845bb9fa54ccf67fa4f9f5282652d54faa6d17452f47d0f369d038673", size = 131638, upload-time = "2026-05-06T15:11:03.696Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/0c6798456bade745c75c452342dabacce5798196483e77e643be1f53877d/orjson-3.11.9-cp314-cp314-win_amd64.whl", hash = "sha256:32ef5f4283a3be81913947d19608eacb7c6608026851123790cd9cc8982af34b", size = 127078, upload-time = "2026-05-06T15:11:05.123Z" },
+    { url = "https://files.pythonhosted.org/packages/16/21/5a3f1e8913103b703a436a5664238e5b965ec392b555fe68943ea3691e6b/orjson-3.11.9-cp314-cp314-win_arm64.whl", hash = "sha256:eebdbdeef0094e4f5aefa20dcd4eb2368ab5e7a3b4edea27f1e7b2892e009cf9", size = 126687, upload-time = "2026-05-06T15:11:06.602Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/54/effdcc3c0ff7a08037889200e148ebe94c16c4f653be078c7b3675955df1/pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3650109c0f22879df8bd6179ab9ee3d7f1d1d4e7e0094a3f0032d9f51e2e64ac", size = 10336065, upload-time = "2026-05-11T18:53:41.099Z" },
+    { url = "https://files.pythonhosted.org/packages/68/10/bf2d6738d72748b961a3751ab89522d58c54efc36a8e1a12161216cd45cf/pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab900348131a7db1f69a7309ef141fd5680f1487094193bcbbb61791573bf8f", size = 9926101, upload-time = "2026-05-11T18:53:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e9/e35cf11c8a136e757b956f5f0efdcaa50aecde85ea055f1898dfc68262f3/pandas-3.0.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba7e08b9ac1d54569cd1e256e3668975ed624d6826f7b68df0342b012007bddb", size = 10457553, upload-time = "2026-05-11T18:53:46.394Z" },
+    { url = "https://files.pythonhosted.org/packages/58/3b/1cdec6772bdbaf7b25dab360c59f03cadf05492dd724c6540af905389b07/pandas-3.0.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d71c63ae4ebdbf70209742096f1fc46a83a0613c99d4b23766cced9ff8cd62a", size = 10914065, upload-time = "2026-05-11T18:53:49.134Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/1ef644445fcd72e3627bceec77e3560636f87ddce4ed841afe76b83b5bf9/pandas-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360", size = 11459188, upload-time = "2026-05-11T18:53:52.527Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/49/4d8d4f42cbc9c4adc7a1870f269c02cbd6cd40d059622c06fb298addcbad/pandas-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:335f62418ed562cfc3c49e9e196375c28b729dcef8543abf4f9438e381bf3c76", size = 11982966, upload-time = "2026-05-11T18:53:55.043Z" },
+    { url = "https://files.pythonhosted.org/packages/38/55/792619469bab9882d8bbd5865d45a72f6478762d04a9af4bf0d08c503e95/pandas-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:3c20a521bbb85902f79f7270c80a59e1b5452d96d170c034f207181870f97ac5", size = 9876755, upload-time = "2026-05-11T18:53:58.067Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/af/33c469653b0ba03b50c3a98192d4c07f0c75c66b263ceb097fce0ee97d31/pandas-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:a2d2dff8a04f3917b55ab3910c32990f8ddf7eceba114947838cefa976a68977", size = 9198658, upload-time = "2026-05-11T18:54:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/fa/b8c257bd76b8bd060c3a9151c1fca05e9b9c5e3af5d0f549c0356f6d143d/pandas-3.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d589105b3c14645af1738ff279b2995102d8f7a03b0a66dc8d95550eb513e04", size = 10787242, upload-time = "2026-05-11T18:54:03.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/eb/f19206ffb0bf1919002969aa448b4702c6594845156a6f8050674855aac3/pandas-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13fc1e853d9e04743d11ba75a985ccbc2a317fe07d8af61e445a6fd24dacd6a6", size = 10436369, upload-time = "2026-05-11T18:54:06.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/24/c7c39fb4fe22b71a0c2d78bf0c585c600092d85f94f086d2b3b2f6ca27e2/pandas-3.0.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:819959dab7bbd0049c15623fbac4e29a191b9528160a61fb1032242d8ced2d9c", size = 10358306, upload-time = "2026-05-11T18:54:09.085Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ec/dd2a9eb7fa1204df88c0864164e35b228ac581062ac612ba0a67fd812e4c/pandas-3.0.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60ae316d3fd75d1858d450d0db0103ea2be3e7d4a95ec2f064f7e2ae63f7b028", size = 10758394, upload-time = "2026-05-11T18:54:11.956Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6e/00c61ea8e85b4f6d8d35e11852a1a4998fc7fafc91c6a602d1cc9c972d64/pandas-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd3a518890b400d32f9023722dc9a9a5c969f00b415419a3c06c043f09bb5d7d", size = 11375717, upload-time = "2026-05-11T18:54:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897, upload-time = "2026-05-11T18:54:17.146Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855, upload-time = "2026-05-11T18:54:19.72Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464, upload-time = "2026-05-11T18:54:22.754Z" },
+]
+
+[[package]]
+name = "parso"
+version = "0.8.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/01/001f65b68192f0228cc1dbbc8d2530ab5d58b61037ba0587f946fea607cd/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9cf95fe4d0f84c82d282745d9bb08ad9f926efa00be4697e767b814ce40d4330", size = 4161736, upload-time = "2026-07-01T11:54:51.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d2/0219746d0fd16fc8a84498e79452375be3797d3ce4044596ce565164b84f/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:8728f216dcdb6e6d555cf971cb34076139ad74b31fc2c14da4fafc741c5f6217", size = 4255435, upload-time = "2026-07-01T11:54:53.414Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/02/8d0bc62ef0302318c46ff2a512822d2610e81c7aa46c9b3abe6cbaca5ad0/pillow-12.3.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a45650e8ce7fafffd731db8550230db6b0d306d181a90b67d3e6bca2f1990930", size = 3696262, upload-time = "2026-07-01T11:54:55.739Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e2/73c77d218410b14f5f2d565e8a998d5317b7b9c75368d29985139f7a46f0/pillow-12.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ba54cfebe86920a559a7c4d6b9050791c20513650a1952ebe3368c7dc70306f8", size = 5350344, upload-time = "2026-07-01T11:54:57.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/da/32c752228ae345f489e3a42499d817b6c3996da7e8a3bc7a04fc806b243b/pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e158cb00350dc278f3b91551101aa7d12415a66ebf2c91d8d5ac14e56ddd3ad0", size = 4780131, upload-time = "2026-07-01T11:54:59.713Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/9d/8b2c807dbef61a5197c047afe99823787eb66f63daf9fb2432f91d6f0462/pillow-12.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9aeb04d6aef139de265b29683e119b638208f88cf73cdd1658aa07221165321", size = 6263757, upload-time = "2026-07-01T11:55:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/44/c85361f65dbe00eea8576ee467c768d25129989efb76e94f205e9ca9bb46/pillow-12.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:251bf95b67017e27b13d82f5b326234ca62d70f9cf4c2b9032de2358a3b12c7b", size = 6936962, upload-time = "2026-07-01T11:55:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7e/e483414b35800b86b6f08dbbc7803fb5cd52c4d6f897f47d53ea2c7e6f65/pillow-12.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fe3cca2e4e8a592be0f269a1ca4835c25199d9f3ce815c8491048f785b0a0198", size = 6339171, upload-time = "2026-07-01T11:55:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f4/68c491844841ede6bed70189546b3ee9731cf9f2cbad396faff5e1ccba45/pillow-12.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:23aceaa007d6172b02c277f0cd359c79492bbb14f7072b4ede9fbcaf20648130", size = 7048116, upload-time = "2026-07-01T11:55:08.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/34/77f3f793fed8efc7d243f21b33c5a3f0d1c97ee70346d3db855587e155ff/pillow-12.3.0-cp314-cp314-win32.whl", hash = "sha256:af8d94b0db561cf68b88a267c5c44b49e134f525d0dc2cb7ed413a66bc23559a", size = 6467209, upload-time = "2026-07-01T11:55:10.408Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e0/492879f69d94f91f60fc8cd05ba03650e9520afebb2fb7aa12777d7c7f38/pillow-12.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:fdafc9cce40277e0f7a0feabce0ee50dd2fa1800f3b38015e51296b5e814048d", size = 7237707, upload-time = "2026-07-01T11:55:12.745Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ac/6b11f2875f1c2ac040d84e1bbf9cf22a88038f901ca1037898b280b38365/pillow-12.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:e91206ee562682b51b98ef4b26a6ef48fd84e15fd4c4bc5ec768eb641d206838", size = 2565995, upload-time = "2026-07-01T11:55:14.736Z" },
+    { url = "https://files.pythonhosted.org/packages/52/69/c2208e56af9bfc1913afb24020297a691eb1d4ef688474c8a04913f65e04/pillow-12.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:164b31cd1a0490ab6efae01aa5df49da7061be0af1b30e035b6e9a1bfe34ee6e", size = 5352503, upload-time = "2026-07-01T11:55:17.076Z" },
+    { url = "https://files.pythonhosted.org/packages/07/70/e5686d753e898a45d778ff1718dba8516ead6ab6b95d85fc8c4b70650cf2/pillow-12.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5afb51d599ea772b8365ae807ae557f18bccfe46ab261fd1c2a9ed700fc6eb17", size = 4782956, upload-time = "2026-07-01T11:55:19.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/37/25c6692f06927ee973ff18c8d9ee98ad0b4d84ee67a09610c2dd1447958e/pillow-12.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3edce1d53195db527e0191f84b71d02022de0540bf43a16ed734ed7537b07385", size = 6322855, upload-time = "2026-07-01T11:55:21.613Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/91/420637fcb8f1bc11029e403b4538e6694744428d8246118e45719f944556/pillow-12.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf16ba1b4d0b6b7c8e534936632270cf70eb00dbe09005bc345b2677b726855c", size = 6989642, upload-time = "2026-07-01T11:55:24.006Z" },
+    { url = "https://files.pythonhosted.org/packages/10/08/b94d7811281ccf0d143a1cf768d1c49e1e54af63e7b708ab2ee3eb87face/pillow-12.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:24870b09b224f7ae3c39ed07d10e819d06f8720bc551847b1d623832b5b0e28d", size = 6391281, upload-time = "2026-07-01T11:55:26.252Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/87/24233f785f55474dc02ce3e739c5528a77e3a862e9333d1dd7a25cc31f70/pillow-12.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:30f2aa603c41533cc25c05acd0da21636e84a315768feb631c937177db558931", size = 7096716, upload-time = "2026-07-01T11:55:28.318Z" },
+    { url = "https://files.pythonhosted.org/packages/23/26/fcb2f6e37175b04f53570b59937867e2b80ee1685e744023153028fc14f9/pillow-12.3.0-cp314-cp314t-win32.whl", hash = "sha256:4b0a7fe987b14c31ebda6083f74f22b561fd3739bc0ac51e019622e3d72668c7", size = 6474125, upload-time = "2026-07-01T11:55:30.956Z" },
+    { url = "https://files.pythonhosted.org/packages/90/de/3634abee5f1c9e13c56787b7d5517b0ba8d6de51700b95578cf338349c9f/pillow-12.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:962864dc93511324d51ddbb5b9f8731bf71675b93ca612a07441896f4688fb8c", size = 7242939, upload-time = "2026-07-01T11:55:34.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/2a/fd13f8eb24de5714a6eb444a3d67e2842c6c576e159a43793adf23051351/pillow-12.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0740a512dc522224c77d9aa5a8d70d8b7d73fb91f2c21125d8d025d3b8990e45", size = 2567506, upload-time = "2026-07-01T11:55:35.988Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "plotly"
+version = "6.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/07/795c79dbce40c39bece88e69d049babbd23ffa95b5d117f248db8ea03abb/plotly-6.9.0.tar.gz", hash = "sha256:967ad33e8c704fed051800d11d985eb206a9c795c14206b30a6f463ed9c67d0d", size = 6919903, upload-time = "2026-07-09T14:55:59.982Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/18/d8544811ab076f876c4892b3714f5b0dad335e1dc33aef826df431b8325d/plotly-6.9.0-py3-none-any.whl", hash = "sha256:36bebe2f1bb13884774fe61689c329071446f6ce4a8927fb1f0d6fb24f581236", size = 9909646, upload-time = "2026-07-09T14:55:55.421Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "psygnal"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/79/20c3e23e75272e9ddf018097cf872ab088bccba978888472656629efa4a3/psygnal-0.15.1.tar.gz", hash = "sha256:f64f62dee2306fc1c22050a59b6c6cdad126e04b0cf50e393ff858a1da719096", size = 123147, upload-time = "2026-01-04T16:38:41.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/2e/975bd61727578d88df62797f78390965ca7905780cf01eb59cb095a13638/psygnal-0.15.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:803fc33c4280c822c6f4b22e6c3ea7c4483e190f3cc69e69350098b3799476f3", size = 595706, upload-time = "2026-01-04T16:38:34.139Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/55/e487f1d91497eb75e86c3fdfef69a21b1cab24d023383dd7648b08797d6a/psygnal-0.15.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4f53b4b83355b0a785b745987fd04e59bbf169a9028ed81a68ca7e05fb76d458", size = 575133, upload-time = "2026-01-04T16:38:35.448Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/2f/f286355accd0e68d3eef52e63c8b9ab6ba33ec3107177719a036b3319657/psygnal-0.15.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bcbca12190f5aa65c1f8fb04a81fa6f4463c5f5dde25cd74c3a56ceff6f37b02", size = 889565, upload-time = "2026-01-04T16:38:37.003Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/dc/40c6026c88d7f9220ecc913afe0501045a512c9b82f9b7e036bb089dc287/psygnal-0.15.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1ac399566852fe4354ce26a1acbe12319232e8c2b615fe5ad1e114c547095cf6", size = 880863, upload-time = "2026-01-04T16:38:38.381Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/85/b4f45ec3057c473b5622fc002b3a636a698c34d3a0917a064ff5247f1984/psygnal-0.15.1-cp314-cp314-win_amd64.whl", hash = "sha256:d3a03055f331ce91d44581c71edb79938ccc133a94af2ce7ad3a18fa57ac7be5", size = 423654, upload-time = "2026-01-04T16:38:39.7Z" },
+    { url = "https://files.pythonhosted.org/packages/46/49/7742544684bee728ec123515d2694cee859aa2a705951a461230b00f18cc/psygnal-0.15.1-py3-none-any.whl", hash = "sha256:4221140e633e45b076953c64bcb9b41a744833527f9a037c1ca98bc270798cbf", size = 90638, upload-time = "2026-01-04T16:38:40.841Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "simplejson"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/2a/54837395a3487c725669428d513293612a48d82b95a0642c936932e5d898/simplejson-4.1.1.tar.gz", hash = "sha256:c08eb9f7a90f77ae470e19a07472e9a79ebc0d1c2315d86a72767665bd5ba79f", size = 118860, upload-time = "2026-04-24T19:24:59.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/18/4a118a6a92eb33bb08c8e2fe7ec85cb96f0673491bb2b829930831ee4fbe/simplejson-4.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ed7473602b6625de793b6acba49aa949f144a475f538792067e4cf2fda2071f5", size = 110492, upload-time = "2026-04-24T19:23:44.957Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f4/84d160e9fa8cada1e0a9381cae4fa81eecd573577a5b34366d8ced59bdf7/simplejson-4.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:225c9caa324c5b554d009fb9cac22aee7711e71bd96f487938c659af467e828e", size = 90152, upload-time = "2026-04-24T19:23:46.355Z" },
+    { url = "https://files.pythonhosted.org/packages/68/31/9a5432c433a7671107182cdc9a20ea78a70f99c4e5334aa54b6d4d0d79ed/simplejson-4.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:95407269340c7f22f09776ea7b717a52cf56cfcf119b5e45f66faa4a26445bea", size = 90115, upload-time = "2026-04-24T19:23:47.743Z" },
+    { url = "https://files.pythonhosted.org/packages/78/91/3635cdb13318cb0a328abaa69e2b91251caad39d6779aa308098f341f6cb/simplejson-4.1.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3851658d642c1184d2023f0e6c9ce44a21eb1629e74e7c84ef956b128841fe12", size = 184036, upload-time = "2026-04-24T19:23:49.472Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/149b6ec5393f6849d98c59cadba888b710a8ef4b805ab91e11a566960d40/simplejson-4.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:95a3bb0f78e85f4937f99092239f2011ce06f0f2d803df5c299cc05abbeae008", size = 180543, upload-time = "2026-04-24T19:23:51.023Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7c/a5d968d0b527a748b667e62bea94309ccbcb1e2b108e8f0cf8547efaa12b/simplejson-4.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbfdaa7c0603f75b7b14b211b7f2be44696d4e26833ad2d91d5c87bf5fb9a920", size = 188725, upload-time = "2026-04-24T19:23:52.995Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e3/6a8d11181d587ef00e2db9112357e6832111e56dd56b01b5c11758a1965d/simplejson-4.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:39e3c584071dced8c21b4689f0254303521daeb9b5bc1f4289755d71fa3cb0d3", size = 177492, upload-time = "2026-04-24T19:23:54.581Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e3/8b0eb8b06e8198cfbd1270487da163d0093df05cc4f557350cd65e2f7e79/simplejson-4.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:036a27bd0469b9d79557cbddb392969f876cd7f278cfbd0fba81534927a06575", size = 185281, upload-time = "2026-04-24T19:23:56.13Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/5f/64990f07ec9e2cb1a814c674e2e21b5693207f74ac70eb72151b847ea4e6/simplejson-4.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b70bfd2f67f3351baba08aa3ae9233c83f21fd95ae5e6b3d0ecb8c647929112f", size = 181848, upload-time = "2026-04-24T19:23:57.92Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/bbc1bc0447f339f79f99ab8c37f7f037cb2f1f93af75d6a4d553096bb0c3/simplejson-4.1.1-cp314-cp314-win32.whl", hash = "sha256:37233c72ce88d06acb92747347742b3c07871eba6789f060c179c9302dde8efe", size = 88761, upload-time = "2026-04-24T19:23:59.397Z" },
+    { url = "https://files.pythonhosted.org/packages/18/72/ec1b5cbdcb140c132e6c7bdf99bd73e4f675439e77126c88f472fcffa09c/simplejson-4.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:cc0442dea71cd9cbf30a0b8b9929ab5aa6c02c0443a3d977351e6ec5bada4388", size = 91018, upload-time = "2026-04-24T19:24:00.85Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/97/4fa437f68ff72219bac3bf3d050de9c6265691f3a170e16954bd69d7cddd/simplejson-4.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:c996a4d38290c515af347740659ce095b425449c164a5c9fa3977caa6eff5dbe", size = 113919, upload-time = "2026-04-24T19:24:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/83/59de041d09eb4a9577f7015d7263c32095dfb7fde49717dff62145d89809/simplejson-4.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c65c763fb20d7ca113c1c14dce2fc04a0fc3a57aceff533d6fdac707c7bffb40", size = 91904, upload-time = "2026-04-24T19:24:03.812Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8e/46bb345d540f6eb31427d984a4e518cdb182d0621814fee4fee045e8815b/simplejson-4.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0da5c9f57206ee7ef280ff7f1d924937b0a64f9a271a5ef371a2ecdbebba7421", size = 91752, upload-time = "2026-04-24T19:24:05.622Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e2/1b2ce97f068835eb3d253c116a4df7a3f436b7bf2fb5ff1ba29287e8b0ec/simplejson-4.1.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ea3426e786425d10e9e82f8a6eda74a7d6eb10d99165ac3d0d3bbcb65c0ea343", size = 214021, upload-time = "2026-04-24T19:24:07.447Z" },
+    { url = "https://files.pythonhosted.org/packages/48/70/d93e556df6a0786298644a7c08304fcbeddc248325f23f38acbebeb21165/simplejson-4.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d75cea7a1025edd7e439b2966b3d977c45b5b899e2adaf422811b3ac702ed9fb", size = 213530, upload-time = "2026-04-24T19:24:09.289Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a5/c93bf305b9f00d7259e09e713d60e75bd0f7f53da970f716ab90491770e7/simplejson-4.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:63c2ada8e58f266491f19eed2eeeb7c25c6141e52f8f9e820f6bb94156cf8dbc", size = 218282, upload-time = "2026-04-24T19:24:10.991Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/20/a9b5d2e27ec44b069ee251bd55544fc76929a067107b1050001566ba86f3/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d1fffb56305c5b475ee746cf9e04f97423ba5aaacd292dc1255bd75b1d3b124b", size = 209249, upload-time = "2026-04-24T19:24:12.662Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e4/e06ee682ed5df67592181f5ecb062e35878967e27f5b6e087237d4548d95/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:a6525ec733f43d0541206cffa64fd2aad5a7ae3eb76566aff49cd4db6382209a", size = 213963, upload-time = "2026-04-24T19:24:14.302Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/9f/1e160e4cd8cdbf062bf6a454cdf814dc7a48eb47e566fdb8f80ccb202605/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:861e393260508efa64d8805a8e49c416c3484907e3f146ce966c69552b49b9a3", size = 210474, upload-time = "2026-04-24T19:24:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e6/cecd913df322df5bbe7ebb8ba39e0708e505a165553900da8a7761026d6f/simplejson-4.1.1-cp314-cp314t-win32.whl", hash = "sha256:d083b89d30948a751d3d97476c2ed91e4caaa24a1a1459bdbadb8876242c71fe", size = 91134, upload-time = "2026-04-24T19:24:17.635Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/f540dde99cc1d393bd062ab3b5735b777561a5d8f8a5f2e241164444d77a/simplejson-4.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4cbb299d0528ec0447fe366d8c9641860e28f997a62730690fef905f1f41046e", size = 94467, upload-time = "2026-04-24T19:24:19.109Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/6a/8b74c52ffd33dbbde00fe7251fee6a0acdc8cea33f7a43805aed258fb79b/simplejson-4.1.1-py3-none-any.whl", hash = "sha256:2ce92b3748f02423e26d2bfb636fb9d7a8f67c8f5854dcae69d350d123b2eee2", size = 69195, upload-time = "2026-04-24T19:24:57.962Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "tornado"
+version = "6.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/24/95ec527ad67b76d59299e5465b3935d05e4294b7e0290a3924b7487df30b/tornado-6.5.7.tar.gz", hash = "sha256:66c513a76cda70d53907bc27cf1447557699c2e95aa48ba27a442ff61c3ddfc2", size = 519252, upload-time = "2026-06-08T17:34:51.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/dc/c7043cab6fed8ae159fc1923ce829ada35c4dbd797d408a43858ffaf9639/tornado-6.5.7-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:148b2eb15c2c765a50796172c1e499649b35f30d2e3c3d3e15913cfa56bfb163", size = 448543, upload-time = "2026-06-08T17:34:38.052Z" },
+    { url = "https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9da38de27f1da3b78a966f0dae12b5a1ea9afe72ca805d84ff06508272ddf100", size = 446707, upload-time = "2026-06-08T17:34:39.594Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d8/ef374952fd5da67d4463122c2b8e5a96536ec10b4b339254c6dcde81d01c/tornado-6.5.7-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8d759e71906ee783f8867b93bf26a265743da4c1e2f4a018464c1ba019862972", size = 449774, upload-time = "2026-06-08T17:34:41.204Z" },
+    { url = "https://files.pythonhosted.org/packages/35/37/d434c73f4c6e014b745b9b37085f34f40c022f007efff3d7fe65991899f3/tornado-6.5.7-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a46347a18f23fb92b396beebe0fb78f61dda0cc302445202c16203d8a18848b", size = 450745, upload-time = "2026-06-08T17:34:42.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/56b9aff361d7f1ab728a805ec7d7ea835f8807afa9f5cc690ea0e630efb9/tornado-6.5.7-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7778b30bef919231265e91c69963ce0f49a1e9c07ac900bbe75b19ce2575ba92", size = 450578, upload-time = "2026-06-08T17:34:43.787Z" },
+    { url = "https://files.pythonhosted.org/packages/02/30/a7444fb23aa76860a14198fab96ac79f1866b0a6e19e26c4381b0938e50f/tornado-6.5.7-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e726f0c75da7726eec023aa62751ff8878bd2737e34fbdd33b1ae5897d2200f5", size = 449985, upload-time = "2026-06-08T17:34:45.326Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/42/5f0e56c01e8d9d36f4e23f367b85ae6cae0c1ecddd5e6977d8388ad27488/tornado-6.5.7-cp39-abi3-win32.whl", hash = "sha256:f8de3bf12d3efdd0cbe7c8887868198f8a91415e3f29fcf258d9b8eb7b1d9ae4", size = 451047, upload-time = "2026-06-08T17:34:46.784Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/b393076ffb21b469eec5b328a0534cf03a3b90bfc6b1f09507cdd075d938/tornado-6.5.7-cp39-abi3-win_amd64.whl", hash = "sha256:de942f843533a039ef9fa3d9c88c7cd8a7c94553fb5ad0154270989b3d99a2c4", size = 451485, upload-time = "2026-06-08T17:34:48.248Z" },
+    { url = "https://files.pythonhosted.org/packages/71/2e/7b1c769803121b809112cf9a00681c472eae1d80e32d7ec0e0bd61d0d0e1/tornado-6.5.7-cp39-abi3-win_arm64.whl", hash = "sha256:ff934fce95643af5f11efdae618eaa73d469dc588641e5c8d19295a0c65c4796", size = 450506, upload-time = "2026-06-08T17:34:49.702Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/a9/a2584b8313b89f94869ddb3c4074617a691de1812a614d2d50e32ca5a7a6/traitlets-5.15.1.tar.gz", hash = "sha256:7b1c07854fe25acb39e009bae49f11b79ff6cbb2f27999104e9110e7a6b53722", size = 163344, upload-time = "2026-06-03T12:26:06.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/8d/1080ee4c231f361b6ce4470d556c8c435b67c7e0753aaa641497ee92f88b/traitlets-5.15.1-py3-none-any.whl", hash = "sha256:770a53705f84b81ac107e83a1b3328ff2dae16094d8fc3cfc004e4b22dfd8e92", size = 85858, upload-time = "2026-06-03T12:26:04.395Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
+name = "widgetsnbextension"
+version = "4.0.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
+]
+
+[[package]]
+name = "xy"
+version = "0.1.0"
+source = { editable = "../../../../" }
+dependencies = [
+    { name = "anywidget" },
+    { name = "numpy" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anywidget", specifier = ">=0.9" },
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6" },
+    { name = "numpy", specifier = ">=1.24" },
+    { name = "plotly", marker = "extra == 'bench'", specifier = ">=5" },
+    { name = "pyarrow", marker = "extra == 'dev'", specifier = ">=15" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
+    { name = "pytest-codspeed", marker = "extra == 'codspeed'", specifier = ">=5,<6" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.8" },
+    { name = "ty", marker = "extra == 'dev'" },
+]
+provides-extras = ["dev", "bench", "codspeed"]
+
+[[package]]
+name = "xy-launch-scatter-baseline"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "kaleido" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pillow" },
+    { name = "plotly" },
+    { name = "psutil" },
+    { name = "tornado" },
+    { name = "websocket-client" },
+    { name = "xy" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "kaleido", specifier = "==1.3.0" },
+    { name = "matplotlib", specifier = "==3.11.0" },
+    { name = "numpy", specifier = "==2.5.1" },
+    { name = "pandas", specifier = "==3.0.3" },
+    { name = "pillow", specifier = "==12.3.0" },
+    { name = "plotly", specifier = "==6.9.0" },
+    { name = "psutil", specifier = "==7.2.2" },
+    { name = "tornado", specifier = "==6.5.7" },
+    { name = "websocket-client", specifier = "==1.9.0" },
+    { name = "xy", editable = "../../../../" },
+]

--- a/docs/app/assets/launch-benchmark-comparison.svg
+++ b/docs/app/assets/launch-benchmark-comparison.svg
@@ -61,30 +61,30 @@
 
     <g fill="#6E56CF">
       <rect x="350" y="225" width="3" height="18" rx="1.5"/>
-      <rect x="350" y="345" width="13" height="18" rx="4"/>
-      <rect x="350" y="465" width="71" height="18" rx="4"/>
+      <rect x="350" y="345" width="14" height="18" rx="4"/>
+      <rect x="350" y="465" width="75" height="18" rx="4"/>
     </g>
     <g fill="#C4C6CF">
-      <rect x="350" y="277" width="690" height="18" rx="4"/>
-      <rect x="350" y="397" width="262" height="18" rx="4"/>
-      <rect x="350" y="517" width="591" height="18" rx="4"/>
+      <rect x="350" y="277" width="694" height="18" rx="4"/>
+      <rect x="350" y="397" width="243" height="18" rx="4"/>
+      <rect x="350" y="517" width="582" height="18" rx="4"/>
     </g>
     <g fill="#A8AAB3">
-      <rect x="350" y="251" width="200" height="18" rx="4"/>
-      <rect x="350" y="371" width="216" height="18" rx="4"/>
-      <rect x="350" y="491" width="265" height="18" rx="4"/>
+      <rect x="350" y="251" width="198" height="18" rx="4"/>
+      <rect x="350" y="371" width="215" height="18" rx="4"/>
+      <rect x="350" y="491" width="260" height="18" rx="4"/>
     </g>
 
     <g fill="#1C2024" font-size="14" font-weight="650">
-      <text x="366" y="239">0.0232 s</text>
-      <text x="562" y="265">2.7842 s</text>
-      <text x="1052" y="291">9.5834 s</text>
-      <text x="377" y="359">0.1797 s</text>
-      <text x="578" y="385">3.0029 s</text>
-      <text x="624" y="411">3.6434 s</text>
-      <text x="433" y="479">0.9920 s</text>
-      <text x="627" y="505">3.6735 s</text>
-      <text x="953" y="531">8.2152 s</text>
+      <text x="365" y="239">0.0184 s</text>
+      <text x="560" y="265">2.7432 s</text>
+      <text x="1056" y="291">9.6433 s</text>
+      <text x="376" y="359">0.1875 s</text>
+      <text x="577" y="385">2.9842 s</text>
+      <text x="605" y="411">3.3729 s</text>
+      <text x="437" y="479">1.0352 s</text>
+      <text x="622" y="505">3.6121 s</text>
+      <text x="944" y="531">8.0888 s</text>
     </g>
   </g>
 </svg>

--- a/docs/app/xy_docs/demos/benchmark_charts.py
+++ b/docs/app/xy_docs/demos/benchmark_charts.py
@@ -95,9 +95,9 @@ _SNAPSHOT_CATEGORIES = [
     "Interactive · CPU fallback",
 ]
 _SNAPSHOT_VALUES = [
-    [0.0232, 0.1797, 0.9920],
-    [2.7842, 3.0029, 3.6735],
-    [9.5834, 3.6434, 8.2152],
+    [0.0184, 0.1875, 1.0352],
+    [2.7432, 2.9842, 3.6121],
+    [9.6433, 3.3729, 8.0888],
 ]
 
 _SNAPSHOT_CHART = xy.bar_chart(
@@ -164,9 +164,9 @@ def launch_snapshot_demo() -> rx.Component:
 
 
 _SIZE_LABELS = ["10k", "100k", "1M", "10M", "1B"]
-_XY_SCALING_VALUES = [0.0085, 0.0108, 0.0114, 0.0232, 1.1452]
-_MATPLOTLIB_SCALING_VALUES = [0.0234, 0.0475, 0.2946, 2.7842]
-_PLOTLY_SCALING_VALUES = [1.8830, 1.9496, 2.6490, 9.5834]
+_XY_SCALING_VALUES = [0.0036, 0.0060, 0.0058, 0.0184, 1.1288]
+_MATPLOTLIB_SCALING_VALUES = [0.0224, 0.0456, 0.2858, 2.7432]
+_PLOTLY_SCALING_VALUES = [2.0231, 2.1100, 2.8086, 9.6433]
 
 _SCALING_CHART = xy.line_chart(
     xy.line(
@@ -204,7 +204,7 @@ _SCALING_CHART = xy.line_chart(
         for size, value, label in zip(
             _SIZE_LABELS,
             _XY_SCALING_VALUES,
-            ["8.5 ms", "10.8 ms", "11.4 ms", "23.2 ms", "1.145 s"],
+            ["3.6 ms", "6.0 ms", "5.8 ms", "18.4 ms", "1.129 s"],
             strict=True,
         )
     ),
@@ -222,7 +222,7 @@ _SCALING_CHART = xy.line_chart(
         for size, value, label in zip(
             _SIZE_LABELS[:4],
             _MATPLOTLIB_SCALING_VALUES,
-            ["23.4 ms", "47.5 ms", "0.295 s", "2.784 s"],
+            ["22.4 ms", "45.6 ms", "0.286 s", "2.743 s"],
             strict=True,
         )
     ),
@@ -240,7 +240,7 @@ _SCALING_CHART = xy.line_chart(
         for size, value, label in zip(
             _SIZE_LABELS[:4],
             _PLOTLY_SCALING_VALUES,
-            ["1.883 s", "1.950 s", "2.649 s", "9.583 s"],
+            ["2.023 s", "2.110 s", "2.809 s", "9.643 s"],
             strict=True,
         )
     ),
@@ -288,7 +288,7 @@ _SCALING_CHART = xy.line_chart(
 )
 
 _MEMORY_CATEGORIES = ["XY", "Matplotlib", "Plotly / Kaleido"]
-_MEMORY_VALUES = [0.283, 0.834, 5.671]
+_MEMORY_VALUES = [0.286, 0.831, 5.298]
 _MEMORY_CHART = xy.bar_chart(
     *(
         xy.bar(
@@ -307,12 +307,12 @@ _MEMORY_CHART = xy.bar_chart(
             strict=True,
         )
     ),
-    xy.text(0.42, "XY", "0.283", color="var(--benchmark-text, #60646c)"),
-    xy.text(0.98, "Matplotlib", "0.834", color="var(--benchmark-text, #60646c)"),
+    xy.text(0.42, "XY", "0.286", color="var(--benchmark-text, #60646c)"),
+    xy.text(0.98, "Matplotlib", "0.831", color="var(--benchmark-text, #60646c)"),
     xy.text(
-        5.48,
+        5.11,
         "Plotly / Kaleido",
-        "5.671",
+        "5.298",
         anchor="end",
         color="var(--benchmark-text, #60646c)",
     ),

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,9 +65,9 @@ JSON, and the WebGL2 client bounds browser work by what the screen can show,
 while exact source data stays in Python for hover and selection.
 
 The numbers back this up. In the recorded 10-million-point launch benchmark, XY
-produced a static PNG in 0.023 s, while Matplotlib took 2.8 s and Plotly
-9.6 s. XY reached first interactive render 16–20× sooner, peaking at a
-third of Matplotlib's memory and a twentieth of Plotly's.
+produced a static PNG in 0.018 s, while Matplotlib took 2.7 s and Plotly
+9.6 s. XY reached first interactive render 16–18× sooner, peaking at a
+third of Matplotlib's memory and under 6% of Plotly's.
 
 ~~~python demo-only exec
 from xy_docs.demos.benchmark_charts import launch_snapshot_demo

--- a/docs/overview/benchmarks.md
+++ b/docs/overview/benchmarks.md
@@ -7,10 +7,16 @@ description: Inspect XY's recorded launch benchmark with its exact output contra
 
 XY's large-data architecture reduces source rows to the representation useful
 for a fixed-size output instead of drawing every row as an individual marker.
-The committed 0.1.0 launch baseline measures identical seeded scatter data at
+The committed launch baseline measures identical seeded scatter data at
 900×420 pixels on an Apple M5 Pro with 64 GiB RAM. Each successful cell below
 is the mean of three isolated cold runs. The machine name and memory are copied
 verbatim from the committed environment record.
+
+The numbers on this page come from the 2026-07-26 rerun of that benchmark. It
+repeats the original 0.1.0 launch contracts on the same machine with the same
+pinned Plotly, Kaleido, Matplotlib, NumPy, and Python versions, so the intended
+variables are the XY revision and a Chrome patch bump. The 0.1.0 baseline stays
+committed and unchanged next to it.
 
 > **How to read this comparison.** XY switches dense scatter output to a
 > screen-bounded density representation, while the default Plotly and
@@ -28,15 +34,15 @@ benchmark_launch_snapshot = launch_snapshot_demo
 
 | 900×420 output contract | XY | Matplotlib | Plotly | XY representation |
 | --- | ---: | ---: | ---: | --- |
-| Static CPU PNG | 0.0232 s | 2.7842 s | 9.5834 s | density |
-| Interactive first render, default GPU | 0.1797 s | 3.0029 s | 3.6434 s | density + sample |
-| Interactive first render, CPU fallback | 0.9920 s | 3.6735 s | 8.2152 s | density + sample |
+| Static CPU PNG | 0.0184 s | 2.7432 s | 9.6433 s | density |
+| Interactive first render, default GPU | 0.1875 s | 2.9842 s | 3.3729 s | density + sample |
+| Interactive first render, CPU fallback | 1.0352 s | 3.6121 s | 8.0888 s | density + sample |
 
 These summary tables show means only; the linked launch report publishes the
 sample standard deviation for every successful timing cell. Small reversals in
-adjacent means, such as 100k versus 1M on the default interactive path, are
-within the observed three-run variation and should not be read as evidence that
-more rows are inherently faster.
+adjacent means, such as 100k versus 1M on the static path, are within the
+observed three-run variation and should not be read as evidence that more rows
+are inherently faster.
 
 The output contracts are intentionally separate. Static PNG rows compare
 validated CPU-rendered images. Interactive rows include figure construction,
@@ -60,12 +66,12 @@ At 10 million points, the static CPU output contract recorded:
 
 | Peak process-tree RSS | XY | Matplotlib | Plotly / Kaleido |
 | --- | ---: | ---: | ---: |
-| Static 900×420 PNG | 0.283 GiB | 0.834 GiB | 5.671 GiB |
+| Static 900×420 PNG | 0.286 GiB | 0.831 GiB | 5.298 GiB |
 
 Plotly's static value includes the Kaleido and Chrome processes used by
 `to_image()`. RSS was sampled across each complete process tree every 50 ms, so
 very brief peaks may be missed. At one billion points, XY's successful static
-row peaked at 22.414 GiB; Matplotlib crossed the 36 GiB guardrail and Plotly did
+row peaked at 22.413 GiB; Matplotlib crossed the 36 GiB guardrail and Plotly did
 not produce a PNG on its first guarded attempt.
 
 ## What scales with rows—and what does not
@@ -80,11 +86,11 @@ That distinction is visible in the recorded sweep:
 
 | Points | Native static PNG | Interactive, default GPU | XY representation |
 | ---: | ---: | ---: | --- |
-| 10k | 0.0085 s | 0.1533 s | direct |
-| 100k | 0.0108 s | 0.1742 s | direct |
-| 1M | 0.0114 s | 0.1688 s | density; density + sample interactive |
-| 10M | 0.0232 s | 0.1797 s | density; density + sample interactive |
-| 1B | 1.1452 s | 1.2530 s | density; density + sample interactive |
+| 10k | 0.0036 s | 0.1643 s | direct |
+| 100k | 0.0060 s | 0.1680 s | direct |
+| 1M | 0.0058 s | 0.1762 s | density; density + sample interactive |
+| 10M | 0.0184 s | 0.1875 s | density; density + sample interactive |
+| 1B | 1.1288 s | 1.2419 s | density; density + sample interactive |
 
 At one billion points, XY ingested the rows and produced a validated density
 PNG and interactive density overview. It did **not** draw one billion markers.
@@ -127,19 +133,20 @@ competitors, and environments.
 
 ## Inspect and reproduce the evidence
 
-The baseline records its source commit (`7228f99`), exact dependency lock,
+The baseline records its source commit (`7604775`), exact dependency lock,
 hardware, browser, raw samples, failure rows, and render oracles:
 
-- [Launch report](https://github.com/reflex-dev/xy/blob/main/benchmarks/launch_baselines/xy-0.1.0/macos-arm64-m5-pro/report.md)
-- [Environment](https://github.com/reflex-dev/xy/blob/main/benchmarks/launch_baselines/xy-0.1.0/macos-arm64-m5-pro/environment.json)
-- [Raw default-path results](https://github.com/reflex-dev/xy/blob/main/benchmarks/launch_baselines/xy-0.1.0/macos-arm64-m5-pro/default-results.json)
+- [Launch report](https://github.com/reflex-dev/xy/blob/main/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/report.md)
+- [Environment](https://github.com/reflex-dev/xy/blob/main/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/environment.json)
+- [Raw default-path results](https://github.com/reflex-dev/xy/blob/main/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/default-results.json)
+- [Original 0.1.0 launch baseline](https://github.com/reflex-dev/xy/blob/main/benchmarks/launch_baselines/xy-0.1.0/macos-arm64-m5-pro/report.md)
 - [Benchmark runbook](https://github.com/reflex-dev/xy/blob/main/benchmarks/README.md)
 
 After completing the runbook setup, reproduce the frozen default-path sweep
 from the source revision recorded in the environment file:
 
 ```bash
-BASELINE=benchmarks/launch_baselines/xy-0.1.0/macos-arm64-m5-pro
+BASELINE=benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro
 uv sync --project "$BASELINE" --frozen --python 3.14.5
 CHROME=$(node -e "console.log(require('playwright').chromium.executablePath())")
 

--- a/docs/overview/benchmarks.md
+++ b/docs/overview/benchmarks.md
@@ -139,6 +139,7 @@ hardware, browser, raw samples, failure rows, and render oracles:
 - [Launch report](https://github.com/reflex-dev/xy/blob/main/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/report.md)
 - [Environment](https://github.com/reflex-dev/xy/blob/main/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/environment.json)
 - [Raw default-path results](https://github.com/reflex-dev/xy/blob/main/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/default-results.json)
+- [Raw CPU-fallback results](https://github.com/reflex-dev/xy/blob/main/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/cpu-fallback-results.json)
 - [Original 0.1.0 launch baseline](https://github.com/reflex-dev/xy/blob/main/benchmarks/launch_baselines/xy-0.1.0/macos-arm64-m5-pro/report.md)
 - [Benchmark runbook](https://github.com/reflex-dev/xy/blob/main/benchmarks/README.md)
 

--- a/spec/assets/launch-benchmark-comparison.svg
+++ b/spec/assets/launch-benchmark-comparison.svg
@@ -61,30 +61,30 @@
 
     <g fill="#6E56CF">
       <rect x="350" y="225" width="3" height="18" rx="1.5"/>
-      <rect x="350" y="345" width="13" height="18" rx="4"/>
-      <rect x="350" y="465" width="71" height="18" rx="4"/>
+      <rect x="350" y="345" width="14" height="18" rx="4"/>
+      <rect x="350" y="465" width="75" height="18" rx="4"/>
     </g>
     <g fill="#C4C6CF">
-      <rect x="350" y="277" width="690" height="18" rx="4"/>
-      <rect x="350" y="397" width="262" height="18" rx="4"/>
-      <rect x="350" y="517" width="591" height="18" rx="4"/>
+      <rect x="350" y="277" width="694" height="18" rx="4"/>
+      <rect x="350" y="397" width="243" height="18" rx="4"/>
+      <rect x="350" y="517" width="582" height="18" rx="4"/>
     </g>
     <g fill="#A8AAB3">
-      <rect x="350" y="251" width="200" height="18" rx="4"/>
-      <rect x="350" y="371" width="216" height="18" rx="4"/>
-      <rect x="350" y="491" width="265" height="18" rx="4"/>
+      <rect x="350" y="251" width="198" height="18" rx="4"/>
+      <rect x="350" y="371" width="215" height="18" rx="4"/>
+      <rect x="350" y="491" width="260" height="18" rx="4"/>
     </g>
 
     <g fill="#1C2024" font-size="14" font-weight="650">
-      <text x="366" y="239">0.0232 s</text>
-      <text x="562" y="265">2.7842 s</text>
-      <text x="1052" y="291">9.5834 s</text>
-      <text x="377" y="359">0.1797 s</text>
-      <text x="578" y="385">3.0029 s</text>
-      <text x="624" y="411">3.6434 s</text>
-      <text x="433" y="479">0.9920 s</text>
-      <text x="627" y="505">3.6735 s</text>
-      <text x="953" y="531">8.2152 s</text>
+      <text x="365" y="239">0.0184 s</text>
+      <text x="560" y="265">2.7432 s</text>
+      <text x="1056" y="291">9.6433 s</text>
+      <text x="376" y="359">0.1875 s</text>
+      <text x="577" y="385">2.9842 s</text>
+      <text x="605" y="411">3.3729 s</text>
+      <text x="437" y="479">1.0352 s</text>
+      <text x="622" y="505">3.6121 s</text>
+      <text x="944" y="531">8.0888 s</text>
     </g>
   </g>
 </svg>

--- a/spec/benchmarks/methodology.md
+++ b/spec/benchmarks/methodology.md
@@ -92,10 +92,13 @@ reported).
   spec (documented CPU/GPU/driver/browser build), labeled as such. Never mix
   tiers in one table. HN's first attack is "benchmarked on a potato/cherry
   machine" — pre-empt by publishing both. `benchmarks/README.md` is the shipped
-  runbook for both tiers: exact dependency pins against
-  `benchmarks/launch_baselines/xy-0.1.0/macos-arm64-m5-pro` (`pyproject.toml`,
-  `uv.lock`, `environment.json`), copy-paste repro commands, and the prescribed
-  `reference hardware` vs `CI (software GL)` table labels.
+  runbook for both tiers: exact dependency pins against the launch baseline
+  directories under `benchmarks/launch_baselines/` (`pyproject.toml`, `uv.lock`,
+  `environment.json` — `xy-0.1.0/macos-arm64-m5-pro` for the original launch
+  record, `xy-main-2026-07-26/macos-arm64-m5-pro` for the rerun the published
+  docs quote, both carrying identical competitor pins), copy-paste repro
+  commands, and the prescribed `reference hardware` vs `CI (software GL)` table
+  labels.
 - Every table header carries: timestamp, python version/implementation,
   platform system/machine, and harness commit + dirty state
   (`bench_vs.to_markdown`). Library versions, executables, CPU count, xy


### PR DESCRIPTION
## What

The README, docs landing page, and public benchmarks page all quoted the 0.1.0 launch baseline recorded on 2026-07-13. This reruns that benchmark on current main (`7604775`) and moves every published figure onto the new measurement.

## Why this is a controlled A/B, not just a fresh run

The rerun uses the 0.1.0 baseline's own uv project with `--frozen`, whose editable `xy` source resolves to the worktree it runs from. So Plotly 6.9.0, Kaleido 1.3.0, Matplotlib 3.11.0, NumPy 2.5.1 and Python 3.14.5 are identical across both runs on the same M5 Pro — the only intended variables are the xy revision and a Chrome patch bump (`150.0.7871.115` → `.186`).

Across the 24 successful competitor timing cells, median absolute drift against 0.1.0 is **3.2%**; 16 of 24 within 5%, all 24 within 10%. The largest deviations sit on the rows dominated by cold browser startup. That's the evidence the machine didn't move, which is what makes the xy-side delta below meaningful.

## Results at 10M

| 900×420 contract | XY | was (0.1.0) | Matplotlib | Plotly |
|---|---:|---:|---:|---:|
| Static CPU PNG | **0.0184 s** | 0.0232 s | 2.7432 s | 9.6433 s |
| Interactive first render, default GPU | **0.1875 s** | 0.1797 s | 2.9842 s | 3.3729 s |
| Interactive first render, CPU fallback | **1.0352 s** | 0.9920 s | 3.6121 s | 8.0888 s |

Static render time improved **1.26–2.37×**, most at 10k–1M where fixed per-call overhead dominates rather than kernel work. Interactive TTFR is unchanged within noise because it is bounded by cold browser startup, not by xy. At 1B only xy completes — 1.129 s static, 1.242 s interactive — and Plotly's static row now fails as a Kaleido timeout at 122 s / 26.09 GiB rather than at the 36 GiB ceiling.

## Baseline handling

The 0.1.0 baseline stays committed and unchanged, as the runbook requires. The refresh lands in a sibling directory `benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/` with raw JSON for both suites, environment, manifest, the copied lock, and a report that carries an explicit 0.1.0-versus-now comparison table.

Both suites, all sizes, three cold runs per successful cell, 180 s and 36 GiB guardrails, hardware-WebGL and SwiftShader rows kept separate. Renderer strings are recorded per sample, so the GPU and SwiftShader tables are verified rather than assumed from flags.

The environment was warmed before measuring: a first invocation in a fresh worktree reads 13× the warm value for the xy 10k static row (cold bytecode, Matplotlib's font cache, Kaleido's browser fetch). The runbook now says so.

## Docs touched

`README.md`, `docs/index.md`, `docs/overview/benchmarks.md`, `docs/app/xy_docs/demos/benchmark_charts.py` (the three live charts on the benchmarks page), `benchmarks/README.md`, `spec/benchmarks/methodology.md`, and both byte-identical copies of `launch-benchmark-comparison.svg`.

Two caveats surfaced by the new data: the CPU-fallback 10M mean now sits slightly below the 1M mean, and static 1M sits below 100k — both flat within noise, so the docs' existing "small reversals" caveat was moved to point at the static path where it now applies.

## Verification

- Docs tests: 92 passed, 1 xfailed
- `ruff check` / `ruff format --check` / `codespell` clean at repo root and in `docs/app`; `pre-commit run --all-files` passed
- All three live docs charts compile and were rendered via `to_png()` and visually checked; the regenerated SVG was screenshotted and checked — its diff is only bar widths and value labels, layout untouched
- A checker re-derived all 13 published figure groups from the committed raw JSON and compared them against the docs tables, the demo module constants, and the SVG labels: all match

Only the launch-scatter suite was rerun, since that is what the README and benchmark docs quote. The other harnesses (`bench_vs`, `bench_interaction`, `bench_dashboard`, `bench_transport`, CodSpeed) feed `spec/benchmarks/results.md` and CI and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated published benchmark timings, memory usage figures, and performance comparisons.
  * Added refreshed launch baseline results and environment details for the latest benchmark rerun.
  * Updated benchmark reproduction instructions, including guidance to warm the environment before measuring.
  * Refreshed benchmark charts, evidence links, and methodology references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->