### PR TITLE
Ship the Rust core with fat LTO and stripped symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ in the README).
   longer a second, defaults-clobbering one.
 
 ### Changed
+- The Rust core's release profile now uses fat LTO and strips symbol tables,
+  shrinking the shipped cdylib ~15% (1.51 → 1.29 MB) with no measured runtime
+  change on the native scatter bench (`spec/design/rust-engine.md` §2 records
+  the profile and why `panic` stays unwinding).
 - Stable animation `key=` identity planes are now retained and shipped only
   when the resolved animation spec can actually key-match. `match` defaults to
   `"index"`, so `key=` combined with a bare `xy.animation(...)`, with

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 png = "0.18.1"
 
+# Whole-program optimization; `strip` keeps .dynsym, which ctypes binds
+# against. `panic` must stay unwinding — lib.rs catches panics at the C ABI.
 [profile.release]
-lto = "thin"
+lto = "fat"
 codegen-units = 1
+strip = true

--- a/spec/design/rust-engine.md
+++ b/spec/design/rust-engine.md
@@ -131,6 +131,19 @@ cannot reach crates.io, so required crates must be vendored or the sandbox
 loses local build/test; prefer feature-gated optional deps (e.g. SIMD
 argminmax, tsdownsample-class speed) with the lean build as default.
 
+Release profile (`Cargo.toml`, 2026-07-27): `lto = "fat"`, `codegen-units =
+1`, `strip = true`. Fat LTO measured no runtime change over thin on the §12
+native scatter bench (run-to-run noise ±15% dominates) but cuts the cdylib
+~15% (1.51 → 1.29 MB); strip removes `.symtab`/debuginfo only — `.dynsym`,
+which ctypes binds against, survives. `panic` must stay `unwind`: the C-ABI
+backstop in `lib.rs` converts kernel panics into sentinel returns via
+`catch_unwind`, and `panic = "abort"` would turn them into aborts of the
+embedding CPython process (the wasm target alone builds with
+`-C panic=abort` in `release.yml`, where unwinding is unsupported anyway).
+PGO is a known open lever, not adopted: it needs a per-target training
+workload and profdata plumbing in the release matrix; revisit when a
+benchmark shows a branch-bound kernel on the hot path.
+
 ### 2.1 Native text is a bounded subset, and misses are visible
 
 Declining FreeType bought the single-cdylib property (§3.1) and paid for it in


### PR DESCRIPTION
## What

Switches the release profile from thin to fat LTO and strips symbol tables from the shipped cdylib:

```toml
[profile.release]
lto = "fat"
codegen-units = 1
strip = true
```

## Measured locally (Linux x86_64)

- **Binary size:** 1.51 MB -> 1.29 MB (**-15%**), which shrinks every wheel since stripping happens at link time.
- **Runtime:** no change on `scripts/bench_scatter_native.py` — 10M-point density prep reads 7.2–8.5 ms across repeats on both builds; run-to-run noise (±15%) dominates. CodSpeed on this PR is the cleaner verdict.
- **Build time:** 11.6 s -> 13.2 s.
- `scripts/abi_smoke.py` passes 140/140 against the stripped build — `strip` removes `.symtab`/debuginfo only, and `.dynsym` (what ctypes binds against) survives.

## Deliberately not changed

- `panic` stays `unwind`: the C-ABI backstop in `lib.rs` converts kernel panics into sentinel returns via `catch_unwind`; `panic = "abort"` would abort the embedding CPython process. The wasm target keeps its explicit `-C panic=abort` in `release.yml`, where unwinding is unsupported anyway.
- No `target-cpu` bump: wheels stay baseline x86-64 (`manylinux_2_17`); AVX2 is already runtime-dispatched in `src/simd.rs`.
- No PGO yet: recorded in `spec/design/rust-engine.md` §2 as an open lever needing per-target training workloads in the release matrix.

Spec updated (`spec/design/rust-engine.md` §2) with the profile, the measurements, and the panic constraint; changelog entry under Unreleased.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced the shipped native library size by approximately 15%, from 1.51 MB to 1.29 MB.
  * Native scatter benchmark performance remains unchanged.

* **Documentation**
  * Added documentation for release build settings and platform-specific panic-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->