### PR TITLE
Fix stable Rust chunk lint

### DIFF
--- a/src/kernels.rs
+++ b/src/kernels.rs
@@ -1898,7 +1898,7 @@ pub fn triangle_edges_into(
     }
     let mut seen = std::collections::HashSet::with_capacity(capacity);
     let mut written = 0;
-    for face in triangles.chunks_exact(3) {
+    for face in triangles.as_chunks::<3>().0 {
         if face
             .iter()
             .any(|index| *index < 0 || *index as usize >= x.len())
@@ -2194,7 +2194,7 @@ pub fn marching_triangles_into(
         && out_y1.is_empty()
         && out_levels.is_empty();
     let mut written = 0;
-    for face in triangles.chunks_exact(3) {
+    for face in triangles.as_chunks::<3>().0 {
         if face
             .iter()
             .any(|index| *index < 0 || *index as usize >= x.len())
@@ -3629,7 +3629,7 @@ pub fn bin_2d_mean_color(
         BinColorSource::Rgba(rgba) => assert_eq!(rgba.len(), x.len() * 4),
     }
     let grid = bin_2d_mean_color_cells(x, y, colors, x0, x1, y0, y1, w, h);
-    for (cell, quad) in grid.iter().zip(out.chunks_exact_mut(4)) {
+    for (cell, quad) in grid.iter().zip(out.as_chunks_mut::<4>().0.iter_mut()) {
         quad.copy_from_slice(&cell.rgba8());
     }
 }

--- a/src/raster.rs
+++ b/src/raster.rs
@@ -2612,7 +2612,9 @@ fn rasterize_with_spans<'a>(
                     let stop_count = r.u32()? as usize;
                     let stop_bytes = r.bytes(stop_count.checked_mul(3)?)?;
                     let stops: Vec<[u8; 3]> = stop_bytes
-                        .chunks_exact(3)
+                        .as_chunks::<3>()
+                        .0
+                        .iter()
                         .map(|stop| [stop[0], stop[1], stop[2]])
                         .collect();
                     let encoded_len = iw.checked_mul(ih)?;
@@ -2645,7 +2647,9 @@ fn rasterize_with_spans<'a>(
                     }
                     let stop_bytes = r.bytes(stop_count.checked_mul(3)?)?;
                     let stops: Vec<[u8; 3]> = stop_bytes
-                        .chunks_exact(3)
+                        .as_chunks::<3>()
+                        .0
+                        .iter()
                         .map(|stop| [stop[0], stop[1], stop[2]])
                         .collect();
                     let width = if encoding == 1 { 8 } else { 4 };
@@ -2865,7 +2869,9 @@ fn rasterize_with_spans<'a>(
                         }
                         let bytes = r.bytes(count.checked_mul(3)?)?;
                         palette = bytes
-                            .chunks_exact(3)
+                            .as_chunks::<3>()
+                            .0
+                            .iter()
                             .map(|entry| [entry[0], entry[1], entry[2]])
                             .collect();
                     }
@@ -3820,7 +3826,7 @@ mod tests {
     fn banded_image_blit_matches_serial() {
         let (iw, ih) = (37usize, 23usize);
         let mut src = vec![0u8; iw * ih * 4];
-        for (i, pixel) in src.chunks_exact_mut(4).enumerate() {
+        for (i, pixel) in src.as_chunks_mut::<4>().0.iter_mut().enumerate() {
             pixel.copy_from_slice(&[
                 (i * 37 % 256) as u8,
                 (i * 101 % 256) as u8,

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -218,7 +218,7 @@ pub fn append(p: &mut Pyramid, x: &[f64], y: &[f64]) -> bool {
 
 /// 4→1 exact reduction of one square level: each output cell is the u64 sum
 /// of its 2×2 source block, saturating to u32 (§5 — every level conserves the
-/// total exactly, up to saturation). Row slices + `chunks_exact(2)` keep the
+/// total exactly, up to saturation). Row slices + `as_chunks::<2>()` keep the
 /// inner loop free of bounds checks so it autovectorizes.
 fn reduce_level(prev: &[u32], dim: usize) -> Vec<u32> {
     let next = dim / 2;
@@ -228,8 +228,8 @@ fn reduce_level(prev: &[u32], dim: usize) -> Vec<u32> {
         let bot = &prev[(2 * cy + 1) * dim..(2 * cy + 1) * dim + dim];
         for ((o, t), b) in out_row
             .iter_mut()
-            .zip(top.chunks_exact(2))
-            .zip(bot.chunks_exact(2))
+            .zip(top.as_chunks::<2>().0.iter())
+            .zip(bot.as_chunks::<2>().0.iter())
         {
             let a = t[0] as u64 + t[1] as u64 + b[0] as u64 + b[1] as u64;
             *o = a.min(u32::MAX as u64) as u32;
@@ -631,7 +631,7 @@ pub fn compose_color(
                 continue;
             }
             let base = cy as usize * dim;
-            for (ox, quad) in quad_row.chunks_exact_mut(4).enumerate() {
+            for (ox, quad) in quad_row.as_chunks_mut::<4>().0.iter_mut().enumerate() {
                 let xdata = lo_x + (ox as f64 + 0.5) / sx;
                 let cx = ((xdata - p.x0) * inv_cell_x) as isize;
                 if cx < 0 || cx as usize >= dim {
@@ -701,7 +701,7 @@ pub fn compose_color(
             }
         }
     }
-    for (bin, quad) in out_rgba.chunks_exact_mut(4).enumerate() {
+    for (bin, quad) in out_rgba.as_chunks_mut::<4>().0.iter_mut().enumerate() {
         let weight = weight_sum[bin];
         if !(count_sum[bin] > 0.0 && weight > 0.0) {
             continue;


### PR DESCRIPTION
## What changed

- Replaced fixed-width `chunks_exact` / `chunks_exact_mut` loops with `as_chunks` / `as_chunks_mut` in the Rust kernels, raster, and tile paths.
- Preserved each call site's remainder handling and tuple width.

## Why

Rust 1.96.1 enables `clippy::chunks_exact_to_as_chunks`, and the repository promotes warnings to errors. The floating stable CI toolchain therefore rejected the existing loops even though their behavior was correct.

## Impact

The required stable-Rust Clippy gate passes again without changing the data-path semantics.

## Validation

- `cargo clippy --all-targets -- -D warnings`
- `cargo test` — 137 passed

Fixes #392

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

