### PR TITLE
Cap socket.io wire attachments in the reflex adapter

### DIFF
--- a/python/reflex-xy/reflex_xy/namespace.py
+++ b/python/reflex-xy/reflex_xy/namespace.py
@@ -58,6 +58,26 @@ XY_NAMESPACE = "/_xy"
 _MAX_PX_HINT = 8192
 _MIN_PX_HINT = 16
 
+# socket.io-parser's Decoder ships with `maxAttachments: 10`; a binary packet
+# with more attachments makes the BROWSER close the whole shared websocket as
+# a parse error — which the app plane then re-opens, re-subscribing every
+# chart into an infinite reconnect loop. Figures stay under the limit or fall
+# back to the joined single-blob payload (`buffer_layout` != "split", which
+# the client's `toSpans` already handles).
+_MAX_WIRE_ATTACHMENTS = 10
+
+
+def _build_wire_payload(
+    figure: "Figure", px: Optional[int] = None
+) -> tuple[dict[str, Any], list[Any]]:
+    """Split-buffer payload, unless it would exceed the attachment limit."""
+    spec, raw = figure.build_payload_split(px)
+    if len(raw) <= _MAX_WIRE_ATTACHMENTS:
+        return spec, list(raw)
+    spec, blob = figure.build_payload(px)
+    return spec, [blob]
+
+
 # An async callable(token) -> Figure | None: given a parseable figure token,
 # rebuild the figure from Reflex state (wired by app.setup; see state_bridge).
 RebuildHook = Callable[[str], Awaitable[Optional["Figure"]]]
@@ -132,7 +152,7 @@ class XYNamespace(AsyncNamespace):
         px = self._px_hint(data)
         await self.enter_room(sid, self._room(token))
         async with entry.lock:
-            spec, raw = await asyncio.to_thread(entry.figure.build_payload_split, px)
+            spec, raw = await asyncio.to_thread(_build_wire_payload, entry.figure, px)
         await self.emit(
             "payload",
             {
@@ -170,10 +190,19 @@ class XYNamespace(AsyncNamespace):
         if reply is None:
             return
         message, buffers = reply
+        wire_buffers = _buffer_bytes(buffers)
+        if len(wire_buffers) > _MAX_WIRE_ATTACHMENTS:
+            # Never exceed the browser parser's attachment limit: one oversized
+            # packet closes the shared websocket for the whole app. Channel
+            # replies are bounded by construction, so this is a contract check.
+            await self.emit(
+                "err", {"fig": token, "error": "reply exceeds wire attachment limit"}, to=sid
+            )
+            return
         envelope: dict[str, Any] = {
             "fig": token,
             "message": _plain(message),
-            "buffers": _buffer_bytes(buffers),
+            "buffers": wire_buffers,
         }
         # Replies are mount-addressed: several charts on one page share one
         # socket, so the client tags requests with a mount id and we echo it.
@@ -188,12 +217,23 @@ class XYNamespace(AsyncNamespace):
         self, token: str, message: dict[str, Any], buffers: Optional[list[bytes]] = None
     ) -> None:
         """Push one channel message to every subscriber of a figure."""
+        wire_buffers = _buffer_bytes(buffers)
+        if len(wire_buffers) > _MAX_WIRE_ATTACHMENTS:
+            # This packet goes to a room: one oversized push would close every
+            # subscriber's shared websocket at once (see _MAX_WIRE_ATTACHMENTS).
+            # A push is droppable, so fail loud instead of emitting it.
+            await self.emit(
+                "err",
+                {"fig": token, "error": "push exceeds wire attachment limit"},
+                room=self._room(token),
+            )
+            return
         await self.emit(
             "msg",
             {
                 "fig": token,
                 "message": _plain(message),
-                "buffers": _buffer_bytes(buffers),
+                "buffers": wire_buffers,
             },
             room=self._room(token),
         )
@@ -201,7 +241,7 @@ class XYNamespace(AsyncNamespace):
     async def broadcast_payload(self, token: str, entry: FigureEntry) -> None:
         """Push a full refreshed payload (figure rebuilt) to subscribers."""
         async with entry.lock:
-            spec, raw = await asyncio.to_thread(entry.figure.build_payload_split)
+            spec, raw = await asyncio.to_thread(_build_wire_payload, entry.figure)
         await self.emit(
             "payload",
             {

--- a/python/reflex-xy/reflex_xy/namespace.py
+++ b/python/reflex-xy/reflex_xy/namespace.py
@@ -73,7 +73,12 @@ def _build_wire_payload(
     """Split-buffer payload, unless it would exceed the attachment limit."""
     spec, raw = figure.build_payload_split(px)
     if len(raw) <= _MAX_WIRE_ATTACHMENTS:
-        return spec, list(raw)
+        return spec, raw
+    # Rebuild joined rather than concatenating `raw`: the split spec addresses
+    # columns by `buf` index and carries `buffer_layout: "split"`, which the
+    # client rejects for a one-buffer packet. Running the emitters twice is
+    # safe — they only assign shipped_sel/drill state, and the caller holds
+    # the figure lock across both builds.
     spec, blob = figure.build_payload(px)
     return spec, [blob]
 

--- a/spec/design/reflex-integration.md
+++ b/spec/design/reflex-integration.md
@@ -132,7 +132,8 @@ the reply path and the room-wide push path (`broadcast_message`, the
 `reflex_xy.append` fan-out, where one oversized packet would close every
 subscriber's connection at once). Regression:
 `tests/reflex_adapter/test_socket_data_plane.py::`
-`test_sub_over_attachment_limit_ships_single_blob` and
+`test_sub_over_attachment_limit_ships_single_blob`,
+`::test_msg_reply_over_attachment_limit_answers_err_not_msg`, and
 `::test_broadcast_over_attachment_limit_answers_err_not_msg`.
 
 The envelope is below; the `m` payload it carries is specified field by field

--- a/spec/design/reflex-integration.md
+++ b/spec/design/reflex-integration.md
@@ -115,6 +115,26 @@ aligned, zero-copy into `Float32Array`s. No JSON numbers for data, no
 base64, no custom framing (§29 preserved; the socket.io protocol already
 length-prefixes attachments).
 
+**Attachment cap (hard browser limit).** socket.io-parser's `Decoder` ships
+with `maxAttachments: 10`; one binary packet with more attachments makes the
+browser throw `"too many attachments"`, which `Manager.ondata` converts into
+closing the *entire shared websocket* as a parse error — the app plane then
+reconnects, every chart re-`sub`s, the oversized payload is re-sent, and the
+connection loops forever with no console error. The namespace therefore never
+emits more than 10 attachments per packet (`_MAX_WIRE_ATTACHMENTS`):
+payloads whose split layout would exceed the cap fall back to the joined
+single-blob `build_payload()` form (no `buffer_layout: "split"` in the spec;
+the wrapper's `toSpans` already dispatches on that flag), trading the join
+copy for staying inside the parser's budget. `msg` replies are bounded by
+channel construction; the namespace enforces the same cap as a contract
+check and answers `err` instead of emitting an unparseable packet — on both
+the reply path and the room-wide push path (`broadcast_message`, the
+`reflex_xy.append` fan-out, where one oversized packet would close every
+subscriber's connection at once). Regression:
+`tests/reflex_adapter/test_socket_data_plane.py::`
+`test_sub_over_attachment_limit_ships_single_blob` and
+`::test_broadcast_over_attachment_limit_answers_err_not_msg`.
+
 The envelope is below; the `m` payload it carries is specified field by field
 in `spec/design/wire-protocol.md`.
 

--- a/tests/reflex_adapter/test_socket_data_plane.py
+++ b/tests/reflex_adapter/test_socket_data_plane.py
@@ -132,6 +132,59 @@ def test_sub_delivers_spec_and_binary_columns(_fresh_registry):
     run(main())
 
 
+def test_sub_over_attachment_limit_ships_single_blob(_fresh_registry):
+    """socket.io-parser's browser Decoder defaults to `maxAttachments: 10` and
+    closes the WHOLE shared websocket ("too many attachments" -> "parse
+    error") on any binary packet exceeding it — which then reconnect-loops
+    the app. Buffer-heavy figures must fall back to the joined single-blob
+    payload, which the wrapper's `toSpans` handles via `buffer_layout`."""
+
+    async def main():
+        xs = np.linspace(0.0, 1.0, 64)
+        figure = xy.scatter_chart(
+            *[xy.scatter(xs, xs * k, color=xs, size=xs) for k in (1.0, 2.0, 3.0)],
+            width=640,
+            height=400,
+        ).figure()
+        _, raw = figure.build_payload_split(640)
+        assert len(raw) > 10, "premise: this figure must exceed the parser cap"
+        token = registry.register(figure)
+        async with data_plane_server() as (url, _):
+            client = await connect_client(url)
+            collector = Collector(client)
+            await client.emit("sub", {"fig": token, "px": 640}, namespace="/_xy")
+            payload = await collector.next(collector.payloads)
+            await client.disconnect()
+        assert payload["fig"] == token
+        assert payload["spec"].get("buffer_layout") != "split"
+        assert len(payload["buffers"]) == 1
+
+    run(main())
+
+
+def test_broadcast_over_attachment_limit_answers_err_not_msg(_fresh_registry):
+    """`broadcast_message` (the `reflex_xy.append` push path) goes to a room:
+    one packet over the parser's attachment cap would close every subscriber's
+    shared websocket at once. Over the cap it must fail loud with an `err`
+    envelope, never emit the unparseable `msg`."""
+
+    async def main():
+        token = registry.register(make_figure(16))
+        async with data_plane_server() as (url, namespace):
+            client = await connect_client(url)
+            collector = Collector(client)
+            await client.emit("sub", {"fig": token, "px": 640}, namespace="/_xy")
+            await collector.next(collector.payloads)
+            await namespace.broadcast_message(token, {"kind": "append"}, [b"\x00" * 4] * 11)
+            error = await collector.next(collector.errors)
+            await client.disconnect()
+        assert error["fig"] == token
+        assert "attachment" in error["error"]
+        assert collector.messages.empty()
+
+    run(main())
+
+
 def test_msg_round_trip_pick_and_select(_fresh_registry):
     async def main():
         token = registry.register(make_figure(16))

--- a/tests/reflex_adapter/test_socket_data_plane.py
+++ b/tests/reflex_adapter/test_socket_data_plane.py
@@ -185,6 +185,38 @@ def test_broadcast_over_attachment_limit_answers_err_not_msg(_fresh_registry):
     run(main())
 
 
+def test_msg_reply_over_attachment_limit_answers_err_not_msg(_fresh_registry, monkeypatch):
+    """The `on_msg` reply guard: channel replies are bounded by construction,
+    so a reply over the parser's attachment cap is a contract violation — the
+    client must get an `err` envelope, never a `msg` whose packet the browser
+    parser would reject (closing the shared websocket)."""
+
+    from reflex_xy import namespace as namespace_module
+
+    def oversized_reply(figure, message, buffers):
+        return {"kind": "pick"}, [b"\x00" * 4] * 11
+
+    monkeypatch.setattr(namespace_module, "handle_message", oversized_reply)
+
+    async def main():
+        token = registry.register(make_figure(16))
+        async with data_plane_server() as (url, _):
+            client = await connect_client(url)
+            collector = Collector(client)
+            await client.emit("sub", {"fig": token, "px": 640}, namespace="/_xy")
+            await collector.next(collector.payloads)
+            await client.emit(
+                "msg", {"fig": token, "m": {"kind": "pick"}, "mid": "m1"}, namespace="/_xy"
+            )
+            error = await collector.next(collector.errors)
+            await client.disconnect()
+        assert error["fig"] == token
+        assert "attachment" in error["error"]
+        assert collector.messages.empty()
+
+    run(main())
+
+
 def test_msg_round_trip_pick_and_select(_fresh_registry):
     async def main():
         token = registry.register(make_figure(16))


### PR DESCRIPTION
## Problem

socket.io-parser's browser `Decoder` ships with `maxAttachments: 10`. One binary packet with more attachments makes the browser throw `"too many attachments"`, which `Manager.ondata` converts into closing the **entire shared websocket** as a parse error — the app plane then reconnects, every chart re-`sub`s, the oversized payload is re-sent, and the connection loops forever with no console error. Since chart data and Reflex app state share one physical connection, one buffer-heavy figure takes down the whole app.

First in-tree reproduction: a `xy.wind_rose` behind an `inline()` token — 4 stacked speed-band traces, an 11-buffer split payload — put the showcase app into a permanent reconnect loop ("Connection Error" toast, 79 reconnects observed, §6 drilldown never loaded).

## Fix

The namespace never emits more than 10 attachments per packet (`_MAX_WIRE_ATTACHMENTS`):

- **`sub` replies and `broadcast_payload`** route through one `_build_wire_payload` choke point: payloads whose split layout would exceed the cap fall back to the joined single-blob `build_payload()` form (no `buffer_layout: "split"`), which the client's `toSpans` already dispatches on — one join copy traded for staying inside the parser's budget, no new protocol surface.
- **`msg` replies** over the cap answer `err` instead of emitting an unparseable packet. Channel replies are bounded by construction, so this is a contract check.
- **`broadcast_message`** — the `reflex_xy.append` room-wide push, where a single oversized packet would close *every subscriber's* connection at once — gets the same guard. Closes #385.

The payload fallback and the `msg`-reply guard were originally written on the unmerged `flights-live-showcase` branch (a075bb7e); this PR extracts that adapter fix on its own, extends it to the push path, and lands the spec + tests with it.

## Spec & tests

- `spec/design/reflex-integration.md` § Wire shape gains the "Attachment cap (hard browser limit)" contract, naming all three guarded paths.
- `tests/reflex_adapter/test_socket_data_plane.py`:
  - `test_sub_over_attachment_limit_ships_single_blob` — an 11-buffer figure subscribes over a real websocket and arrives as one blob without the split layout;
  - `test_broadcast_over_attachment_limit_answers_err_not_msg` — an 11-buffer push reaches subscribers as an `err` envelope, never as `msg`;
  - `test_msg_reply_over_attachment_limit_answers_err_not_msg` — an oversized `on_msg` reply (forced via a patched `handle_message`) answers `err`, never `msg`.

All 13 data-plane tests pass; `pre-commit run --all-files`, `ruff check`, and `ruff format --check` are clean.

Verified end-to-end against the reflex showcase app: with the cap in place the wind rose renders (single-blob payload), the websocket holds one stable connection, and the reconnect loop is gone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a safety cap to prevent oversized websocket data-plane packets from disrupting connections.
  * Automatically falls back to a single-blob payload when split data exceeds the attachment limit.
  * Returns bounded `err` responses for oversized message replies and drops oversized room broadcasts/pushes instead of sending invalid payloads.
* **Documentation**
  * Expanded guidance on attachment limit behavior, reconnect/re-subscribe impact, fallback strategy, and `err` handling.
* **Tests**
  * Added end-to-end coverage for oversized `on_msg` reply handling (verifies `err` and no `msg`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
