### PR TITLE
Retain a covering M4 overview during line refinement

### DIFF
--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -4060,12 +4060,17 @@ export class ChartView {
       }
       if (g.tier === "decimated" && g._decimatedRefined && g._homeDecimated) {
         const r = g._decimatedWindow;
+        // _axisRange preserves axis direction (a reversed axis yields
+        // hi-before-lo) while the served window arrives normalized, so the
+        // coverage compare runs on normalized bounds.
         const [vx0, vx1] = this._axisRange(g.xAxis);
+        const viewLo = Math.min(vx0, vx1);
+        const viewHi = Math.max(vx0, vx1);
         const eps = r ? Math.abs(r[1] - r[0]) * 1e-9 + 1e-300 : 0;
         // A prior refined window is not a truthful covering representation
         // after a pan/zoom leaves it.  Draw the retained overview until the
         // pending reply installs a buffer covering this view (T1/T8).
-        if (!r || vx0 < r[0] - eps || vx1 > r[1] + eps) {
+        if (!r || viewLo < r[0] - eps || viewHi > r[1] + eps) {
           markOf(g.trace.kind).draw(this, g._homeDecimated, x0, x1, y0, y1);
           return;
         }

--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -3031,6 +3031,18 @@ export class ChartView {
     // Per-mark GPU setup is dispatched through MARK_KINDS (55_marks.js) so a
     // new chart kind is an entry in that registry, not another branch here.
     markOf(t.kind).build(this, g, t, buffer);
+    if (t.tier === "decimated") {
+      // T1 covering representation for M4 traces.  Density has its texture
+      // cache; decimated line/area traces need the same guarantee while a
+      // window-specific re-decimation is in flight.  Keep the initial (home)
+      // buffers in a separate drawable so refined replies never overwrite
+      // the only geometry that covers the full initial domain.
+      g._homeDecimated = {
+        ...g, _vaos: null, _homeDecimated: null, _decimatedWindow: null,
+      };
+      g._decimatedWindow = [...this._axisRange(g.xAxis)];
+      g._decimatedRefined = false;
+    }
     if (t.keys && Number.isInteger(t.keys.lo) && Number.isInteger(t.keys.hi)) {
       const lo = this._columnView(buffer, this.spec.columns[t.keys.lo]);
       const hi = this._columnView(buffer, this.spec.columns[t.keys.hi]);
@@ -4045,6 +4057,18 @@ export class ChartView {
         const [gy0, gy1] = this._axisRange(g.yAxis);
         lodDrawDensityTier(this, g, gx0, gx1, gy0, gy1);
         return;
+      }
+      if (g.tier === "decimated" && g._decimatedRefined && g._homeDecimated) {
+        const r = g._decimatedWindow;
+        const [vx0, vx1] = this._axisRange(g.xAxis);
+        const eps = r ? Math.abs(r[1] - r[0]) * 1e-9 + 1e-300 : 0;
+        // A prior refined window is not a truthful covering representation
+        // after a pan/zoom leaves it.  Draw the retained overview until the
+        // pending reply installs a buffer covering this view (T1/T8).
+        if (!r || vx0 < r[0] - eps || vx1 > r[1] + eps) {
+          markOf(g.trace.kind).draw(this, g._homeDecimated, x0, x1, y0, y1);
+          return;
+        }
       }
       markOf(g.trace.kind).draw(this, g, x0, x1, y0, y1);
     };
@@ -6194,6 +6218,7 @@ export class ChartView {
     this._destroyDensitySample(g);
     lodDropPointCache(this, g); // retired point windows die with the trace (T13)
     this._deleteVaos(g);
+    this._deleteVaos(g._homeDecimated);
     this._deleteVaos(g.drill);
     this._deleteBuffers(g, [
       "xBuf", "yBuf", "cBuf", "sBuf", "selBuf", "baseBuf",
@@ -6202,6 +6227,12 @@ export class ChartView {
       "_transitionPrevXBuf", "_transitionPrevYBuf",
       "_transitionPrevPosBuf", "_transitionPrevValue1Buf", "_transitionPrevValue0Buf",
     ]);
+    // Only geometry is owned independently by the retained M4 overview;
+    // style/channel buffers are shared with the live trace and were deleted
+    // above exactly once.
+    if (g._decimatedRefined) {
+      this._deleteBuffers(g._homeDecimated, ["xBuf", "yBuf", "baseBuf"]);
+    }
     this._deleteBuffers(g.drill, [
       "xBuf", "yBuf", "cBuf", "rgbaBuf", "sBuf", "styleBuf", "strokeBuf", "selBuf", "dBuf",
     ]);
@@ -6228,6 +6259,7 @@ export class ChartView {
     g.densityCache = [];
     g.heatmap = null;
     g._cpu = null;
+    g._homeDecimated = null;
   }
 
   _destroyGlResources() {

--- a/js/src/54_kernel.ts
+++ b/js/src/54_kernel.ts
@@ -744,6 +744,16 @@ Object.assign(ChartView.prototype, {
         const sm = this._smoothArrays(g.trace, xArr, yArr, bArr, n);
         const src = sm || { x: xArr, y: yArr, n };
         const st = this._stepArrays(g.trace, src.x, src.y, src.n);
+        if (g.tier === "decimated" && !g._decimatedRefined) {
+          // The initial buffers belong to the retained home drawable (T1).
+          // Give refinements their own stores rather than destroying that
+          // covering representation with the first window reply.
+          this._deleteVaos(g);
+          g.xBuf = gl.createBuffer();
+          g.yBuf = gl.createBuffer();
+          if (bArr && g.baseBuf) g.baseBuf = gl.createBuffer();
+          g._decimatedRefined = true;
+        }
         gl.bindBuffer(gl.ARRAY_BUFFER, g.xBuf);
         gl.bufferData(gl.ARRAY_BUFFER, st ? st.x : src.x, gl.STATIC_DRAW);
         gl.bindBuffer(gl.ARRAY_BUFFER, g.yBuf);
@@ -766,6 +776,9 @@ Object.assign(ChartView.prototype, {
           g.baseMeta = { ...g.baseMeta, offset: upd.base.offset, scale: upd.base.scale };
         }
         g.n = st ? st.n : src.n;
+        if (Array.isArray(upd.x_range) && upd.x_range.length === 2) {
+          g._decimatedWindow = [Number(upd.x_range[0]), Number(upd.x_range[1])];
+        }
       }
       this.draw();
     } else if (msg.type === "density_update") {

--- a/python/xy/interaction.py
+++ b/python/xy/interaction.py
@@ -471,6 +471,10 @@ def decimate_view(
         )
         update = {
             "id": t.id,
+            # The client retains the home M4 buffer as T1's covering
+            # representation.  Record the exact window served by this reply
+            # so it can fall back to home while a later pan is in flight.
+            "x_range": [lo_x, hi_x],
             "x": writer.add_encoded(x_col),
             "y": writer.add_encoded(y_col),
         }

--- a/spec/design/lod-architecture.md
+++ b/spec/design/lod-architecture.md
@@ -356,8 +356,13 @@ invariants so future kinds don't regress them:
   finer one arrives. Density uses density-under-points and its broadest-cache
   fallback; an M4-decimated line/area retains its initial home/overview buffer
   and draws that whenever the current refined window does not cover the view.
-  Each tier reply records its served `x_range`; the overview hold ends only
-  when that reply has installed covering geometry (T8).
+  Each tier reply records its served `x_range` (small JSON metadata per the
+  Transport Matrix — the served window is a scalar control descriptor, not
+  point data, and stays f64 so deep-zoom coverage compares stay exact); the
+  overview hold ends only when that reply has installed covering geometry
+  (T8). Coverage compares normalized `[lo, hi]` bounds on both sides, so a
+  direction-preserving (reversed) axis range still resolves coverage
+  correctly.
 - **T2 — never hard-cut:** representation changes crossfade (entry fade on
   the aggregate→marks transition only — restarting per refresh reads as
   flashing; exit fade with the "dying" state so buffers outlive the fade).

--- a/spec/design/lod-architecture.md
+++ b/spec/design/lod-architecture.md
@@ -353,7 +353,11 @@ The transition system was built and debugged in this repo; codifying the
 invariants so future kinds don't regress them:
 
 - **T1 — never blank:** a coarser covering representation draws until the
-  finer one arrives (density-under-points; broadest-cache fallback).
+  finer one arrives. Density uses density-under-points and its broadest-cache
+  fallback; an M4-decimated line/area retains its initial home/overview buffer
+  and draws that whenever the current refined window does not cover the view.
+  Each tier reply records its served `x_range`; the overview hold ends only
+  when that reply has installed covering geometry (T8).
 - **T2 — never hard-cut:** representation changes crossfade (entry fade on
   the aggregate→marks transition only — restarting per refresh reads as
   flashing; exit fade with the "dying" state so buffers outlive the fade).

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -41,6 +41,7 @@ def test_valid_view_returns_tier_update():
     assert reply is not None
     msg, buffers = reply
     assert msg["type"] == "tier_update"
+    assert msg["traces"][0]["x_range"] == [100.0, 5_000.0]
     assert msg["seq"] == 3
     assert msg["traces"]
     assert buffers


### PR DESCRIPTION
### Motivation

- Fix the blank-area symptom observed during a fast zoom/decimation dance where the left third of the plot went empty because the decimated tier had no covering overview while a refined M4 window reply was in flight.  
- The repository spec's T1 invariant (`never blank`) described a density covering fallback but the decimated tier lacked an equivalent retained overview, creating a spec/implementation mismatch.  
- The change implements the safer behavior: decimated traces provide a covering home/overview until a reply that truly covers the current view is installed, matching the intent of T1/T8.

### Description

- Add `x_range` metadata to M4/tier replies in `python/xy/interaction.py` so the client knows the exact window each decimation reply served.  
- Make decimated line/area traces retain their initial (home/overview) GPU geometry on the client by introducing `g._homeDecimated`, `g._decimatedWindow`, and `g._decimatedRefined` in `js/src/50_chartview.ts`, and draw the retained overview whenever the active refined window does not cover the current view.  
- Allocate separate GPU buffers for refined replies in `js/src/54_kernel.ts` (so the initial covering geometry is not destroyed by the first refinement) and record the replied `x_range` on the client-side trace object.  
- Add lifecycle cleanup for the retained overview (`_deleteVaos`, `_deleteBuffers`, and `_destroyTraceResources`) and update the LOD design doc (`spec/design/lod-architecture.md`) to document the T1/T8 behavior for decimated traces.  
- Update the transport test in `tests/test_channel.py` to assert that decimation replies include the `x_range` field (transport contract change).  

### Testing

- Ran `node js/build.mjs`, which completed successfully and produced the minified client bundles.  
- Ran `uv run pytest tests/test_channel.py tests/test_figure.py -q`, which completed successfully for the targeted tests.  
- Ran linters/format checks with `uv run ruff check .` and `uv run ruff format --check .`, both of which passed.  
- Pre-commit hooks (`uv run --with pre-commit pre-commit run --all-files`) could not be executed in this environment due to PyPI access being unavailable, but Ruff hooks were exercised directly and passed.  
- The render smoke (`python3 scripts/smoke_render.py`) could not be executed in this environment because no Chromium binary is available, so an end-to-end headless render probe was not run here.

Fixes https://github.com/reflex-dev/xy/issues/352
------


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chart rendering during zooming and panning by retaining a stable “home/overview” representation for density decimated traces until refined coverage fully applies.
  - Prevented charts from showing blank or incomplete regions when the view extends outside the newly refined window.

- **New Features**
  - Tier update messages now include the served horizontal `x_range` to support more reliable coverage checks.

- **Tests**
  - Added assertions validating the expected normalized `x_range` in tier update payloads.

- **Documentation**
  - Expanded smooth-transition spec with clarified fallback rules and coverage determination behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->