### PR TITLE
Resolve categorical palettes once per trace in authored-marker scatters

### DIFF
--- a/js/src/51_annotations.ts
+++ b/js/src/51_annotations.ts
@@ -285,20 +285,13 @@ function xyTaperPolygon(points, w0, w1) {
 }
 
 Object.assign(ChartView.prototype, {
-  _authoredScatterRgba(g, index, continuousLut = null) {
+  _authoredScatterRgba(g, index, continuousLut = null, paletteRgba = null) {
     if (g.colorMode === 3 && g._cpu.rgba) {
       const offset = index * 4;
       return Array.from(g._cpu.rgba.slice(offset, offset + 4), (value: number) => value / 255);
     }
-    if (g.colorMode === 2 && g._cpu.color) {
-      const palette = g.trace.color?.palette || [];
-      if (palette.length) {
-        return parseColor(
-          this.root,
-          palette[Math.round(g._cpu.color[index]) % palette.length],
-          g.color,
-        );
-      }
+    if (g.colorMode === 2 && g._cpu.color && paletteRgba && paletteRgba.length) {
+      return paletteRgba[Math.round(g._cpu.color[index]) % paletteRgba.length];
     }
     if (g.colorMode === 1 && g._cpu.color) {
       // The caller prepares this once per trace/redraw. Falling back to a
@@ -335,6 +328,10 @@ Object.assign(ChartView.prototype, {
         g._authoredLut = buildLutData(colormap);
       }
       const continuousLut = g.colorMode === 1 ? g._authoredLut : null;
+      const palette = g.trace.color?.palette || [];
+      const paletteRgba = g.colorMode === 2 && palette.length
+        ? palette.map((c) => parseColor(this.root, c, g.color))
+        : null;
       for (let index = 0; index < g.n; index++) {
         const sourceIndex = g._visMap ? g._visMap[index] : index;
         const x = this._decodeValue(g._cpu.x, g.xMeta, sourceIndex);
@@ -349,7 +346,7 @@ Object.assign(ChartView.prototype, {
               : g._cpu.size[sourceIndex])
           : g.size;
         const size = Math.max(0, Number(sizeValue) * zoomStyle.sizeFactor);
-        const rgba = this._authoredScatterRgba(g, sourceIndex, continuousLut);
+        const rgba = this._authoredScatterRgba(g, sourceIndex, continuousLut, paletteRgba);
         const styleOffset = sourceIndex * 4;
         const itemStyle = g._cpuStyle && g._cpuStyle.length >= styleOffset + 4
           ? g._cpuStyle.subarray(styleOffset, styleOffset + 4)


### PR DESCRIPTION
> Note: used AI to draft this PR message as a first time contrib.

Authored-marker scatters (custom `marker_path`/`marker_glyph`/per-item symbols on the Canvas2D path) with a categorical palette resolved every point's color through `parseColor` inside the per-point draw loop, every frame. For non-hex palette entries (named colors, `rgb()`, `var()`, `oklch()`, all validated and passed through by `_validate.css_color`) that means a DOM probe (`createElement` + `getComputedStyle` + `removeChild`) and a forced style recalc per point per frame, ~4 us/point: 20 ms/frame at 5,000 points spends the whole 60 fps budget before drawing a mark, and 100,000 points runs at ~2.5 fps on color resolution alone.

The palette is now resolved once per trace per draw, mirroring the existing continuous-color `_authoredLut`, and indexed per point, removing the per-point cost entirely (up to ~1000x at 100k points) with identical point colors; hex palettes (including the default) were never affected. Resolving per draw rather than caching across frames keeps `var(--token)` theme toggles correct with no invalidation logic, at ~4 probes/frame.

| points | before | after |
|---|---|---|
| 100 | 0.4 ms/frame | ~0 ms/frame |
| 1,000 | 4.4 ms/frame | ~0 ms/frame |
| 5,000 | 20.4 ms/frame | 0.1 ms/frame |
| 20,000 | 84.1 ms/frame | 0.1 ms/frame |
| 100,000 | 399.7 ms/frame | 0.4 ms/frame |

**Verification**

- `node js/build.mjs` clean (typecheck + bundle)
- `python3 scripts/abi_smoke.py` 140 checks passed
- `python3 scripts/render_smoke_nonumpy.py` all probes pass, lit fraction 96.586%
- `uv run pytest` full suite: 3354 passed, 74 skipped
- `uv run ruff check .`, `uv run ruff format --check .`, pre-commit hooks (ruff + codespell) pass
- Spec intentionally unchanged: pure client-side caching, pixel-identical output

Measured on: Linux 6.8 (Ubuntu, x86_64), Intel i7-12800H, 30 GB RAM, Node 22, Playwright 1.61.1 bundled Chromium, headless.

<details>
<summary>Benchmark (headless Chromium via Playwright, median of 20 frames)</summary>

```js
import { chromium } from "playwright";

const browser = await chromium.launch();
const page = await browser.newPage();
await page.setContent("<div id='root'></div>");

const result = await page.evaluate(() => {
  const root = document.getElementById("root");
  const palette = ["seagreen", "rgb(213,81,129)", "var(--brand, #c48300)", "oklch(0.7 0.1 200)"];

  function parseRgbFunc(raw) {
    const m = raw && raw.match(/rgba?\(([^)]+)\)/);
    if (!m) return null;
    const parts = m[1].split(/[,/\s]+/).filter(Boolean).map(Number);
    const [r, g, b, a = 1] = parts;
    return [r / 255, g / 255, b / 255, a];
  }
  // js/src/20_theme.ts resolveCssColor, verbatim
  function resolveCssColor(host, expr) {
    const probe = document.createElement("span");
    probe.style.display = "none";
    probe.style.color = expr;
    host.appendChild(probe);
    const rgb = getComputedStyle(probe).color;
    host.removeChild(probe);
    return parseRgbFunc(rgb);
  }

  function bench(name, n, frames, perFrame) {
    const times = [];
    let sink = 0;
    for (let f = 0; f < frames; f++) {
      const t0 = performance.now();
      sink += perFrame(n);
      times.push(performance.now() - t0);
    }
    times.sort((a, b) => a - b);
    return { name, n, medianMs: +times[(frames / 2) | 0].toFixed(3), sink };
  }

  const out = [];
  for (const n of [100, 1000, 5000, 20000, 100000]) {
    // before: DOM probe per point (per-frame loop body on main)
    out.push(bench("before", n, 20, (n) => {
      let s = 0;
      for (let i = 0; i < n; i++) s += (resolveCssColor(root, palette[i % 4]) || [0])[0];
      return s;
    }));
    // after: palette resolved once per trace per draw, indexed per point
    out.push(bench("after", n, 20, (n) => {
      const paletteRgba = palette.map((c) => resolveCssColor(root, c) || [0, 0, 0, 1]);
      let s = 0;
      for (let i = 0; i < n; i++) s += paletteRgba[i % 4][0];
      return s;
    }));
  }
  return out;
});

for (const r of result) console.log(`${r.name.padEnd(8)} N=${String(r.n).padStart(6)}  median ${r.medianMs} ms/frame`);
await browser.close();
```

Run from the repo root (playwright is already a pinned devDependency): `node bench.mjs`

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved rendering efficiency for scatter-marker annotations that use discrete color palettes.
  * Preserved existing behavior for continuous color scales and direct RGBA color settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->