### PR TITLE
docs: add alpha callout to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ same process for the new range, and a selection returns the original rows.
 
 > [!IMPORTANT]
 > **XY is in alpha** and is receiving frequent enhancements.
-> ⭐️ [Star the repo](https://github.com/reflex-dev/xy) to follow the progress —
-> contributions are appreciated!
+> ⭐️ [Star the repo](https://github.com/reflex-dev/xy) to follow the progress.
 
 ## Is XY right for me?
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ same process for the new range, and a selection returns the original rows.
 
 > [!IMPORTANT]
 > **XY is in alpha** and is receiving frequent enhancements.
-> ⭐️ [Star the repo](https://github.com/reflex-dev/xy) to follow the progress.
+> ⭐️ Star the repo to follow the progress.
 
 ## Is XY right for me?
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ Rust core computes only what the screen needs to display, based on its
 resolution. Pan, zoom, hover, and selection can show full details by running the
 same process for the new range, and a selection returns the original rows.
 
-XY is early alpha, and is receiving frequent enhancements. Any contributions are
-appreciated!
+> [!IMPORTANT]
+> **XY is in alpha** and is receiving frequent enhancements.
+> ⭐️ [Star the repo](https://github.com/reflex-dev/xy) to follow the progress —
+> contributions are appreciated!
 
 ## Is XY right for me?
 


### PR DESCRIPTION
Replaces the plain "XY is early alpha, and is receiving frequent enhancements. Any contributions are appreciated!" sentence in `README.md` with a GitHub `[!IMPORTANT]` callout:

> **XY is in alpha** and is receiving frequent enhancements.
> ⭐️ Star the repo to follow the progress.

README-only change; no code or behavior affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPmmQVoJsVuFEsCtHQTsuh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to clarify that XY is in alpha.
  * Added a prompt for readers to star the repository to follow progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->