### PR TITLE
Fall back to standalone-HTML display on WASM notebook kernels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ in the README).
 ## [Unreleased]
 
 ### Added
+- Notebook display-host resolution (`spec/design/reflex-shaped-api.md` §3.3):
+  `show(display=...)` on charts, facet charts, and the internal figure objects
+  accepts `"auto"` (default), `"widget"`, or `"html"`, with the
+  `XY_NOTEBOOK_DISPLAY` environment variable as the process-wide override. On
+  Emscripten/WASM kernels (JupyterLite, Pyodide) `"auto"` now displays through
+  the standalone-HTML iframe host instead of the anywidget comm, so charts
+  render on hosted JupyterLite deployments (for example try-jupyter) whose
+  prebuilt frontends cannot load the anywidget extension `%pip` installs
+  kernel-side ("Failed to load model class 'AnyModel' from module
+  'anywidget'"). Marimo's WASM build keeps the live widget host, and
+  `show(display="html")` returns an `xy.export.HtmlView` rich-repr handle.
 - `xy.box(...)` exposes its four visible parts without a parallel styling
   language: the main `style=` now controls body fill and border, while
   `whisker_style=`, `median_style=`, and `outlier_style=` reuse the validated

--- a/docs/app/tests/test_docs_site.py
+++ b/docs/app/tests/test_docs_site.py
@@ -1184,12 +1184,13 @@ def test_installation_distinguishes_supported_targets_from_pypi_artifacts() -> N
 
     assert all(value in windows_row for value in ("`x86_64`", "`x86`", "`arm64`"))
     assert "| Supported | Not included |" in windows_row
-    assert "Pyodide 0.29.4" in wasm_row
-    assert "`wasm32` | Supported | Not accepted by PyPI |" in wasm_row
+    assert "Pyodide 314" in wasm_row
+    assert "`wasm32` | Supported | Not in 0.0.1 (on PyPI since 0.0.3) |" in wasm_row
     assert "Windows is supported by XY's native core and release pipeline." in content
     assert "0.0.1 PyPI upload does not include Windows wheels" in content
-    assert "runtime-verified Pyodide wheel" in content
-    assert "`pyodide_2025_0_wasm32` platform" in content
+    assert "runtime-verified WebAssembly wheel" in content
+    assert "`pyemscripten_2026_0_wasm32` platform" in content
+    assert "%pip install xy" in content
 
 
 def test_chart_gallery_grid_renders_every_type_as_inline_svg(

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -32,6 +32,16 @@ chart or component height while debugging.
 Python package and bundled `anywidget` client come from the same installation,
 then display `chart.widget()` directly to isolate surrounding layout.
 
+**JupyterLite shows `Failed to load model class 'AnyModel' from module
+'anywidget'`.** The deployment's prebuilt frontend lacks the anywidget
+extension, and `%pip install anywidget` adds only the kernel-side package —
+frontend JavaScript cannot be installed at runtime. Current XY releases
+detect WASM kernels and display through the standalone-HTML host instead, so
+`chart.show()` renders without the widget comm; upgrade XY if you still see
+this error. Set `XY_NOTEBOOK_DISPLAY=widget` only in a self-built JupyterLite
+deployment that bundled the anywidget frontend extension. See
+[Notebooks](/docs/xy/integrations/notebooks/).
+
 **Only some charts in a large dashboard remain live.** Browsers limit WebGL
 contexts. Avoid keeping more than XY's default context budget of 12 charts
 simultaneously visible; see

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -38,8 +38,11 @@ extension, and `%pip install anywidget` adds only the kernel-side package —
 frontend JavaScript cannot be installed at runtime. Current XY releases
 detect WASM kernels and display through the standalone-HTML host instead, so
 `chart.show()` renders without the widget comm; upgrade XY if you still see
-this error. Set `XY_NOTEBOOK_DISPLAY=widget` only in a self-built JupyterLite
-deployment that bundled the anywidget frontend extension. See
+this error. If the error persists on a current release, check for an explicit
+`XY_NOTEBOOK_DISPLAY=widget` or `show(display="widget")` override forcing the
+widget host — set those only in a self-built JupyterLite deployment that
+bundled the anywidget frontend extension. Marimo's WASM notebook never shows
+this error: it bundles its own anywidget frontend and keeps live widgets. See
 [Notebooks](/docs/xy/integrations/notebooks/).
 
 **Only some charts in a large dashboard remain live.** Browsers limit WebGL

--- a/docs/integrations/notebooks.md
+++ b/docs/integrations/notebooks.md
@@ -37,6 +37,36 @@ The JavaScript/WebGL client is bundled in the installed XY wheel. Notebook
 display does not fetch a client from a CDN, so it also works in an air-gapped
 runtime once the Python packages are installed.
 
+## JupyterLite and Pyodide (WASM Kernels)
+
+XY publishes a Pyodide/Emscripten wheel, so `%pip install xy` works in a
+JupyterLite notebook. Hosted deployments with a prebuilt frontend — for
+example [try Jupyter](https://jupyter.org/try-jupyter/lab/) — cannot load the
+`anywidget` frontend extension at runtime, because `%pip` installs only the
+kernel-side package. Displaying the live widget there fails in the browser
+with `Failed to load model class 'AnyModel' from module 'anywidget'`.
+
+On WASM kernels XY therefore switches to its standalone-HTML display host
+automatically: `chart.show()` (or a bare `chart`) renders the same
+self-contained interactive document as `to_html()` inside an isolated iframe.
+Pan, zoom, hover, the modebar, and export all work in the browser. Python
+callbacks (`on_select`, ...), `chart.append(...)` live refreshes, and
+kernel-served zoom refinement need the live widget host, so they stay
+inactive on the HTML host; re-run the cell to display mutated chart state.
+
+Override the automatic choice per call with `chart.show(display="widget")` /
+`chart.show(display="html")`, or process-wide with the `XY_NOTEBOOK_DISPLAY`
+environment variable (`auto`, `widget`, or `html`):
+
+~~~python
+import os
+
+os.environ["XY_NOTEBOOK_DISPLAY"] = "widget"
+~~~
+
+Forcing `widget` is useful in a self-built JupyterLite deployment that added
+`anywidget` to `jupyter lite build`, where the frontend extension does exist.
+
 ## Callbacks
 
 Pass `on_hover`, `on_click`, `on_brush`, `on_select`, or `on_view_change` to a

--- a/docs/integrations/notebooks.md
+++ b/docs/integrations/notebooks.md
@@ -54,6 +54,10 @@ callbacks (`on_select`, ...), `chart.append(...)` live refreshes, and
 kernel-served zoom refinement need the live widget host, so they stay
 inactive on the HTML host; re-run the cell to display mutated chart state.
 
+Marimo is the exception among WASM hosts: it ships its own anywidget frontend
+as part of the app, so charts in Marimo's WASM build keep the live widget
+host automatically.
+
 Override the automatic choice per call with `chart.show(display="widget")` /
 `chart.show(display="html")`, or process-wide with the `XY_NOTEBOOK_DISPLAY`
 environment variable (`auto`, `widget`, or `html`):

--- a/docs/overview/installation.md
+++ b/docs/overview/installation.md
@@ -39,7 +39,7 @@ the current 0.0.1 upload, not whether XY supports the platform.
 | Linux | glibc (`manylinux_2_17`) | `x86_64`, `aarch64`, `armv7l` | Supported | Included |
 | Linux | musl (`musllinux_1_2`, including Alpine) | `x86_64`, `aarch64`, `armv7l` | Supported | Included |
 | Windows | Native Windows | `x86_64`, `x86`, `arm64` | Supported | Not included |
-| WebAssembly | Pyodide 0.29.4 (Emscripten) | `wasm32` | Supported | Not accepted by PyPI |
+| WebAssembly | Pyodide 314 (Emscripten, PEP 783) | `wasm32` | Supported | Not in 0.0.1 (on PyPI since 0.0.3) |
 
 Windows is supported by XY's native core and release pipeline. The current
 0.0.1 PyPI upload does not include Windows wheels or a source distribution, so
@@ -47,13 +47,14 @@ Windows is supported by XY's native core and release pipeline. The current
 Windows yet. Until a Windows wheel is published, install the tagged source
 with a Rust MSVC toolchain as described below.
 
-A runtime-verified Pyodide wheel has been built for in-browser Python, but the
-`v0.0.1` wheel is not yet publicly distributed as a durable release asset.
-PyPI does not accept its `pyodide_2025_0_wasm32` platform tag, so the WASM
-wheel is not available through the normal install commands. This target runs
-XY's Python and Rust core inside Pyodide; it is separate from the
-JavaScript/WebGL client included with every chart. Track publication in
-[#97](https://github.com/reflex-dev/xy/issues/97).
+The runtime-verified WebAssembly wheel targets the standardized PEP 783
+`pyemscripten_2026_0_wasm32` platform and, as of 0.0.3, is published to PyPI
+alongside the native wheels. In-browser Python installs it by package name —
+`micropip.install("xy")`, or `%pip install xy` in a JupyterLite notebook.
+This target runs XY's Python and Rust core inside Pyodide; it is separate
+from the JavaScript/WebGL client included with every chart. See
+[Notebooks](/docs/xy/integrations/notebooks/) for how charts display on WASM
+kernels.
 
 ## What the package includes
 

--- a/python/xy/_figure.py
+++ b/python/xy/_figure.py
@@ -1746,13 +1746,22 @@ class Figure(AnnotationsMixin, PayloadMixin):
             self._widget = FigureWidget(self)
         return self._widget
 
-    def show(self) -> Any:
-        return self.widget()
+    def show(self, display: Optional[str] = None) -> Any:
+        """The live widget, or a standalone-HTML view when the html display
+        host is selected (reflex-shaped-api.md §3.3: "auto" falls back to
+        html only on WASM kernels, whose prebuilt frontends cannot load the
+        anywidget extension)."""
+        if export.notebook_display_mode(display) == "widget":
+            return self.widget()
+        return export.HtmlView(self._repr_html_())
 
     def _ipython_display_(self) -> None:
         from IPython.display import display  # type: ignore[import-not-found]
 
-        display(self.widget())
+        if export.notebook_display_mode() == "widget":
+            display(self.widget())
+        else:
+            display({"text/html": self._repr_html_()}, raw=True)
 
     def to_html(
         self,

--- a/python/xy/components.py
+++ b/python/xy/components.py
@@ -3662,9 +3662,20 @@ class Chart(Component):
             self._widget = FigureWidget(self.figure(), **widget_kwargs)
         return self._widget
 
-    def show(self) -> Any:
-        """Display the chart: returns the live widget (see `widget`)."""
-        return self.widget()
+    def show(self, display: Optional[str] = None) -> Any:
+        """Display the chart: the live widget, or a standalone-HTML view.
+
+        ``display`` picks the notebook host — ``"widget"`` (anywidget comm;
+        Python callbacks live), ``"html"`` (the same isolated iframe as
+        `_repr_html_`; interactive in the browser, no kernel channel), or
+        ``None``/``"auto"``, which follows ``XY_NOTEBOOK_DISPLAY`` and falls
+        back to ``"html"`` only on WASM kernels (JupyterLite/Pyodide), whose
+        prebuilt frontends cannot load the anywidget extension `%pip`
+        installs kernel-side.
+        """
+        if export.notebook_display_mode(display) == "widget":
+            return self.widget()
+        return export.HtmlView(self._repr_html_())
 
     # -- programmatic view state (kernel-connected; view-state.md §5.1) ------
 
@@ -3699,7 +3710,10 @@ class Chart(Component):
     def _ipython_display_(self) -> None:
         from IPython.display import display  # type: ignore[import-not-found]
 
-        display(self.widget())
+        if export.notebook_display_mode() == "widget":
+            display(self.widget())
+        else:
+            display({"text/html": self._repr_html_()}, raw=True)
 
     def to_html(
         self,
@@ -4993,9 +5007,12 @@ class FacetChart(Component):
         """Live notebook widgets, one per facet panel."""
         return self.figure().widget()
 
-    def show(self) -> list[Any]:
-        """Display the facet grid: returns the panel widgets."""
-        return self.widget()
+    def show(self, display: Optional[str] = None) -> Any:
+        """Display the facet grid: the panel widgets, or a standalone-HTML
+        view of the whole grid (see `Chart.show` for display-host resolution)."""
+        if export.notebook_display_mode(display) == "widget":
+            return self.widget()
+        return export.HtmlView(self._repr_html_())
 
     def to_html(
         self, path: Optional[str | PathLike[str]] = None, *, custom_css: Optional[str] = None

--- a/python/xy/export.py
+++ b/python/xy/export.py
@@ -12,6 +12,7 @@ import os
 import re as _re
 import shutil
 import subprocess
+import sys
 import tempfile
 import warnings
 from contextlib import suppress
@@ -411,6 +412,62 @@ def notebook_iframe(doc: str, *, width: object, height: object) -> str:
         'border:0;background:transparent" '
         f'srcdoc="{source}"></iframe>'
     )
+
+
+# Notebook display-host resolution (reflex-shaped-api.md §3.3). The widget
+# host needs the anywidget frontend extension; a WASM-kernel deployment with a
+# prebuilt frontend (JupyterLite's `%pip`, e.g. try-jupyter) installs only the
+# kernel-side package, so the comm opens against a frontend that cannot answer
+# it. The kernel cannot observe the frontend registry, so "auto" resolves from
+# the runtime instead: an Emscripten kernel defaults to the standalone HTML
+# host, everything else to the widget. Marimo bundles its own anywidget
+# frontend even in its WASM build, so it keeps the widget host under "auto".
+_NOTEBOOK_DISPLAY_ENV = "XY_NOTEBOOK_DISPLAY"
+_NOTEBOOK_DISPLAY_MODES = ("auto", "widget", "html")
+
+
+class HtmlView:
+    """A displayable handle over the standalone-HTML notebook host.
+
+    Returned by ``show(display="html")`` so the isolated iframe renders through
+    the ordinary rich-repr path with no widget comm; ``str()`` yields the
+    fragment for direct embedding.
+    """
+
+    def __init__(self, html: str) -> None:
+        self._html = html
+
+    def _repr_html_(self) -> str:
+        return self._html
+
+    def __str__(self) -> str:
+        return self._html
+
+    def __repr__(self) -> str:
+        return f"<xy.export.HtmlView ({len(self._html)} chars; rich display renders it)>"
+
+
+def notebook_display_mode(display: Optional[str] = None) -> str:
+    """Resolve the notebook display host: ``"widget"`` or ``"html"``.
+
+    Precedence: the explicit ``display=`` argument, then the
+    ``XY_NOTEBOOK_DISPLAY`` environment variable, then ``"auto"`` — which
+    picks the standalone HTML host on Emscripten/WASM kernels (JupyterLite,
+    Pyodide; their prebuilt frontends cannot gain the anywidget extension at
+    runtime) and the live widget host everywhere else.
+    """
+    if display is not None:
+        mode, source = display, "display"
+    else:
+        mode, source = os.environ.get(_NOTEBOOK_DISPLAY_ENV) or "auto", _NOTEBOOK_DISPLAY_ENV
+    if not isinstance(mode, str) or mode.strip().lower() not in _NOTEBOOK_DISPLAY_MODES:
+        raise ValueError(f'{source} must be one of "auto", "widget", or "html"; got {mode!r}')
+    mode = mode.strip().lower()
+    if mode != "auto":
+        return mode
+    if sys.platform == "emscripten" and "marimo" not in sys.modules:
+        return "html"
+    return "widget"
 
 
 def _installed_browser(candidate: object) -> Optional[str]:

--- a/python/xy/facets.py
+++ b/python/xy/facets.py
@@ -472,9 +472,18 @@ for(const p of panels){{
 
         return [FigureWidget(fig) for fig in self.figures]
 
-    def show(self) -> list[Any]:
-        """Display the facet grid: returns the panel widgets."""
-        return self.widget()
+    def show(self, display: Optional[str] = None) -> Any:
+        """Display the facet grid: the panel widgets, or one standalone-HTML
+        view of the whole grid on the html display host (see `Chart.show`)."""
+        if export.notebook_display_mode(display) == "widget":
+            return self.widget()
+        return export.HtmlView(
+            export.notebook_iframe(
+                self.to_html(),
+                width=self.width,
+                height=self.grid_height + self._title_height,
+            )
+        )
 
     def memory_report(self) -> dict[str, Any]:
         """Aggregated data/cache buffer accounting across all panels."""

--- a/spec/api/api-examples.md
+++ b/spec/api/api-examples.md
@@ -450,7 +450,11 @@ chart
 
 Composed `Chart` objects expose `to_html(...)`, `html(...)`, `_repr_html_()`,
 `to_png(...)`, `to_svg(...)`, `to_image(...)`, `write_image(...)`, `widget()`,
-`show()`, and `memory_report()` readout methods directly.
+`show()`, and `memory_report()` readout methods directly. `show(display=...)`
+picks the notebook host — `"widget"`, `"html"`, or auto, which falls back to
+the standalone-HTML iframe only on WASM kernels (JupyterLite/Pyodide), where a
+prebuilt frontend cannot load the anywidget extension
+(design/reflex-shaped-api.md §3.3).
 `to_image(format="png", ...)` returns bytes and `write_image(path, ...)` writes
 one file atomically with the format inferred from its extension; together they
 are the unified export surface across PNG/JPEG/WebP/SVG/PDF (and standalone

--- a/spec/api/api-examples.md
+++ b/spec/api/api-examples.md
@@ -453,7 +453,8 @@ Composed `Chart` objects expose `to_html(...)`, `html(...)`, `_repr_html_()`,
 `show()`, and `memory_report()` readout methods directly. `show(display=...)`
 picks the notebook host — `"widget"`, `"html"`, or auto, which falls back to
 the standalone-HTML iframe only on WASM kernels (JupyterLite/Pyodide), where a
-prebuilt frontend cannot load the anywidget extension
+prebuilt frontend cannot load the anywidget extension; Marimo's WASM build
+bundles its own anywidget frontend and keeps the widget host
 (design/reflex-shaped-api.md §3.3).
 `to_image(format="png", ...)` returns bytes and `write_image(path, ...)` writes
 one file atomically with the format inferred from its extension; together they

--- a/spec/design-dossier.md
+++ b/spec/design-dossier.md
@@ -1178,7 +1178,12 @@ hits a source build requiring a Rust toolchain — an instant adoption cliff.
    implementation works across Jupyter, JupyterLab, VS Code, Colab, and Marimo, and
    gives us the binary comm channel (§29's Jupyter row) without maintaining N
    frontend extensions. Server frameworks (Reflex/Dash-style) mount the same client
-   as a component.
+   as a component. One boundary is spec'd (reflex-shaped-api.md §3.3): the widget
+   host still needs the anywidget *frontend* extension, which a prebuilt
+   WASM-kernel frontend (JupyterLite's `%pip`, e.g. try-jupyter) cannot gain at
+   runtime — there `show()`/rich display resolve to the standalone-HTML iframe
+   host instead (same client, §29 static-export row; no kernel channel), with
+   `XY_NOTEBOOK_DISPLAY` / `show(display=...)` overriding in both directions.
 
 **Contracts that keep it honest:**
 - **Comm-protocol versioning.** The native core and JS client ship together but can

--- a/spec/design-dossier.md
+++ b/spec/design-dossier.md
@@ -1184,6 +1184,8 @@ hits a source build requiring a Rust toolchain — an instant adoption cliff.
    runtime — there `show()`/rich display resolve to the standalone-HTML iframe
    host instead (same client, §29 static-export row; no kernel channel), with
    `XY_NOTEBOOK_DISPLAY` / `show(display=...)` overriding in both directions.
+   Marimo's WASM build is the carve-out: it bundles its own anywidget frontend,
+   so it stays on the widget host under "auto".
 
 **Contracts that keep it honest:**
 - **Comm-protocol versioning.** The native core and JS client ship together but can

--- a/spec/design/reflex-shaped-api.md
+++ b/spec/design/reflex-shaped-api.md
@@ -220,6 +220,29 @@ already exists and clearly communicates export behavior. `Chart.to_html(path)`
 delegates to the engine's standalone export path, including same-directory
 atomic file replacement for path writes.
 
+`show(display=None)` resolves which notebook host renders the chart, and bare
+rich display (`_ipython_display_`) follows the same resolution with no
+argument. `"widget"` is the live anywidget host (Python callbacks, streaming
+`append`, kernel-served LOD); `"html"` is the standalone-HTML host — the same
+isolated `notebook_iframe` document as `_repr_html_()`, interactive in the
+browser but with no kernel channel; on it `show()` returns an
+`export.HtmlView` rich-repr handle instead of a widget. `None`/`"auto"`
+consults the `XY_NOTEBOOK_DISPLAY` environment variable, then defaults by
+runtime: an Emscripten/WASM kernel (JupyterLite, Pyodide) resolves to
+`"html"`, everything else to `"widget"`. The WASM rule exists because the
+widget host needs the anywidget *frontend* extension, which a prebuilt Lite
+frontend cannot gain from a kernel-side `%pip install` — the comm opens
+against a frontend that cannot answer it ("No version of module anywidget is
+registered") and the kernel cannot observe that failure, so the fallback must
+be decided kernel-side from the runtime. Two carve-outs keep the heuristic
+honest: Marimo bundles its own anywidget frontend even in its WASM build, so
+an Emscripten kernel with `marimo` imported stays on the widget host; and a
+custom JupyterLite deployment that ships the anywidget extension can force
+the widget host back via `XY_NOTEBOOK_DISPLAY=widget` or
+`show(display="widget")`. Invalid values fail loud, naming the argument or
+environment variable. `Figure.show`, `FacetChart.show`, and `FacetGrid.show`
+follow the same resolution.
+
 ## 4. Styling Contract
 
 XY should support styling through three layers, in this order:
@@ -484,8 +507,8 @@ The component tree compiles once and can target multiple renderers.
 
 | Target | Method | Notes |
 |---|---|---|
-| Notebook widget | `show()` / `widget()` | Python callbacks available |
-| Notebook/static HTML repr | `_repr_html_()` | Self-contained fallback that reuses standalone export |
+| Notebook widget | `show()` / `widget()` | Python callbacks available; the `show()` default except on WASM kernels (§3.3) |
+| Notebook/static HTML repr | `_repr_html_()` / `show(display="html")` | Self-contained fallback that reuses standalone export; auto-selected by `show()` on WASM kernels (JupyterLite/Pyodide), whose prebuilt frontends cannot load the anywidget extension |
 | Standalone HTML | `to_html()` / optional `html()` alias | Self-contained, no Python callbacks |
 | Static PNG | `to_png()` | Fast native default; optional Chromium standalone screenshot |
 | Future Reflex | external adapter package | Uses the smallest supported Reflex surface; core does not import Reflex |

--- a/spec/design/reflex-shaped-api.md
+++ b/spec/design/reflex-shaped-api.md
@@ -221,8 +221,8 @@ delegates to the engine's standalone export path, including same-directory
 atomic file replacement for path writes.
 
 `show(display=None)` resolves which notebook host renders the chart, and bare
-rich display (`_ipython_display_`) follows the same resolution with no
-argument. `"widget"` is the live anywidget host (Python callbacks, streaming
+rich display (`_ipython_display_`) on `Chart` and `Figure` follows the same
+resolution with no argument. `"widget"` is the live anywidget host (Python callbacks, streaming
 `append`, kernel-served LOD); `"html"` is the standalone-HTML host — the same
 isolated `notebook_iframe` document as `_repr_html_()`, interactive in the
 browser but with no kernel channel; on it `show()` returns an
@@ -241,7 +241,11 @@ custom JupyterLite deployment that ships the anywidget extension can force
 the widget host back via `XY_NOTEBOOK_DISPLAY=widget` or
 `show(display="widget")`. Invalid values fail loud, naming the argument or
 environment variable. `Figure.show`, `FacetChart.show`, and `FacetGrid.show`
-follow the same resolution.
+follow the same resolution. `FacetChart`'s *bare* rich display is the one
+deliberate exception: it always emits the composed standalone-grid document —
+the only representation that preserves the grid layout (N stacked panel
+widgets would not) — and that document is WASM-safe on every host. Live panel
+widgets remain an explicit `widget()` / `show(display="widget")` choice.
 
 ## 4. Styling Contract
 

--- a/tests/test_notebook_display.py
+++ b/tests/test_notebook_display.py
@@ -1,0 +1,204 @@
+"""Notebook display-host resolution (reflex-shaped-api.md §3.3).
+
+The widget host needs the anywidget *frontend* extension. A WASM-kernel
+deployment with a prebuilt frontend — JupyterLite's `%pip`, e.g.
+jupyter.org/try-jupyter — installs only the kernel-side package, so the comm
+opens against a frontend that cannot answer it ("No version of module
+anywidget is registered"). The kernel cannot observe the frontend registry,
+so `show()`/rich display resolve a display host from the runtime instead:
+Emscripten kernels fall back to the standalone-HTML iframe (the same isolated
+document as `_repr_html_`), and an explicit `display=` argument or
+`XY_NOTEBOOK_DISPLAY` overrides the heuristic in both directions.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+import xy
+from xy import export
+
+
+@pytest.fixture(autouse=True)
+def _no_display_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("XY_NOTEBOOK_DISPLAY", raising=False)
+
+
+def _chart() -> xy.Chart:
+    return xy.scatter_chart(
+        xy.scatter([0.0, 1.0, 2.0], [2.0, 4.0, 3.0]),
+        xy.x_axis(label="x"),
+        xy.y_axis(label="y"),
+    )
+
+
+class _StubWidget:
+    def __init__(self, figure, **kwargs):
+        self.figure = figure
+
+
+# -- mode resolution ----------------------------------------------------------
+
+
+def test_default_mode_is_widget() -> None:
+    assert export.notebook_display_mode() == "widget"
+
+
+def test_explicit_argument_wins_over_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XY_NOTEBOOK_DISPLAY", "widget")
+    assert export.notebook_display_mode("html") == "html"
+
+
+def test_environment_variable_selects_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XY_NOTEBOOK_DISPLAY", " HTML ")
+    assert export.notebook_display_mode() == "html"
+
+
+def test_empty_environment_variable_means_auto(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XY_NOTEBOOK_DISPLAY", "")
+    assert export.notebook_display_mode() == "widget"
+
+
+def test_invalid_argument_raises_naming_the_argument() -> None:
+    with pytest.raises(ValueError, match=r'display must be one of "auto", "widget", or "html"'):
+        export.notebook_display_mode("iframe")
+
+
+def test_invalid_environment_raises_naming_the_variable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XY_NOTEBOOK_DISPLAY", "iframe")
+    with pytest.raises(ValueError, match="XY_NOTEBOOK_DISPLAY must be one of"):
+        export.notebook_display_mode()
+
+
+def test_auto_falls_back_to_html_on_emscripten(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "emscripten")
+    monkeypatch.delitem(sys.modules, "marimo", raising=False)
+    assert export.notebook_display_mode() == "html"
+
+
+def test_marimo_keeps_widget_host_on_emscripten(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Marimo bundles its own anywidget frontend even in its WASM build, so an
+    # Emscripten kernel with marimo imported still hosts the live widget.
+    monkeypatch.setattr(sys, "platform", "emscripten")
+    monkeypatch.setitem(sys.modules, "marimo", types.ModuleType("marimo"))
+    assert export.notebook_display_mode() == "widget"
+
+
+def test_environment_variable_overrides_emscripten_auto(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A custom JupyterLite deployment that bundled the anywidget extension at
+    # build time can force the widget host back on.
+    monkeypatch.setattr(sys, "platform", "emscripten")
+    monkeypatch.setenv("XY_NOTEBOOK_DISPLAY", "widget")
+    assert export.notebook_display_mode() == "widget"
+
+
+# -- show() and rich display --------------------------------------------------
+
+
+def test_show_html_returns_isolated_iframe_view_without_widget() -> None:
+    chart = _chart()
+    view = chart.show(display="html")
+    html = view._repr_html_()
+    assert isinstance(view, export.HtmlView)
+    assert html.startswith('<iframe class="xy-notebook-frame"')
+    assert 'sandbox="allow-scripts"' in html
+    assert str(view) == html
+    assert chart._widget is None  # the html host never opens a widget comm
+
+
+def test_show_auto_uses_html_host_on_emscripten(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "emscripten")
+    monkeypatch.delitem(sys.modules, "marimo", raising=False)
+    chart = _chart()
+    view = chart.show()
+    assert isinstance(view, export.HtmlView)
+    assert chart._widget is None
+
+
+def test_show_widget_override_wins_on_emscripten(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "platform", "emscripten")
+    monkeypatch.setattr("xy.widget.FigureWidget", _StubWidget)
+    chart = _chart()
+    assert chart.show(display="widget") is chart.widget()
+
+
+def test_show_invalid_display_raises() -> None:
+    with pytest.raises(ValueError, match="display must be one of"):
+        _chart().show(display="standalone")
+
+
+def test_ipython_display_uses_html_payload_on_emscripten(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import IPython.display
+
+    displayed: list[tuple[object, bool]] = []
+
+    def record(value: object, *, raw: bool = False) -> None:
+        displayed.append((value, raw))
+
+    monkeypatch.setattr(IPython.display, "display", record)
+    monkeypatch.setattr(sys, "platform", "emscripten")
+    monkeypatch.delitem(sys.modules, "marimo", raising=False)
+
+    _chart()._ipython_display_()
+
+    assert len(displayed) == 1
+    payload, raw = displayed[0]
+    assert raw is True
+    assert isinstance(payload, dict)
+    assert payload["text/html"].startswith('<iframe class="xy-notebook-frame"')
+
+
+def test_ipython_display_keeps_widget_host_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import IPython.display
+
+    displayed: list[object] = []
+    monkeypatch.setattr(IPython.display, "display", lambda value, **kw: displayed.append(value))
+    monkeypatch.setattr("xy.widget.FigureWidget", _StubWidget)
+
+    chart = _chart()
+    chart._ipython_display_()
+
+    assert displayed == [chart.widget()]
+
+
+# -- parity across the renderable surfaces ------------------------------------
+
+
+def test_figure_show_honors_display_host() -> None:
+    fig = _chart().figure()
+    view = fig.show(display="html")
+    assert isinstance(view, export.HtmlView)
+    assert view._repr_html_().startswith('<iframe class="xy-notebook-frame"')
+
+
+def test_facet_chart_show_honors_display_host() -> None:
+    chart = xy.facet_chart(
+        xy.line(x="x", y="y"),
+        by="g",
+        data={"x": [0.0, 1.0, 0.0, 1.0], "y": [1.0, 2.0, 3.0, 4.0], "g": ["a", "a", "b", "b"]},
+    )
+    view = chart.show(display="html")
+    assert isinstance(view, export.HtmlView)
+    assert view._repr_html_().startswith('<iframe class="xy-notebook-frame"')
+
+
+def test_facet_grid_show_honors_display_host() -> None:
+    grid = xy.facet_chart(
+        xy.line(x="x", y="y"),
+        by="g",
+        data={"x": [0.0, 1.0, 0.0, 1.0], "y": [1.0, 2.0, 3.0, 4.0], "g": ["a", "a", "b", "b"]},
+    ).figure()
+    view = grid.show(display="html")
+    assert isinstance(view, export.HtmlView)
+    assert view._repr_html_().startswith('<iframe class="xy-notebook-frame"')

--- a/tests/test_notebook_display.py
+++ b/tests/test_notebook_display.py
@@ -193,6 +193,38 @@ def test_facet_chart_show_honors_display_host() -> None:
     assert view._repr_html_().startswith('<iframe class="xy-notebook-frame"')
 
 
+def test_facet_chart_bare_display_is_composed_document_on_every_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The one deliberate §3.3 exception: FacetChart's bare rich display always
+    # emits the composed standalone-grid document (the only representation
+    # that preserves the grid layout), which is WASM-safe as-is. Pin that it
+    # stays the document on an Emscripten kernel; test_facets.py pins the
+    # default-platform case.
+    import IPython.display
+
+    displayed: list[tuple[object, bool]] = []
+
+    def record(value: object, *, raw: bool = False) -> None:
+        displayed.append((value, raw))
+
+    monkeypatch.setattr(IPython.display, "display", record)
+    monkeypatch.setattr(sys, "platform", "emscripten")
+    monkeypatch.delitem(sys.modules, "marimo", raising=False)
+
+    xy.facet_chart(
+        xy.line(x="x", y="y"),
+        by="g",
+        data={"x": [0.0, 1.0, 0.0, 1.0], "y": [1.0, 2.0, 3.0, 4.0], "g": ["a", "a", "b", "b"]},
+    )._ipython_display_()
+
+    assert len(displayed) == 1
+    payload, raw = displayed[0]
+    assert raw is True
+    assert isinstance(payload, dict)
+    assert payload["text/html"].startswith('<iframe class="xy-notebook-frame"')
+
+
 def test_facet_grid_show_honors_display_host() -> None:
     grid = xy.facet_chart(
         xy.line(x="x", y="y"),


### PR DESCRIPTION
https://claude.ai/code/session_012S1ZDVaP9iNJMiFCfJL9QD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `display` control to `show()` for figures, charts, facet charts, and facet grids (live widget vs standalone HTML).
  * Notebook rendering now resolves via explicit `display`, then `XY_NOTEBOOK_DISPLAY`, then `"auto"` (WebAssembly/Pyodide default to standalone HTML; Marimo stays widget).
  * Added `HtmlView` rich-render support for `show(display="html")`.
* **Documentation**
  * Expanded JupyterLite/Pyodide troubleshooting and installation guidance, including the `anywidget`-extension missing scenario and overrides.
* **Tests**
  * Added notebook display-host resolution and rendering tests, including overrides, sandboxed iframe HTML expectations, and invalid mode error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->