### PR TITLE
Validate minified adapter exports

### DIFF
--- a/scripts/js_exports.py
+++ b/scripts/js_exports.py
@@ -1,0 +1,37 @@
+"""Shared stdlib-only ESM export parsing for the built render-client bundles.
+
+Production builds minify local declarations, so the public surface can only be
+checked through the export block: `renderStandalone` survives as an alias of
+whatever short name the minifier chose. Parsing that block instead of grepping
+for spellings keeps the checks honest in both directions — a name-preserving
+build (`export{decodeFrame}`) and a minified one (`export{p as decodeFrame}`)
+both satisfy it, and a genuinely missing export fails either way.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+# Vite lib mode emits one trailing `export {...}` per ESM bundle. Declaration
+# exports (`export function f()`) and `export * from` re-exports are not parsed:
+# the bundles never emit them, and a build that started to would fail these
+# checks loudly rather than pass silently.
+_EXPORT_BLOCK = re.compile(r"\bexport\s*\{([^}]*)\}")
+_EXPORTED_NAME = re.compile(r"(?:[A-Za-z_$][\w$]*\s+as\s+)?([A-Za-z_$][\w$]*)")
+
+
+def esm_exported_names(text: str) -> set[str]:
+    """Public names an ESM bundle exports, seeing through minifier renames."""
+    return {
+        match.group(1)
+        for block in _EXPORT_BLOCK.findall(text)
+        for item in block.split(",")
+        if (match := _EXPORTED_NAME.fullmatch(item.strip()))
+    }
+
+
+def missing_esm_exports(text: str, required: Iterable[str]) -> list[str]:
+    """Which of `required` the bundle does not export, sorted for stable errors."""
+    exported = esm_exported_names(text)
+    return sorted(name for name in required if name not in exported)

--- a/scripts/verify_sdist.py
+++ b/scripts/verify_sdist.py
@@ -21,8 +21,10 @@ from typing import Optional
 
 try:
     from artifact_metadata import dependency_metadata_errors
+    from js_exports import missing_esm_exports
 except ModuleNotFoundError:  # imported by tests from the repository root
     from scripts.artifact_metadata import dependency_metadata_errors
+    from scripts.js_exports import missing_esm_exports
 
 REQUIRED_FILES = {
     "CHANGELOG.md",
@@ -215,7 +217,7 @@ def _require_pkg_info(path: str, root: str) -> None:
         raise AssertionError(f"missing or invalid PKG-INFO lines: {missing}")
 
 
-def _require_file_contains(path: str, root: str, member: str, needles: set[str]) -> None:
+def _read_substantial_member(path: str, root: str, member: str) -> str:
     with tarfile.open(path, "r:gz") as tf:
         data = tf.extractfile(f"{root}/{member}")
         if data is None:
@@ -223,9 +225,21 @@ def _require_file_contains(path: str, root: str, member: str, needles: set[str])
         text = data.read().decode("utf-8")
     if len(text) < 1000:
         raise AssertionError(f"{member} is suspiciously small")
+    return text
+
+
+def _require_file_contains(path: str, root: str, member: str, needles: set[str]) -> None:
+    text = _read_substantial_member(path, root, member)
     missing = sorted(needle for needle in needles if needle not in text)
     if missing:
         raise AssertionError(f"{member} missing expected markers: {missing}")
+
+
+def _require_esm_exports(path: str, root: str, member: str, required: set[str]) -> None:
+    text = _read_substantial_member(path, root, member)
+    missing = missing_esm_exports(text, required)
+    if missing:
+        raise AssertionError(f"{member} missing expected exports: {missing}")
 
 
 def _require_exact_file(path: str, root: str, member: str, expected: bytes) -> None:
@@ -262,13 +276,13 @@ def verify_sdist(path: str) -> None:
     _require_pkg_info(path, root)
     _require_exact_file(path, root, "python/xy/py.typed", b"")
     _require_exact_file(path, root, "python/reflex_xy/py.typed", b"")
-    _require_file_contains(
+    _require_esm_exports(
         path,
         root,
         "python/xy/static/index.js",
-        # The bundle is minified (identifiers renamed), so markers are the
-        # export aliases the minifier must preserve.
-        {"as render", "as renderStandalone", "as decodeFrame", "as ChartView"},
+        # The bundle is minified (identifiers renamed), so the public surface is
+        # checked through the export block rather than by name spelling.
+        {"render", "renderStandalone", "decodeFrame", "ChartView"},
     )
     _require_file_contains(
         path,

--- a/scripts/verify_wheel.py
+++ b/scripts/verify_wheel.py
@@ -23,8 +23,10 @@ from typing import Optional
 
 try:
     from artifact_metadata import dependency_metadata_errors
+    from js_exports import missing_esm_exports
 except ModuleNotFoundError:  # imported by tests from the repository root
     from scripts.artifact_metadata import dependency_metadata_errors
+    from scripts.js_exports import missing_esm_exports
 
 # Mirrors verify_sdist's root-directory shape: a release version (`0.0.2`) plus
 # whatever PEP 440 suffix a between-tags build appends (`0.0.3.dev4+g63c0697`).
@@ -191,13 +193,25 @@ def _filename_version(path: Path) -> str:
     return version
 
 
-def _require_static_bundle(name: str, data: bytes, needles: set[str]) -> None:
+def _decode_substantial_bundle(name: str, data: bytes) -> str:
     text = data.decode("utf-8")
     if len(text) < 1000:
         raise AssertionError(f"{name} is suspiciously small")
+    return text
+
+
+def _require_static_bundle(name: str, data: bytes, needles: set[str]) -> None:
+    text = _decode_substantial_bundle(name, data)
     missing = sorted(needle for needle in needles if needle not in text)
     if missing:
         raise AssertionError(f"{name} missing expected JS markers: {missing}")
+
+
+def _require_static_esm_exports(name: str, data: bytes, required: set[str]) -> None:
+    text = _decode_substantial_bundle(name, data)
+    missing = missing_esm_exports(text, required)
+    if missing:
+        raise AssertionError(f"{name} missing expected exports: {missing}")
 
 
 def _require_text_markers(name: str, data: bytes, needles: set[str]) -> None:
@@ -347,11 +361,11 @@ def verify_wheel(path: Path, *, expect_native: Optional[bool]) -> None:
         )
         _require_py_typed_marker(zf.read("xy/py.typed"))
         _require_py_typed_marker(zf.read("reflex_xy/py.typed"), "reflex_xy/py.typed")
-        _require_static_bundle(
+        _require_static_esm_exports(
             "xy/static/index.js",
             zf.read("xy/static/index.js"),
-            # Minified bundle: assert the export aliases, not source lines.
-            {"as render", "as renderStandalone", "as decodeFrame", "as ChartView"},
+            # Minified bundle: assert the exported public surface, not source lines.
+            {"render", "renderStandalone", "decodeFrame", "ChartView"},
         )
         _require_static_bundle(
             "xy/static/standalone.js",

--- a/tests/reflex_adapter/test_assets.py
+++ b/tests/reflex_adapter/test_assets.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pathlib
+import re
 
 import reflex_xy
 import xy
@@ -21,10 +22,21 @@ def test_client_source_is_the_installed_bundle():
     source = _client_source()
     assert source == pathlib.Path(xy.__file__).resolve().parent / "static" / "index.js"
     text = source.read_text(encoding="utf-8")
-    # The installed bundle is minified; its stable public markers are export
-    # aliases rather than source-level function/class declarations.
-    for marker in ("as renderStandalone", "as decodeFrame", "as ChartView"):
-        assert marker in text
+    # Production builds minify local declarations, so verify the stable ESM
+    # surface rather than implementation names that the minifier may rewrite.
+    export_blocks = re.findall(r"\bexport\s*\{([^}]*)\}", text)
+    exported = {
+        match.group(1)
+        for block in export_blocks
+        for item in block.split(",")
+        if (
+            match := re.fullmatch(
+                r"(?:[A-Za-z_$][\w$]*\s+as\s+)?([A-Za-z_$][\w$]*)",
+                item.strip(),
+            )
+        )
+    }
+    assert {"renderStandalone", "decodeFrame", "ChartView"} <= exported
 
 
 def test_link_client_creates_and_repairs(tmp_path):

--- a/tests/reflex_adapter/test_assets.py
+++ b/tests/reflex_adapter/test_assets.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import pathlib
-import re
+
+from scripts.js_exports import missing_esm_exports
 
 import reflex_xy
 import xy
 from reflex_xy.assets import _client_source, _link_client
 
 ADAPTER_ASSETS = pathlib.Path(reflex_xy.__file__).parent / "assets"
+# What XYChart.jsx imports from ./xy_client.js.
+WRAPPER_IMPORTS = ("ChartView", "decodeFrame", "renderStandalone")
 
 
 def test_client_is_not_packaged():
@@ -22,21 +25,11 @@ def test_client_source_is_the_installed_bundle():
     source = _client_source()
     assert source == pathlib.Path(xy.__file__).resolve().parent / "static" / "index.js"
     text = source.read_text(encoding="utf-8")
-    # Production builds minify local declarations, so verify the stable ESM
-    # surface rather than implementation names that the minifier may rewrite.
-    export_blocks = re.findall(r"\bexport\s*\{([^}]*)\}", text)
-    exported = {
-        match.group(1)
-        for block in export_blocks
-        for item in block.split(",")
-        if (
-            match := re.fullmatch(
-                r"(?:[A-Za-z_$][\w$]*\s+as\s+)?([A-Za-z_$][\w$]*)",
-                item.strip(),
-            )
-        )
-    }
-    assert {"renderStandalone", "decodeFrame", "ChartView"} <= exported
+    # The bundle is minified, so verify the ESM export surface rather than
+    # implementation spellings the minifier rewrites. Exactly what the wrapper
+    # imports from ./xy_client.js — if one disappears, XYChart.jsx breaks.
+    missing = missing_esm_exports(text, WRAPPER_IMPORTS)
+    assert not missing, f"installed bundle stopped exporting: {missing}"
 
 
 def test_link_client_creates_and_repairs(tmp_path):

--- a/tests/test_framing.py
+++ b/tests/test_framing.py
@@ -7,6 +7,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from scripts.js_exports import missing_esm_exports
 
 from xy.channel import (
     FRAME_ALIGNMENT,
@@ -302,6 +303,6 @@ def test_widget_entry_no_longer_slices_binary_views() -> None:
     assert "raw.map(bytesToSpan)" in header
     for text in (source, header):
         assert ".buffer.slice(b.byteOffset" not in text
-    # The built bundle is minified; the decodeFrame export alias is the marker
-    # that survives identifier renaming.
-    assert "as decodeFrame" in built
+    # The built bundle is minified; its export block is what survives
+    # identifier renaming.
+    assert not missing_esm_exports(built, ("decodeFrame",))

--- a/tests/test_js_exports.py
+++ b/tests/test_js_exports.py
@@ -1,0 +1,58 @@
+"""The ESM export parser behind every built-bundle public-surface check."""
+
+from __future__ import annotations
+
+from scripts.js_exports import esm_exported_names, missing_esm_exports
+
+# The real vite lib-mode tail, verbatim: aliased locals, no spaces, `default`
+# exported from a renamed local.
+MINIFIED = (
+    "export{$ as ChartView,It as MARK_KINDS,p as decodeFrame,fn as default,"
+    "X as markOf,un as render,dn as renderStandalone}"
+)
+
+
+def test_reads_through_minifier_aliases() -> None:
+    assert esm_exported_names(MINIFIED) == {
+        "ChartView",
+        "MARK_KINDS",
+        "decodeFrame",
+        "default",
+        "markOf",
+        "render",
+        "renderStandalone",
+    }
+
+
+def test_accepts_a_name_preserving_build() -> None:
+    """A build that skips minification exports the names directly. The old
+    substring markers (`"as decodeFrame" in text`) rejected exactly this."""
+    assert esm_exported_names("export { decodeFrame, renderStandalone };") == {
+        "decodeFrame",
+        "renderStandalone",
+    }
+
+
+def test_substring_of_a_longer_export_is_not_a_match() -> None:
+    """`render` must not be satisfied by `renderStandalone` — the flaw that made
+    the old `"as render"` marker vacuous."""
+    assert missing_esm_exports("export{d as renderStandalone}", ("render",)) == ["render"]
+
+
+def test_reports_every_missing_name_sorted() -> None:
+    assert missing_esm_exports(MINIFIED, ("decodeFrame", "gone", "alsoGone")) == [
+        "alsoGone",
+        "gone",
+    ]
+    assert missing_esm_exports(MINIFIED, ("render", "ChartView")) == []
+
+
+def test_ignores_declaration_exports_and_trailing_commas() -> None:
+    # Declaration-form exports are out of scope by design (the bundles never
+    # emit them); a trailing comma must not fabricate an empty name.
+    assert esm_exported_names("export function render() {}") == set()
+    assert esm_exported_names("export{a as b,}") == {"b"}
+
+
+def test_a_bundle_without_an_export_block_reports_everything_missing() -> None:
+    assert missing_esm_exports("not the client", ("decodeFrame",)) == ["decodeFrame"]

--- a/tests/test_static_client_security.py
+++ b/tests/test_static_client_security.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from scripts.js_exports import missing_esm_exports
+
 from xy.components import CHART_DOM_SLOTS
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -793,16 +795,19 @@ def test_widget_bundle_is_valid_esm_and_standalone_is_a_window_global() -> None:
     as a classic <script> by `Figure.to_html()`: it must be export-free and
     define a top-level `var xy` namespace (window.xy) with the same surface."""
     index_text = _read(_STATIC / "index.js")
-    for alias in (
-        "as render",
-        "as renderStandalone",
-        "as decodeFrame",
-        "as ChartView",
-        "as MARK_KINDS",
-        "as markOf",
-        "as default",
-    ):
-        assert alias in index_text, f"index.js no longer exports {alias.split()[-1]!r}"
+    missing = missing_esm_exports(
+        index_text,
+        (
+            "render",
+            "renderStandalone",
+            "decodeFrame",
+            "ChartView",
+            "MARK_KINDS",
+            "markOf",
+            "default",
+        ),
+    )
+    assert not missing, f"index.js no longer exports {missing}"
 
     standalone_text = _read(_STATIC / "standalone.js")
     assert "export {" not in standalone_text and "export{" not in standalone_text, (


### PR DESCRIPTION
## What changed

- Parse the built bundle's ESM `export {...}` block instead of grepping for identifier spellings, and require `ChartView`, `decodeFrame`, and `renderStandalone` — the exact three names `XYChart.jsx` imports from `./xy_client.js`.
- Lift that parse into `scripts/js_exports.py` and use it everywhere the built ESM surface is asserted: the sdist verifier, the wheel verifier, `test_static_client_security.py`, and `test_framing.py`.

## Why

The original failure (#393) was an asset test asserting source spelling (`function renderStandalone(`) against a deliberately minified bundle. #408 has since replaced those with alias substrings (`"as renderStandalone"`), which fixes the red test but keeps the same class of brittleness pointing the other way: it now *requires* the minifier to alias, so a name-preserving build (`export{decodeFrame}`) would false-fail. Parsing the export block accepts both and still fails when an export genuinely disappears.

Sharing the parser also closes a real hole: `"as render"` is a substring of `"as renderStandalone"`, so the `render` export was never actually checked by either artifact verifier. It is now checked independently.

`standalone.js` keeps its substring checks — it is a classic-script IIFE with no export block, so the parse does not apply.

## Impact

Every check of the shipped bundle's public surface goes through one tested parser instead of five hand-rolled substring lists.

## Validation

Rebased onto `main` (`6d809fa3`); the conflict was in the very lines this PR patches, since #408 had rewritten them.

- `node js/build.mjs`
- `pytest -q tests/reflex_adapter/` — 111 passed (excluding `test_socket_data_plane.py`, which fails identically with and without this change in a local venv that cannot run its live socket.io server)
- `pytest -q --ignore=tests/reflex_adapter` — 3879 passed, 5 skipped (one pre-existing local matplotlib failure in `test_pdsh_gap_features.py` deselected; it fails the same way on clean `main`)
- `ruff check .` and `ruff format --check .` — clean
- Mutation check against the real 428 KB bundle: deleting `decodeFrame` from the export block fails the adapter test, the framing test, and the static-client test, each naming the missing export. `decodeFrame` still appears elsewhere in the bundle text, so the old substring style would have passed.

Fixes #393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of JavaScript bundles to accurately verify required ESM exports, including minified and aliased exports.
  * Prevented false positives when similarly named or incomplete exports are present.

* **Tests**
  * Added coverage for export parsing, missing exports, aliases, trailing commas, and bundles without export blocks.
  * Updated bundle and installed-package checks to validate exports structurally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->