### PR TITLE
Remove unused _pow10_label helper from pyplot axes

### DIFF
--- a/python/xy/pyplot/_axes.py
+++ b/python/xy/pyplot/_axes.py
@@ -8928,10 +8928,6 @@ def _pow_label(value: float, base: float = 10.0) -> str:
     return f"{base:g}" + str(round(float(exponent))).translate(_SUPERSCRIPT_DIGITS)
 
 
-def _pow10_label(value: float) -> str:
-    return _pow_label(value, 10.0)
-
-
 def _plain_text(value: Any) -> str:
     text = str(value)
     converted = mathtext_to_unicode(text)


### PR DESCRIPTION
`_pow10_label` in `python/xy/pyplot/_axes.py` was a one-line wrapper over `_pow_label(value, 10.0)` with no call sites anywhere in `python/`, `tests/`, `scripts/`, `js/`, or `docs/`. 

`Axes._apply_tickers` already calls `_pow_label` directly with the base pulled from the tick spec (`_pow_label(value, float(spec.get("base", 10.0)))`), so the hardcoded-base wrapper had been superseded.
