### PR TITLE
Upload log-u8 density grids directly to GPU in reduced-motion mode

### DIFF
--- a/js/src/45_lod.ts
+++ b/js/src/45_lod.ts
@@ -118,10 +118,14 @@ export function lodWriteGridTexture(
       }
     }
   }
+  lodUploadGridBytes(gl, tex, data, w, h, !!rgba, filter);
+}
+
+function lodUploadGridBytes(gl, tex, data, w, h, isRgba, filter) {
   gl.bindTexture(gl.TEXTURE_2D, tex);
   const align = gl.getParameter(gl.UNPACK_ALIGNMENT);
   gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1);
-  if (rgba) {
+  if (isRgba) {
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, w, h, 0, gl.RGBA, gl.UNSIGNED_BYTE, data);
   } else {
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.R8, w, h, 0, gl.RED, gl.UNSIGNED_BYTE, data);
@@ -134,6 +138,12 @@ export function lodWriteGridTexture(
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gf);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+}
+
+function lodUploadWireGrid(gl, u8Wire, w, h, filter) {
+  const tex = gl.createTexture();
+  lodUploadGridBytes(gl, tex, u8Wire, w, h, false, filter);
+  return tex;
 }
 
 // Treat the color scale like exposure: brighten slowly on drill-in so a
@@ -1220,14 +1230,18 @@ export function lodApplyDensityUpdate(view, g, upd, buffers) {
       }
     }
   }
-  const grid = d.enc === "log-u8"
-    ? lodDecodeLogU8(buffers[d.buf], d.max)
-    : lodCopyGrid(view._asF32(buffers[d.buf]));
   // Mean point color plane (LOD doc §2), copied because exposure easing
   // re-reads it on every norm step, after the wire buffer may be gone.
   const rgba = d.rgba !== undefined ? new Uint8Array(view._asU8(buffers[d.rgba])) : null;
   const normStart = lodNormMax(g, d.max);
-  const normMax = view._prefersReducedMotion() ? d.max : normStart;
+  const reducedMotion = view._prefersReducedMotion();
+  const normMax = reducedMotion ? d.max : normStart;
+  const directWire = d.enc === "log-u8" && !rgba && reducedMotion;
+  const grid = directWire
+    ? null
+    : d.enc === "log-u8"
+      ? lodDecodeLogU8(buffers[d.buf], d.max)
+      : lodCopyGrid(view._asF32(buffers[d.buf]));
   g.densityNormMax = normMax;
   g.prevDensity = g.density;
   g._densityFadeStart = view._now();
@@ -1244,9 +1258,11 @@ export function lodApplyDensityUpdate(view, g, upd, buffers) {
     rgba,
     filter,
     _filterKey: replyFilterKey,
-    tex: view._uploadGrid(
-      grid, d.w, d.h, normMax, rgba, filter, view._fillOpacity(g.trace.style),
-    ),
+    tex: directWire
+      ? lodUploadWireGrid(view.gl, view._asU8(buffers[d.buf]), d.w, d.h, filter)
+      : view._uploadGrid(
+        grid, d.w, d.h, normMax, rgba, filter, view._fillOpacity(g.trace.style),
+      ),
     lut: g.density.lut,
   };
   // Exact scans include a view-specific sample and replace the overlay.

--- a/js/src/45_lod.ts
+++ b/js/src/45_lod.ts
@@ -140,7 +140,7 @@ function lodUploadGridBytes(gl, tex, data, w, h, isRgba, filter) {
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 }
 
-function lodUploadWireGrid(gl, u8Wire, w, h, filter) {
+export function lodUploadWireGrid(gl, u8Wire, w, h, filter) {
   const tex = gl.createTexture();
   lodUploadGridBytes(gl, tex, u8Wire, w, h, false, filter);
   return tex;
@@ -1237,6 +1237,7 @@ export function lodApplyDensityUpdate(view, g, upd, buffers) {
   const reducedMotion = view._prefersReducedMotion();
   const normMax = reducedMotion ? d.max : normStart;
   const directWire = d.enc === "log-u8" && !rgba && reducedMotion;
+  const wire = directWire ? new Uint8Array(view._asU8(buffers[d.buf])) : null;
   const grid = directWire
     ? null
     : d.enc === "log-u8"
@@ -1255,11 +1256,12 @@ export function lodApplyDensityUpdate(view, g, upd, buffers) {
     // enough to points territory to be worth a round-trip at all.
     visible: upd.visible,
     grid,
+    wire,
     rgba,
     filter,
     _filterKey: replyFilterKey,
     tex: directWire
-      ? lodUploadWireGrid(view.gl, view._asU8(buffers[d.buf]), d.w, d.h, filter)
+      ? lodUploadWireGrid(view.gl, wire, d.w, d.h, filter)
       : view._uploadGrid(
         grid, d.w, d.h, normMax, rgba, filter, view._fillOpacity(g.trace.style),
       ),

--- a/js/src/45_lod.ts
+++ b/js/src/45_lod.ts
@@ -1230,8 +1230,8 @@ export function lodApplyDensityUpdate(view, g, upd, buffers) {
       }
     }
   }
-  // Mean point color plane (LOD doc §2), copied because exposure easing
-  // re-reads it on every norm step, after the wire buffer may be gone.
+  // Mean point color plane (LOD doc §2), copied because legend-hover dimming
+  // and home-restore re-uploads re-read it after the wire buffer may be gone.
   const rgba = d.rgba !== undefined ? new Uint8Array(view._asU8(buffers[d.rgba])) : null;
   const normStart = lodNormMax(g, d.max);
   const reducedMotion = view._prefersReducedMotion();

--- a/js/src/54_kernel.ts
+++ b/js/src/54_kernel.ts
@@ -4,6 +4,7 @@ import { parseColor } from "./20_theme";
 import {
   lodAggregateStands, lodAggregateStepWindow, lodApplyDensityUpdate, lodApplyDrill,
   lodDrillServesView, lodDropDrill, lodFilterKey, lodPromoteCachedDrill, lodRememberDensity,
+  lodUploadWireGrid,
 } from "./45_lod";
 import { xyCreateRebinWorker } from "./46_worker";
 import { ChartView } from "./50_chartview";
@@ -280,10 +281,12 @@ Object.assign(ChartView.prototype, {
         const hd = g._homeDensity;
         this._applySampleRebinGrid(g, {
           ...hd,
-          tex: this._uploadGrid(
-            hd.grid, hd.w, hd.h, hd.normMax || hd.max || 1, hd.rgba, hd.filter,
-            this._fillOpacity(g.trace.style),
-          ),
+          tex: hd.grid
+            ? this._uploadGrid(
+              hd.grid, hd.w, hd.h, hd.normMax || hd.max || 1, hd.rgba, hd.filter,
+              this._fillOpacity(g.trace.style),
+            )
+            : lodUploadWireGrid(this.gl, hd.wire, hd.w, hd.h, hd.filter),
         }, false);
       }
       return;

--- a/scripts/render_smoke_nonumpy.py
+++ b/scripts/render_smoke_nonumpy.py
@@ -790,6 +790,35 @@ try{{
         if(c>0&&Math.abs(qg[i]-c)/c>0.08)qok=0;}}
     }}
     const qwire=(qok && Math.abs(gd.density.max-qmax)<1e-9)?1:0;
+    // --- Direct-wire density (reduced motion): a count-only log-u8 reply
+    // uploads the wire bytes verbatim (grid null, normMax pinned to max) and
+    // retains a copy on density.wire so re-uploads survive without a decoded
+    // grid. Then the home-extent restore in _requestSampleRebin — the path
+    // that dereferenced the null grid — must re-upload from the wire copy.
+    const rmPrev=v._prefersReducedMotion.bind(v);
+    v._prefersReducedMotion=()=>true;
+    const rmax=9, renc=new Uint8Array(64);
+    for(let i=0;i<64;i++){{const c=(i%4===0)?9:(i%7===0?1:0);
+      renc[i]=c>0?Math.max(1,Math.min(255,Math.round(255*Math.log1p(c)/Math.log1p(rmax)))):0;}}
+    v._onKernelMsg({{type:"density_update",traces:[{{id:gd.trace.id,mode:"density",visible:12345,
+      density:{{buf:0,w:8,h:8,max:rmax,enc:"log-u8",x_range:[0,100],y_range:[0,100]}}}}]}},[renc.buffer.slice(0)]);
+    let dwire=(gd.density.grid===null && gd.density.wire instanceof Uint8Array &&
+      gd.density.wire.length===64 && gd.density.normMax===rmax &&
+      v.gl.isTexture(gd.density.tex))?1:0;
+    if(dwire){{for(let i=0;i<64;i++) if(gd.density.wire[i]!==renc[i]) dwire=0;}}
+    let drestore=0;
+    try{{
+      gd._homeDensity=gd.density;
+      v._onKernelMsg({{type:"density_update",traces:[{{id:gd.trace.id,mode:"density",visible:2345,
+        density:{{buf:0,w:8,h:8,max:rmax,enc:"log-u8",x_range:[40,60],y_range:[40,60]}}}}]}},[renc.buffer.slice(0)]);
+      const zoomed=gd.density!==gd._homeDensity;
+      if(!v.view0) v.view0={{...v.view}};
+      v._requestSampleRebin(gd, v.view0, 0);
+      drestore=(zoomed && gd.density.grid===null && gd.density.wire instanceof Uint8Array &&
+        gd.density.xRange[1]===100 && v.gl.isTexture(gd.density.tex))?1:0;
+    }}catch(e){{ drestore=0; }}
+    gd._homeDensity=null;
+    v._prefersReducedMotion=rmPrev;
     // --- Rapid zoom in/out torture (drill thrash): the marks/density alphas
     // must be CONTINUOUS across window-boundary crossings, dying-drill
     // revives, and kernel replies landing mid-transition. Runs on a virtual
@@ -1169,7 +1198,7 @@ try{{
     gMc.readPixels(Math.round(WM*0.8),Math.round(HM*0.5),1,1,gMc.RGBA,gMc.UNSIGNED_BYTE,rpx);
     const meancolor=(lpx[0]>60 && lpx[0]>lpx[2]*3 && rpx[2]>60 && rpx[2]>rpx[0]*3)?1:0;
     vMc.destroy();holderMc.remove();
-    const base=`XY_OK lit=${{lit}} total=${{w*h}} labels=${{labels}} pick=${{hits}} row=${{hasXY}} selAll=${{selAll}} selSome=${{selSome}} active=${{active}} btns=${{btns}} modebarHidden=${{modebarHiddenAtRest}} modebarTopLeft=${{modebarTopLeft}} modebarHover=${{modebarHoverReveal}} modebarNoCollapse=${{modebarNoCollapse}} modebarMenu=${{modebarMenu}} modebarDrag=${{modebarDrag}} modebarSelect=${{modebarSelect}} lassoEdit=${{lassoEdit}} modebarExport=${{modebarExport}} panToggle=${{panToggle}} zin=${{zin}} smooth=${{smooth}} labelThrottle=${{labelThrottle}} hoverSkip=${{hoverSkip}} zanch=${{zanch}} retarget=${{retarget}} nosnap=${{nosnap}} prefetch=${{prefetch}} maxwait=${{maxwait}} box=${{boxOk}} xonly=${{xonly}} zmode=${{zmode}} densityLit=${{densityLit}} drill=${{drilled}} pending=${{pending}} dblend=${{dblend}} dseq=${{dseq}} hov=${{hov}} sstale=${{sstale}} sfresh=${{sfresh}} srestore=${{srestore}} plut=${{plut}} reg=${{reg}} refresh=${{refresh}} dpick=${{dpick}} hold=${{hold}} zoomout=${{zoomout}} broad=${{broadfallback}} dying=${{dying}} dback=${{dback}} dnorm=${{dnorm}} dnormDone=${{dnormDone}} stale=${{stale}} thrash=${{thrash}} qwire=${{qwire}} stream=${{stream}} tj=${{Math.round(maxJump*100)}} td=${{Math.round(reviveDip*100)}} malformed=${{malformed}} pixdet=${{pixdet}} splitbuf=${{splitbuf}} barBase=${{barBase}} histBase=${{histBase}} edgepad=${{edgepad}} mgrad=${{mgrad}} axisontop=${{axisontop}} mtipbase=${{mtipbase}} mcorner=${{mcorner}} mstroke=${{mstroke}} bgrad=${{bgrad}} bcorner=${{bcorner}} msmooth=${{msmooth}} bgocc=${{bgocc}} meancolor=${{meancolor}} dretire=${{dretire}}`;
+    const base=`XY_OK lit=${{lit}} total=${{w*h}} labels=${{labels}} pick=${{hits}} row=${{hasXY}} selAll=${{selAll}} selSome=${{selSome}} active=${{active}} btns=${{btns}} modebarHidden=${{modebarHiddenAtRest}} modebarTopLeft=${{modebarTopLeft}} modebarHover=${{modebarHoverReveal}} modebarNoCollapse=${{modebarNoCollapse}} modebarMenu=${{modebarMenu}} modebarDrag=${{modebarDrag}} modebarSelect=${{modebarSelect}} lassoEdit=${{lassoEdit}} modebarExport=${{modebarExport}} panToggle=${{panToggle}} zin=${{zin}} smooth=${{smooth}} labelThrottle=${{labelThrottle}} hoverSkip=${{hoverSkip}} zanch=${{zanch}} retarget=${{retarget}} nosnap=${{nosnap}} prefetch=${{prefetch}} maxwait=${{maxwait}} box=${{boxOk}} xonly=${{xonly}} zmode=${{zmode}} densityLit=${{densityLit}} drill=${{drilled}} pending=${{pending}} dblend=${{dblend}} dseq=${{dseq}} hov=${{hov}} sstale=${{sstale}} sfresh=${{sfresh}} srestore=${{srestore}} plut=${{plut}} reg=${{reg}} refresh=${{refresh}} dpick=${{dpick}} hold=${{hold}} zoomout=${{zoomout}} broad=${{broadfallback}} dying=${{dying}} dback=${{dback}} dnorm=${{dnorm}} dnormDone=${{dnormDone}} stale=${{stale}} thrash=${{thrash}} qwire=${{qwire}} dwire=${{dwire}} drestore=${{drestore}} stream=${{stream}} tj=${{Math.round(maxJump*100)}} td=${{Math.round(reviveDip*100)}} malformed=${{malformed}} pixdet=${{pixdet}} splitbuf=${{splitbuf}} barBase=${{barBase}} histBase=${{histBase}} edgepad=${{edgepad}} mgrad=${{mgrad}} axisontop=${{axisontop}} mtipbase=${{mtipbase}} mcorner=${{mcorner}} mstroke=${{mstroke}} bgrad=${{bgrad}} bcorner=${{bcorner}} msmooth=${{msmooth}} bgocc=${{bgocc}} meancolor=${{meancolor}} dretire=${{dretire}}`;
     const baseWithStyle=`${{base}} vstyle=${{vstyle}}`;
     // Responsive: 100%-by-100% chart in a 400x300 container tracks its parent;
     // growing the container must fire the ResizeObserver and re-render bigger.
@@ -1398,6 +1427,8 @@ try{{
     stale = int(re.search(r"stale=(\d+)", title).group(1))
     thrash = int(re.search(r"thrash=(\d+)", title).group(1))
     qwire = int(re.search(r"qwire=(\d+)", title).group(1))
+    dwire = int(re.search(r"dwire=(\d+)", title).group(1))
+    drestore = int(re.search(r"drestore=(\d+)", title).group(1))
     stream = int(re.search(r"stream=(\d+)", title).group(1))
     malformed = int(re.search(r"malformed=(\d+)", title).group(1))
     pixdet = int(re.search(r"pixdet=(\d+)", title).group(1))
@@ -1564,6 +1595,16 @@ try{{
         )
     if qwire != 1:
         raise SystemExit("log-u8 density decode failed (quantized wire)")
+    if dwire != 1:
+        raise SystemExit(
+            "direct-wire density failed (reduced motion must upload the "
+            "log-u8 wire bytes verbatim and retain them on density.wire)"
+        )
+    if drestore != 1:
+        raise SystemExit(
+            "direct-wire home restore failed (null-grid density must "
+            "re-upload from the retained wire bytes, not throw)"
+        )
     if meancolor != 1:
         raise SystemExit(
             "mean-color density failed (surface must wear the per-cell mean "

--- a/spec/design/lod-architecture.md
+++ b/spec/design/lod-architecture.md
@@ -376,6 +376,13 @@ invariants so future kinds don't regress them:
 - **T4 — normalization is eased, never stepped** (exposure-style normMax) —
   count-only surfaces; a mean-color texture's physical alpha is
   max-independent, so it has no normalization to ease.
+  When there is nothing to ease, the wire bytes ARE the texture: a
+  count-only `log-u8` reply under `prefers-reduced-motion` pins normMax at
+  the reply's own `max`, so decoding to floats and re-encoding against that
+  same max is the identity. Those replies upload `buf` straight to R8
+  (`lodUploadWireGrid`) and keep `grid` null, retaining the wire bytes so the
+  `_homeDensity` restore (T7) can re-upload after the buffer is gone. Every
+  other reply still decodes through `_uploadGrid`.
 - **T5 — stale replies die:** seq on view updates, drill_seq on subsets,
   pending-view hold for prefetched drills.
 - **T6 — invalid requests do not mutate:** malformed viewport/screen requests


### PR DESCRIPTION
Reduced-motion density replies decoded the log-u8 wire grid to f32 and re-encoded it with the identical formula before upload. Count-only grids now hand `texImage2D` the wire bytes unchanged, with pixel-identical output.  A copy of the wire bytes is retained on the density object so home-extent restores and context recovery can re-upload without a decoded grid (§27).

CPU removed per density reply, seeded power-law grid, excluding the unchanged `gl.texImage2D`:

| grid | CPU removed | alloc freed |
|---|---|---|
| 128×96 (12k cells) | 0.31 ms (0.28–0.37) | 60 KB |
| 256×192 (49k) | 1.51 ms (1.47–1.84) | 240 KB |
| 512×384 (197k, typical screen) | 6.27 ms (5.99–7.04) | 960 KB |
| 1024×768 (786k) | 24.6 ms (23.6–26.5) | 3840 KB |
| 2048×1536 (3.1M, 4K-class) | 100.1 ms (97.7–113.5) | 15360 KB |

**Verification**

- Under forced reduced motion, every `texImage2D` payload hashes identically to main in the same order (minus the redundant `lodStartNormAnim` re-upload), with identical rendered output
- Identity gate: `encode(decode(u)) == u` for all 256 byte values × 8 max values
- New render smoke probes (`dwire`, `drestore`) cover the direct-wire upload and the home-extent restore; both fail against the first commit alone
- All smokes, `uv run pytest`, Ruff, and pre-commit hooks pass

Measured on: Ubuntu 22.04.5 (Linux 6.8, x86_64), Intel i7-12800H, 30 GB RAM, Node 22.22.2, headless Chromium via SwiftShader.

<details>
<summary>Benchmark (Node)</summary>

```js
// js/src/45_lod.ts, arithmetic verbatim, GL calls removed.

function lodDecodeLogU8(u8, maxVal) {
  const out = new Float32Array(u8.length);
  const denom = Math.log1p(Math.max(0, maxVal || 0));
  if (denom > 0) {
    for (let i = 0; i < u8.length; i++) {
      if (u8[i] > 0) out[i] = Math.expm1((u8[i] / 255) * denom);
    }
  }
  return out;
}

// lodWriteGridTexture, count-only (!rgba) branch.
function encodeR8(f32, maxVal) {
  const denom = Math.log1p(Math.max(0, maxVal || 0));
  const data = new Uint8Array(f32.length);
  if (denom > 0) {
    for (let i = 0; i < f32.length; i++) {
      const c = f32[i];
      if (c > 0 && Number.isFinite(c)) {
        data[i] = Math.max(1, Math.min(255, Math.round(255 * Math.log1p(c) / denom)));
      }
    }
  }
  return data;
}

// Identity gate: the direct path is only sound because decode-then-encode
// reproduces the wire bytes. Algebraically exact, but it is floating point.
const all = new Uint8Array(256);
for (let i = 0; i < 256; i++) all[i] = i;
for (const max of [1, 2, 10, 255, 1e3, 5e5, 1e7, 2 ** 31]) {
  const back = encodeR8(lodDecodeLogU8(all, max), max);
  for (let i = 0; i < 256; i++) {
    if (back[i] !== all[i]) throw new Error(`identity broken: max=${max} byte=${i} -> ${back[i]}`);
  }
}
console.log("identity verified: encode(decode(u)) == u, all 256 bytes x 8 max values\n");

// mulberry32 — reproducible grids.
function rng(seed) {
  let a = seed >>> 0;
  return () => {
    a = (a + 0x6d2b79f5) >>> 0;
    let t = Math.imul(a ^ (a >>> 15), 1 | a);
    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
  };
}

// Power-law occupancy: a few hot cells, a sparse tail, mostly empty — the
// shape bin_2d produces, and what drives the branch rate in both loops.
function wireGrid(w, h) {
  const rand = rng(0x5eed);
  const u8 = new Uint8Array(w * h);
  for (let i = 0; i < u8.length; i++) {
    const r = rand();
    if (r < 0.001) u8[i] = 200 + Math.floor(rand() * 55);
    else if (r < 0.05) u8[i] = 40 + Math.floor(rand() * 160);
    else if (r < 0.3) u8[i] = 1 + Math.floor(rand() * 39);
  }
  return u8;
}

const RUNS = 31;
function bench(fn) {
  for (let i = 0; i < 5; i++) fn();
  const t = [];
  for (let r = 0; r < RUNS; r++) {
    const t0 = performance.now();
    fn();
    t.push(performance.now() - t0);
  }
  return t.sort((a, b) => a - b)[(RUNS / 2) | 0];
}

// Reduced motion, count-only: one decode + two encodes (the second from
// lodStartNormAnim's re-upload) vs. the one retained wire-byte copy.
const MAX = 5e5;
for (const [w, h] of [[128, 96], [256, 192], [512, 384], [1024, 768], [2048, 1536]]) {
  const u8 = wireGrid(w, h);
  const before = bench(() => {
    const f32 = lodDecodeLogU8(u8, MAX);
    encodeR8(f32, MAX);
    return encodeR8(f32, MAX);
  });
  const after = bench(() => new Uint8Array(u8));
  const alloc = ((w * h * 5) / 1024).toFixed(0);
  console.log(
    `${String(w + "x" + h).padEnd(11)} ${(w * h / 1000).toFixed(0).padStart(5)}k cells  ` +
    `before ${before.toFixed(3).padStart(8)} ms   after ${after.toFixed(4)} ms   ` +
    `alloc freed ${alloc.padStart(6)} KB`,
  );
}
```

Run from the repo root: `node bench.mjs`

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved density rendering for reduced-motion clients when only compact “wire” data is available.
  * Ensured density textures can be restored reliably after switching the displayed area, even if precomputed grid data is missing.

* **Tests**
  * Added Chromium smoke coverage to verify reduced-motion “wire” handling and correct restoration behavior.

* **Documentation**
  * Updated the LOD architecture notes to clarify reduced-motion count-only rendering and restore behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
