### PR TITLE
ci: dual-push images to Harbor (apps) + ACR alongside ECR

### DIFF
--- a/.github/workflows/_build-docs-images.yml
+++ b/.github/workflows/_build-docs-images.yml
@@ -24,7 +24,11 @@ permissions:
 env:
   REGISTRY: 176771536320.dkr.ecr.us-west-2.amazonaws.com
   CADDY_IMAGE: 176771536320.dkr.ecr.us-west-2.amazonaws.com/xy/frontend
+  HARBOR_CADDY_IMAGE: oci.main.reflexsandbox.com/apps/xy/frontend
+  ACR_CADDY_IMAGE: reflexdev.azurecr.io/xy/frontend
   BACKEND_IMAGE: 176771536320.dkr.ecr.us-west-2.amazonaws.com/xy/backend
+  HARBOR_BACKEND_IMAGE: oci.main.reflexsandbox.com/apps/xy/backend
+  ACR_BACKEND_IMAGE: reflexdev.azurecr.io/xy/backend
   DEPOT_PROJECT: ${{ vars.DOCS_DEPOT_PROJECT }}
 
 jobs:
@@ -118,6 +122,18 @@ jobs:
           REGISTRY: ${{ env.REGISTRY }}
         run: aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin "$REGISTRY"
 
+      - name: Log in to Harbor
+        run: echo "$HARBOR_SECRET" | docker login oci.main.reflexsandbox.com -u "$HARBOR_USER" --password-stdin
+        env:
+          HARBOR_USER: ${{ secrets.HARBOR_PUSH_USERNAME }}
+          HARBOR_SECRET: ${{ secrets.HARBOR_PUSH_SECRET }}
+
+      - name: Log in to Azure Container Registry
+        run: echo "$ACR_PASSWORD" | docker login reflexdev.azurecr.io -u "$ACR_USERNAME" --password-stdin
+        env:
+          ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
+          ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
+
       - name: Set up Depot CLI
         uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
 
@@ -127,11 +143,15 @@ jobs:
           DEPOT_PROJECT: ${{ env.DEPOT_PROJECT }}
           IMAGE_TAG: ${{ inputs.image_tag }}
           CADDY_IMAGE: ${{ env.CADDY_IMAGE }}
+          HARBOR_CADDY_IMAGE: ${{ env.HARBOR_CADDY_IMAGE }}
+          ACR_CADDY_IMAGE: ${{ env.ACR_CADDY_IMAGE }}
         run: |
           depot build \
             --project "$DEPOT_PROJECT" \
             --file docs/app/dockerfiles/caddy.Dockerfile \
             --tag "${CADDY_IMAGE}:${IMAGE_TAG}" \
+            --tag "${HARBOR_CADDY_IMAGE}:${IMAGE_TAG}" \
+            --tag "${ACR_CADDY_IMAGE}:${IMAGE_TAG}" \
             --push \
             --platform linux/amd64,linux/arm64 \
             --provenance=false \
@@ -143,12 +163,16 @@ jobs:
           DEPOT_PROJECT: ${{ env.DEPOT_PROJECT }}
           IMAGE_TAG: ${{ inputs.image_tag }}
           BACKEND_IMAGE: ${{ env.BACKEND_IMAGE }}
+          HARBOR_BACKEND_IMAGE: ${{ env.HARBOR_BACKEND_IMAGE }}
+          ACR_BACKEND_IMAGE: ${{ env.ACR_BACKEND_IMAGE }}
           XY_VERSION: ${{ steps.xy_version.outputs.version }}
         run: |
           depot build \
             --project "$DEPOT_PROJECT" \
             --file docs/app/dockerfiles/backend.Dockerfile \
             --tag "${BACKEND_IMAGE}:${IMAGE_TAG}" \
+            --tag "${HARBOR_BACKEND_IMAGE}:${IMAGE_TAG}" \
+            --tag "${ACR_BACKEND_IMAGE}:${IMAGE_TAG}" \
             --build-arg "XY_VERSION=${XY_VERSION}" \
             --push \
             --platform linux/amd64,linux/arm64 \
@@ -159,13 +183,23 @@ jobs:
         env:
           IMAGE_TAG: ${{ inputs.image_tag }}
           CADDY_IMAGE: ${{ env.CADDY_IMAGE }}
+          HARBOR_CADDY_IMAGE: ${{ env.HARBOR_CADDY_IMAGE }}
+          ACR_CADDY_IMAGE: ${{ env.ACR_CADDY_IMAGE }}
           BACKEND_IMAGE: ${{ env.BACKEND_IMAGE }}
+          HARBOR_BACKEND_IMAGE: ${{ env.HARBOR_BACKEND_IMAGE }}
+          ACR_BACKEND_IMAGE: ${{ env.ACR_BACKEND_IMAGE }}
         run: |
           {
             echo "### XY docs images built"
             echo ""
             echo "**Tag:** \`${IMAGE_TAG}\`"
             echo ""
-            echo "- Frontend: \`${CADDY_IMAGE}:${IMAGE_TAG}\`"
-            echo "- Backend: \`${BACKEND_IMAGE}:${IMAGE_TAG}\`"
+            echo "**Frontend** (\`${IMAGE_TAG}\`):"
+            echo "- ECR: \`${CADDY_IMAGE}\`"
+            echo "- Harbor: \`${HARBOR_CADDY_IMAGE}\`"
+            echo "- ACR: \`${ACR_CADDY_IMAGE}\`"
+            echo "**Backend** (\`${IMAGE_TAG}\`):"
+            echo "- ECR: \`${BACKEND_IMAGE}\`"
+            echo "- Harbor: \`${HARBOR_BACKEND_IMAGE}\`"
+            echo "- ACR: \`${ACR_BACKEND_IMAGE}\`"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds **Harbor** (`oci.main.reflexsandbox.com/apps/…`) and **Azure Container Registry** (`reflexdev.azurecr.io/…`) as image push targets alongside the existing **ECR** push.

## What changed
- Two `docker login` steps (Harbor push robot + ACR `ci-push` token).
- Each `depot build` fans out to all three registries via extra `--tag`s (Depot pushes to every tag in one build).

## Safety
**Additive / non-breaking.** ECR stays the primary pull source — clusters still pull via the Harbor `ecr` proxy-cache — until the pull side is switched over separately. If Harbor/ACR push fails, it fails the build loudly rather than silently shipping to the wrong place.

## Prereqs (already done)
- ACR `reflexdev` (Standard, westus2) created.
- Harbor `apps` project (regular/pushable) + push robot created.
- Repo secrets set: `HARBOR_PUSH_USERNAME`, `HARBOR_PUSH_SECRET`, `ACR_USERNAME`, `ACR_PASSWORD`.

First CI run validates the push credentials end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation frontend and backend images are now published to Harbor and Azure Container Registry in addition to AWS ECR.
  * Added registry login and expanded image tagging to publish the same version tags across the additional registries.
  * Updated the workflow summary to display Harbor and ACR image names for both frontend and backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->