### PR TITLE
Honor authored plot and text styles [codex bughunt]

### DIFF
--- a/python/xy/_svg.py
+++ b/python/xy/_svg.py
@@ -3303,6 +3303,7 @@ def _annotation_svg(
                 stroke_attr = (
                     f' stroke="{escape(_css(style.get("stroke_color"), color))}"'
                     f' stroke-width="{_num(stroke_w)}"'
+                    + (f' stroke-opacity="{_num(opacity)}"' if opacity < 1 else "")
                     if stroke_w
                     else ""
                 )

--- a/python/xy/pyplot/__init__.py
+++ b/python/xy/pyplot/__init__.py
@@ -2972,6 +2972,7 @@ _NAMED_STYLES: dict[str, dict[str, Any]] = {
         "axes.facecolor": "black",
         "axes.edgecolor": "white",
         "axes.labelcolor": "white",
+        "text.color": "white",
         "grid.color": "white",
         "xtick.color": "white",
         "ytick.color": "white",

--- a/python/xy/pyplot/_artists.py
+++ b/python/xy/pyplot/_artists.py
@@ -997,9 +997,11 @@ class ErrorbarContainer:
         )
 
     def set_label(self, value: Any) -> None:
-        label = str(value)
+        label = None if value is None else str(value)
         self._artist._entry["_mpl_container_label"] = label
-        self._artist._entry["kwargs"]["name"] = None if label.startswith("_") else label
+        self._artist._entry["kwargs"]["name"] = (
+            None if label is None or label.startswith("_") else label
+        )
         self._artist._touch()
 
     def remove(self) -> None:

--- a/python/xy/pyplot/_artists.py
+++ b/python/xy/pyplot/_artists.py
@@ -991,10 +991,15 @@ class ErrorbarContainer:
         return iter(self.lines)
 
     def get_label(self) -> Any:
-        return self._artist._entry["kwargs"].get("name")
+        return self._artist._entry.get(
+            "_mpl_container_label",
+            self._artist._entry["kwargs"].get("name"),
+        )
 
     def set_label(self, value: Any) -> None:
-        self._artist._entry["kwargs"]["name"] = str(value)
+        label = str(value)
+        self._artist._entry["_mpl_container_label"] = label
+        self._artist._entry["kwargs"]["name"] = None if label.startswith("_") else label
         self._artist._touch()
 
     def remove(self) -> None:

--- a/python/xy/pyplot/_axes.py
+++ b/python/xy/pyplot/_axes.py
@@ -31,7 +31,6 @@ from ._artists import (
     Artist,
     AxesImage,
     BarContainer,
-    ErrorbarContainer,
     Legend,
     Line2D,
     PathCollection,
@@ -81,6 +80,8 @@ from ._translate import (
     marker_size_to_scatter_size,
     not_implemented,
 )
+
+_UNSET = object()
 
 # matplotlib's default look: white panel, no grid until grid(True).
 _MPL_THEME_TOKENS = {
@@ -2170,9 +2171,21 @@ class Axes(PlotTypeMixin):
         linewidth = kwargs.pop("linewidth", None)
         xerr = kwargs.pop("xerr", None)
         yerr = kwargs.pop("yerr", None)
-        error_kw = kwargs.pop("error_kw", {}) or {}
-        capsize = kwargs.pop("capsize", error_kw.pop("capsize", None))
-        kwargs.pop("ecolor", error_kw.pop("ecolor", None))
+        raw_error_kw = kwargs.pop("error_kw", None)
+        if raw_error_kw is None:
+            error_kw: dict[str, Any] = {}
+        elif isinstance(raw_error_kw, Mapping):
+            # Matplotlib copies this caller-owned mapping before adding the
+            # independent bar defaults.  Its setdefault order deliberately
+            # gives nested error_kw values precedence over direct ecolor and
+            # capsize arguments.
+            error_kw = dict(raw_error_kw)
+        else:
+            raise TypeError("bar()/barh() error_kw must be a mapping or None")
+        direct_capsize = kwargs.pop("capsize", rcParams["errorbar.capsize"])
+        direct_ecolor = kwargs.pop("ecolor", "#000000")
+        error_kw.setdefault("capsize", direct_capsize)
+        error_kw.setdefault("ecolor", direct_ecolor)
         align = kwargs.pop("align", "center")
         if align not in {"center", "edge"}:
             raise ValueError("bar()/barh() align must be 'center' or 'edge'")
@@ -2261,7 +2274,7 @@ class Axes(PlotTypeMixin):
                 **({"patch_labels": patch_labels} if patch_labels is not None else {}),
             },
         )
-        container = BarContainer(self, entry)
+        errorbar = None
         if xerr is not None or yerr is not None:
             positions = np.asarray(cats)
             values = np.asarray(vals, dtype=np.float64)
@@ -2270,20 +2283,17 @@ class Axes(PlotTypeMixin):
                 ex, ey, exerr, eyerr = positions, bases + values, xerr, yerr
             else:
                 ex, ey, exerr, eyerr = bases + values, positions, xerr, yerr
-            err_kwargs = {
-                "xerr": exerr,
-                "yerr": eyerr,
-                "color": error_kw.pop("color", "#000000"),
-                "cap_size": capsize,
-            }
-            error_entry = self._add(
-                "@mark", {"factory": "errorbar", "args": (ex, ey), "kwargs": err_kwargs}
+            error_kw.setdefault("label", "_nolegend_")
+            errorbar = self.errorbar(
+                ex,
+                ey,
+                xerr=exerr,
+                yerr=eyerr,
+                fmt="none",
+                **error_kw,
             )
-            # Matplotlib exposes the bar's error geometry through
-            # ``BarContainer.errorbar``.  Keep the same relationship so
-            # ``bar_label`` can anchor edge labels at the outer error endpoint
-            # instead of at the rectangle edge.
-            container.errorbar = ErrorbarContainer(Artist(self, error_entry))
+        container = BarContainer(self, entry)
+        container.errorbar = errorbar
         return container
 
     def hist(
@@ -3512,7 +3522,10 @@ class Axes(PlotTypeMixin):
         rotation = kwargs.pop("rotation", None)
         bbox = kwargs.pop("bbox", None)
         check_unsupported(kwargs, "text()")
-        akw = {"color": resolve_color(color)} if color is not None else {}
+        # Matplotlib snapshots the active text default when the Text artist is
+        # created.  Preserve that value on the entry so a later style-context
+        # change cannot recolor an already-authored label at render time.
+        akw = {"color": resolve_color(rcParams["text.color"] if color is None else color)}
         if bbox is not None:
             if not isinstance(bbox, Mapping):
                 raise TypeError("text() bbox must be a mapping or None")
@@ -3576,9 +3589,12 @@ class Axes(PlotTypeMixin):
         bbox = kwargs.pop("bbox", None)
         zorder = kwargs.pop("zorder", None)
         check_unsupported(kwargs, "annotate()")
-        akw: dict[str, Any] = {}
-        if color is not None:
-            akw["color"] = resolve_color(color)
+        # Match Text creation semantics: the active rc default belongs to the
+        # annotation even if materialization happens after a style context
+        # exits.
+        akw: dict[str, Any] = {
+            "color": resolve_color(rcParams["text.color"] if color is None else color)
+        }
         if arrowprops is not None:
             akw["arrowprops"] = dict(arrowprops)
         if bbox is not None:
@@ -4988,19 +5004,17 @@ class Axes(PlotTypeMixin):
             for container in host._containers
             if isinstance(container, ErrorbarContainer)
         }
+        bar_containers = {
+            id(container._entry): container
+            for container in host._containers
+            if isinstance(container, BarContainer) and container._entry.get("kind") == "bar"
+        }
         handles: list[Any] = []
         labels: list[str] = []
         for entry in host._entries:
             patch_labels = entry.get("patch_labels")
             if patch_labels is not None:
-                container = next(
-                    (
-                        item
-                        for item in host._containers
-                        if isinstance(item, BarContainer) and item._entry is entry
-                    ),
-                    None,
-                )
+                container = bar_containers.get(id(entry))
                 for index, label in enumerate(patch_labels):
                     if label and not str(label).startswith("_"):
                         handles.append(
@@ -5008,10 +5022,28 @@ class Axes(PlotTypeMixin):
                         )
                         labels.append(str(label))
                 continue
+            # Matplotlib scans ordinary child artists first, then containers.
+            # Defer container-owned entries so an errorbar/bar pair follows
+            # the public Axes.containers registration order.
+            if id(entry) in errorbar_containers or id(entry) in bar_containers:
+                continue
             label = entry.get("kwargs", {}).get("name")
             if label and not str(label).startswith("_"):
-                handle = errorbar_containers.get(id(entry))
-                handles.append(handle if handle is not None else Artist(self, entry))
+                handles.append(Artist(self, entry))
+                labels.append(str(label))
+        for container in host._containers:
+            if not isinstance(container, (BarContainer, ErrorbarContainer)):
+                continue
+            if isinstance(container, BarContainer) and container._entry.get("kind") != "bar":
+                continue
+            if (
+                isinstance(container, BarContainer)
+                and container._entry.get("patch_labels") is not None
+            ):
+                continue
+            label = container.get_label()
+            if label and not str(label).startswith("_"):
+                handles.append(container)
                 labels.append(str(label))
         return handles, labels
 
@@ -8702,6 +8734,8 @@ def _apply_axis_label_kwargs(
             axis_style[target] = float(value) * point_scale if source == "font_size" else value
     if labelpad is not None:
         props["label_offset"] = float(labelpad)
+    if "rotation" in text_style:
+        props["label_angle"] = float(text_style["rotation"])
     if loc is not None:
         positions = {
             "left": "start",
@@ -8736,12 +8770,12 @@ def _pop_text_style_kwargs(kwargs: dict[str, Any], context: str) -> dict[str, An
     family = pop_alias("fontfamily", "family")
     font_style = pop_alias("fontstyle", "style")
     color = kwargs.pop("color", None)
+    rotation = kwargs.pop("rotation", _UNSET)
     for key in (
         "horizontalalignment",
         "ha",
         "verticalalignment",
         "va",
-        "rotation",
         "pad",
         "y",
         "x",
@@ -8765,6 +8799,16 @@ def _pop_text_style_kwargs(kwargs: dict[str, Any], context: str) -> dict[str, An
         style["font_style"] = font_style
     if color is not None:
         style["color"] = resolve_color(color)
+    if rotation is not _UNSET:
+        if rotation is None or rotation == "horizontal":
+            rotation = 0.0
+        elif rotation == "vertical":
+            rotation = 90.0
+        # Matplotlib angles use a y-up coordinate system, while SVG/CSS uses
+        # y-down coordinates.  Store the renderer-facing angle with the
+        # opposite sign so positive Matplotlib rotation stays counterclockwise.
+        rendered_rotation = -float(rotation)
+        style["rotation"] = 0.0 if rendered_rotation == 0.0 else rendered_rotation
     return style
 
 

--- a/python/xy/pyplot/_mplfig.py
+++ b/python/xy/pyplot/_mplfig.py
@@ -660,7 +660,12 @@ class Figure:
         size = kwargs.pop("fontsize", kwargs.pop("size", "large"))
         weight = kwargs.pop("fontweight", kwargs.pop("weight", "normal"))
         family = kwargs.pop("fontfamily", kwargs.pop("family", "system-ui, sans-serif"))
-        color = kwargs.pop("color", "#262626")
+        # Figure titles are Text artists in Matplotlib: snapshot the active
+        # text default when authored, rather than hard-coding the light-theme
+        # paint or consulting rcParams later during export.
+        color = kwargs.pop("color", None)
+        if color is None:
+            color = rcParams["text.color"]
         x = kwargs.pop("x", 0.5)
         y = kwargs.pop("y", 0.98)
         ha = kwargs.pop("ha", kwargs.pop("horizontalalignment", "center"))

--- a/python/xy/pyplot/_plot_types.py
+++ b/python/xy/pyplot/_plot_types.py
@@ -3238,6 +3238,7 @@ class PlotTypeMixin:
         errorbar_width = float(
             elinewidth if elinewidth is not None else base.get("width", rcParams["lines.linewidth"])
         )
+        container_label = base.get("name")
         entry = self._add(
             "@mark",
             {
@@ -3246,7 +3247,10 @@ class PlotTypeMixin:
                 "kwargs": {
                     "yerr": yerr,
                     "xerr": xerr,
-                    "name": base.get("name"),
+                    # Matplotlib keeps underscore-prefixed labels on the
+                    # container but excludes them from automatic legends.
+                    # Do not expose those private labels to XY's renderer.
+                    "name": (None if str(container_label).startswith("_") else container_label),
                     "color": color,
                     "width": errorbar_width,
                     # Core XY caps are symmetric data-unit geometry. Matplotlib
@@ -3257,6 +3261,7 @@ class PlotTypeMixin:
                 },
             },
         )
+        entry["_mpl_container_label"] = container_label
         cap_artists: list[Artist] = []
         if resolved_capsize > 0.0:
             for cap_x, cap_y, marker_symbol in cap_markers:

--- a/tests/pyplot/test_bughunt_authored_style_parity.py
+++ b/tests/pyplot/test_bughunt_authored_style_parity.py
@@ -1,0 +1,204 @@
+"""Focused regressions for authored bar-error and axis-label styles."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+import xy.pyplot as plt
+
+
+def teardown_function() -> None:
+    plt.close("all")
+
+
+def _payload(ax):
+    return ax._build_chart(640, 480).figure().build_payload()[0]
+
+
+def _error_trace(ax):
+    return next(trace for trace in _payload(ax)["traces"] if trace["kind"] == "errorbar")
+
+
+def _label_element(svg: str, label: str) -> str:
+    match = re.search(rf"<text\b[^>]*>{re.escape(label)}</text>", svg)
+    assert match is not None
+    return match.group()
+
+
+def test_bar_direct_error_style_reaches_state_and_payload() -> None:
+    _fig, ax = plt.subplots()
+    options = {"linewidth": 2.25}
+
+    bars = ax.bar(
+        [0, 1],
+        [2, 3],
+        yerr=[0.2, 0.3],
+        ecolor="tab:red",
+        capsize=3,
+        error_kw=options,
+    )
+
+    assert options == {"linewidth": 2.25}
+    error = bars.errorbar
+    assert error is not None
+    assert error._artist._entry["kwargs"] == {
+        "yerr": [0.2, 0.3],
+        "color": "#d62728",
+        "width": 2.25,
+        "cap_size": 0.0,
+        "opacity": 1.0,
+    }
+    assert error._cap_artists
+    assert all(cap._entry["_mpl_line_marker_path_points"] == 6.0 for cap in error._cap_artists)
+
+    trace = _error_trace(ax)
+    assert trace["style"]["color"] == "#d62728"
+    assert trace["style"]["width"] == 2.25
+    assert trace["style"]["role"] == "y-errorbar"
+
+
+def test_nested_error_style_wins_without_mutating_the_caller_dict() -> None:
+    _fig, ax = plt.subplots()
+    options = {
+        "ecolor": "tab:blue",
+        "capsize": 4,
+        "linewidth": 2,
+        "elinewidth": 5,
+    }
+    original = dict(options)
+
+    bars = ax.bar(
+        [0, 1],
+        [2, 3],
+        yerr=0.5,
+        ecolor="tab:red",
+        capsize=9,
+        error_kw=options,
+    )
+
+    assert options == original
+    error = bars.errorbar
+    assert error is not None
+    assert error._artist._entry["kwargs"]["color"] == "#1f77b4"
+    assert error._artist._entry["kwargs"]["width"] == 5.0
+    assert error._cap_artists
+    assert all(cap._entry["_mpl_line_marker_path_points"] == 8.0 for cap in error._cap_artists)
+
+    trace = _error_trace(ax)
+    assert trace["style"]["color"] == "#1f77b4"
+    assert trace["style"]["width"] == 5.0
+
+
+def test_barh_forwards_error_color_and_elinewidth() -> None:
+    _fig, ax = plt.subplots()
+
+    bars = ax.barh(
+        [0, 1],
+        [2, 3],
+        xerr=[0.2, 0.3],
+        error_kw={"ecolor": "tab:green", "elinewidth": 3},
+    )
+
+    error = bars.errorbar
+    assert error is not None
+    assert error._artist._entry["kwargs"]["xerr"] == [0.2, 0.3]
+    assert error._artist._entry["kwargs"]["color"] == "#2ca02c"
+    assert error._artist._entry["kwargs"]["width"] == 3.0
+
+    trace = _error_trace(ax)
+    assert trace["style"]["color"] == "#2ca02c"
+    assert trace["style"]["width"] == 3.0
+    assert trace["style"]["role"] == "x-errorbar"
+
+
+def test_bar_error_kw_rejects_options_errorbar_cannot_render() -> None:
+    _fig, ax = plt.subplots()
+
+    with pytest.raises(TypeError, match="mystery"):
+        ax.bar([0], [1], yerr=0.2, error_kw={"mystery": True})
+
+
+def test_bar_error_container_public_semantics_and_default_legend_label() -> None:
+    _fig, ax = plt.subplots()
+
+    bars = ax.bar([0, 1], [2, 3], yerr=[0.2, 0.3], capsize=3, label="bars")
+
+    error = bars.errorbar
+    assert error is not None
+    assert ax.containers == [error, bars]
+    assert error.get_label() == "_nolegend_"
+    assert error.has_yerr is True
+    assert error.has_xerr is False
+    _handles, labels = ax.get_legend_handles_labels()
+    assert labels == ["bars"]
+    assert "_nolegend_" not in ax._build_chart(640, 480).figure().to_svg()
+
+
+def test_bar_error_kw_keeps_an_explicit_public_container_label() -> None:
+    _fig, ax = plt.subplots()
+
+    bars = ax.bar(
+        [0],
+        [1],
+        yerr=0.2,
+        label="bars",
+        error_kw={"label": "uncertainty"},
+    )
+
+    assert bars.errorbar is not None
+    assert bars.errorbar.get_label() == "uncertainty"
+    handles, labels = ax.get_legend_handles_labels()
+    assert handles == [bars.errorbar, bars]
+    assert labels == ["uncertainty", "bars"]
+
+
+def test_numeric_axis_label_rotation_reaches_both_rendered_axes() -> None:
+    _fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+
+    ax.set_xlabel("Elapsed time", rotation=27)
+    ax.set_ylabel("Power", rotation=-31)
+
+    assert ax._axis_props("x")["label_angle"] == -27.0
+    assert ax._axis_props("y")["label_angle"] == 31.0
+
+    svg = ax._build_chart(640, 480).figure().to_svg()
+    assert 'transform="rotate(-27 ' in _label_element(svg, "Elapsed time")
+    assert 'transform="rotate(31 ' in _label_element(svg, "Power")
+
+
+def test_named_axis_label_rotation_and_explicit_none_reset() -> None:
+    _fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+
+    ax.set_xlabel("Elapsed time", rotation="vertical")
+    ax.set_ylabel("Power", rotation="horizontal")
+
+    assert ax._axis_props("x")["label_angle"] == -90.0
+    assert ax._axis_props("y")["label_angle"] == 0.0
+    svg = ax._build_chart(640, 480).figure().to_svg()
+    assert 'transform="rotate(-90 ' in _label_element(svg, "Elapsed time")
+    assert "transform=" not in _label_element(svg, "Power")
+
+    ax.set_xlabel("Elapsed time")
+    ax.set_ylabel("Power")
+
+    assert ax._axis_props("x")["label_angle"] == -90.0
+    assert ax._axis_props("y")["label_angle"] == 0.0
+
+    ax.set_xlabel("Elapsed time", rotation=None)
+    ax.set_ylabel("Power", rotation="vertical")
+
+    assert ax._axis_props("x")["label_angle"] == 0.0
+    assert ax._axis_props("y")["label_angle"] == -90.0
+    svg = ax._build_chart(640, 480).figure().to_svg()
+    assert "transform=" not in _label_element(svg, "Elapsed time")
+    assert 'transform="rotate(-90 ' in _label_element(svg, "Power")
+
+    ax.set_ylabel("Power", rotation=None)
+
+    assert ax._axis_props("y")["label_angle"] == 0.0
+    svg = ax._build_chart(640, 480).figure().to_svg()
+    assert "transform=" not in _label_element(svg, "Power")

--- a/tests/pyplot/test_bughunt_authored_style_parity.py
+++ b/tests/pyplot/test_bughunt_authored_style_parity.py
@@ -154,6 +154,17 @@ def test_bar_error_kw_keeps_an_explicit_public_container_label() -> None:
     assert labels == ["uncertainty", "bars"]
 
 
+def test_errorbar_container_set_label_none_clears_the_public_label() -> None:
+    _fig, ax = plt.subplots()
+    container = ax.errorbar([0, 1], [1, 2], yerr=0.1, label="uncertainty")
+
+    container.set_label(None)
+
+    assert container.get_label() is None
+    _handles, labels = ax.get_legend_handles_labels()
+    assert labels == []
+
+
 def test_numeric_axis_label_rotation_reaches_both_rendered_axes() -> None:
     _fig, ax = plt.subplots()
     ax.plot([0, 1], [0, 1])

--- a/tests/pyplot/test_dark_background_text_parity.py
+++ b/tests/pyplot/test_dark_background_text_parity.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+import xy.pyplot as plt
+
+
+def teardown_function() -> None:
+    plt.close("all")
+    plt.rcdefaults()
+
+
+def _annotation_colors(*, explicit: bool) -> dict[str, str]:
+    suffix = "explicit" if explicit else "default"
+    colors = {"axes": "gold", "annotation": "cyan", "figure": "magenta"} if explicit else {}
+    with plt.style.context("dark_background"):
+        fig, ax = plt.subplots()
+        ax.text(0.1, 0.2, f"axes {suffix}", **({"color": colors["axes"]} if explicit else {}))
+        ax.annotate(
+            f"annotation {suffix}",
+            xy=(0.5, 0.5),
+            **({"color": colors["annotation"]} if explicit else {}),
+        )
+        fig.text(
+            0.5,
+            0.9,
+            f"figure {suffix}",
+            **({"color": colors["figure"]} if explicit else {}),
+        )
+    # Materialize only after the context exits. Matplotlib snapshots the
+    # active default when each Text artist is created.
+    spec, _ = ax._build_chart(400, 300).figure().build_payload()
+    return {
+        annotation["text"]: annotation["style"]["label_color"] for annotation in spec["annotations"]
+    }
+
+
+def test_dark_background_defaults_all_pyplot_text_to_white() -> None:
+    assert _annotation_colors(explicit=False) == {
+        "axes default": "white",
+        "annotation default": "white",
+        "figure default": "white",
+    }
+
+
+def test_dark_background_keeps_explicit_text_colors() -> None:
+    assert _annotation_colors(explicit=True) == {
+        "axes explicit": "gold",
+        "annotation explicit": "cyan",
+        "figure explicit": "magenta",
+    }
+
+
+def _delayed_dark_suptitle(**kwargs: object) -> tuple[str, bytes]:
+    with plt.style.context("dark_background"):
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1])
+        fig.suptitle("visible figure title", **kwargs)
+
+    output = BytesIO()
+    fig.savefig(output, format="svg")
+    return fig._suptitle_style["color"], output.getvalue()
+
+
+def test_dark_background_suptitle_snapshots_default_and_none_before_export() -> None:
+    for kwargs in ({}, {"color": None}):
+        color, svg = _delayed_dark_suptitle(**kwargs)
+        assert color == "white"
+        assert b"visible figure title" in svg
+        assert b'fill="white"' in svg
+
+
+def test_dark_background_suptitle_keeps_explicit_color() -> None:
+    color, svg = _delayed_dark_suptitle(color="gold")
+
+    assert color == "gold"
+    assert b'fill="gold"' in svg

--- a/tests/pyplot/test_gallery_text_pie_compat.py
+++ b/tests/pyplot/test_gallery_text_pie_compat.py
@@ -218,6 +218,7 @@ def test_text_accepts_matplotlib_style_alias_and_bbox_properties() -> None:
     )
 
     assert label._entry["kwargs"] == {
+        "color": "black",
         "bbox": {"facecolor": "red", "alpha": 0.5, "pad": 10},
         "style": {"font_style": "italic"},
     }

--- a/tests/test_svg_annotation_marker_opacity.py
+++ b/tests/test_svg_annotation_marker_opacity.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import xy
+
+
+def _marker_shape(opacity: float) -> ET.Element:
+    svg = (
+        xy.chart(
+            xy.scatter(x=[0.0, 1.0], y=[0.0, 1.0]),
+            xy.marker(
+                0.5,
+                0.5,
+                color="#2563eb",
+                stroke_color="#dc2626",
+                stroke_width=2.0,
+                opacity=opacity,
+            ),
+            width=320,
+            height=240,
+        )
+        .figure()
+        .to_svg()
+    )
+    root = ET.fromstring(svg)
+    return next(element for element in root.iter() if element.get("stroke") == "#dc2626")
+
+
+def test_annotation_marker_opacity_applies_to_fill_and_stroke() -> None:
+    marker = _marker_shape(0.25)
+
+    assert marker.get("fill-opacity") == "0.25"
+    assert marker.get("stroke-opacity") == "0.25"
+
+
+def test_opaque_annotation_marker_keeps_implicit_stroke_opacity() -> None:
+    marker = _marker_shape(1.0)
+
+    assert marker.get("fill-opacity") == "1"
+    assert marker.get("stroke-opacity") is None


### PR DESCRIPTION
## Summary

This is the first bug-hunt PR stacked directly on #340 (`agent/gallery-layout-text-round2`). It fixes a coherent set of cases where user-authored styling was accepted but lost, mutated, or exported inconsistently.

### Bar and errorbar styling

- route `bar()` / `barh()` error geometry through the shim's canonical `errorbar()` path;
- preserve `ecolor`, `elinewidth` / `linewidth`, and point-sized caps;
- match Matplotlib's `error_kw` precedence over direct bar arguments;
- copy caller-owned `error_kw` mappings instead of mutating them;
- register the `ErrorbarContainer` before the `BarContainer`, preserve public labels, and keep the default `_nolegend_` label out of rendered automatic legends;
- preserve Matplotlib container order when both the uncertainty and bar series are explicitly labeled.

### Text and axis labels

- forward numeric, `"vertical"`, and `"horizontal"` axis-label rotations with the renderer-coordinate sign Matplotlib expects;
- distinguish omitted rotation from explicit `rotation=None`, so omission preserves prior state and `None` resets it;
- add `text.color="white"` to `dark_background`;
- snapshot default text paint when axes text, annotations, figure text, and suptitles are authored, so later style-context changes cannot recolor them;
- treat `suptitle(color=None)` like the Matplotlib default and preserve explicit overrides.

### SVG marker paint

- apply annotation-marker opacity to both fill and stroke; previously a translucent marker could retain a fully opaque outline.

## Why

These were fidelity bugs rather than palette differences: valid Matplotlib inputs were silently discarded, a caller-owned mapping was modified, dark-background labels became unreadable when exported after leaving a style context, a private `_nolegend_` label leaked into the visible chart, and SVG fill/stroke opacity disagreed.

## Visual comparisons

Review-only artifacts live on immutable evidence commit `15620da82939f25be38c53a174f819a027b1c0dc`; they are not in this PR diff.

### Matplotlib / XY before / XY after

![Authored bar error, text, annotation, and rotation styles](https://raw.githubusercontent.com/reflex-dev/xy/15620da82939f25be38c53a174f819a027b1c0dc/review-evidence/bughunt-authored-style-parity/authored-style-comparison.png)

The same script now preserves red error bars and width, visible dark-theme text/annotation defaults, and the authored x-label rotation. The comparison uses an explicit `labelpad` so it demonstrates rotation forwarding without conflating the separate general rotated-label-layout issue.

### SVG marker opacity

![Marker stroke opacity before and after](https://raw.githubusercontent.com/reflex-dev/xy/15620da82939f25be38c53a174f819a027b1c0dc/review-evidence/bughunt-authored-style-parity/marker-opacity-comparison.png)

Before, `opacity=0.22` affected the purple fill but left the cyan outline opaque. After, both paints honor the authored alpha.

## Verification

- `143 passed` across the focused and adjacent bar/errorbar, legend, text/theme, artist-state, chrome, and exporter regressions;
- a separate `92 passed` SVG, figure-text, and multiline-layout exporter pass;
- full-worktree Ruff lint and format: `437 files` clean;
- repository pre-commit hooks: Ruff check, Ruff format, and docs codespell all passed;
- `git diff --check` passed;
- independent final review found no remaining blocker in this PR scope.

No browser or Playwright process was launched locally. No compatibility ledger, changelog, shim-todo, docs spec, or PR asset file is part of the product diff.

## Explicitly deferred

The existing compact public capline artist graph is not changed here. A partial two/four-capline repair was rejected during review because mixed `xerr` + `yerr` and limit-carets also require correct `Line2D` ordering and one barline collection per error axis. That broader public-artist repair should land as a complete later stack layer rather than a misleading partial fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SVG annotation markers now apply opacity consistently to both fills and strokes.
  * Dark-background plots now render default text in white while preserving explicitly chosen colors.
  * Improved compatibility for error bars, legends, labels, and error styling.
  * Text and axis-label colors and rotations now behave consistently with Matplotlib, including delayed exports.
* **Tests**
  * Added regression coverage for marker opacity, dark-background text, error bars, legends, and label rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->