### PR TITLE
Update benchmark docs with interactive UX results

### DIFF
--- a/docs/app/tests/test_docs_site.py
+++ b/docs/app/tests/test_docs_site.py
@@ -678,7 +678,7 @@ def test_what_is_xy_restores_the_sdf_hero_and_ends_with_a_short_pitch() -> None:
     # call-to-action); embedded demo and shell fences don't count.
     why_prose = re.sub(r"~~~.*?~~~|```.*?```", "", why_copy, flags=re.DOTALL)
     assert len(why_prose.split()) < 260
-    assert "10-million-point launch benchmark" in why_copy
+    assert "recorded live interactive sweep" in why_copy
     assert "Compare by workflow, not by slogan" not in why_copy
 
 

--- a/docs/app/xy_docs/demos/benchmark_charts.py
+++ b/docs/app/xy_docs/demos/benchmark_charts.py
@@ -1,4 +1,4 @@
-"""Live XY charts for the public launch-benchmark documentation."""
+"""Live XY chart for the public interactive-UX benchmark documentation."""
 
 from __future__ import annotations
 
@@ -8,10 +8,13 @@ import reflex_xy
 import xy
 
 XY_COLOR = "#6E56CF"
+XY_EXACT_COLOR = "#A594E8"
 MATPLOTLIB_COLOR = "#8B8D98"
 PLOTLY_COLOR = "#B9BBC6"
+FAILURE_COLOR = "#D64545"
 SERIES = (
     ("XY", XY_COLOR),
+    ("XY · density off", XY_EXACT_COLOR),  # noqa: RUF001
     ("Matplotlib", MATPLOTLIB_COLOR),
     ("Plotly", PLOTLY_COLOR),
 )
@@ -27,14 +30,10 @@ _CARD_CLASS = (
     "w-full overflow-hidden rounded-xl border border-secondary-4 bg-white "
     "shadow-[0_12px_32px_#1c20240f] dark:bg-black"
 )
-_PANEL_CLASS = (
-    "min-w-0 overflow-hidden rounded-xl border border-secondary-4 "
-    "bg-white shadow-[0_8px_24px_#1c20240a] dark:bg-black"
-)
 
 
 def _theme() -> xy.Theme:
-    """Return the neutral benchmark theme shared by every live chart."""
+    """Return the neutral benchmark theme shared by the docs site."""
     return xy.theme(
         background="var(--benchmark-bg, #ffffff)",
         plot_background="var(--benchmark-plot, #fcfcfd)",
@@ -45,7 +44,7 @@ def _theme() -> xy.Theme:
 
 
 def _legend() -> rx.Component:
-    """Render the compact Reflex legend used by both benchmark cards."""
+    """Render the benchmark series legend."""
     return rx.el.div(
         *(
             rx.el.div(
@@ -62,338 +61,153 @@ def _legend() -> rx.Component:
             )
             for label, color in SERIES
         ),
-        class_name="flex shrink-0 flex-wrap items-center justify-end gap-x-2 gap-y-2",
+        class_name="flex flex-wrap items-center gap-x-3 gap-y-2",
         aria_label="Benchmark series legend",
     )
 
 
-def _heading(title: str, subtitle: str, *, show_legend: bool = True) -> rx.Component:
-    """Render benchmark title, methodology subtitle, and optional legend."""
-    return rx.el.div(
-        rx.el.div(
-            rx.el.h3(
-                title,
-                class_name="text-xl font-semibold tracking-[-0.02em] text-secondary-12",
-            ),
-            rx.el.p(
-                subtitle,
-                class_name="mt-1 text-sm font-medium text-secondary-10",
-            ),
-            class_name="min-w-0 flex-1",
-        ),
-        _legend() if show_legend else rx.fragment(),
-        class_name=(
-            "flex flex-col gap-4 px-5 pt-5 sm:px-4 sm:pt-7 lg:flex-row "
-            "lg:items-start lg:justify-between"
-        ),
+_SIZES = [
+    10_000,
+    100_000,
+    500_000,
+    1_000_000,
+    2_500_000,
+    5_000_000,
+    10_000_000,
+    25_000_000,
+    50_000_000,
+    100_000_000,
+]
+_XY_VALUES = [0.071, 0.072, 0.075, 0.084, 0.083, 0.089, 0.083, 0.077, 0.076, 0.081]
+_XY_EXACT_VALUES = [
+    0.085,
+    0.074,
+    0.087,
+    0.098,
+    0.111,
+    0.144,
+    0.206,
+    0.424,
+    0.645,
+    1.343,
+]
+_MATPLOTLIB_VALUES = [0.086, 0.115, 0.224, 0.357, 0.758, 1.424, 2.804, 6.838, 13.385]
+_PLOTLY_VALUES = [0.341, 0.373, 0.477, 0.614, 1.033, 1.785, 3.367, 9.794]
+
+
+def _series(values: list[float], name: str, color: str, width: float) -> tuple[xy.Mark, xy.Mark]:
+    """Return a line and a dot for every measured benchmark cell."""
+    sizes = _SIZES[: len(values)]
+    return (
+        xy.line(sizes, values, name=name, color=color, width=width),
+        xy.scatter(x=sizes, y=values, color=color, size=6.5),
     )
 
 
-_SNAPSHOT_CATEGORIES = [
-    "Static CPU PNG",
-    "Interactive · default GPU",
-    "Interactive · CPU fallback",
-]
-_SNAPSHOT_VALUES = [
-    [0.0184, 0.1875, 1.0352],
-    [2.7432, 2.9842, 3.6121],
-    [9.6433, 3.3729, 8.0888],
-]
-
-_SNAPSHOT_CHART = xy.bar_chart(
-    xy.bar(
-        _SNAPSHOT_CATEGORIES,
-        _SNAPSHOT_VALUES,
-        orientation="horizontal",
-        mode="grouped",
-        series=[label for label, _color in SERIES],
-        colors=[color for _label, color in SERIES],
-        opacity=1,
-        # Square ends keep the true 1–2 px linear bar visible; a rounded cap
-        # collapses this particular value into a dot at the current scale.
-        corner_radius=0,
-        stroke_width=1,
-    ),
-    xy.tooltip(title="{x}", format={"y": ".4f s"}),
-    xy.legend(show=False),
-    xy.modebar(show=False),
-    xy.interaction_config(navigation=False),
-    xy.x_axis(
-        label="Render time (seconds) · lower is better",
-        domain=(0, 10),
-        tick_values=[0, 2, 4, 6, 8, 10],
-        tick_labels=["0 s", "2 s", "4 s", "6 s", "8 s", "10 s"],
-        style={"grid_width": 1, "grid_opacity": 1},
-    ),
-    xy.y_axis(
-        reverse=True,
-        style={"grid_opacity": 0, "axis_width": 0, "tick_width": 0},
-    ),
-    _theme(),
-    width="100%",
-    height=430,
-    padding=(18, 30, 58, 170),
-    class_name=_CHART_CLASS,
-)
-
-
-def launch_snapshot_demo() -> rx.Component:
-    """Render the 10M comparison as a live grouped horizontal bar chart."""
-    return rx.el.section(
-        _heading(
-            "10M-point cold-render time",
-            "900×420 output · mean of three isolated runs · shared linear scale",  # noqa: RUF001
-        ),
-        rx.el.div(
-            rx.el.div(
-                reflex_xy.chart(_SNAPSHOT_CHART, height="430px"),
-                rx.el.span(
-                    class_name=(
-                        "pointer-events-none absolute left-[170px] top-[30px] "
-                        "h-[31px] w-2 bg-[#6E56CF]"
-                    ),
-                    aria_hidden="true",
-                ),
-                class_name="relative",
-            ),
-            class_name="px-2 pb-2 sm:px-4 sm:pb-4",
-        ),
-        class_name=_CARD_CLASS,
-        aria_label="10-million-point cold-render benchmark comparison",
-    )
-
-
-_SIZE_LABELS = ["10k", "100k", "1M", "10M", "1B"]
-_XY_SCALING_VALUES = [0.0036, 0.0060, 0.0058, 0.0184, 1.1288]
-_MATPLOTLIB_SCALING_VALUES = [0.0224, 0.0456, 0.2858, 2.7432]
-_PLOTLY_SCALING_VALUES = [2.0231, 2.1100, 2.8086, 9.6433]
-
-_SCALING_CHART = xy.line_chart(
+_RENDER_TIME_CHART = xy.line_chart(
+    *_series(_XY_VALUES, "XY", XY_COLOR, 3),
+    *_series(_XY_EXACT_VALUES, "XY · density off", XY_EXACT_COLOR, 2.5),  # noqa: RUF001
+    *_series(_MATPLOTLIB_VALUES, "Matplotlib WebAgg", MATPLOTLIB_COLOR, 2),
+    *_series(_PLOTLY_VALUES, "Plotly scattergl", PLOTLY_COLOR, 2),
     xy.line(
-        _SIZE_LABELS,
-        _XY_SCALING_VALUES,
-        name="XY",
-        color=XY_COLOR,
-        width=2.5,
-    ),
-    xy.line(
-        _SIZE_LABELS[:4],
-        _MATPLOTLIB_SCALING_VALUES,
-        name="Matplotlib",
-        color=MATPLOTLIB_COLOR,
-        width=2,
-    ),
-    xy.line(
-        _SIZE_LABELS[:4],
-        _PLOTLY_SCALING_VALUES,
-        name="Plotly",
-        color=PLOTLY_COLOR,
-        width=2,
-    ),
-    *(
-        xy.marker(
-            size,
-            value,
-            text=label,
-            size=9,
-            dx=0,
-            dy=-11,
-            anchor="middle",
-            color=XY_COLOR,
-        )
-        for size, value, label in zip(
-            _SIZE_LABELS,
-            _XY_SCALING_VALUES,
-            ["3.6 ms", "6.0 ms", "5.8 ms", "18.4 ms", "1.129 s"],
-            strict=True,
-        )
-    ),
-    *(
-        xy.marker(
-            size,
-            value,
-            text=label,
-            size=9,
-            dx=0,
-            dy=-27,
-            anchor="middle",
-            color=MATPLOTLIB_COLOR,
-        )
-        for size, value, label in zip(
-            _SIZE_LABELS[:4],
-            _MATPLOTLIB_SCALING_VALUES,
-            ["22.4 ms", "45.6 ms", "0.286 s", "2.743 s"],
-            strict=True,
-        )
-    ),
-    *(
-        xy.marker(
-            size,
-            value,
-            text=label,
-            size=9,
-            dx=0,
-            dy=16 if size == "10M" else -11,
-            anchor="middle",
-            color=PLOTLY_COLOR,
-        )
-        for size, value, label in zip(
-            _SIZE_LABELS[:4],
-            _PLOTLY_SCALING_VALUES,
-            ["2.023 s", "2.110 s", "2.809 s", "9.643 s"],
-            strict=True,
-        )
-    ),
-    xy.vline(
-        "1M",
-        text="Density threshold",
-        color=XY_COLOR,
-        opacity=0.28,
+        [_SIZES[7], _SIZES[8]],
+        [_PLOTLY_VALUES[-1], _PLOTLY_VALUES[-1]],
+        color=FAILURE_COLOR,
         width=1.5,
+        dash="dashed",
+        opacity=0.6,
+    ),
+    xy.marker(
+        _SIZES[8],
+        _PLOTLY_VALUES[-1],
+        size=10,
+        symbol="cross",
+        color=FAILURE_COLOR,
     ),
     xy.text(
-        "1B",
-        9.6,
-        "× Plotly · failed",  # noqa: RUF001
-        dx=-4,
-        anchor="end",
-        color=PLOTLY_COLOR,
+        _SIZES[8],
+        _PLOTLY_VALUES[-1],
+        "fails at 50M",
+        dx=12,
+        dy=4,
+        anchor="start",
+        color=FAILURE_COLOR,
+    ),
+    xy.line(
+        [_SIZES[8], _SIZES[9]],
+        [_MATPLOTLIB_VALUES[-1], _MATPLOTLIB_VALUES[-1]],
+        color=FAILURE_COLOR,
+        width=1.5,
+        dash="dashed",
+        opacity=0.6,
+    ),
+    xy.marker(
+        _SIZES[9],
+        _MATPLOTLIB_VALUES[-1],
+        size=10,
+        symbol="cross",
+        color=FAILURE_COLOR,
     ),
     xy.text(
-        "1B",
-        8.7,
-        "× Matplotlib · >36 GiB",  # noqa: RUF001
-        dx=-4,
-        anchor="end",
-        color=MATPLOTLIB_COLOR,
+        70_710_678,
+        _MATPLOTLIB_VALUES[-1],
+        "fails at 100M",
+        dy=18,
+        anchor="middle",
+        color=FAILURE_COLOR,
     ),
-    xy.tooltip(format={"y": ".4f s"}),
-    xy.legend(show=False),
-    xy.modebar(show=False),
-    xy.interaction_config(navigation=False),
-    xy.x_axis(tick_label_anchor="center"),
-    xy.y_axis(
-        label="Render time (seconds)",
-        label_position="center",
-        domain=(0, 10.5),
-        tick_values=[0, 2, 4, 6, 8, 10],
-        tick_labels=["0 s", "2 s", "4 s", "6 s", "8 s", "10 s"],
-        style={"grid_width": 1, "grid_opacity": 1},
-    ),
-    _theme(),
-    width="100%",
-    height=360,
-    padding=(18, 24, 44, 68),
-    class_name=_CHART_CLASS,
-)
-
-_MEMORY_CATEGORIES = ["XY", "Matplotlib", "Plotly / Kaleido"]
-_MEMORY_VALUES = [0.286, 0.831, 5.298]
-_MEMORY_CHART = xy.bar_chart(
-    *(
-        xy.bar(
-            [category],
-            [value],
-            name=category,
-            orientation="horizontal",
-            color=color,
-            opacity=1,
-            corner_radius=6,
-        )
-        for category, value, color in zip(
-            _MEMORY_CATEGORIES,
-            _MEMORY_VALUES,
-            (XY_COLOR, MATPLOTLIB_COLOR, PLOTLY_COLOR),
-            strict=True,
-        )
-    ),
-    xy.text(0.42, "XY", "0.286", color="var(--benchmark-text, #60646c)"),
-    xy.text(0.98, "Matplotlib", "0.831", color="var(--benchmark-text, #60646c)"),
-    xy.text(
-        5.11,
-        "Plotly / Kaleido",
-        "5.298",
-        anchor="end",
-        color="var(--benchmark-text, #60646c)",
-    ),
-    xy.tooltip(format={"y": ".3f GiB"}),
+    xy.tooltip(format={"y": ".3f s"}),
     xy.legend(show=False),
     xy.modebar(show=False),
     xy.interaction_config(navigation=False),
     xy.x_axis(
-        label="Peak process-tree RSS (GiB)",
-        domain=(0, 6),
-        tick_values=[0, 2, 4, 6],
-        tick_labels=["0", "2", "4", "6 GiB"],
+        label="Points plotted",
+        type_="log",
+        domain=(8_000, 125_000_000),
+        tick_values=[10_000, 100_000, 1_000_000, 10_000_000, 100_000_000],
+        tick_labels=["10k", "100k", "1M", "10M", "100M"],
         style={"grid_width": 1, "grid_opacity": 1},
     ),
     xy.y_axis(
-        reverse=True,
-        style={"grid_opacity": 0, "axis_width": 0, "tick_width": 0},
+        label="Time until every point is on screen",
+        domain=(0, 14.6),
+        tick_values=[0, 2, 4, 6, 8, 10, 12, 14],
+        tick_labels=["0", "2", "4", "6", "8", "10", "12", "14 s"],
+        style={"grid_width": 1, "grid_opacity": 1},
     ),
     _theme(),
     width="100%",
-    height=260,
-    padding=(16, 22, 46, 110),
+    height=500,
+    padding=(24, 30, 58, 92),
     class_name=_CHART_CLASS,
 )
 
 
-def _panel(
-    title: str,
-    subtitle: str,
-    chart: xy.Chart,
-    *,
-    height: str,
-    show_legend: bool = False,
-) -> rx.Component:
-    """Wrap one XY chart in a titled responsive panel."""
+def interactive_ux_demo() -> rx.Component:
+    """Render the published 10k-to-100M interactive UX comparison."""
     return rx.el.section(
         rx.el.div(
             rx.el.div(
                 rx.el.h3(
-                    title,
-                    class_name="text-lg font-semibold tracking-[-0.01em] text-secondary-12",
+                    "Live interactive render time",
+                    class_name="text-xl font-semibold tracking-[-0.02em] text-secondary-12",
                 ),
                 rx.el.p(
-                    subtitle,
+                    "Correct and stable canvas · Apple M5 Pro · lower is better",  # noqa: RUF001
                     class_name="mt-1 text-sm font-medium text-secondary-10",
                 ),
-                class_name="min-w-0 flex-1",
+                class_name="min-w-0",
             ),
-            _legend() if show_legend else rx.fragment(),
-            class_name=(
-                "flex flex-col gap-3 px-5 pb-2 pt-5 sm:flex-row "
-                "sm:items-start sm:justify-between sm:px-6 sm:pt-6"
-            ),
+            _legend(),
+            class_name="flex flex-col gap-4 px-5 pt-5 sm:px-6 sm:pt-7",
         ),
         rx.el.div(
-            reflex_xy.chart(chart, height=height),
-            class_name="px-2 pb-2 sm:px-3 sm:pb-3",
+            reflex_xy.chart(_RENDER_TIME_CHART, height="500px"),
+            class_name="px-2 pb-2 sm:px-4 sm:pb-4",
         ),
-        class_name=_PANEL_CLASS,
+        class_name=_CARD_CLASS,
+        aria_label="Interactive render-time benchmark from 10,000 to 100 million points",
     )
 
 
-def scaling_and_memory_demo() -> rx.Component:
-    """Render coordinated live scaling-time and peak-memory charts."""
-    return rx.el.div(
-        _panel(
-            "Static render time by input size",
-            "Static 900×420 PNG · measured runs · × marks guarded failures",  # noqa: RUF001
-            _SCALING_CHART,
-            height="360px",
-            show_legend=True,
-        ),
-        _panel(
-            "10M static peak RSS",
-            "Static 900×420 PNG · complete process tree · GiB",  # noqa: RUF001
-            _MEMORY_CHART,
-            height="260px",
-        ),
-        class_name="grid w-full grid-cols-1 gap-5",
-        aria_label="Launch benchmark scaling time and peak memory",
-    )
-
-
-__all__ = ["launch_snapshot_demo", "scaling_and_memory_demo"]
+__all__ = ["interactive_ux_demo"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,22 +64,21 @@ kernels aggregate data before display, binary transport keeps numbers out of
 JSON, and the WebGL2 client bounds browser work by what the screen can show,
 while exact source data stays in Python for hover and selection.
 
-The numbers back this up. In the recorded 10-million-point launch benchmark, XY
-produced a static PNG in 0.018 s, while Matplotlib took 2.7 s and Plotly
-9.6 s. XY reached first interactive render 16–18× sooner, peaking at a
-third of Matplotlib's memory and under 6% of Plotly's.
+The numbers back this up. In the recorded live interactive sweep, XY reached a
+correct, stable canvas in 0.071 seconds at 10,000 points and 0.081 seconds at
+100 million. Matplotlib reached 13.4 seconds at 50 million points, while Plotly
+reached 9.8 seconds at 25 million.
 
 ~~~python demo-only exec
-from xy_docs.demos.benchmark_charts import launch_snapshot_demo
+from xy_docs.demos.benchmark_charts import interactive_ux_demo
 
-benchmark_launch_snapshot = launch_snapshot_demo
+benchmark_interactive_ux = interactive_ux_demo
 ~~~
 
-The benchmark also tested one billion points. At that size XY switches to a
-density view, a heatmap-like summary of where the points fall, and still
-delivered a working interactive chart in just over a second. The default
-Matplotlib and Plotly approach of drawing every single point did not finish
-within the run's memory and time limits.
+Above 200,000 rows, XY's default path switches to a density view while keeping
+exact source rows available for deeper zooms. With density disabled, the same
+engine still rendered 100 million individual markers in 1.34 seconds. The
+benchmark publishes both paths so the effect of aggregation stays visible.
 [Inspect the benchmark evidence](/docs/xy/overview/benchmarks/) or
 [browse the chart gallery](/docs/xy/overview/gallery/).
 

--- a/docs/overview/benchmarks.md
+++ b/docs/overview/benchmarks.md
@@ -1,163 +1,120 @@
 ---
 title: Benchmarks
-description: Inspect XY's recorded launch benchmark with its exact output contracts and caveats.
+description: Inspect XY's live interactive benchmark from 10,000 to 100 million points, including its output contract, memory use, and caveats.
 ---
 
 # Benchmarks
 
-XY's large-data architecture reduces source rows to the representation useful
-for a fixed-size output instead of drawing every row as an individual marker.
-The committed launch baseline measures identical seeded scatter data at
-900×420 pixels on an Apple M5 Pro with 64 GiB RAM. Each successful cell below
-is the mean of three isolated cold runs. The machine name and memory are copied
-verbatim from the committed environment record.
+This benchmark measures what a user waits for on a live interactive scatter
+chart. Every library receives every source row and runs through its own normal
+input path in a real browser. The sweep covers 10,000 to 100 million points on
+one Apple M5 Pro.
 
-The numbers on this page come from the 2026-07-26 rerun of that benchmark. It
-repeats the original 0.1.0 launch contracts on the same machine with the same
-pinned Plotly, Kaleido, Matplotlib, NumPy, and Python versions, so the intended
-variables are the XY revision and a Chrome patch bump. The 0.1.0 baseline stays
-committed and unchanged next to it.
-
-> **How to read this comparison.** XY switches dense scatter output to a
-> screen-bounded density representation, while the default Plotly and
-> Matplotlib paths retain every marker. These results compare each library's
-> default user-visible outcome at the same output size; the libraries send
-> different geometry to the renderer.
-
-## Snapshot at 10 million points
+The clock stops only when the canvas is both correct and stable. Correct means
+sentinel points planted at known coordinates are lit in the expected places.
+Stable means the full drawing buffer is byte-identical for 10 consecutive
+frames. Progressive renderers are therefore charged until their last chunk
+lands, not just until their first paint.
 
 ~~~python demo-only exec
-from xy_docs.demos.benchmark_charts import launch_snapshot_demo
+from xy_docs.demos.benchmark_charts import interactive_ux_demo
 
-benchmark_launch_snapshot = launch_snapshot_demo
+benchmark_interactive_ux = interactive_ux_demo
 ~~~
 
-| 900×420 output contract | XY | Matplotlib | Plotly | XY representation |
-| --- | ---: | ---: | ---: | --- |
-| Static CPU PNG | 0.0184 s | 2.7432 s | 9.6433 s | density |
-| Interactive first render, default GPU | 0.1875 s | 2.9842 s | 3.3729 s | density + sample |
-| Interactive first render, CPU fallback | 1.0352 s | 3.6121 s | 8.0888 s | density + sample |
+XY holds **0.071 seconds at 10k and 0.081 seconds at 100M**, nearly flat across
+four orders of magnitude. Above 200k rows, the default path draws a
+screen-bounded density surface and retains a sample for interaction instead of
+drawing one marker per row. Deep zooms request exact source rows.
 
-These summary tables show means only; the linked launch report publishes the
-sample standard deviation for every successful timing cell. Small reversals in
-adjacent means, such as 100k versus 1M on the static path, are within the
-observed three-run variation and should not be read as evidence that more rows
-are inherently faster.
+Every exact-marker path scales with the row count. Matplotlib crosses one
+second at about 3M and reaches 13.4 seconds at 50M. Plotly crosses one second
+at about 2.5M and reaches 9.8 seconds at 25M.
 
-The output contracts are intentionally separate. Static PNG rows compare
-validated CPU-rendered images. Interactive rows include figure construction,
-standalone HTML, a fresh browser, readiness, GPU completion, and a nonblank
-pixel check. Hardware-WebGL and SwiftShader results are never merged.
+## Time until every point is on screen
 
-## Time and memory across scale
+Times are seconds. `✕` marks a size that did not satisfy the full benchmark
+contract: Plotly never finished constructing the 50M figure, while Matplotlib
+drew 100M points but did not resolve the zoom that followed.
 
-The 10-million-point snapshot is one point on a larger curve. Static render
-time stays close to the output cost after XY switches to density, while the
-exact-marker paths continue to grow with the number of rows. Peak process-tree
-RSS tells the same practical story from a different angle.
+| Points | 10k | 100k | 500k | 1M | 2.5M | 5M | 10M | 25M | 50M | 100M |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| *XY speedup* | *1×* | *2×* | *3×* | *4×* | *9×* | *16×* | *34×* | *89×* | *177×* | *—* |
+| **XY** | **0.071** | **0.072** | **0.075** | **0.084** | **0.083** | **0.089** | **0.083** | **0.077** | **0.076** | **0.081** |
+| XY (`density=False`) | 0.085 | 0.074 | 0.087 | 0.098 | 0.111 | 0.144 | 0.206 | 0.424 | 0.645 | 1.343 |
+| Matplotlib (WebAgg) | 0.086 | 0.115 | 0.224 | 0.357 | 0.758 | 1.424 | 2.804 | 6.838 | 13.385 | ✕ |
+| Plotly (scattergl) | 0.341 | 0.373 | 0.477 | 0.614 | 1.033 | 1.785 | 3.367 | 9.794 | ✕ | ✕ |
 
-~~~python demo-only exec
-from xy_docs.demos.benchmark_charts import scaling_and_memory_demo
+The speedup row compares default XY with the next-fastest other library at each
+size. One run was recorded per cell. At the small end, timings carry roughly
+±10 ms of run-to-run spread.
 
-benchmark_scaling_and_memory = scaling_and_memory_demo
-~~~
+## Peak Python-side memory
 
-At 10 million points, the static CPU output contract recorded:
+Peak resident memory is reported in GiB. Browser memory is measured separately
+and excluded here because headless Chrome occupies about 1 GiB before it draws
+a chart.
 
-| Peak process-tree RSS | XY | Matplotlib | Plotly / Kaleido |
-| --- | ---: | ---: | ---: |
-| Static 900×420 PNG | 0.286 GiB | 0.831 GiB | 5.298 GiB |
+| Points | 10k | 100k | 500k | 1M | 2.5M | 5M | 10M | 25M | 50M | 100M |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| *XY advantage* | *1.8×* | *1.7×* | *1.9×* | *2.1×* | *2.1×* | *2.4×* | *2.6×* | *2.9×* | *2.8×* | *—* |
+| **XY** | **0.05** | **0.05** | **0.06** | **0.07** | **0.13** | **0.19** | **0.32** | **0.70** | **1.36** | **2.58** |
+| XY (`density=False`) | 0.05 | 0.05 | 0.07 | 0.10 | 0.18 | 0.31 | 0.57 | 1.35 | 2.66 | 5.26 |
+| Matplotlib (WebAgg) | 0.09 | 0.09 | 0.12 | 0.15 | 0.28 | 0.46 | 0.84 | 2.06 | 3.85 | ✕ |
+| Plotly (scattergl) | 0.21 | 0.18 | 0.28 | 0.36 | 0.60 | 1.05 | 1.86 | 4.70 | ✕ | ✕ |
 
-Plotly's static value includes the Kaleido and Chrome processes used by
-`to_image()`. RSS was sampled across each complete process tree every 50 ms, so
-very brief peaks may be missed. At one billion points, XY's successful static
-row peaked at 22.413 GiB; Matplotlib crossed the 36 GiB guardrail and Plotly did
-not produce a PNG on its first guarded attempt.
+The advantage row compares default XY with the next-lowest Python-side peak
+from another library. The exact-marker XY path reaches 100M in 1.343 seconds
+and 5.26 GiB, showing the engine's scaling without giving it aggregation
+credit.
 
-## What scales with rows—and what does not
+## Why the density path is a fair product comparison
 
-XY keeps exact source columns in Python. Ingest, range scans, binning, and line
-decimation still perform work that depends on the number of source rows. Once a
-large scatter has been reduced, however, the density grid and retained sample
-are bounded by the viewport rather than growing one marker per row. Long line
-output is similarly bounded after decimation.
+No benchmark arm receives pre-thinned input. Each library gets all rows, then
+uses its normal rendering strategy. XY's density arm proves that all rows were
+included with a count oracle, while Matplotlib, Plotly, and `density=False`
+draw one marker per row.
 
-That distinction is visible in the recorded sweep:
+That makes the default comparison an end-to-end product question: what does a
+user get from the ordinary API at this data size? The pale exact-marker XY
+series answers the separate like-for-like question of how the same engine
+scales when every row stays an individual marker.
 
-| Points | Native static PNG | Interactive, default GPU | XY representation |
-| ---: | ---: | ---: | --- |
-| 10k | 0.0036 s | 0.1643 s | direct |
-| 100k | 0.0060 s | 0.1680 s | direct |
-| 1M | 0.0058 s | 0.1762 s | density; density + sample interactive |
-| 10M | 0.0184 s | 0.1875 s | density; density + sample interactive |
-| 1B | 1.1288 s | 1.2419 s | density; density + sample interactive |
+## What this benchmark does and does not show
 
-At one billion points, XY ingested the rows and produced a validated density
-PNG and interactive density overview. It did **not** draw one billion markers.
-The exact-point Plotly and Matplotlib paths did not complete at that size within
-this run's 36 GiB process-tree and 180-second limits; those are local guarded
-outcomes, not universal limits.
-
-## What this benchmark does—and does not show
-
-| The recorded baseline shows | It does not establish |
+| The recorded sweep shows | It does not establish |
 | --- | --- |
-| Cold time to a validated, nonblank 900×420 output | Warm-service throughput after browser or Kaleido startup is amortized |
-| Peak process-tree RSS on one reference machine | GPU memory or performance on every platform |
-| Default large-scatter behavior for each library | Equivalent rendered geometry after XY enters density mode |
-| The effect of a screen-bounded representation at large sizes | Performance for every chart family, dashboard, or interaction |
+| Navigation to a correct, stable live scatter chart | Performance for every chart family or dashboard layout |
+| Default XY and exact-marker XY across the same row ladder | Equivalent rendered geometry after default XY enters density mode |
+| Whether the scripted zoom returns a final correct frame | Every interaction pattern or server deployment |
+| Python-side peak RSS on one Apple M5 Pro | Browser memory, GPU memory, or performance on every platform |
 
-The result is strongest as an end-to-end product comparison: what a user gets
-from the default API under a fixed output contract. A separate like-for-like
-representation study is still useful when the question is about the cost of
-aggregation itself.
-
-## Next benchmark coverage
-
-The repository already has harnesses for more than the launch scatter. Results
-will be published separately as their contracts and reference artifacts are
-frozen:
-
-- **Adaptive peers:** dense scatter against Datashader / HoloViews and long
-  lines against Plotly Resampler, kept separate from exact-marker baselines.
-- **Interaction and applications:** pan and zoom refinement, selection,
-  append/streaming updates, transport, and 10/20/50-chart dashboards.
-- **More chart families:** long lines and heatmaps, where decimation and
-  fixed-resolution aggregation exercise different kernels.
-- **Release and hardware tracking:** immutable release directories plus
-  clearly separated macOS hardware-WebGL and CI SwiftShader results.
-
-The launch scatter is the first committed proof point. The competitive
-benchmark program expands it across these workloads, chart families,
-competitors, and environments.
+The benchmark also records first paint, during-gesture frame timing, settle
+time, browser memory, screenshots, raw JSON, and a synchronized video for each
+size. Those measurements remain separate so a fast first frame cannot hide
+unfinished rendering or deferred work.
 
 ## Inspect and reproduce the evidence
 
-The baseline records its source commit (`7604775`), exact dependency lock,
-hardware, browser, raw samples, failure rows, and render oracles:
+The methodology and artifact contracts are documented in the repository:
 
-- [Launch report](https://github.com/reflex-dev/xy/blob/main/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/report.md)
-- [Environment](https://github.com/reflex-dev/xy/blob/main/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/environment.json)
-- [Raw default-path results](https://github.com/reflex-dev/xy/blob/main/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/default-results.json)
-- [Raw CPU-fallback results](https://github.com/reflex-dev/xy/blob/main/benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro/cpu-fallback-results.json)
-- [Original 0.1.0 launch baseline](https://github.com/reflex-dev/xy/blob/main/benchmarks/launch_baselines/xy-0.1.0/macos-arm64-m5-pro/report.md)
+- [README benchmark summary](https://github.com/reflex-dev/xy#benchmarks)
 - [Benchmark runbook](https://github.com/reflex-dev/xy/blob/main/benchmarks/README.md)
+- [Interactive UX harness](https://github.com/reflex-dev/xy/blob/main/benchmarks/bench_ux.py)
+- [Full ladder runner](https://github.com/reflex-dev/xy/blob/main/benchmarks/run_ux_suite.sh)
+- [Result summarizer](https://github.com/reflex-dev/xy/blob/main/benchmarks/summarize_ux.py)
+- [Competitive benchmark specification](https://github.com/reflex-dev/xy/blob/main/spec/benchmarks/results.md)
 
-After completing the runbook setup, reproduce the frozen default-path sweep
-from the source revision recorded in the environment file:
+After completing the runbook setup, run the same size ladder:
 
 ```bash
-BASELINE=benchmarks/launch_baselines/xy-main-2026-07-26/macos-arm64-m5-pro
-uv sync --project "$BASELINE" --frozen --python 3.14.5
-CHROME=$(node -e "console.log(require('playwright').chromium.executablePath())")
+export CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+./benchmarks/run_ux_suite.sh /path/to/xy-ux-suite
 
-uv run --project "$BASELINE" --frozen python benchmarks/bench_launch_scatter.py \
-  --sizes 10000,100000,1000000,10000000,1000000000 \
-  --repetitions 3 --timeout 180 --memory-gib 36 \
-  --chrome "$CHROME" --out launch-scatter-default.json
+.venv/bin/python benchmarks/summarize_ux.py /path/to/xy-ux-suite
+.venv/bin/python benchmarks/plot_ux.py /path/to/xy-ux-suite --out-dir charts
 ```
 
-Each new comparison records its chart type, data size, representation, backend,
-output target, and browser-TTFR status so the result can be reproduced and
-improved. For the rendering model behind the numbers, read
-[Large data and performance](/docs/xy/core-concepts/large-data-and-performance/).
+Keep results separated by environment. Hardware WebGL and SwiftShader rows are
+not interchangeable. For the rendering model behind XY's flat default curve,
+read [Large data and performance](/docs/xy/core-concepts/large-data-and-performance/).


### PR DESCRIPTION
## Summary

- replace the older launch/static benchmark documentation with the README's 10k–100M interactive UX results
- update the live benchmark chart, timing and Python-memory tables, methodology, caveats, and reproduction links
- refresh the homepage benchmark summary and its docs assertion

## Why

The README now publishes the interactive browser sweep, but the public docs still described the older launch PNG and first-render baseline. This brings the docs site back in sync with the current benchmark evidence and makes the density-versus-exact comparison explicit.

## Impact

Readers now see the current end-to-end interactive results, including failure points, memory measurements, measurement contracts, and environment caveats. The benchmark remains a live XY chart in the docs site.

## Validation

- `pytest tests -q` — 92 passed, 1 expected xfail
- Ruff check and format checks
- codespell
- repository pre-commit hooks
- production Reflex build
- sitemap, Markdown asset, and HTML route validators

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive rendering performance demo covering datasets from 10,000 to 100 million points.
  * Updated documentation with live interactive benchmark results, timing comparisons, memory usage, and reproducibility guidance.
  * Documented automatic switching to a density view for larger datasets while preserving exact-point inspection when zoomed in.

* **Documentation**
  * Replaced launch benchmark content with interactive UX benchmark guidance and updated charts.
  * Refined navigation and call-to-action presentation in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->