### PR TITLE
Delete five unreachable Python helpers

### DIFF
--- a/python/xy/_chromium.py
+++ b/python/xy/_chromium.py
@@ -324,18 +324,6 @@ class ChromiumSession:
                 self._call("Target.closeTarget", {"targetId": target_id})
             page_path.unlink(missing_ok=True)
 
-    def render_png(
-        self,
-        html: str,
-        width: int,
-        height: int,
-        *,
-        scale: float = 2.0,
-        timeout_s: float = 120.0,
-    ) -> bytes:
-        """Compatibility wrapper: `render_image` with format="png"."""
-        return self.render_image(html, width, height, scale=scale, timeout_s=timeout_s)
-
     def render_pdf(
         self,
         html: str,

--- a/python/xy/_native.py
+++ b/python/xy/_native.py
@@ -749,17 +749,6 @@ def _load() -> ctypes.CDLL:
         ctypes.c_size_t,  # w
         ctypes.c_size_t,  # h
     ]
-    lib.xy_rasterize_png_data.restype = ctypes.c_size_t
-    lib.xy_rasterize_png_data.argtypes = [
-        ctypes.c_void_p,  # cmd
-        ctypes.c_size_t,  # cmd_len
-        ctypes.c_void_p,  # external data arena
-        ctypes.c_size_t,  # data_len
-        ctypes.c_void_p,  # out PNG bytes
-        ctypes.c_size_t,  # out_capacity
-        ctypes.c_size_t,  # w
-        ctypes.c_size_t,  # h
-    ]
     lib.xy_rasterize_spans.restype = ctypes.c_int32
     lib.xy_rasterize_spans.argtypes = [
         ctypes.c_void_p,  # cmd
@@ -3242,32 +3231,6 @@ def rasterize_data(cmds: bytes, data: bytes, w: int, h: int) -> npt.NDArray[np.u
     if not ok:
         raise ValueError("native rasterizer rejected the command buffer or external data")
     return out
-
-
-def rasterize_png_data(cmds: bytes, data: bytes, w: int, h: int) -> bytes:
-    """Paint and encode a display list backed by a synchronous external arena."""
-    w = _positive_int(w, "raster width")
-    h = _positive_int(h, "raster height")
-    buf = np.frombuffer(cmds, dtype=np.uint8)
-    arena = np.frombuffer(data, dtype=np.uint8)
-    raw_len = operator.mul(operator.mul(w, h), 4)
-    capacity = raw_len + raw_len // 8 + 65_536
-    out = np.empty(capacity, dtype=np.uint8)
-    written = _lib.xy_rasterize_png_data(
-        _ptr_u8(buf) if buf.size else None,
-        buf.size,
-        _ptr_u8(arena) if arena.size else None,
-        arena.size,
-        _ptr_u8(out),
-        out.size,
-        w,
-        h,
-    )
-    if written == _USIZE_MAX or written > out.size:
-        raise ValueError(
-            "native raster-to-PNG encoder rejected the command buffer or external data"
-        )
-    return out[:written].tobytes()
 
 
 def _byte_span_arrays(spans):  # noqa: ANN001, ANN202 - private ctypes adapter

--- a/python/xy/_raster.py
+++ b/python/xy/_raster.py
@@ -1235,28 +1235,6 @@ def _emit_line(
         cmd.stroke(pts, width, c, dash=style.get("dash"), cap=cap)
 
 
-def _annotation_point(
-    ann: dict[str, Any],
-    style: dict[str, Any],
-    sx: _Scale,
-    sy: _Scale,
-    plot: dict[str, float],
-    width: float,
-    height: float,
-) -> tuple[float, float]:
-    space = style.get("coordinate_space")
-    x, y = float(ann.get("x", 0.0)), float(ann.get("y", 0.0))
-    if space == "axes_fraction":
-        return plot["x"] + x * plot["w"], plot["y"] + (1.0 - y) * plot["h"]
-    if space == "figure_fraction":
-        return x * width, (1.0 - y) * height
-    if space == "yaxis_transform":
-        return plot["x"] + x * plot["w"], float(sy(y))
-    if space == "xaxis_transform":
-        return float(sx(x)), plot["y"] + (1.0 - y) * plot["h"]
-    return float(sx(x)), float(sy(y))
-
-
 def _native_font_emphasis(style: dict[str, Any]) -> tuple[bool, bool]:
     """Return baked-font italic/bold approximations for an annotation."""
     italic = str(style.get("font_style", "")).lower() in {"italic", "oblique"}

--- a/python/xy/lod.py
+++ b/python/xy/lod.py
@@ -938,24 +938,6 @@ def add_window_xy(
     return writer.add_encoded(x_col), writer.add_encoded(y_col)
 
 
-def encode_window_xy(
-    xs: np.ndarray,
-    ys: np.ndarray,
-    lo_x: float,
-    hi_x: float,
-    lo_y: float,
-    hi_y: float,
-    x_scale: str | None = None,
-    y_scale: str | None = None,
-) -> tuple[dict, dict, np.ndarray, np.ndarray]:
-    """Offset-encode a drilled subset re-centered on the window midpoint (the
-    design dossier's §16 deep-zoom rule) — f32 precision follows the viewport,
-    not the dataset (log-family axes pin offset 0; see `geometry_offset`).
-    Returns wire metas ({offset, scale}) plus the encoded arrays."""
-    x_col, y_col = encode_window_xy_columns(xs, ys, lo_x, hi_x, lo_y, hi_y, x_scale, y_scale)
-    return (x_col.meta, y_col.meta, x_col.values, y_col.values)
-
-
 def grid_shape(
     w: int, h: int, visible: int, target_per_cell: float = DENSITY_TARGET_POINTS_PER_CELL
 ) -> tuple[int, int]:

--- a/python/xy/pyplot/__init__.py
+++ b/python/xy/pyplot/__init__.py
@@ -3117,8 +3117,4 @@ def cycler(*args: Any, **kwargs: Any) -> Any:
     return _PropCycle(list(values))
 
 
-def np_asarray_passthrough(x: Any) -> Any:  # pragma: no cover - numpy re-export shim
-    return np.asarray(x)
-
-
 _install_ipython_display_hook()


### PR DESCRIPTION
## What

Removes five Python functions/methods that no longer have a caller anywhere in the repository, 93 lines in total.

A [vulture](https://github.com/jendrikseipp/vulture) pass over `python/`, `tests/`, `scripts/`, `benchmarks/` and `examples/` reported 155 candidates. Nearly all are false positives worth naming explicitly, since they are the reason a tool like this can't be run as a gate as-is:

- framework entry points — pytest autouse fixtures, socket.io `on_<event>` handlers in `reflex_xy/namespace.py`, Reflex event vars, `hatch_build.CustomBuildHook`, FastAPI routes, `__getattr__`/`__dir__`;
- the `_payload._emit_<kind>` family, reached through `getattr(self, f"_emit_{t.kind}")` at `_payload.py:378`;
- ~35 `pyplot/` methods and properties (`invert_yaxis`, `inset_axes`, `theta2`, `has_xerr`, …) that are deliberate matplotlib compat surface — being unused internally is the point, and the corpus plus `spec/matplotlib/compat.md` define what has to exist.

Each survivor below was verified by hand against the whole repo, including `spec/`, `docs/` and the TypeScript client:

| Removed | Why it's dead |
| --- | --- |
| `_raster._annotation_point` | Orphaned once `_emit_annotations` moved to `annotation_label_placement`. `_svg.py:2610` keeps the equivalent logic it still needs. |
| `lod.encode_window_xy` | A wrapper over `encode_window_xy_columns` — the entry point callers and `spec/design/lod-architecture.md` actually name. |
| `pyplot.np_asarray_passthrough` | A two-line numpy re-export shim, already `# pragma: no cover`. |
| `_native.rasterize_png_data` | Never called. Removed with the `xy_rasterize_png_data` argtypes block it was the sole consumer of. |
| `_chromium.ChromiumRenderer.render_png` | A wrapper over `render_image(format="png")`. |

## Notes

**ABI is unaffected.** No signature changed, so `ABI_VERSION` is untouched in both `src/lib.rs` and `python/xy/_native.py`. The Rust `xy_rasterize_png_data` export is unchanged and stays exercised by `scripts/abi_smoke.py`, which binds the symbol with its own ctypes declarations rather than going through `_native.py`.

**No spec updates apply.** None of the five appear anywhere in `spec/` or `docs/`. The one neighbouring reference, `spec/design/lod-architecture.md:70`, names `encode_window_xy_columns` and `add_window_xy`, both of which survive.

## Verification

- `uv run ruff check .` and `uv run ruff format --check .` — clean.
- `uv run --with pre-commit pre-commit run --all-files` — all hooks pass, tree left unmodified.
- `python3 scripts/abi_smoke.py` — 140 checks pass.
- `uv run pytest` — 3186 passed, 1 skipped.
- `uv run ty check` — the same 26 diagnostics before and after these edits, none in the touched files.
- Re-running vulture drops 155 findings to 150: exactly these five, with nothing newly orphaned.

## Deliberately left out

Two further vulture findings need a decision rather than a deletion, so they are not in this PR:

- `lod.visible_mask` has no caller, but `spec/design/rust-engine.md:38` lists it as a live promote-to-Rust candidate. Either it goes together with that row, or the row is already stale.
- `styling.capabilities.MarkStyleProperty.compiles_to` is populated on all 10 entries and read by nothing; `scripts/gen_capability_matrix.py` emits `id`/`notes`/`support`/`status` but skips it. That reads as a missing capability-matrix column rather than dead data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed legacy PNG rendering and rasterization entry points.
  * Use the current image-rendering API with PNG output for Chromium screenshots.
  * Use supported data or span-based rasterization APIs for native rendering.
  * Removed several internal convenience helpers for coordinate conversion, window encoding, and NumPy array handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->