### PR TITLE
Center resolved Y-axis titles in the browser [codex bughunt]

### DIFF
--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -5952,6 +5952,63 @@ export class ChartView {
         label(item.text, placement.css, sideAxis, "tick", null, placement);
       }
     }
+    const attachYTitleToTicks = (title, axis, onRight) => {
+      if (!title || !axis) return;
+      const position = String(axis.label_position || "center").replace(/-/g, "_");
+      if (position.startsWith("inside_")) return;
+      const tickLabels = [...this.labels.children].filter((element) =>
+        element.dataset.xyLabelKind === "tick"
+        && element.dataset.xyAxis === String(axis.id ?? "")
+        && element.dataset.xyAxisSide === (onRight ? "right" : "left")
+      );
+      const root = this.root.getBoundingClientRect();
+      const tickRects = tickLabels.map((element) => element.getBoundingClientRect());
+      const titleRect = title.getBoundingClientRect();
+      const fontSize = parseFloat(getComputedStyle(title).fontSize) || 12;
+      const rawOffset = axis.label_offset;
+      const gap = rawOffset !== undefined
+        && rawOffset !== null
+        && Number.isFinite(Number(rawOffset))
+        ? Number(rawOffset)
+        : 0.4 * fontSize;
+      // Matplotlib centers the title along the axis, then offsets it
+      // perpendicular to the union of the tick-label bounds and the
+      // corresponding spine. Including the spine keeps inward/negative-pad
+      // labels from pulling an outside title back into the plot.
+      const spineEdge = root.left + (onRight ? p.x + p.w : p.x);
+      const tickEdge = onRight
+        ? Math.max(spineEdge, ...tickRects.map((rect) => rect.right))
+        : Math.min(spineEdge, ...tickRects.map((rect) => rect.left));
+      const targetEdge = onRight ? tickEdge + gap : tickEdge - gap;
+      const currentEdge = onRight ? titleRect.left : titleRect.right;
+      const currentLeft = parseFloat(title.style.left) || 0;
+      const delta = targetEdge - currentEdge;
+      // Keep an unusually large title inside the chart canvas. Moving an
+      // absolutely positioned label by `delta` translates its measured box by
+      // the same amount, so derive the clamp from the captured geometry and
+      // avoid a write-then-layout-read on every chrome redraw.
+      const adjustedLeft = titleRect.left + delta;
+      const adjustedRight = titleRect.right + delta;
+      const correction = adjustedLeft < root.left
+        ? root.left - adjustedLeft + 1
+        : adjustedRight > root.right ? root.right - adjustedRight - 1 : 0;
+      title.style.left = `${currentLeft + delta + correction}px`;
+    };
+    const renderYTitle = (axis, text, onRight) => {
+      const angle = onRight ? 90 : -90;
+      const fallbackCss =
+        `left:${onRight ? p.x + p.w : p.x}px;top:${p.y + p.h / 2}px;` +
+        `transform:translate(-50%,-50%) rotate(${angle}deg);` +
+        "transform-origin:center;";
+      const placement = this._axisLabelCss(axis, "y", fallbackCss);
+      const title = label(text, placement.css, axis, "label", placement.style);
+      // A structured CSS label_position is the placement authority. It may
+      // deliberately omit `left` in favor of `right`, so tick attachment must
+      // not synthesize a competing left offset.
+      if (placement.style === null) {
+        attachYTitleToTicks(title, axis, onRight);
+      }
+    };
     for (const axis of extraYAxes) {
       const ticks = this._axisTicks(axis.id, this._axisTickTarget(axis.id, Math.max(3, p.h / 45)));
       const labelCandidates = [];
@@ -5969,45 +6026,9 @@ export class ChartView {
         }
       }
       if (axis.label && this._axisTickLabelStrategy(axis) !== "none") {
-        const fallbackCss = axis.side === "left"
-          ? `left:10px;top:${p.y + p.h / 2}px;transform:rotate(-90deg) translateX(50%);transform-origin:left;`
-          : `left:${p.x + p.w + 40}px;top:${p.y + p.h / 2}px;transform:rotate(90deg) translateX(-50%);transform-origin:left;`;
-        const placement = this._axisLabelCss(axis, "y", fallbackCss);
-        label(axis.label, placement.css, axis, "label", placement.style);
+        renderYTitle(axis, axis.label, axis.side !== "left");
       }
     }
-    const attachYTitleToTicks = (title, axis, onRight) => {
-      if (!title || !axis) return;
-      const position = String(axis.label_position || "center").replace(/-/g, "_");
-      if (position.startsWith("inside_")) return;
-      const tickLabels = [...this.labels.children].filter((element) =>
-        element.dataset.xyLabelKind === "tick"
-        && element.dataset.xyAxis === String(axis.id ?? "")
-        && element.dataset.xyAxisSide === (onRight ? "right" : "left")
-      );
-      if (!tickLabels.length) return;
-      const root = this.root.getBoundingClientRect();
-      const tickRects = tickLabels.map((element) => element.getBoundingClientRect());
-      const titleRect = title.getBoundingClientRect();
-      const fontSize = parseFloat(getComputedStyle(title).fontSize) || 12;
-      const labelOffset = Number(axis.label_offset || 0);
-      const targetEdge = onRight
-        ? Math.max(...tickRects.map((rect) => rect.right)) + 0.4 * fontSize + labelOffset
-        : Math.min(...tickRects.map((rect) => rect.left)) - 0.4 * fontSize - labelOffset;
-      const currentEdge = onRight ? titleRect.left : titleRect.right;
-      const currentLeft = parseFloat(title.style.left) || 0;
-      const delta = targetEdge - currentEdge;
-      // Keep an unusually large title inside the chart canvas. Moving an
-      // absolutely positioned label by `delta` translates its measured box by
-      // the same amount, so derive the clamp from the captured geometry and
-      // avoid a write-then-layout-read on every chrome redraw.
-      const adjustedLeft = titleRect.left + delta;
-      const adjustedRight = titleRect.right + delta;
-      const correction = adjustedLeft < root.left
-        ? root.left - adjustedLeft + 1
-        : adjustedRight > root.right ? root.right - adjustedRight - 1 : 0;
-      title.style.left = `${currentLeft + delta + correction}px`;
-    };
     if (s.x_axis.label && !hideX) {
       const top = xAxis.side === "top" ? p.y - 34 : p.y + p.h + 24;
       const fallbackCss = `left:${p.x + p.w / 2}px;top:${top}px;transform:translateX(-50%);`;
@@ -6015,17 +6036,7 @@ export class ChartView {
       label(s.x_axis.label, placement.css, xAxis, "label", placement.style);
     }
     if (s.y_axis.label && !hideY) {
-      const fallbackCss = yAxis.side === "right"
-        ? `left:${p.x + p.w + 40}px;top:${p.y + p.h / 2}px;transform:rotate(90deg) translateX(-50%);transform-origin:left;`
-        : `left:10px;top:${p.y + p.h / 2}px;transform:rotate(-90deg) translateX(50%);transform-origin:left;`;
-      const placement = this._axisLabelCss(yAxis, "y", fallbackCss);
-      const title = label(s.y_axis.label, placement.css, yAxis, "label", placement.style);
-      // A structured CSS label_position is the placement authority. It may
-      // deliberately omit `left` in favor of `right`, so tick attachment must
-      // not synthesize a competing left offset.
-      if (placement.style === null) {
-        attachYTitleToTicks(title, yAxis, yAxis.side === "right");
-      }
+      renderYTitle(yAxis, s.y_axis.label, yAxis.side === "right");
     }
     this._drawAnnotationLabels(updateLabels);
     // Label layout resolves responsive callout offsets before the pointer is

--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -5960,7 +5960,8 @@ export class ChartView {
         label(item.text, placement.css, sideAxis, "tick", null, placement);
       }
     }
-    const attachYTitleToTicks = (title, axis, onRight) => {
+    const pendingYTitleAttachments = [];
+    const measureYTitleAttachment = (title, axis, onRight, root) => {
       if (!title || !axis) return;
       const position = String(axis.label_position || "center").replace(/-/g, "_");
       if (position.startsWith("inside_")) return;
@@ -5969,7 +5970,6 @@ export class ChartView {
         && element.dataset.xyAxis === String(axis.id ?? "")
         && element.dataset.xyAxisSide === (onRight ? "right" : "left")
       );
-      const root = this.root.getBoundingClientRect();
       const tickRects = tickLabels.map((element) => element.getBoundingClientRect());
       const titleRect = title.getBoundingClientRect();
       const fontSize = parseFloat(getComputedStyle(title).fontSize) || 12;
@@ -6000,7 +6000,7 @@ export class ChartView {
       const correction = adjustedLeft < root.left
         ? root.left - adjustedLeft + 1
         : adjustedRight > root.right ? root.right - adjustedRight - 1 : 0;
-      title.style.left = `${currentLeft + delta + correction}px`;
+      return { title, left: currentLeft + delta + correction };
     };
     const renderYTitle = (axis, text, onRight) => {
       const angle = onRight ? 90 : -90;
@@ -6013,8 +6013,8 @@ export class ChartView {
       // A structured CSS label_position is the placement authority. It may
       // deliberately omit `left` in favor of `right`, so tick attachment must
       // not synthesize a competing left offset.
-      if (placement.style === null) {
-        attachYTitleToTicks(title, axis, onRight);
+      if (title && placement.style === null) {
+        pendingYTitleAttachments.push({ title, axis, onRight });
       }
     };
     for (const axis of extraYAxes) {
@@ -6045,6 +6045,20 @@ export class ChartView {
     }
     if (s.y_axis.label && !hideY) {
       renderYTitle(yAxis, s.y_axis.label, yAxis.side === "right");
+    }
+    if (pendingYTitleAttachments.length) {
+      // Finish creating every y-axis label before the first geometry read,
+      // then apply all offsets after the complete measurement pass. Keeping
+      // DOM reads and writes in separate phases avoids one forced layout per
+      // named axis during settled interaction redraws.
+      const root = this.root.getBoundingClientRect();
+      const adjustments = pendingYTitleAttachments
+        .map(({ title, axis, onRight }) =>
+          measureYTitleAttachment(title, axis, onRight, root))
+        .filter(Boolean);
+      for (const { title, left } of adjustments) {
+        title.style.left = `${left}px`;
+      }
     }
     this._drawAnnotationLabels(updateLabels);
     // Label layout resolves responsive callout offsets before the pointer is

--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -713,10 +713,18 @@ export class ChartView {
         const gap = Number.isFinite(Number(axis.label_offset))
           ? Number(axis.label_offset)
           : 0.4 * labelSize;
+        const labelBlock = this._estimateTickLabel(axis.label, labelSize);
+        const rawLabelAngle = Number(axis.label_angle);
+        // The default quarter-turn consumes the text block's height. An
+        // authored angle projects both dimensions into the left gutter.
+        const labelExtent = Number.isFinite(rawLabelAngle)
+          ? Math.abs(Math.cos(rawLabelAngle * Math.PI / 180)) * labelBlock.w
+            + Math.abs(Math.sin(rawLabelAngle * Math.PI / 180)) * labelBlock.h
+          : labelBlock.h;
         needed +=
           Y_TITLE_MEASURE_SAFETY_PX
           + gap
-          + this._estimateTickLabel(axis.label, labelSize).h;
+          + labelExtent;
       }
       room = Math.max(room, needed);
     }

--- a/tests/test_ui_issue_regressions.py
+++ b/tests/test_ui_issue_regressions.py
@@ -2,17 +2,71 @@
 
 from __future__ import annotations
 
+import json
+import re
 from pathlib import Path
+from xml.etree import ElementTree
 
 import pytest
 
 import xy
 from conftest import run_browser_probe
+from xy import _svg
 from xy.export import find_chromium
 
 # Browser renderer rule: rotated y titles clear the tick-label union by this
 # multiple of the title's font size.
 _Y_TITLE_TICK_GAP_EM = 0.4
+
+
+def _svg_y_title_geometry(chart: xy.Chart, labels: set[str]) -> dict[str, dict[str, float]]:
+    """Return the static renderer's resolved title anchors for named labels."""
+    geometry: dict[str, dict[str, float]] = {}
+    for element in ElementTree.fromstring(chart.to_svg()).iter():
+        if not element.tag.endswith("text"):
+            continue
+        text = "".join(element.itertext())
+        if text not in labels:
+            continue
+        transform = element.attrib.get("transform", "")
+        rotation = re.match(r"rotate\((-?[\d.]+)", transform)
+        geometry[text] = {
+            "x": float(element.attrib["x"]),
+            "y": float(element.attrib["y"]),
+            "angle": float(rotation.group(1)) if rotation else 0.0,
+        }
+    assert geometry.keys() == labels
+    return geometry
+
+
+def test_svg_y_axis_title_locations_center_primary_and_named_axes() -> None:
+    labels = {"primary default", "right start", "left center", "right end"}
+    chart = xy.chart(
+        xy.line([0, 1], [0, 1]),
+        xy.line([0, 1], [1, 2], y_axis="y2"),
+        xy.line([0, 1], [2, 3], y_axis="y3"),
+        xy.line([0, 1], [3, 4], y_axis="y4"),
+        xy.x_axis(),
+        xy.y_axis(label="primary default", side="left"),
+        xy.y_axis(id="y2", label="right start", side="right", label_position="start"),
+        xy.y_axis(id="y3", label="left center", side="left", label_position="center"),
+        xy.y_axis(id="y4", label="right end", side="right", label_position="end"),
+        width=720,
+        height=440,
+        padding=(48, 120, 48, 120),
+    )
+    spec, _blob = chart.figure().build_payload()
+    _width, _height, _compact, plot = _svg.layout(spec)
+    geometry = _svg_y_title_geometry(chart, labels)
+
+    assert geometry["primary default"]["y"] == pytest.approx(plot["y"] + plot["h"] / 2)
+    assert geometry["primary default"]["angle"] == -90
+    assert geometry["right start"]["y"] == pytest.approx(plot["y"] + plot["h"])
+    assert geometry["right start"]["angle"] == 90
+    assert geometry["left center"]["y"] == pytest.approx(plot["y"] + plot["h"] / 2)
+    assert geometry["left center"]["angle"] == -90
+    assert geometry["right end"]["y"] == pytest.approx(plot["y"])
+    assert geometry["right end"]["angle"] == 90
 
 
 def _probe(chart: xy.Chart, script: str, tmp_path: Path, name: str) -> dict:
@@ -597,6 +651,209 @@ def test_y_axis_title_stays_attached_when_left_padding_is_wide(tmp_path: Path) -
     assert result["titleInside"] is True, result
     assert result["tickInside"] is True, result
     assert result["titleLayoutReads"] == 1, result
+
+
+def test_y_axis_titles_center_and_match_svg_longitudinally_for_named_axes(
+    tmp_path: Path,
+) -> None:
+    labels = {
+        "primary default",
+        "right start",
+        "left center",
+        "right end",
+    }
+    chart = xy.chart(
+        xy.line([0, 1], [0, 1]),
+        xy.line([0, 1], [1, 2], y_axis="y2"),
+        xy.line([0, 1], [2, 3], y_axis="y3"),
+        xy.line([0, 1], [3, 4], y_axis="y4"),
+        xy.x_axis(),
+        xy.y_axis(label="primary default", side="left"),
+        xy.y_axis(id="y2", label="right start", side="right", label_position="start"),
+        xy.y_axis(id="y3", label="left center", side="left", label_position="center"),
+        xy.y_axis(id="y4", label="right end", side="right", label_position="end"),
+        width=720,
+        height=440,
+        padding=(48, 120, 48, 120),
+    )
+    svg_geometry = _svg_y_title_geometry(chart, labels)
+    script = (
+        _PRELUDE
+        + f"""
+    const expected = {json.dumps(svg_geometry)};
+    const root = view.root.getBoundingClientRect();
+    const titles = Object.fromEntries(
+      [...view.root.querySelectorAll('[data-xy-label-kind="label"][data-xy-axis^="y"]')]
+        .map((title) => {{
+          const box = title.getBoundingClientRect();
+          return [title.textContent, {{
+            axis: title.dataset.xyAxis,
+            side: title.dataset.xyAxisSide,
+            centerX: (box.left + box.right) / 2 - root.left,
+            centerY: (box.top + box.bottom) / 2 - root.top,
+            top: parseFloat(title.style.top),
+            transform: title.style.transform,
+            origin: title.style.transformOrigin,
+            svgY: expected[title.textContent].y,
+          }}];
+        }})
+    );
+    document.body.setAttribute("data-xy-issue-probe", JSON.stringify({{
+      plot: view.plot,
+      titles,
+    }}));
+"""
+        + _POSTLUDE
+    )
+    result = _probe(chart, script, tmp_path, "centered primary and named y titles")
+
+    plot = result["plot"]
+    titles = result["titles"]
+    assert titles.keys() == labels
+    assert titles["primary default"]["centerY"] == pytest.approx(
+        plot["y"] + plot["h"] / 2,
+        abs=0.75,
+    )
+    assert titles["right start"]["centerY"] == pytest.approx(plot["y"] + plot["h"], abs=0.75)
+    assert titles["left center"]["centerY"] == pytest.approx(
+        plot["y"] + plot["h"] / 2,
+        abs=0.75,
+    )
+    assert titles["right end"]["centerY"] == pytest.approx(plot["y"], abs=0.75)
+    for title in titles.values():
+        assert title["centerY"] == pytest.approx(title["svgY"], abs=0.75)
+        assert title["origin"].replace(" ", "") in {"center", "centercenter"}
+        assert title["transform"].replace(" ", "").startswith("translate(-50%,-50%)rotate(")
+    assert titles["primary default"]["centerX"] < plot["x"]
+    assert titles["left center"]["centerX"] < plot["x"]
+    assert titles["right start"]["centerX"] > plot["x"] + plot["w"]
+    assert titles["right end"]["centerX"] > plot["x"] + plot["w"]
+
+
+def test_y_axis_title_offset_unions_inward_tick_labels_with_the_spine(
+    tmp_path: Path,
+) -> None:
+    label_size = 15
+    inside_tick_style = {
+        "label_size": label_size,
+        "tick_length": 4,
+        "tick_direction": "in",
+        "tick_padding": -12,
+    }
+    chart = xy.chart(
+        xy.line([0, 1], [0, 1]),
+        xy.line([0, 1], [1, 2], y_axis="y2"),
+        xy.x_axis(),
+        xy.y_axis(
+            label="left spine union",
+            side="left",
+            tick_values=[0, 0.5, 1],
+            tick_label_anchor="start",
+            style=inside_tick_style,
+        ),
+        xy.y_axis(
+            id="y2",
+            label="right spine union",
+            side="right",
+            tick_values=[1, 1.5, 2],
+            tick_label_anchor="end",
+            style=inside_tick_style,
+        ),
+        width=640,
+        height=400,
+        padding=(48, 110, 48, 110),
+    )
+    script = (
+        _PRELUDE
+        + """
+    const root = view.root.getBoundingClientRect();
+    const leftSpine = root.left + view.plot.x;
+    const rightSpine = leftSpine + view.plot.w;
+    const titleBox = (axis) => view.root.querySelector(
+      `[data-xy-label-kind="label"][data-xy-axis="${axis}"]`
+    ).getBoundingClientRect();
+    const tickBoxes = (axis) => [...view.root.querySelectorAll(
+      `[data-xy-label-kind="tick"][data-xy-axis="${axis}"]`
+    )].map((tick) => tick.getBoundingClientRect());
+    const leftTitle = titleBox("y");
+    const rightTitle = titleBox("y2");
+    const leftTicks = tickBoxes("y");
+    const rightTicks = tickBoxes("y2");
+    document.body.setAttribute("data-xy-issue-probe", JSON.stringify({
+      leftTicksInside: leftTicks.every((box) => box.left > leftSpine),
+      rightTicksInside: rightTicks.every((box) => box.right < rightSpine),
+      leftGap: leftSpine - leftTitle.right,
+      rightGap: rightTitle.left - rightSpine,
+    }));
+"""
+        + _POSTLUDE
+    )
+    result = _probe(chart, script, tmp_path, "y title spine and inward tick union")
+
+    assert result["leftTicksInside"] is True
+    assert result["rightTicksInside"] is True
+    assert result["leftGap"] == pytest.approx(_Y_TITLE_TICK_GAP_EM * label_size, abs=0.75)
+    assert result["rightGap"] == pytest.approx(_Y_TITLE_TICK_GAP_EM * label_size, abs=0.75)
+
+
+def test_y_axis_title_rotation_labelpad_and_tickless_spine_fallback(
+    tmp_path: Path,
+) -> None:
+    chart = xy.chart(
+        xy.line([0, 1], [0, 1]),
+        xy.line([0, 1], [1, 2], y_axis="y2"),
+        xy.x_axis(),
+        xy.y_axis(
+            label="angled primary",
+            side="left",
+            label_angle=-45,
+            label_offset=18,
+            tick_values=[0, 0.5, 1],
+        ),
+        xy.y_axis(
+            id="y2",
+            label="tickless secondary",
+            side="right",
+            tick_values=[],
+            style={"label_size": 15},
+        ),
+        width=640,
+        height=400,
+        padding=(48, 110, 48, 110),
+    )
+    script = (
+        _PRELUDE
+        + """
+    const root = view.root.getBoundingClientRect();
+    const primary = view.root.querySelector(
+      '[data-xy-label-kind="label"][data-xy-axis="y"]'
+    );
+    const secondary = view.root.querySelector(
+      '[data-xy-label-kind="label"][data-xy-axis="y2"]'
+    );
+    const primaryBox = primary.getBoundingClientRect();
+    const secondaryBox = secondary.getBoundingClientRect();
+    const primaryTicks = [...view.root.querySelectorAll(
+      '[data-xy-label-kind="tick"][data-xy-axis="y"][data-xy-axis-side="left"]'
+    )].map((tick) => tick.getBoundingClientRect());
+    const secondaryTicks = [...view.root.querySelectorAll(
+      '[data-xy-label-kind="tick"][data-xy-axis="y2"]'
+    )];
+    document.body.setAttribute("data-xy-issue-probe", JSON.stringify({
+      primaryGap: Math.min(...primaryTicks.map((box) => box.left)) - primaryBox.right,
+      primaryTransform: primary.style.transform,
+      secondaryTicks: secondaryTicks.length,
+      secondaryGap: secondaryBox.left - (root.left + view.plot.x + view.plot.w),
+    }));
+"""
+        + _POSTLUDE
+    )
+    result = _probe(chart, script, tmp_path, "y title angle labelpad and spine fallback")
+
+    assert result["primaryGap"] == pytest.approx(18, abs=0.75)
+    assert "rotate(-45deg)" in result["primaryTransform"].replace(" ", "")
+    assert result["secondaryTicks"] == 0
+    assert result["secondaryGap"] == pytest.approx(_Y_TITLE_TICK_GAP_EM * 15, abs=0.75)
 
 
 def test_structured_y_axis_title_position_remains_authoritative(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- restore centered browser placement for resolved Y-axis titles using `translate(-50%, -50%) rotate(...)` and a centered transform origin
- apply the same path to primary and named/secondary Y axes on either side
- position outside titles from the union of the relevant spine and tick-label bounds, while respecting explicit label rotation and label padding
- reserve the rotation-projected title extent in the gutter so the edge clamp cannot consume authored label padding
- batch all Y-title geometry reads before applying position writes on multi-axis charts
- keep structured `label_position` CSS authoritative

This is a general renderer fix for a consolidation regression, not a Cohere special case. It ports the relevant placement model from `8cd0c9c` without cherry-picking the old commit wholesale. The static SVG renderer already resolves the longitudinal axis-label anchor correctly; the browser renderer now follows the same semantics.

Stack: this PR is layer 3 and targets `agent/bughunt-axes-helper-parity` (#355).

## Focused coverage

- default primary Y title centered at `plot.y + plot.h / 2`
- named/secondary Y axes
- left and right sides
- `label_position=start|center|end`
- explicit rotation and label padding
- inward tick labels and tickless spine fallback
- browser/static-SVG longitudinal placement consistency

## Validation

- `uv run --with pre-commit pre-commit run --all-files`
- `uv run ruff check .`
- `uv run ruff format --check .`
- TypeScript typecheck and non-browser client build
- focused static/SVG and layout regressions: 12 passed
- batching-adjacent non-browser selection: 3 passed
- `git diff --check`

The browser geometry tests run in CI, including the exact rotated-title labelpad case that previously failed. Local browser capture was intentionally avoided; no Chrome workaround was used.

## Visual acceptance: Matplotlib Cohere

The Matplotlib Cohere gallery example is the acceptance target. Static XY already centers `Coherence`; this PR makes the interactive browser title use that same resolved position. Evidence images will be linked in a follow-up comment so they remain outside the product branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Y-axis title sizing, placement, and rotation for both primary and secondary (named) axes.
  * Corrected title alignment relative to tick labels and axis spines on left and right sides, including consistent behavior for inward offset calculations.
  * Enhanced handling for secondary axes without ticks to ensure correct fallback spacing and positioning.
* **Tests**
  * Added SVG- and browser-based UI regression coverage to verify Y-axis title geometry, offsets, and centered layout consistency across axes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->