### PR TITLE
update CHANGELOG.md for xy and reflex-xy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ in the README).
 
 ## [Unreleased]
 
+## [0.0.4] - 2026-07-27
+
 ### Added
 - Notebook display-host resolution (`spec/design/reflex-shaped-api.md` §3.3):
   `show(display=...)` on charts, facet charts, and the internal figure objects

--- a/python/reflex-xy/CHANGELOG.md
+++ b/python/reflex-xy/CHANGELOG.md
@@ -6,6 +6,8 @@ documented here. The format follows
 
 ## [Unreleased]
 
+## [0.0.2] — 2026-07-27
+
 ### Added
 - `reflex_xy.chart(..., tailwind_classes=...)` exposes complete utility names
   for live token/Var charts to Reflex's Tailwind build without leaking a scan


### PR DESCRIPTION
prepare for v0.0.4 release and reflex-v0.0.2 release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.0.4, dated July 27, 2026.
  * Added release notes for version 0.0.2, dated July 27, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->