### PR TITLE
Keep wheel zoom and double-click reset alive under the box-zoom tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ in the README).
   longer a second, defaults-clobbering one.
 
 ### Changed
+- The Rust core's release profile now uses fat LTO and strips symbol tables,
+  shrinking the shipped cdylib ~15% (1.51 → 1.29 MB) with no measured runtime
+  change on the native scatter bench (`spec/design/rust-engine.md` §2 records
+  the profile and why `panic` stays unwinding).
 - Stable animation `key=` identity planes are now retained and shipped only
   when the resolved animation spec can actually key-match. `match` defaults to
   `"index"`, so `key=` combined with a bare `xy.animation(...)`, with

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 png = "0.18.1"
 
+# Whole-program optimization; `strip` keeps .dynsym, which ctypes binds
+# against. `panic` must stay unwinding — lib.rs catches panics at the C ABI.
 [profile.release]
-lto = "thin"
+lto = "fat"
 codegen-units = 1
+strip = true

--- a/js/src/53_interaction.ts
+++ b/js/src/53_interaction.ts
@@ -369,7 +369,10 @@ Object.assign(ChartView.prototype, {
     this._listen(c, "click", (e) => this._click(e));
 
     this._listen(c, "wheel", (e) => {
-      if (this.dragMode !== "pan") return;
+      // The drag tool never disables the wheel (box-zoom/select drags are
+      // drag-only tools) — except `none`, the modebar's escape hatch that
+      // releases page scroll for embedded charts.
+      if (this.dragMode === "none") return;
       if (!this._interactionFlag("navigation", true)) return;
       if (!this._interactionFlag("zoom", true)) return;
       if (!this._interactionFlag("wheel_zoom", true)) return;
@@ -386,7 +389,7 @@ Object.assign(ChartView.prototype, {
         clearSelectionOnDoubleClick();
         return;
       }
-      if (this.dragMode !== "pan") return;
+      if (this.dragMode === "none") return;
       if (!this._interactionFlag("navigation", true)) return;
       if (!this._interactionFlag("double_click_reset", true)) return;
       this._resetView(true, "reset");

--- a/spec/api/interaction.md
+++ b/spec/api/interaction.md
@@ -53,13 +53,13 @@ the switch is never set. The non-boolean viewport keys — `default_drag_action`
 | `select` | on | Suppresses the `xy:select` event and the `select_clear` message, removes the modebar Selection menu, and (with `brush`) disables shift-drag. |
 | `brush` | on | Same conjunction: `canBrush = brush && select` (`53_interaction.ts:115`) gates every selection drag and the modebar Selection menu. |
 | `crosshair` | off | The two guide elements are created only when the flag is true, at init (`53_interaction.ts:80`). Not togglable after mount. |
-| `navigation` | on | Master gate on pointer-drag pan, wheel zoom, box-zoom drags, pan-mode dblclick reset, and every modebar viewport control. Selection-mode double-click clear is a selection action and is unaffected. |
+| `navigation` | on | Master gate on pointer-drag pan, wheel zoom, box-zoom drags, dblclick reset, and every modebar viewport control. Selection-mode double-click clear is a selection action and is unaffected. |
 | `pan` | on | Plain-drag pan is ignored, the modebar Pan button is not built, and every zoom-enabled axis is contained (§2.2). Requires `navigation`. Pans `pan_axes` (§2.1). |
 | `zoom` | on | Master zoom gate: wheel zoom, box zoom, and the zoom actions inside the modebar menu are all ignored. The same dropdown can remain for view history when `history` is on. Requires `navigation`. Zooms `zoom_axes` (§2.1). |
 | `wheel_zoom` | on | Cursor-anchored wheel/trackpad zoom is ignored and the page keeps scrolling; box and button zoom are unaffected. Requires `navigation` and `zoom` (`53_interaction.ts:271-273`). |
 | `box_zoom` | on | Box-zoom drags and the modebar Box Zoom button are removed, and `default_drag_action="zoom"` has no usable drag tool. Requires `navigation` and `zoom` (`53_interaction.ts:112-113`, `50_chartview.ts:419`). |
 | `zoom_buttons` | on | The modebar Zoom In (×0.5) / Zoom Out (×2) commands are removed; wheel and box zoom keep working. Requires `navigation` and `zoom` (`53_interaction.ts:883`). |
-| `double_click_reset` | on | Pan-mode double-click no longer resets the view. The modebar Reset View button and selection-mode double-click clear are unaffected. Requires `navigation` only — reset is independent of `zoom` (`53_interaction.ts`). |
+| `double_click_reset` | on | Double-click (in `pan` or `zoom` mode) no longer resets the view. The modebar Reset View button and selection-mode double-click clear are unaffected. Requires `navigation` only — reset is independent of `zoom` (`53_interaction.ts`). |
 | `history` | on | Removes Back/Next from the modebar zoom menu and stops durable-state snapshotting entirely (`57_viewstate.ts`). The full history contract is [`../design/view-state.md`](../design/view-state.md) §4: a client-local 64-entry stack of durable-state snapshots, coalesced per gesture by `interaction_id`; linked and history-sourced writes never push; reset pushes (Back undoes a double-click). |
 | `link_group` | unset | See §4. |
 | `link_axes` | all declared axes | See §4. |
@@ -108,7 +108,7 @@ including per-source semantics and the shared clamp pipeline, is
 
 | Key | Type | Default | Role |
 | --- | --- | --- | --- |
-| `default_drag_action` | `"auto" \| "none" \| "pan" \| "zoom" \| "select" \| "select-x" \| "select-y" \| "select-lasso"` | `"auto"` | Initial tool for an unmodified primary-button drag. `"auto"` resolves pan → box zoom → rectangular select → none. `"zoom"` means **box zoom for drag only**; it does not touch wheel or button zoom. The modebar can change the live tool without mutating this configured default. |
+| `default_drag_action` | `"auto" \| "none" \| "pan" \| "zoom" \| "select" \| "select-x" \| "select-y" \| "select-lasso"` | `"auto"` | Initial tool for an unmodified primary-button drag. `"auto"` resolves pan → box zoom → rectangular select → none. `"zoom"` means **box zoom for drag only**; it does not touch wheel, button zoom, or double-click reset. `"none"` additionally releases the wheel to the page (embedded charts must not trap page scroll) and disables double-click reset. The modebar can change the live tool without mutating this configured default. |
 | `pan_axes` | axis-ID tuple | all declared axes | Concrete axis IDs a pan gesture may translate freely. An axis excluded here while zoom can navigate it is **contained** (§2.2). |
 | `zoom_axes` | axis-ID tuple | all declared axes | Concrete axis IDs wheel, box, and button zoom may scale. Selecting `"y"` never implies `"y2"`. |
 | `reset_axes` | axis-ID tuple | enabled `pan_axes` ∪ enabled `zoom_axes` | Axis IDs restored by reset. Resolved client-side; the modebar Reset button hides when it resolves empty. |
@@ -278,8 +278,8 @@ renderer reads anywhere in `js/src/`.
 | **Shift**-drag | Box select, overriding the current drag mode (`53_interaction.ts:117`) | `brush`, `select`, `_pickable` |
 | Drag in `select` / `select-lasso` / `select-x` / `select-y` mode | That selection shape | `brush`, `select`, `_pickable` |
 | Drag in `zoom` mode | Box zoom, fitting `zoom_axes` on release | `navigation`, `zoom`, and `box_zoom` |
-| Wheel | Cursor-anchored zoom of `zoom_axes`, factor `1.0015 ** deltaY`; `preventDefault` | `navigation`, `zoom`, and `wheel_zoom` |
-| Double click in `pan` mode | Reset `reset_axes` to home (animated); does **not** clear selection | `navigation` and `double_click_reset` |
+| Wheel | Cursor-anchored zoom of `zoom_axes`, factor `1.0015 ** deltaY`; `preventDefault`. The active drag tool never disables it — box-zoom and select tools are drag-only — except `none`, which releases the wheel to the page | `navigation`, `zoom`, and `wheel_zoom` |
+| Double click in `pan` or `zoom` mode | Reset `reset_axes` to home (animated); does **not** clear selection | `navigation` and `double_click_reset` |
 | Double click in `select` / `select-lasso` / `select-x` / `select-y` mode | Clear the active selection and, for lasso, its editable polygon; no-op when no selection exists | active selection |
 | Click without drag | Pick; a drag past threshold sets `_ignoreNextClick` and swallows the click | `click` |
 | Pointer down on a lasso vertex handle | Drag that vertex; re-runs the selection on release | an existing lasso |

--- a/spec/design/pan-and-zoom-configuration.md
+++ b/spec/design/pan-and-zoom-configuration.md
@@ -182,13 +182,13 @@ defensively and falls back to safe defaults.
 ### 5.5 What `default_drag_action` controls
 
 `default_drag_action` selects the initial tool for an unmodified primary-button drag inside the
-plot. It does not enable a capability, choose axes, configure the wheel, or perform an
-action immediately.
+plot. It does not enable a capability, choose axes, or perform an action immediately, and
+no tool other than `"none"` touches the wheel or double-click reset.
 
 | `default_drag_action` | Plain-drag behavior | Required capability |
 | --- | --- | --- |
 | `"auto"` | Resolve the first usable tool from the priority below. | None |
-| `"none"` | Do nothing on plain drag. Wheel, click, and toolbar actions may still work. | None |
+| `"none"` | Do nothing on plain drag, release the wheel to the page, and ignore double-click reset. Click and toolbar actions still work. | None |
 | `"pan"` | Translate the ranges in `pan_axes`. | `navigation and pan` |
 | `"zoom"` | Draw a rectangle and box-zoom `zoom_axes` on release. | `navigation and zoom and box_zoom` |
 | `"select"` | Rectangular x/y selection. | `select and brush` plus pickable data |
@@ -196,9 +196,12 @@ action immediately.
 | `"select-y"` | Select a y interval across the full visible x range. | `select and brush` plus pickable data |
 | `"select-lasso"` | Draw a free-form polygon selection. | `select and brush` plus pickable data |
 
-`"zoom"` means **box zoom for drag only**. It does not control wheel zoom or the
-Zoom In/Out toolbar commands. Those remain governed by `wheel_zoom` and
-`zoom_buttons`.
+`"zoom"` means **box zoom for drag only**. It does not control wheel zoom,
+double-click reset, or the Zoom In/Out toolbar commands. Those remain governed
+by `wheel_zoom`, `double_click_reset`, and `zoom_buttons`. `"none"` is the one
+tool that reaches beyond the drag: it releases the wheel to the page and
+disables double-click reset, so the modebar's pan toggle (pan ↔ none) gives an
+embedded chart back to page scroll.
 
 `"auto"` resolves once at mount and whenever configuration invalidates the active
 tool:
@@ -229,11 +232,9 @@ xy.interaction_config(
     box_zoom=True,
 )
 
-# No plain-drag gesture; keep cursor-anchored wheel zoom.
-xy.interaction_config(
-    default_drag_action="none",
-    wheel_zoom=True,
-)
+# Inert plot for a scrolling page: no drag gesture, and the wheel
+# stays with the page. Toolbar navigation keeps working.
+xy.interaction_config(default_drag_action="none")
 ```
 
 ## 6. Shared mutation pipeline

--- a/spec/design/rust-engine.md
+++ b/spec/design/rust-engine.md
@@ -131,6 +131,19 @@ cannot reach crates.io, so required crates must be vendored or the sandbox
 loses local build/test; prefer feature-gated optional deps (e.g. SIMD
 argminmax, tsdownsample-class speed) with the lean build as default.
 
+Release profile (`Cargo.toml`, 2026-07-27): `lto = "fat"`, `codegen-units =
+1`, `strip = true`. Fat LTO measured no runtime change over thin on the §12
+native scatter bench (run-to-run noise ±15% dominates) but cuts the cdylib
+~15% (1.51 → 1.29 MB); strip removes `.symtab`/debuginfo only — `.dynsym`,
+which ctypes binds against, survives. `panic` must stay `unwind`: the C-ABI
+backstop in `lib.rs` converts kernel panics into sentinel returns via
+`catch_unwind`, and `panic = "abort"` would turn them into aborts of the
+embedding CPython process (the wasm target alone builds with
+`-C panic=abort` in `release.yml`, where unwinding is unsupported anyway).
+PGO is a known open lever, not adopted: it needs a per-target training
+workload and profdata plumbing in the release matrix; revisit when a
+benchmark shows a branch-bound kernel on the hot path.
+
 ### 2.1 Native text is a bounded subset, and misses are visible
 
 Declining FreeType bought the single-cdylib property (§3.1) and paid for it in

--- a/tests/test_boxzoom_tool_keeps_wheel_and_reset.py
+++ b/tests/test_boxzoom_tool_keeps_wheel_and_reset.py
@@ -1,0 +1,165 @@
+"""The active drag tool must not disable wheel zoom or double-click reset.
+
+Regression for the modebar Box Zoom tool (PR #198's `dragMode !== "pan"` wheel
+guard): with the box-zoom tool active, wheel zoom and double-click reset both
+went dead after the first box-zoom gesture. Per the pan/zoom design spec §5.5,
+`default_drag_action` (and the live modebar tool) selects the *drag* gesture
+only — `"zoom"` never touches the wheel or double-click reset. The one
+exception is `"none"`, the modebar's escape hatch that releases page scroll
+for embedded charts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import xy
+from conftest import run_browser_probe
+from xy.export import find_chromium
+
+_RENDER_CALL = 'xy.renderStandalone(document.getElementById("chart"), spec, buf);'
+
+_PROBE = """
+  const view = xy.renderStandalone(document.getElementById("chart"), spec, buf);
+  try {
+    view._drawNow();
+    view._raf = null;
+
+    const c = view.canvas;
+    const rect = c.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const ranges = () => Object.fromEntries(
+      view._axisIds().map((id) => [id, [...view._axisRange(id)]])
+    );
+    const differs = (a, b) => JSON.stringify(a) !== JSON.stringify(b);
+    const home = ranges();
+
+    // Wheel deltas apply a frame later; make frames deterministic.
+    const realRaf = window.requestAnimationFrame;
+    let frames = [];
+    window.requestAnimationFrame = (fn) => { frames.push(fn); return frames.length; };
+    const flush = () => {
+      for (let round = 0; round < 4 && frames.length; round++) {
+        const queued = frames;
+        frames = [];
+        for (const fn of queued) fn();
+      }
+    };
+
+    // The reset lands through an animation; the guard under test is whether
+    // the dblclick listener invokes it at all, so spy on the entry point.
+    let resetCalls = 0;
+    const realReset = view._resetView;
+    view._resetView = function (...args) { resetCalls++; return realReset.apply(this, args); };
+
+    const wheelAt = () => {
+      const e = new WheelEvent("wheel", {
+        deltaY: -240, clientX: cx, clientY: cy, bubbles: true, cancelable: true,
+      });
+      c.dispatchEvent(e);
+      return e.defaultPrevented;
+    };
+    const dblclickAt = () => c.dispatchEvent(new MouseEvent("dblclick", {
+      clientX: cx, clientY: cy, bubbles: true, cancelable: true,
+    }));
+
+    let probe;
+    try {
+      // The repro: activate the modebar Box Zoom tool and complete a gesture.
+      view._setDragMode("zoom");
+      view._zoomToBox(
+        [home.x[0] + (home.x[1] - home.x[0]) * 0.25, home.y[0] + (home.y[1] - home.y[0]) * 0.25],
+        [home.x[0] + (home.x[1] - home.x[0]) * 0.75, home.y[0] + (home.y[1] - home.y[0]) * 0.75],
+        false,
+        { source: "box_zoom", phase: "end", interactionId: 1 },
+      );
+      flush();
+      const afterBox = ranges();
+      const boxZoomApplied = differs(afterBox, home);
+
+      // Wheel must keep zooming while the box-zoom tool is active.
+      const wheelPreventedInZoomMode = wheelAt();
+      flush();
+      const wheelChangedView = differs(ranges(), afterBox);
+
+      // Double click must keep resetting while the box-zoom tool is active.
+      dblclickAt();
+      const resetCalledInZoomMode = resetCalls === 1;
+      flush();
+
+      // `none` stays the escape hatch: the wheel passes through to the page
+      // and double click does nothing.
+      view._setDragMode("none");
+      const before = ranges();
+      const wheelPreventedInNoneMode = wheelAt();
+      flush();
+      const wheelChangedViewInNoneMode = differs(ranges(), before);
+      dblclickAt();
+      const resetCalledInNoneMode = resetCalls > 1;
+
+      probe = {
+        boxZoomApplied,
+        wheelPreventedInZoomMode,
+        wheelChangedView,
+        resetCalledInZoomMode,
+        wheelPreventedInNoneMode,
+        wheelChangedViewInNoneMode,
+        resetCalledInNoneMode,
+      };
+    } finally {
+      window.requestAnimationFrame = realRaf;
+    }
+
+    document.body.setAttribute("data-xy-boxzoom-tool-probe", JSON.stringify(probe));
+  } catch (err) {
+    document.body.setAttribute(
+      "data-xy-boxzoom-tool-probe-error",
+      String((err && err.stack) || err),
+    );
+  }
+"""
+
+
+def _chart_html() -> str:
+    chart = xy.scatter_chart(
+        xy.scatter([0.0, 1.0, 2.0, 3.0, 4.0], [0.0, 1.0, 4.0, 9.0, 16.0]),
+        xy.x_axis(),
+        xy.y_axis(),
+        width=480,
+        height=360,
+    )
+    html = chart.to_html()
+    assert _RENDER_CALL in html
+    return html
+
+
+def test_box_zoom_tool_keeps_wheel_zoom_and_double_click_reset(tmp_path: Path) -> None:
+    chromium = find_chromium()
+    if chromium is None:
+        pytest.skip("Chromium unavailable")
+
+    document = _chart_html().replace(_RENDER_CALL, _PROBE)
+    result = run_browser_probe(
+        chromium,
+        document,
+        tmp_path / "boxzoom_tool.html",
+        "data-xy-boxzoom-tool-probe",
+        label="box-zoom tool wheel/reset probe",
+    )
+
+    # Precondition: the box-zoom gesture actually moved the view.
+    assert result["boxZoomApplied"] is True
+
+    # The reported bug: both must survive the box-zoom tool being active.
+    assert result["wheelPreventedInZoomMode"] is True
+    assert result["wheelChangedView"] is True
+    assert result["resetCalledInZoomMode"] is True
+
+    # The deliberate carve-out from PR #198 stays: `none` releases the wheel
+    # to the page and ignores double click.
+    assert result["wheelPreventedInNoneMode"] is False
+    assert result["wheelChangedViewInNoneMode"] is False
+    assert result["resetCalledInNoneMode"] is False


### PR DESCRIPTION
## Problem

After selecting the modebar **Box Zoom** tool (drag mode `"zoom"`), cursor-anchored wheel zoom and double-click view reset both stop working — the chart can only be navigated back out via the toolbar.

## Cause

The toolbar restyle (#198) added `if (this.dragMode !== "pan") return;` to the plot-canvas `wheel` and `dblclick` handlers in `js/src/53_interaction.ts`. The intent was the deliberate `pan ↔ none` modebar escape hatch (embedded charts release page scroll), but the guard also blocked the `zoom` and select tools — contradicting the pan/zoom design spec (§5.5: *"`zoom` means box zoom for drag only. It does not control wheel zoom…"*) and the axis-band wheel handler, which has no drag-tool guard.

## Fix

- Guard both handlers on the actual exception, `dragMode === "none"`, instead of `!== "pan"`. Wheel zoom now works under the pan, box-zoom, and select tools; double-click reset works under pan and box-zoom. `"none"` stays fully inert so the modebar pan toggle still hands wheel scroll back to the page.
- Record the contract in `spec/api/interaction.md` (flag table + gesture map) and `spec/design/pan-and-zoom-configuration.md` §5.5, including fixing the stale `default_drag_action="none", wheel_zoom=True` example that had promised behavior #198 removed.
- New regression test `tests/test_boxzoom_tool_keeps_wheel_and_reset.py`: a headless-Chromium probe that activates the box-zoom tool, completes a box zoom, then asserts wheel still zooms (and `preventDefault`s) and double-click still resets — plus the `"none"` carve-out in both directions. Verified it fails against the old guard.

## Testing

- `node js/build.mjs` (typecheck + bundle) clean
- New probe passes; fails when the old guard is reinstated
- All 64 tests touching wheel/dblclick behavior pass (`test_wheel_gesture_end`, `test_modebar_select_drill`, `test_view_state_client`, …)
- `pre-commit run --all-files`, `ruff check .`, `ruff format --check .` all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Wheel zooming and double-click view reset now remain available while using box zoom and other drag tools.
  - Added support for creating inert plots that allow page scrolling while retaining toolbar navigation.

- **Bug Fixes**
  - Corrected interaction behavior when drag mode is set to `none`.

- **Documentation**
  - Updated interaction and configuration guidance to clarify zoom, reset, and scrolling behavior.

- **Performance**
  - Reduced the native release library size by approximately 15% without measured runtime impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->