### PR TITLE
Fix GitHub code scanning alerts

### DIFF
--- a/.github/workflows/benchmark-refresh.yml
+++ b/.github/workflows/benchmark-refresh.yml
@@ -18,6 +18,10 @@ on:
         type: string
         default: "45"
 
+# Limit this manual benchmark workflow to repository reads.
+permissions:
+  contents: read
+
 jobs:
   cross-library:
     name: Cross-library benchmark (Ubuntu, native)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
       - "spec/**"
   workflow_dispatch:
 
+# Limit every job to the only repository permission needed by this workflow.
+permissions:
+  contents: read
+
 # Multiple sessions push to two branches in bursts; without this the runner
 # pool drowns in runs for superseded commits and fresh tips queue for ~30 min.
 # Only the newest run per ref carries signal — cancel the rest.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,11 @@ on:
         type: boolean
         default: true
 
+# Limit build jobs to repository reads. The publish job declares its separate
+# OIDC-only token permissions below.
+permissions:
+  contents: read
+
 jobs:
   # One wheel per platform (the C-ABI core is CPython-version-independent, so
   # each entry produces a single py3-none-<platform> wheel). Coverage matches

--- a/spec/process/production-readiness.md
+++ b/spec/process/production-readiness.md
@@ -72,6 +72,7 @@ These must pass before publishing.
 | Public API | `__all__`, lazy exports, `__version__`, the source `py.typed` marker, focused type-surface tests, and fresh-process import-time budget stay coherent | `make check-api` |
 | Import-time budget | `xy.__init__`, `dir(xy)`, export helpers, chart construction, and `.widget()` keep their lazy import boundaries | `make check-import` |
 | CI/release workflows | Hard gates, non-blocking benchmarks, best-effort benchmark artifact upload/download, trusted publishing, and no-Rust clear-error jobs stay wired | `make check-ci` |
+| GitHub Actions token scope | CI, release, and manual benchmark workflows declare an explicit least-privilege `GITHUB_TOKEN` default; privileged jobs use narrow job-level overrides | GitHub code scanning (`actions/missing-workflow-permissions`) |
 | HTML export safety | Inline JSON/script escaping, atomic path writes, hostile user strings, and browser client text-node insertion stay protected | `make check-security` |
 | Python tests | Native backend passes | `pytest -q` |
 | Python style | Library, tests, scripts, and benchmarks lint clean | `ruff check .` and `ruff format --check .` |

--- a/spec/process/security-audit-2026-07-06.md
+++ b/spec/process/security-audit-2026-07-06.md
@@ -136,6 +136,38 @@ Fix:
 - Added a narrow file-level `allow(dead_code)` with rationale on `src/simd.rs`.
 - Verified the exact CI clippy command now passes.
 
+### XY-CI-2026-02: Workflows inherited default GITHUB_TOKEN permissions
+
+Severity: medium CI hardening.
+
+GitHub CodeQL reported 13 jobs across `ci.yml`, `release.yml`, and
+`benchmark-refresh.yml` that did not set an explicit `GITHUB_TOKEN` permission
+ceiling. Their effective permissions therefore depended on repository or
+organization defaults instead of being reviewable in the workflow.
+
+Fix:
+
+- Added workflow-level `permissions: { contents: read }` defaults to all three
+  workflows.
+- Kept release jobs with privileged duties on explicit job-level permission
+  blocks, which replace the workflow default rather than inheriting extra
+  grants.
+
+### XY-SEC-2026-05: Workflow-test regex allowed exponential backtracking
+
+Severity: high scanner severity; practical exposure limited to a test fixture.
+
+A negative test removed one CI step with a nested, ambiguous regular
+expression. GitHub CodeQL showed that tab-only lines could be repartitioned
+across the repeated whitespace groups, causing exponential backtracking if the
+terminal lookahead failed.
+
+Fix:
+
+- Replaced the regex with deterministic string-boundary lookup and slicing.
+- Preserved the fixture's deliberate failure on workflow-shape drift and its
+  independence from the pinned `upload-artifact` commit SHA.
+
 ## Confirmed Controls
 
 - Standalone JSON uses `json.dumps(..., allow_nan=False)` and escapes `<`, `>`,

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -502,14 +502,12 @@ def test_ci_workflow_rejects_missing_kernel_benchmark_verification(tmp_path: Pat
 
 def test_ci_workflow_rejects_missing_regression_benchmark_upload(tmp_path: Path) -> None:
     workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
-    # Strip the whole "Upload regression benchmark report" step (name line through
-    # its trailing blank), independent of the pinned upload-artifact SHA.
-    broken = re.sub(
-        r" *- name: Upload regression benchmark report\n(?:[ \t]+.*\n|\n)*?(?=\S| *- |\Z)",
-        "",
-        workflow,
-        count=1,
-    )
+    # Strip the whole step up to its next sibling, independent of the pinned
+    # upload-artifact SHA. Explicit boundaries avoid regex backtracking on
+    # adversarially long workflow text.
+    step_start = workflow.index("      - name: Upload regression benchmark report\n")
+    next_step = workflow.index("\n      - ", step_start)
+    broken = workflow[:step_start] + workflow[next_step + 1 :]
     assert "regression-benchmark-report" not in broken
     path = tmp_path / "ci.yml"
     path.write_text(broken, encoding="utf-8")


### PR DESCRIPTION
## Summary

- cap the default `GITHUB_TOKEN` permissions at `contents: read` in the CI, release, and manual benchmark workflows
- replace the workflow-test regex flagged for exponential backtracking with deterministic string-boundary slicing
- record the new controls in the security audit and production-readiness specification

## Root cause

GitHub CodeQL reported 13 `actions/missing-workflow-permissions` alerts because jobs inherited repository or organization token defaults. It also reported one high-severity `py/redos` alert in a negative test whose nested, ambiguous whitespace groups could backtrack exponentially on adversarial input.

## Impact

This changes no product/runtime behavior. Workflow jobs now have an explicit least-privilege token default, while the release jobs' existing job-level permission overrides retain their prior effective permissions. The test fixture mutation remains behavior-equivalent and SHA-independent.

## Validation

- `pre-commit run --all-files`
- `ruff check .`
- `ruff format --check .`
- `python3 scripts/verify_ci_workflow.py`
- `pytest -q tests/test_verify_ci_workflow.py` — 56 passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened automated workflow permissions by applying least-privilege access controls.
  * Preserved narrowly scoped permissions for publishing and other privileged release operations.
  * Improved safeguards against unsafe workflow behavior and permission-related risks.

* **Documentation**
  * Updated release-readiness and security audit documentation to record the new controls and verification coverage.

* **Tests**
  * Made workflow validation more reliable when checking required benchmark reporting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->