### PR TITLE
Use CDP for standalone render smoke

### DIFF
--- a/python/xy/_chromium.py
+++ b/python/xy/_chromium.py
@@ -238,6 +238,12 @@ class ChromiumSession:
         def wait_timeout() -> float:
             return min(10.0, max(0.0, deadline - time.monotonic()))
 
+        def reap_timeout() -> float:
+            # SIGKILL still needs wait() to collect the child.  Preserve the
+            # caller's remaining budget when possible, but allow one bounded
+            # second after expiry so cleanup does not leave a zombie.
+            return max(1.0, wait_timeout())
+
         try:
             running = proc.poll() is None
         except Exception:
@@ -251,12 +257,12 @@ class ChromiumSession:
             with contextlib.suppress(Exception):
                 proc.kill()
             with contextlib.suppress(Exception):
-                proc.wait(timeout=wait_timeout())
+                proc.wait(timeout=reap_timeout())
         except Exception:
             with contextlib.suppress(Exception):
                 proc.kill()
             with contextlib.suppress(Exception):
-                proc.wait(timeout=wait_timeout())
+                proc.wait(timeout=reap_timeout())
 
     def _abort_session(self, deadline: float) -> None:
         """Make an ambiguously mutated CDP session impossible to reuse."""

--- a/python/xy/_chromium.py
+++ b/python/xy/_chromium.py
@@ -197,7 +197,7 @@ class ChromiumSession:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise ChromiumError("Chromium did not connect to DevTools in time")
-            self._ws = _WebSocket(ws_url, timeout_s=remaining)
+            self._ws: _WebSocket | None = _WebSocket(ws_url, timeout_s=remaining)
             self._next_id = 0
             self._events: dict[tuple[Optional[str], str], list[dict[str, Any]]] = {}
         except BaseException:
@@ -248,6 +248,9 @@ class ChromiumSession:
         session_id: Optional[str] = None,
         timeout_s: float = 60.0,
     ) -> dict[str, Any]:
+        websocket = self._ws
+        if websocket is None:
+            raise ChromiumError("Chromium session websocket is no longer usable")
         self._next_id += 1
         call_id = self._next_id
         message: dict[str, Any] = {"id": call_id, "method": method, "params": params or {}}
@@ -257,14 +260,23 @@ class ChromiumSession:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             raise ChromiumError(f"timeout waiting for {method}")
-        self._ws.settimeout(remaining)
-        self._ws.send_text(json.dumps(message))
+        websocket.settimeout(remaining)
+        try:
+            websocket.send_text(json.dumps(message))
+        except OSError:
+            # sendall() may have written only part of a WebSocket frame.  The
+            # stream cannot be resynchronized, so do not let later CDP calls
+            # reuse it.
+            self._ws = None
+            with contextlib.suppress(Exception):
+                websocket.close()
+            raise
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise ChromiumError(f"timeout waiting for {method}")
-            self._ws.settimeout(remaining)
-            reply = json.loads(self._ws.recv_text())
+            websocket.settimeout(remaining)
+            reply = json.loads(websocket.recv_text())
             if reply.get("id") == call_id:
                 if "error" in reply:
                     raise ChromiumError(f"{method}: {reply['error']}")
@@ -275,6 +287,9 @@ class ChromiumSession:
                 )
 
     def _wait_event(self, method: str, *, session_id: Optional[str], timeout_s: float) -> None:
+        websocket = self._ws
+        if websocket is None:
+            raise ChromiumError("Chromium session websocket is no longer usable")
         key = (session_id, method)
         deadline = time.monotonic() + timeout_s
         while True:
@@ -285,8 +300,8 @@ class ChromiumSession:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise ChromiumError(f"timeout waiting for event {method}")
-            self._ws.settimeout(remaining)
-            reply = json.loads(self._ws.recv_text())
+            websocket.settimeout(remaining)
+            reply = json.loads(websocket.recv_text())
             if reply.get("method"):
                 self._events.setdefault((reply.get("sessionId"), reply["method"]), []).append(
                     reply.get("params", {})
@@ -303,16 +318,31 @@ class ChromiumSession:
             return value
 
         target = self._call("Target.createTarget", {"url": "about:blank"}, timeout_s=remaining())
-        attached = self._call(
-            "Target.attachToTarget",
-            {"targetId": target["targetId"], "flatten": True},
-            timeout_s=remaining(),
-        )
-        sid = attached["sessionId"]
-        page_path = Path(self._tmp.name) / f"chart-{target['targetId'][:8]}.html"
-        page_path.write_text(html, encoding="utf-8")
-        self._call("Page.enable", session_id=sid, timeout_s=remaining())
-        return target["targetId"], sid, page_path
+        target_id = target["targetId"]
+        page_path = Path(self._tmp.name) / f"chart-{target_id[:8]}.html"
+        try:
+            attached = self._call(
+                "Target.attachToTarget",
+                {"targetId": target_id, "flatten": True},
+                timeout_s=remaining(),
+            )
+            sid = attached["sessionId"]
+            page_path.write_text(html, encoding="utf-8")
+            self._call("Page.enable", session_id=sid, timeout_s=remaining())
+            return target_id, sid, page_path
+        except BaseException:
+            # Prefer the caller's remaining budget.  If setup consumed it all,
+            # allow only a short best-effort window rather than leaking a tab.
+            cleanup_timeout_s = min(10.0, max(0.1, deadline - time.monotonic()))
+            with contextlib.suppress(Exception):
+                self._call(
+                    "Target.closeTarget",
+                    {"targetId": target_id},
+                    timeout_s=cleanup_timeout_s,
+                )
+            with contextlib.suppress(OSError):
+                page_path.unlink(missing_ok=True)
+            raise
 
     def _navigate_and_settle(self, sid: str, page_path: "Path", timeout_s: float) -> None:
         self._call(
@@ -463,8 +493,11 @@ class ChromiumSession:
         # keep writing into Default/ while rmtree walks it (ENOTEMPTY races).
         with contextlib.suppress(Exception):
             self._call("Browser.close", timeout_s=10.0)
-        with contextlib.suppress(Exception):
-            self._ws.close()
+        websocket = self._ws
+        self._ws = None
+        if websocket is not None:
+            with contextlib.suppress(Exception):
+                websocket.close()
         try:
             self._proc.wait(timeout=15)
         except subprocess.TimeoutExpired:

--- a/python/xy/_chromium.py
+++ b/python/xy/_chromium.py
@@ -37,28 +37,45 @@ class _WebSocket:
         parts = urlsplit(url)
         if parts.scheme != "ws" or parts.hostname is None:
             raise ChromiumError(f"unsupported DevTools endpoint {url!r}")
-        self._sock = socket.create_connection((parts.hostname, parts.port or 80), timeout=timeout_s)
-        key = base64.b64encode(secrets.token_bytes(16)).decode("ascii")
-        path = parts.path + (f"?{parts.query}" if parts.query else "")
-        self._sock.sendall(
-            (
-                f"GET {path} HTTP/1.1\r\n"
-                f"Host: {parts.hostname}:{parts.port or 80}\r\n"
-                "Upgrade: websocket\r\n"
-                "Connection: Upgrade\r\n"
-                f"Sec-WebSocket-Key: {key}\r\n"
-                "Sec-WebSocket-Version: 13\r\n\r\n"
-            ).encode("ascii")
+        deadline = time.monotonic() + timeout_s
+
+        def remaining() -> float:
+            value = deadline - time.monotonic()
+            if value <= 0:
+                raise ChromiumError("timeout connecting to DevTools websocket")
+            return value
+
+        self._sock = socket.create_connection(
+            (parts.hostname, parts.port or 80), timeout=remaining()
         )
-        response = b""
-        while b"\r\n\r\n" not in response:
-            chunk = self._sock.recv(4096)
-            if not chunk:
-                raise ChromiumError("websocket handshake: connection closed")
-            response += chunk
-        if b"101" not in response.split(b"\r\n", 1)[0]:
-            raise ChromiumError("websocket handshake rejected")
-        self._buffer = response.split(b"\r\n\r\n", 1)[1]
+        try:
+            key = base64.b64encode(secrets.token_bytes(16)).decode("ascii")
+            path = parts.path + (f"?{parts.query}" if parts.query else "")
+            self._sock.settimeout(remaining())
+            self._sock.sendall(
+                (
+                    f"GET {path} HTTP/1.1\r\n"
+                    f"Host: {parts.hostname}:{parts.port or 80}\r\n"
+                    "Upgrade: websocket\r\n"
+                    "Connection: Upgrade\r\n"
+                    f"Sec-WebSocket-Key: {key}\r\n"
+                    "Sec-WebSocket-Version: 13\r\n\r\n"
+                ).encode("ascii")
+            )
+            response = b""
+            while b"\r\n\r\n" not in response:
+                self._sock.settimeout(remaining())
+                chunk = self._sock.recv(4096)
+                if not chunk:
+                    raise ChromiumError("websocket handshake: connection closed")
+                response += chunk
+            if b"101" not in response.split(b"\r\n", 1)[0]:
+                raise ChromiumError("websocket handshake rejected")
+            self._buffer = response.split(b"\r\n\r\n", 1)[1]
+        except BaseException:
+            with contextlib.suppress(OSError):
+                self._sock.close()
+            raise
 
     def settimeout(self, timeout_s: float | None) -> None:
         self._sock.settimeout(timeout_s)
@@ -131,50 +148,97 @@ class ChromiumSession:
         sandbox: bool = True,
         launch_timeout_s: float = 30.0,
     ) -> None:
+        if launch_timeout_s <= 0:
+            raise ChromiumError("Chromium launch timeout must be positive")
+        deadline = time.monotonic() + launch_timeout_s
         # ignore_cleanup_errors covers the GC-finalizer path; close() does its
         # own retrying removal (see _cleanup_tmp) for the common `with` path.
         self._tmp = tempfile.TemporaryDirectory(prefix="xy-export-", ignore_cleanup_errors=True)
-        stderr_path = Path(self._tmp.name) / "chromium-stderr.log"
-        self._stderr_file = stderr_path.open("w+b")
-        gl_flags = (
-            ["--use-angle=swiftshader", "--enable-unsafe-swiftshader"] if gl == "software" else []
-        )
-        args = [
-            executable,
-            "--headless=new",
-            "--remote-debugging-port=0",
-            f"--user-data-dir={Path(self._tmp.name) / 'profile'}",
-            "--no-first-run",
-            "--no-default-browser-check",
-            "--disable-dev-shm-usage",
-            # No crashpad handler: it is a detached process that writes into
-            # the profile dir on its own schedule, past the browser's exit.
-            "--disable-breakpad",
-            "--disable-crash-reporter",
-            "--hide-scrollbars",
-            *gl_flags,
-        ]
-        if not sandbox:
-            args.insert(2, "--no-sandbox")
-        self._proc = subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=self._stderr_file)
-        deadline = time.monotonic() + launch_timeout_s
-        ws_url = None
-        while time.monotonic() < deadline:
-            if self._proc.poll() is not None:
-                tail = stderr_path.read_text(errors="replace")[-400:]
-                raise ChromiumError(f"Chromium exited during launch: {tail}")
-            m = re.search(
-                r"DevTools listening on (ws://\S+)", stderr_path.read_text(errors="replace")
+        try:
+            stderr_path = Path(self._tmp.name) / "chromium-stderr.log"
+            self._stderr_file = stderr_path.open("w+b")
+            gl_flags = (
+                ["--use-angle=swiftshader", "--enable-unsafe-swiftshader"]
+                if gl == "software"
+                else []
             )
-            if m:
-                ws_url = m.group(1)
-                break
-            time.sleep(0.05)
-        if ws_url is None:
-            raise ChromiumError("Chromium did not report a DevTools endpoint in time")
-        self._ws = _WebSocket(ws_url)
-        self._next_id = 0
-        self._events: dict[tuple[Optional[str], str], list[dict[str, Any]]] = {}
+            args = [
+                executable,
+                "--headless=new",
+                "--remote-debugging-port=0",
+                f"--user-data-dir={Path(self._tmp.name) / 'profile'}",
+                "--no-first-run",
+                "--no-default-browser-check",
+                "--disable-dev-shm-usage",
+                # No crashpad handler: it is a detached process that writes into
+                # the profile dir on its own schedule, past the browser's exit.
+                "--disable-breakpad",
+                "--disable-crash-reporter",
+                "--hide-scrollbars",
+                *gl_flags,
+            ]
+            if not sandbox:
+                args.insert(2, "--no-sandbox")
+            self._proc = subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=self._stderr_file)
+            ws_url = None
+            while time.monotonic() < deadline:
+                if self._proc.poll() is not None:
+                    tail = stderr_path.read_text(errors="replace")[-400:]
+                    raise ChromiumError(f"Chromium exited during launch: {tail}")
+                m = re.search(
+                    r"DevTools listening on (ws://\S+)", stderr_path.read_text(errors="replace")
+                )
+                if m:
+                    ws_url = m.group(1)
+                    break
+                time.sleep(min(0.05, max(0.0, deadline - time.monotonic())))
+            if ws_url is None:
+                raise ChromiumError("Chromium did not report a DevTools endpoint in time")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise ChromiumError("Chromium did not connect to DevTools in time")
+            self._ws = _WebSocket(ws_url, timeout_s=remaining)
+            self._next_id = 0
+            self._events: dict[tuple[Optional[str], str], list[dict[str, Any]]] = {}
+        except BaseException:
+            self._cleanup_failed_init()
+            raise
+
+    def _cleanup_failed_init(self) -> None:
+        """Release every resource acquired before ``__init__`` raised."""
+        websocket = getattr(self, "_ws", None)
+        if websocket is not None:
+            with contextlib.suppress(Exception):
+                websocket.close()
+
+        proc = getattr(self, "_proc", None)
+        if proc is not None:
+            try:
+                running = proc.poll() is None
+            except Exception:
+                running = True
+            if running:
+                with contextlib.suppress(Exception):
+                    proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                with contextlib.suppress(Exception):
+                    proc.kill()
+                with contextlib.suppress(Exception):
+                    proc.wait(timeout=10)
+            except Exception:
+                with contextlib.suppress(Exception):
+                    proc.kill()
+                with contextlib.suppress(Exception):
+                    proc.wait(timeout=10)
+
+        stderr_file = getattr(self, "_stderr_file", None)
+        if stderr_file is not None:
+            with contextlib.suppress(Exception):
+                stderr_file.close()
+        with contextlib.suppress(Exception):
+            self._cleanup_tmp()
 
     def _call(
         self,
@@ -189,8 +253,12 @@ class ChromiumSession:
         message: dict[str, Any] = {"id": call_id, "method": method, "params": params or {}}
         if session_id is not None:
             message["sessionId"] = session_id
-        self._ws.send_text(json.dumps(message))
         deadline = time.monotonic() + timeout_s
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise ChromiumError(f"timeout waiting for {method}")
+        self._ws.settimeout(remaining)
+        self._ws.send_text(json.dumps(message))
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -226,14 +294,24 @@ class ChromiumSession:
 
     def _page_session(self, html: str, timeout_s: float) -> tuple[str, str, "Path"]:
         """Open a fresh tab on `html` (written to disk) and return its ids."""
-        target = self._call("Target.createTarget", {"url": "about:blank"})
+        deadline = time.monotonic() + timeout_s
+
+        def remaining() -> float:
+            value = deadline - time.monotonic()
+            if value <= 0:
+                raise ChromiumError("timeout opening Chromium page session")
+            return value
+
+        target = self._call("Target.createTarget", {"url": "about:blank"}, timeout_s=remaining())
         attached = self._call(
-            "Target.attachToTarget", {"targetId": target["targetId"], "flatten": True}
+            "Target.attachToTarget",
+            {"targetId": target["targetId"], "flatten": True},
+            timeout_s=remaining(),
         )
         sid = attached["sessionId"]
         page_path = Path(self._tmp.name) / f"chart-{target['targetId'][:8]}.html"
         page_path.write_text(html, encoding="utf-8")
-        self._call("Page.enable", session_id=sid, timeout_s=timeout_s)
+        self._call("Page.enable", session_id=sid, timeout_s=remaining())
         return target["targetId"], sid, page_path
 
     def _navigate_and_settle(self, sid: str, page_path: "Path", timeout_s: float) -> None:

--- a/python/xy/_chromium.py
+++ b/python/xy/_chromium.py
@@ -230,7 +230,7 @@ class ChromiumSession:
                 websocket.abort()
 
     def _stop_process(self, deadline: float) -> None:
-        """Stop and reap Chromium without waiting past ``deadline``."""
+        """Stop Chromium by ``deadline``; allow one extra second to reap after killing it."""
         proc = getattr(self, "_proc", None)
         if proc is None:
             return

--- a/python/xy/_chromium.py
+++ b/python/xy/_chromium.py
@@ -317,10 +317,10 @@ class ChromiumSession:
             websocket.settimeout(remaining)
             try:
                 reply = json.loads(websocket.recv_text(deadline=deadline))
-            except OSError:
-                # A receive timeout can leave only part of a frame buffered.
-                # Fail closed instead of letting another CDP call resume an
-                # indeterminate stream.
+            except BaseException:
+                # Any receive or decode failure can leave only part of a frame
+                # consumed. Fail closed instead of letting another CDP call
+                # resume an indeterminate stream.
                 self._invalidate_websocket()
                 raise
             if reply.get("id") == call_id:
@@ -349,7 +349,7 @@ class ChromiumSession:
             websocket.settimeout(remaining)
             try:
                 reply = json.loads(websocket.recv_text(deadline=deadline))
-            except OSError:
+            except BaseException:
                 self._invalidate_websocket()
                 raise
             if reply.get("method"):

--- a/python/xy/_chromium.py
+++ b/python/xy/_chromium.py
@@ -80,8 +80,17 @@ class _WebSocket:
     def settimeout(self, timeout_s: float | None) -> None:
         self._sock.settimeout(timeout_s)
 
-    def _recv_exact(self, n: int) -> bytes:
+    def _set_deadline_timeout(self, deadline: float | None) -> None:
+        if deadline is None:
+            return
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("websocket receive deadline expired")
+        self._sock.settimeout(remaining)
+
+    def _recv_exact(self, n: int, *, deadline: float | None = None) -> bytes:
         while len(self._buffer) < n:
+            self._set_deadline_timeout(deadline)
             chunk = self._sock.recv(65536)
             if not chunk:
                 raise ChromiumError("websocket closed mid-frame")
@@ -105,23 +114,27 @@ class _WebSocket:
         header += mask
         self._sock.sendall(bytes(header) + bytes(b ^ mask[i % 4] for i, b in enumerate(payload)))
 
-    def recv_text(self) -> str:
+    def recv_text(self, *, deadline: float | None = None) -> str:
         """Next complete text message (transparently answers pings)."""
         message = bytearray()
         while True:
-            b0, b1 = self._recv_exact(2)
+            b0, b1 = self._recv_exact(2, deadline=deadline)
             opcode, fin = b0 & 0x0F, b0 & 0x80
             length = b1 & 0x7F
             if length == 126:
-                length = int.from_bytes(self._recv_exact(2), "big")
+                length = int.from_bytes(self._recv_exact(2, deadline=deadline), "big")
             elif length == 127:
-                length = int.from_bytes(self._recv_exact(8), "big")
+                length = int.from_bytes(self._recv_exact(8, deadline=deadline), "big")
             if b1 & 0x80:  # masked server frame: illegal, but drain it
-                mask = self._recv_exact(4)
-                data = bytes(b ^ mask[i % 4] for i, b in enumerate(self._recv_exact(length)))
+                mask = self._recv_exact(4, deadline=deadline)
+                data = bytes(
+                    b ^ mask[i % 4]
+                    for i, b in enumerate(self._recv_exact(length, deadline=deadline))
+                )
             else:
-                data = self._recv_exact(length)
+                data = self._recv_exact(length, deadline=deadline)
             if opcode == 0x9:  # ping -> pong
+                self._set_deadline_timeout(deadline)
                 self._sock.sendall(bytes([0x8A, 0x80]) + secrets.token_bytes(4))
                 continue
             if opcode == 0x8:
@@ -134,6 +147,10 @@ class _WebSocket:
     def close(self) -> None:
         with contextlib.suppress(OSError):
             self._sock.sendall(bytes([0x88, 0x80]) + secrets.token_bytes(4))
+        self._sock.close()
+
+    def abort(self) -> None:
+        """Close immediately without writing another frame to a broken stream."""
         self._sock.close()
 
 
@@ -151,6 +168,7 @@ class ChromiumSession:
         if launch_timeout_s <= 0:
             raise ChromiumError("Chromium launch timeout must be positive")
         deadline = time.monotonic() + launch_timeout_s
+        self._ws: _WebSocket | None = None
         # ignore_cleanup_errors covers the GC-finalizer path; close() does its
         # own retrying removal (see _cleanup_tmp) for the common `with` path.
         self._tmp = tempfile.TemporaryDirectory(prefix="xy-export-", ignore_cleanup_errors=True)
@@ -197,48 +215,65 @@ class ChromiumSession:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise ChromiumError("Chromium did not connect to DevTools in time")
-            self._ws: _WebSocket | None = _WebSocket(ws_url, timeout_s=remaining)
+            self._ws = _WebSocket(ws_url, timeout_s=remaining)
             self._next_id = 0
             self._events: dict[tuple[Optional[str], str], list[dict[str, Any]]] = {}
         except BaseException:
-            self._cleanup_failed_init()
+            self._cleanup_failed_init(deadline)
             raise
 
-    def _cleanup_failed_init(self) -> None:
-        """Release every resource acquired before ``__init__`` raised."""
-        websocket = getattr(self, "_ws", None)
+    def _invalidate_websocket(self) -> None:
+        websocket = self._ws
+        self._ws = None
         if websocket is not None:
             with contextlib.suppress(Exception):
-                websocket.close()
+                websocket.abort()
 
+    def _stop_process(self, deadline: float) -> None:
+        """Stop and reap Chromium without waiting past ``deadline``."""
         proc = getattr(self, "_proc", None)
-        if proc is not None:
-            try:
-                running = proc.poll() is None
-            except Exception:
-                running = True
-            if running:
-                with contextlib.suppress(Exception):
-                    proc.terminate()
-            try:
-                proc.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                with contextlib.suppress(Exception):
-                    proc.kill()
-                with contextlib.suppress(Exception):
-                    proc.wait(timeout=10)
-            except Exception:
-                with contextlib.suppress(Exception):
-                    proc.kill()
-                with contextlib.suppress(Exception):
-                    proc.wait(timeout=10)
+        if proc is None:
+            return
+
+        def wait_timeout() -> float:
+            return min(10.0, max(0.0, deadline - time.monotonic()))
+
+        try:
+            running = proc.poll() is None
+        except Exception:
+            running = True
+        if running:
+            with contextlib.suppress(Exception):
+                proc.terminate()
+        try:
+            proc.wait(timeout=wait_timeout())
+        except subprocess.TimeoutExpired:
+            with contextlib.suppress(Exception):
+                proc.kill()
+            with contextlib.suppress(Exception):
+                proc.wait(timeout=wait_timeout())
+        except Exception:
+            with contextlib.suppress(Exception):
+                proc.kill()
+            with contextlib.suppress(Exception):
+                proc.wait(timeout=wait_timeout())
+
+    def _abort_session(self, deadline: float) -> None:
+        """Make an ambiguously mutated CDP session impossible to reuse."""
+        self._invalidate_websocket()
+        self._stop_process(deadline)
+
+    def _cleanup_failed_init(self, deadline: float) -> None:
+        """Release every resource acquired before ``__init__`` raised."""
+        self._invalidate_websocket()
+        self._stop_process(deadline)
 
         stderr_file = getattr(self, "_stderr_file", None)
         if stderr_file is not None:
             with contextlib.suppress(Exception):
                 stderr_file.close()
         with contextlib.suppress(Exception):
-            self._cleanup_tmp()
+            self._cleanup_tmp(deadline=deadline)
 
     def _call(
         self,
@@ -267,16 +302,21 @@ class ChromiumSession:
             # sendall() may have written only part of a WebSocket frame.  The
             # stream cannot be resynchronized, so do not let later CDP calls
             # reuse it.
-            self._ws = None
-            with contextlib.suppress(Exception):
-                websocket.close()
+            self._invalidate_websocket()
             raise
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise ChromiumError(f"timeout waiting for {method}")
             websocket.settimeout(remaining)
-            reply = json.loads(websocket.recv_text())
+            try:
+                reply = json.loads(websocket.recv_text(deadline=deadline))
+            except OSError:
+                # A receive timeout can leave only part of a frame buffered.
+                # Fail closed instead of letting another CDP call resume an
+                # indeterminate stream.
+                self._invalidate_websocket()
+                raise
             if reply.get("id") == call_id:
                 if "error" in reply:
                     raise ChromiumError(f"{method}: {reply['error']}")
@@ -301,7 +341,11 @@ class ChromiumSession:
             if remaining <= 0:
                 raise ChromiumError(f"timeout waiting for event {method}")
             websocket.settimeout(remaining)
-            reply = json.loads(websocket.recv_text())
+            try:
+                reply = json.loads(websocket.recv_text(deadline=deadline))
+            except OSError:
+                self._invalidate_websocket()
+                raise
             if reply.get("method"):
                 self._events.setdefault((reply.get("sessionId"), reply["method"]), []).append(
                     reply.get("params", {})
@@ -317,7 +361,18 @@ class ChromiumSession:
                 raise ChromiumError("timeout opening Chromium page session")
             return value
 
-        target = self._call("Target.createTarget", {"url": "about:blank"}, timeout_s=remaining())
+        try:
+            target = self._call(
+                "Target.createTarget",
+                {"url": "about:blank"},
+                timeout_s=remaining(),
+            )
+        except BaseException:
+            # The command may have reached Chromium even if its response did
+            # not reach us.  Without a target id the only safe cleanup is to
+            # stop the browser and make this session impossible to reuse.
+            self._abort_session(deadline)
+            raise
         target_id = target["targetId"]
         page_path = Path(self._tmp.name) / f"chart-{target_id[:8]}.html"
         try:
@@ -510,7 +565,7 @@ class ChromiumSession:
         self._stderr_file.close()
         self._cleanup_tmp()
 
-    def _cleanup_tmp(self) -> None:
+    def _cleanup_tmp(self, *, deadline: float | None = None) -> None:
         # Chromium's child processes (zygote/GPU) can keep flushing the profile
         # dir for a beat after the main process exits, so a bare rmtree races
         # them and dies with "Directory not empty". Retry the removal briefly,
@@ -518,7 +573,13 @@ class ChromiumSession:
         # under the OS temp dir and is disposable.
         for delay in (0.0, 0.1, 0.25, 0.5):
             if delay:
-                time.sleep(delay)
+                if deadline is None:
+                    time.sleep(delay)
+                else:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        break
+                    time.sleep(min(delay, remaining))
             try:
                 shutil.rmtree(self._tmp.name)
                 break

--- a/scripts/render_smoke_nonumpy.py
+++ b/scripts/render_smoke_nonumpy.py
@@ -17,9 +17,8 @@ import math
 import re
 import shutil
 import struct
-import subprocess
 import sys
-import tempfile
+import time
 from array import array
 from pathlib import Path
 
@@ -27,6 +26,10 @@ from _protocol import PROTOCOL_VERSION
 
 ROOT = Path(__file__).resolve().parent.parent
 STATIC = ROOT / "python" / "xy" / "static"
+sys.path.insert(0, str(ROOT / "python"))
+
+from xy._chromium import ChromiumSession  # noqa: E402
+
 CHROMIUM_CANDIDATES = [
     "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
     "/Applications/Chromium.app/Contents/MacOS/Chromium",
@@ -45,6 +48,45 @@ def find_chromium() -> str:
         if Path(c).is_file() or shutil.which(c):
             return c
     raise SystemExit("no chromium found")
+
+
+def run_probe(page: str, *, timeout_s: float = 300.0) -> str:
+    """Run the page until its probe replaces the sentinel title.
+
+    CDP lets the smoke stop as soon as the assertions finish. In contrast,
+    Chromium's ``--dump-dom`` waits for the entire page to become idle, which
+    can leave a successful WebGL page running until the subprocess timeout.
+    """
+    with ChromiumSession(find_chromium(), gl="software", sandbox=False) as session:
+        _, sid, page_path = session._page_session(page, timeout_s)
+        session._call(
+            "Page.navigate",
+            {"url": page_path.as_uri()},
+            session_id=sid,
+            timeout_s=timeout_s,
+        )
+        session._wait_event("Page.loadEventFired", session_id=sid, timeout_s=timeout_s)
+
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            reply = session._call(
+                "Runtime.evaluate",
+                {"expression": "document.title", "returnByValue": True},
+                session_id=sid,
+                # The page's deliberately broad synchronous WebGL probe can
+                # occupy one renderer task for well over 30 seconds on a
+                # software-only CI runner. The overall deadline still catches
+                # a real hang without imposing a shorter per-poll timeout.
+                timeout_s=max(1.0, remaining),
+            )
+            if reply.get("exceptionDetails"):
+                raise RuntimeError(f"probe page exception: {reply['exceptionDetails']}")
+            title = str(reply.get("result", {}).get("value", ""))
+            if title != "pending":
+                return title
+            time.sleep(0.1)
+    raise TimeoutError(f"render probe did not finish within {timeout_s:g} seconds")
 
 
 def encode_f32(vals, offset):  # noqa: ANN001
@@ -943,13 +985,10 @@ try{{
       return hsh;
     }};
     // NOTE: the standalone density re-bin worker is deliberately NOT exercised
-    // here. This harness renders under Chromium `--virtual-time-budget
-    // --dump-dom`; a real Web Worker runs on wall-clock, not virtual time, so a
-    // pending worker message keeps the page from settling and `--dump-dom`
-    // hangs to the subprocess timeout. Worker source is asserted in
-    // tests/test_static_client_security.py; runtime behavior is verified
-    // interactively. Every probe chart sets `_sampleRebinDisabled = true` so no
-    // worker ever spawns during the smoke.
+    // here. This deterministic probe hand-feeds its density updates; worker
+    // source is asserted in tests/test_static_client_security.py and runtime
+    // behavior is covered separately. Probe charts that can schedule a re-bin
+    // set `_sampleRebinDisabled = true`.
     const dv1 = xy.renderStandalone(mk(), JSON.parse(JSON.stringify(spec)), bytes.buffer);
     const dv2 = xy.renderStandalone(mk(), JSON.parse(JSON.stringify(spec)), bytes.buffer);
     if (dv1.gpuTraces) for (const gg of dv1.gpuTraces) gg._densityNormAnim = null;
@@ -1312,39 +1351,9 @@ try{{
 }}catch(e){{document.title="XY_ERROR "+(e.stack||e.message)}}
 </script></body></html>"""
 
-    with tempfile.TemporaryDirectory() as td:
-        p = Path(td) / "s.html"
-        p.write_text(page, encoding="utf-8")
-        out = subprocess.run(
-            [
-                find_chromium(),
-                "--headless=new",
-                "--no-sandbox",
-                "--disable-dev-shm-usage",
-                "--use-angle=swiftshader",
-                "--enable-unsafe-swiftshader",
-                "--virtual-time-budget=4000",
-                "--dump-dom",
-                p.as_uri(),
-            ],
-            capture_output=True,
-            text=True,
-            # This probe is the widest one in the tree — a single page that
-            # exercises every mark family, LOD drill-in, picking, selection,
-            # the modebar, context-loss recovery and the DPR watch — and it
-            # SOFTWARE-rasterizes all of it through SwiftShader. On a GitHub
-            # runner it measured 98 s against the 120 s it used to allow, so a
-            # slightly slower runner timed the whole job out with nothing
-            # broken. Sized for headroom instead: a real hang still fails,
-            # 22 s of jitter no longer does. `append_stream_smoke.py` already
-            # allows 180 s for a far smaller page.
-            timeout=300,
-        )
-    m = re.search(r"<title>([^<]*)</title>", out.stdout)
-    title = m.group(1) if m else "(none)"
+    title = run_probe(page)
     print("probe:", title)
     if not title.startswith("XY_OK"):
-        print(out.stderr[-2000:], file=sys.stderr)
         raise SystemExit("render failed")
     lit = int(re.search(r"lit=(\d+)", title).group(1))
     total = int(re.search(r"total=(\d+)", title).group(1))

--- a/scripts/render_smoke_nonumpy.py
+++ b/scripts/render_smoke_nonumpy.py
@@ -57,19 +57,30 @@ def run_probe(page: str, *, timeout_s: float = 300.0) -> str:
     Chromium's ``--dump-dom`` waits for the entire page to become idle, which
     can leave a successful WebGL page running until the subprocess timeout.
     """
-    with ChromiumSession(find_chromium(), gl="software", sandbox=False) as session:
-        _, sid, page_path = session._page_session(page, timeout_s)
+    deadline = time.monotonic() + timeout_s
+
+    def remaining() -> float:
+        value = deadline - time.monotonic()
+        if value <= 0:
+            raise TimeoutError(f"render probe did not finish within {timeout_s:g} seconds")
+        return value
+
+    with ChromiumSession(
+        find_chromium(),
+        gl="software",
+        sandbox=False,
+        launch_timeout_s=remaining(),
+    ) as session:
+        _, sid, page_path = session._page_session(page, remaining())
         session._call(
             "Page.navigate",
             {"url": page_path.as_uri()},
             session_id=sid,
-            timeout_s=timeout_s,
+            timeout_s=remaining(),
         )
-        session._wait_event("Page.loadEventFired", session_id=sid, timeout_s=timeout_s)
+        session._wait_event("Page.loadEventFired", session_id=sid, timeout_s=remaining())
 
-        deadline = time.monotonic() + timeout_s
-        while time.monotonic() < deadline:
-            remaining = deadline - time.monotonic()
+        while True:
             reply = session._call(
                 "Runtime.evaluate",
                 {"expression": "document.title", "returnByValue": True},
@@ -78,15 +89,14 @@ def run_probe(page: str, *, timeout_s: float = 300.0) -> str:
                 # occupy one renderer task for well over 30 seconds on a
                 # software-only CI runner. The overall deadline still catches
                 # a real hang without imposing a shorter per-poll timeout.
-                timeout_s=max(1.0, remaining),
+                timeout_s=remaining(),
             )
             if reply.get("exceptionDetails"):
                 raise RuntimeError(f"probe page exception: {reply['exceptionDetails']}")
             title = str(reply.get("result", {}).get("value", ""))
             if title != "pending":
                 return title
-            time.sleep(0.1)
-    raise TimeoutError(f"render probe did not finish within {timeout_s:g} seconds")
+            time.sleep(min(0.1, remaining()))
 
 
 def encode_f32(vals, offset):  # noqa: ANN001

--- a/spec/process/contributing.md
+++ b/spec/process/contributing.md
@@ -179,8 +179,10 @@ This runs seven split browser checks, which CI runs as separate steps:
 The stdlib payload gate runs `scripts/render_smoke_nonumpy.py`. It hand-builds a
 payload from stdlib `array` and `struct` in exactly the wire shape
 `build_payload` emits, drives the standalone JS bundle in Chromium, and reads
-back a lit-pixel count via `gl.readPixels`. It needs neither numpy nor PyPI, so
-it covers the render client in a locked-down environment.
+back a lit-pixel count via `gl.readPixels`. A stdlib-only DevTools Protocol
+session stops the browser as soon as the page publishes its result instead of
+waiting for a WebGL page to become idle. It needs neither numpy nor PyPI, so it
+covers the render client in a locked-down environment.
 
 The real-Figure gate runs `scripts/smoke_render.py`. It builds a standalone page
 the same way `Chart.to_html` does from an actual Figure (line decimation plus

--- a/tests/test_chromium_session.py
+++ b/tests/test_chromium_session.py
@@ -171,7 +171,7 @@ def test_websocket_closes_socket_when_handshake_fails(monkeypatch: pytest.Monkey
     assert sock.closed
 
 
-def test_failed_init_cleanup_does_not_wait_past_launch_deadline(
+def test_failed_init_cleanup_uses_only_bounded_reap_grace_after_deadline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     temp_paths = _track_tempdirs(monkeypatch)
@@ -211,10 +211,10 @@ def test_failed_init_cleanup_does_not_wait_past_launch_deadline(
     with pytest.raises(_chromium.ChromiumError, match="handshake failed"):
         _chromium.ChromiumSession("/fake/chromium", launch_timeout_s=5.0)
 
-    assert now == pytest.approx(5.0)
+    assert now == pytest.approx(6.0)
     assert process.terminate_calls == 1
     assert process.kill_calls == 1
-    assert process.wait_calls == [pytest.approx(1.0), 0.0]
+    assert process.wait_calls == [pytest.approx(1.0), pytest.approx(1.0)]
     assert stderr_files[0].closed
     assert len(temp_paths) == 1
     assert not temp_paths[0].exists()
@@ -421,7 +421,7 @@ def test_page_session_aborts_browser_when_target_creation_is_ambiguous(
     assert session._ws is None
     assert process.terminate_calls == 1
     assert process.kill_calls == 1
-    assert process.wait_calls == [0.0, 0.0]
+    assert process.wait_calls == [0.0, pytest.approx(1.0)]
     with pytest.raises(_chromium.ChromiumError, match="no longer usable"):
         _chromium.ChromiumSession._call(session, "Page.navigate", timeout_s=1.0)
 

--- a/tests/test_chromium_session.py
+++ b/tests/test_chromium_session.py
@@ -109,6 +109,42 @@ def test_chromium_session_cleans_files_when_browser_exits_during_launch(
     assert not temp_paths[0].exists()
 
 
+def test_chromium_session_cleans_running_browser_when_devtools_endpoint_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    temp_paths = _track_tempdirs(monkeypatch)
+    process = _FakeProcess()
+    stderr_files = []
+    now = 0.0
+
+    def popen(_args, *, stdout, stderr):  # noqa: ANN001, ANN202
+        del stdout
+        stderr_files.append(stderr)
+        return process
+
+    def monotonic() -> float:
+        return now
+
+    def sleep(seconds: float) -> None:
+        nonlocal now
+        now += seconds
+
+    monkeypatch.setattr(_chromium.subprocess, "Popen", popen)
+    monkeypatch.setattr(_chromium.time, "monotonic", monotonic)
+    monkeypatch.setattr(_chromium.time, "sleep", sleep)
+
+    with pytest.raises(_chromium.ChromiumError, match="did not report a DevTools endpoint"):
+        _chromium.ChromiumSession("/fake/chromium", launch_timeout_s=0.1)
+
+    assert now == pytest.approx(0.1)
+    assert process.terminate_calls == 1
+    assert process.kill_calls == 0
+    assert process.wait_calls == [10]
+    assert stderr_files[0].closed
+    assert len(temp_paths) == 1
+    assert not temp_paths[0].exists()
+
+
 def test_websocket_closes_socket_when_handshake_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeSocket:
         def __init__(self) -> None:

--- a/tests/test_chromium_session.py
+++ b/tests/test_chromium_session.py
@@ -139,7 +139,7 @@ def test_chromium_session_cleans_running_browser_when_devtools_endpoint_times_ou
     assert now == pytest.approx(0.1)
     assert process.terminate_calls == 1
     assert process.kill_calls == 0
-    assert process.wait_calls == [10]
+    assert process.wait_calls == [0.0]
     assert stderr_files[0].closed
     assert len(temp_paths) == 1
     assert not temp_paths[0].exists()
@@ -169,6 +169,107 @@ def test_websocket_closes_socket_when_handshake_fails(monkeypatch: pytest.Monkey
         _chromium._WebSocket("ws://127.0.0.1:9222/devtools/browser/test")
 
     assert sock.closed
+
+
+def test_failed_init_cleanup_does_not_wait_past_launch_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    temp_paths = _track_tempdirs(monkeypatch)
+    now = 0.0
+    stderr_files = []
+
+    class DeadlineProcess(_FakeProcess):
+        def wait(self, timeout: float | None = None) -> int:
+            nonlocal now
+            self.wait_calls.append(timeout)
+            assert timeout is not None
+            now += timeout
+            if self.kill_calls == 0:
+                raise subprocess.TimeoutExpired("chromium", timeout)
+            self.returncode = -9
+            return self.returncode
+
+    process = DeadlineProcess()
+
+    def popen(_args, *, stdout, stderr):  # noqa: ANN001, ANN202
+        del stdout
+        stderr.write(b"DevTools listening on ws://127.0.0.1:9222/devtools/browser/test\n")
+        stderr.flush()
+        stderr_files.append(stderr)
+        return process
+
+    def fail_websocket(_url: str, *, timeout_s: float):  # noqa: ANN202
+        nonlocal now
+        assert timeout_s == pytest.approx(5.0)
+        now = 4.0
+        raise _chromium.ChromiumError("websocket handshake failed")
+
+    monkeypatch.setattr(_chromium.subprocess, "Popen", popen)
+    monkeypatch.setattr(_chromium, "_WebSocket", fail_websocket)
+    monkeypatch.setattr(_chromium.time, "monotonic", lambda: now)
+
+    with pytest.raises(_chromium.ChromiumError, match="handshake failed"):
+        _chromium.ChromiumSession("/fake/chromium", launch_timeout_s=5.0)
+
+    assert now == pytest.approx(5.0)
+    assert process.terminate_calls == 1
+    assert process.kill_calls == 1
+    assert process.wait_calls == [pytest.approx(1.0), 0.0]
+    assert stderr_files[0].closed
+    assert len(temp_paths) == 1
+    assert not temp_paths[0].exists()
+
+
+def test_websocket_receive_deadline_bounds_incremental_frame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 0.0
+
+    class DribblingSocket:
+        def __init__(self) -> None:
+            self.timeout = 0.0
+            self.timeouts: list[float] = []
+            self.chunks = iter((b"\x81", b"\x02", b"O", b"K"))
+
+        def settimeout(self, timeout_s: float) -> None:
+            self.timeout = timeout_s
+            self.timeouts.append(timeout_s)
+
+        def recv(self, _size: int) -> bytes:
+            nonlocal now
+            chunk_delay = 0.49
+            if self.timeout < chunk_delay:
+                now += self.timeout
+                raise TimeoutError("socket timed out")
+            now += chunk_delay
+            return next(self.chunks)
+
+        def sendall(self, _data: bytes) -> None:
+            pass
+
+        def close(self) -> None:
+            self.closed = True
+
+    sock = DribblingSocket()
+    sock.closed = False
+    websocket = object.__new__(_chromium._WebSocket)
+    websocket._sock = sock
+    websocket._buffer = b""
+    session = object.__new__(_chromium.ChromiumSession)
+    session._ws = websocket
+    session._next_id = 0
+    session._events = {}
+    monkeypatch.setattr(_chromium.time, "monotonic", lambda: now)
+
+    with pytest.raises(TimeoutError, match="timed out"):
+        session._call("Runtime.evaluate", timeout_s=1.0)
+
+    assert now == pytest.approx(1.0)
+    assert sock.timeouts == pytest.approx([1.0, 1.0, 1.0, 0.51, 0.02])
+    assert sock.closed
+    assert session._ws is None
+    with pytest.raises(_chromium.ChromiumError, match="no longer usable"):
+        session._call("Runtime.evaluate", timeout_s=1.0)
 
 
 def test_page_session_shares_one_timeout_across_setup_calls(
@@ -219,6 +320,7 @@ def test_cdp_call_deadline_includes_sending_the_request(monkeypatch: pytest.Monk
     class FakeWebSocket:
         def __init__(self) -> None:
             self.timeouts: list[float] = []
+            self.recv_deadlines: list[float] = []
 
         def settimeout(self, timeout_s: float) -> None:
             self.timeouts.append(timeout_s)
@@ -227,7 +329,8 @@ def test_cdp_call_deadline_includes_sending_the_request(monkeypatch: pytest.Monk
             nonlocal now
             now += 4.0
 
-        def recv_text(self) -> str:
+        def recv_text(self, *, deadline: float) -> str:
+            self.recv_deadlines.append(deadline)
             return json.dumps({"id": 1, "result": {"status": "ok"}})
 
     websocket = FakeWebSocket()
@@ -239,6 +342,7 @@ def test_cdp_call_deadline_includes_sending_the_request(monkeypatch: pytest.Monk
 
     assert session._call("Page.navigate", timeout_s=5.0) == {"status": "ok"}
     assert websocket.timeouts == [pytest.approx(5.0), pytest.approx(1.0)]
+    assert websocket.recv_deadlines == [pytest.approx(5.0)]
 
 
 def test_cdp_call_closes_and_invalidates_websocket_when_send_fails() -> None:
@@ -254,7 +358,7 @@ def test_cdp_call_closes_and_invalidates_websocket_when_send_fails() -> None:
             self.send_calls += 1
             raise TimeoutError("partial frame")
 
-        def close(self) -> None:
+        def abort(self) -> None:
             self.closed = True
 
     websocket = FakeWebSocket()
@@ -271,6 +375,55 @@ def test_cdp_call_closes_and_invalidates_websocket_when_send_fails() -> None:
     with pytest.raises(_chromium.ChromiumError, match="no longer usable"):
         session._call("Page.navigate", timeout_s=5.0)
     assert websocket.send_calls == 1
+
+
+def test_page_session_aborts_browser_when_target_creation_is_ambiguous(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 0.0
+    process = _FakeProcess(stall_on_wait=True)
+
+    class FakeWebSocket:
+        def __init__(self) -> None:
+            self.aborted = False
+
+        def abort(self) -> None:
+            self.aborted = True
+
+    websocket = FakeWebSocket()
+    session = object.__new__(_chromium.ChromiumSession)
+    session._ws = websocket
+    session._proc = process
+    session._next_id = 0
+    session._events = {}
+
+    def call(
+        method: str,
+        _params=None,  # noqa: ANN001
+        *,
+        session_id: str | None = None,
+        timeout_s: float,
+    ) -> dict[str, str]:
+        nonlocal now
+        del session_id
+        assert method == "Target.createTarget"
+        assert timeout_s == pytest.approx(5.0)
+        now = 5.0
+        raise _chromium.ChromiumError("timeout waiting for Target.createTarget")
+
+    monkeypatch.setattr(_chromium.time, "monotonic", lambda: now)
+    session._call = call
+
+    with pytest.raises(_chromium.ChromiumError, match=r"Target\.createTarget"):
+        session._page_session("<p>probe</p>", 5.0)
+
+    assert websocket.aborted
+    assert session._ws is None
+    assert process.terminate_calls == 1
+    assert process.kill_calls == 1
+    assert process.wait_calls == [0.0, 0.0]
+    with pytest.raises(_chromium.ChromiumError, match="no longer usable"):
+        _chromium.ChromiumSession._call(session, "Page.navigate", timeout_s=1.0)
 
 
 @pytest.mark.parametrize("failure_stage", ["attach", "write", "enable"])

--- a/tests/test_chromium_session.py
+++ b/tests/test_chromium_session.py
@@ -377,6 +377,105 @@ def test_cdp_call_closes_and_invalidates_websocket_when_send_fails() -> None:
     assert websocket.send_calls == 1
 
 
+@pytest.mark.parametrize(
+    "received, expected_exception",
+    [
+        pytest.param(
+            _chromium.ChromiumError("websocket closed by browser"),
+            _chromium.ChromiumError,
+            id="closed-stream",
+        ),
+        pytest.param("{invalid json", json.JSONDecodeError, id="invalid-json"),
+    ],
+)
+def test_cdp_call_invalidates_websocket_on_receive_or_decode_failure(
+    received: BaseException | str,
+    expected_exception: type[BaseException],
+) -> None:
+    class FakeWebSocket:
+        def __init__(self) -> None:
+            self.aborted = False
+            self.send_calls = 0
+
+        def settimeout(self, _timeout_s: float) -> None:
+            pass
+
+        def send_text(self, _message: str) -> None:
+            self.send_calls += 1
+
+        def recv_text(self, *, deadline: float) -> str:
+            assert deadline > 0
+            if isinstance(received, BaseException):
+                raise received
+            return received
+
+        def abort(self) -> None:
+            self.aborted = True
+
+    websocket = FakeWebSocket()
+    session = object.__new__(_chromium.ChromiumSession)
+    session._ws = websocket
+    session._next_id = 0
+    session._events = {}
+
+    with pytest.raises(expected_exception):
+        session._call("Page.navigate", timeout_s=5.0)
+
+    assert websocket.aborted
+    assert session._ws is None
+    with pytest.raises(_chromium.ChromiumError, match="no longer usable"):
+        session._call("Page.navigate", timeout_s=5.0)
+    assert websocket.send_calls == 1
+
+
+@pytest.mark.parametrize(
+    "received, expected_exception",
+    [
+        pytest.param(
+            _chromium.ChromiumError("websocket closed mid-frame"),
+            _chromium.ChromiumError,
+            id="closed-stream",
+        ),
+        pytest.param("{invalid json", json.JSONDecodeError, id="invalid-json"),
+    ],
+)
+def test_cdp_event_wait_invalidates_websocket_on_receive_or_decode_failure(
+    received: BaseException | str,
+    expected_exception: type[BaseException],
+) -> None:
+    class FakeWebSocket:
+        def __init__(self) -> None:
+            self.aborted = False
+            self.recv_calls = 0
+
+        def settimeout(self, _timeout_s: float) -> None:
+            pass
+
+        def recv_text(self, *, deadline: float) -> str:
+            assert deadline > 0
+            self.recv_calls += 1
+            if isinstance(received, BaseException):
+                raise received
+            return received
+
+        def abort(self) -> None:
+            self.aborted = True
+
+    websocket = FakeWebSocket()
+    session = object.__new__(_chromium.ChromiumSession)
+    session._ws = websocket
+    session._events = {}
+
+    with pytest.raises(expected_exception):
+        session._wait_event("Page.loadEventFired", session_id="page", timeout_s=5.0)
+
+    assert websocket.aborted
+    assert session._ws is None
+    with pytest.raises(_chromium.ChromiumError, match="no longer usable"):
+        session._wait_event("Page.loadEventFired", session_id="page", timeout_s=5.0)
+    assert websocket.recv_calls == 1
+
+
 def test_page_session_aborts_browser_when_target_creation_is_ambiguous(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_chromium_session.py
+++ b/tests/test_chromium_session.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from xy import _chromium
+
+
+class _FakeProcess:
+    def __init__(self, *, returncode: int | None = None, stall_on_wait: bool = False) -> None:
+        self.returncode = returncode
+        self.stall_on_wait = stall_on_wait
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self.wait_calls: list[float | None] = []
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        self.returncode = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        self.wait_calls.append(timeout)
+        if self.stall_on_wait and self.kill_calls == 0:
+            raise subprocess.TimeoutExpired("chromium", timeout)
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+
+def _track_tempdirs(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+    real_temporary_directory = _chromium.tempfile.TemporaryDirectory
+    paths: list[Path] = []
+
+    def temporary_directory(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        directory = real_temporary_directory(*args, **kwargs)
+        paths.append(Path(directory.name))
+        return directory
+
+    monkeypatch.setattr(_chromium.tempfile, "TemporaryDirectory", temporary_directory)
+    return paths
+
+
+def test_chromium_session_cleans_every_resource_when_websocket_handshake_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    temp_paths = _track_tempdirs(monkeypatch)
+    process = _FakeProcess(stall_on_wait=True)
+    stderr_files = []
+
+    def popen(_args, *, stdout, stderr):  # noqa: ANN001, ANN202
+        del stdout
+        stderr.write(b"DevTools listening on ws://127.0.0.1:9222/devtools/browser/test\n")
+        stderr.flush()
+        stderr_files.append(stderr)
+        return process
+
+    def fail_websocket(_url: str, *, timeout_s: float):  # noqa: ANN202
+        assert timeout_s > 0
+        raise _chromium.ChromiumError("websocket handshake failed")
+
+    monkeypatch.setattr(_chromium.subprocess, "Popen", popen)
+    monkeypatch.setattr(_chromium, "_WebSocket", fail_websocket)
+
+    with pytest.raises(_chromium.ChromiumError, match="handshake failed"):
+        _chromium.ChromiumSession("/fake/chromium")
+
+    assert process.terminate_calls == 1
+    assert process.kill_calls == 1
+    assert process.wait_calls == [10, 10]
+    assert stderr_files[0].closed
+    assert len(temp_paths) == 1
+    assert not temp_paths[0].exists()
+
+
+def test_chromium_session_cleans_files_when_browser_exits_during_launch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    temp_paths = _track_tempdirs(monkeypatch)
+    process = _FakeProcess(returncode=23)
+    stderr_files = []
+
+    def popen(_args, *, stdout, stderr):  # noqa: ANN001, ANN202
+        del stdout
+        stderr.write(b"fatal startup failure\n")
+        stderr.flush()
+        stderr_files.append(stderr)
+        return process
+
+    monkeypatch.setattr(_chromium.subprocess, "Popen", popen)
+
+    with pytest.raises(_chromium.ChromiumError, match="fatal startup failure"):
+        _chromium.ChromiumSession("/fake/chromium")
+
+    assert process.terminate_calls == 0
+    assert process.kill_calls == 0
+    assert process.wait_calls == [10]
+    assert stderr_files[0].closed
+    assert len(temp_paths) == 1
+    assert not temp_paths[0].exists()
+
+
+def test_websocket_closes_socket_when_handshake_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeSocket:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def settimeout(self, _timeout_s: float) -> None:
+            pass
+
+        def sendall(self, _data: bytes) -> None:
+            pass
+
+        def recv(self, _size: int) -> bytes:
+            return b""
+
+        def close(self) -> None:
+            self.closed = True
+
+    sock = FakeSocket()
+    monkeypatch.setattr(_chromium.socket, "create_connection", lambda *_args, **_kwargs: sock)
+
+    with pytest.raises(_chromium.ChromiumError, match="connection closed"):
+        _chromium._WebSocket("ws://127.0.0.1:9222/devtools/browser/test")
+
+    assert sock.closed
+
+
+def test_page_session_shares_one_timeout_across_setup_calls(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    now = 0.0
+    timeouts: list[tuple[str, float]] = []
+    session = object.__new__(_chromium.ChromiumSession)
+    session._tmp = SimpleNamespace(name=str(tmp_path))
+
+    def monotonic() -> float:
+        return now
+
+    def call(
+        method: str,
+        _params=None,  # noqa: ANN001
+        *,
+        session_id: str | None = None,
+        timeout_s: float,
+    ) -> dict[str, str]:
+        nonlocal now
+        del session_id
+        timeouts.append((method, timeout_s))
+        now += 1.0
+        if method == "Target.createTarget":
+            return {"targetId": "target123"}
+        if method == "Target.attachToTarget":
+            return {"sessionId": "session123"}
+        return {}
+
+    monkeypatch.setattr(_chromium.time, "monotonic", monotonic)
+    session._call = call
+
+    target_id, session_id, page_path = session._page_session("<p>probe</p>", 5.0)
+
+    assert (target_id, session_id) == ("target123", "session123")
+    assert page_path.read_text(encoding="utf-8") == "<p>probe</p>"
+    assert timeouts == [
+        ("Target.createTarget", pytest.approx(5.0)),
+        ("Target.attachToTarget", pytest.approx(4.0)),
+        ("Page.enable", pytest.approx(3.0)),
+    ]
+
+
+def test_cdp_call_deadline_includes_sending_the_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = 0.0
+
+    class FakeWebSocket:
+        def __init__(self) -> None:
+            self.timeouts: list[float] = []
+
+        def settimeout(self, timeout_s: float) -> None:
+            self.timeouts.append(timeout_s)
+
+        def send_text(self, _message: str) -> None:
+            nonlocal now
+            now += 4.0
+
+        def recv_text(self) -> str:
+            return json.dumps({"id": 1, "result": {"status": "ok"}})
+
+    websocket = FakeWebSocket()
+    session = object.__new__(_chromium.ChromiumSession)
+    session._ws = websocket
+    session._next_id = 0
+    session._events = {}
+    monkeypatch.setattr(_chromium.time, "monotonic", lambda: now)
+
+    assert session._call("Page.navigate", timeout_s=5.0) == {"status": "ok"}
+    assert websocket.timeouts == [pytest.approx(5.0), pytest.approx(1.0)]

--- a/tests/test_chromium_session.py
+++ b/tests/test_chromium_session.py
@@ -239,3 +239,93 @@ def test_cdp_call_deadline_includes_sending_the_request(monkeypatch: pytest.Monk
 
     assert session._call("Page.navigate", timeout_s=5.0) == {"status": "ok"}
     assert websocket.timeouts == [pytest.approx(5.0), pytest.approx(1.0)]
+
+
+def test_cdp_call_closes_and_invalidates_websocket_when_send_fails() -> None:
+    class FakeWebSocket:
+        def __init__(self) -> None:
+            self.closed = False
+            self.send_calls = 0
+
+        def settimeout(self, _timeout_s: float) -> None:
+            pass
+
+        def send_text(self, _message: str) -> None:
+            self.send_calls += 1
+            raise TimeoutError("partial frame")
+
+        def close(self) -> None:
+            self.closed = True
+
+    websocket = FakeWebSocket()
+    session = object.__new__(_chromium.ChromiumSession)
+    session._ws = websocket
+    session._next_id = 0
+    session._events = {}
+
+    with pytest.raises(TimeoutError, match="partial frame"):
+        session._call("Page.navigate", timeout_s=5.0)
+
+    assert websocket.closed
+    assert session._ws is None
+    with pytest.raises(_chromium.ChromiumError, match="no longer usable"):
+        session._call("Page.navigate", timeout_s=5.0)
+    assert websocket.send_calls == 1
+
+
+@pytest.mark.parametrize("failure_stage", ["attach", "write", "enable"])
+def test_page_session_cleans_target_and_file_after_setup_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    failure_stage: str,
+) -> None:
+    now = 0.0
+    calls: list[tuple[str, float]] = []
+    page_path = tmp_path / "chart-target12.html"
+    session = object.__new__(_chromium.ChromiumSession)
+    session._tmp = SimpleNamespace(name=str(tmp_path))
+
+    def call(
+        method: str,
+        _params=None,  # noqa: ANN001
+        *,
+        session_id: str | None = None,
+        timeout_s: float,
+    ) -> dict[str, str]:
+        nonlocal now
+        del session_id
+        calls.append((method, timeout_s))
+        now += 1.0
+        if method == "Target.createTarget":
+            return {"targetId": "target123"}
+        if method == "Target.attachToTarget":
+            if failure_stage == "attach":
+                raise _chromium.ChromiumError("attach failed")
+            return {"sessionId": "session123"}
+        if method == "Page.enable" and failure_stage == "enable":
+            raise _chromium.ChromiumError("enable failed")
+        return {}
+
+    real_write_text = Path.write_text
+
+    def write_text(path: Path, data: str, *, encoding: str) -> int:
+        if failure_stage == "write":
+            real_write_text(path, "partial", encoding=encoding)
+            raise OSError("write failed")
+        return real_write_text(path, data, encoding=encoding)
+
+    monkeypatch.setattr(_chromium.time, "monotonic", lambda: now)
+    monkeypatch.setattr(Path, "write_text", write_text)
+    session._call = call
+
+    expected_error = {
+        "attach": _chromium.ChromiumError,
+        "write": OSError,
+        "enable": _chromium.ChromiumError,
+    }[failure_stage]
+    with pytest.raises(expected_error):
+        session._page_session("<p>probe</p>", 5.0)
+
+    assert calls[-1][0] == "Target.closeTarget"
+    assert 0.0 < calls[-1][1] <= 5.0
+    assert not page_path.exists()

--- a/tests/test_render_smoke_nonumpy.py
+++ b/tests/test_render_smoke_nonumpy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -10,17 +11,60 @@ import pytest
 def _load_render_smoke():
     root = Path(__file__).resolve().parents[1]
     scripts = root / "scripts"
-    sys.path.insert(0, str(scripts))
     path = scripts / "render_smoke_nonumpy.py"
     spec = importlib.util.spec_from_file_location("render_smoke_nonumpy", path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
+    original_path = sys.path[:]
+    missing = object()
+    original_modules = {name: sys.modules.get(name, missing) for name in (spec.name, "_protocol")}
+    try:
+        sys.path.insert(0, str(scripts))
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path[:] = original_path
+        for name, original in original_modules.items():
+            if original is missing:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original  # type: ignore[assignment]
 
 
 render_smoke = _load_render_smoke()
+
+
+def test_load_render_smoke_restores_preexisting_import_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_path = sys.path[:]
+    previous_smoke = ModuleType("render_smoke_nonumpy")
+    previous_protocol = ModuleType("_protocol")
+    previous_protocol.PROTOCOL_VERSION = render_smoke.PROTOCOL_VERSION
+    monkeypatch.setitem(sys.modules, "render_smoke_nonumpy", previous_smoke)
+    monkeypatch.setitem(sys.modules, "_protocol", previous_protocol)
+
+    loaded = _load_render_smoke()
+
+    assert loaded is not previous_smoke
+    assert sys.path == original_path
+    assert sys.modules["render_smoke_nonumpy"] is previous_smoke
+    assert sys.modules["_protocol"] is previous_protocol
+
+
+def test_load_render_smoke_removes_transient_import_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_path = sys.path[:]
+    monkeypatch.delitem(sys.modules, "render_smoke_nonumpy", raising=False)
+    monkeypatch.delitem(sys.modules, "_protocol", raising=False)
+
+    _load_render_smoke()
+
+    assert sys.path == original_path
+    assert "render_smoke_nonumpy" not in sys.modules
+    assert "_protocol" not in sys.modules
 
 
 class _Clock:

--- a/tests/test_render_smoke_nonumpy.py
+++ b/tests/test_render_smoke_nonumpy.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_render_smoke():
+    root = Path(__file__).resolve().parents[1]
+    scripts = root / "scripts"
+    sys.path.insert(0, str(scripts))
+    path = scripts / "render_smoke_nonumpy.py"
+    spec = importlib.util.spec_from_file_location("render_smoke_nonumpy", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+render_smoke = _load_render_smoke()
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def test_run_probe_propagates_one_deadline_through_every_phase(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clock = _Clock()
+    calls: list[tuple[str, float]] = []
+    page_path = tmp_path / "probe.html"
+
+    class FakeSession:
+        def __init__(
+            self,
+            _executable: str,
+            *,
+            gl: str,
+            sandbox: bool,
+            launch_timeout_s: float,
+        ) -> None:
+            assert (gl, sandbox) == ("software", False)
+            calls.append(("launch", launch_timeout_s))
+            clock.advance(40.0)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, _exc_type, _exc, _tb) -> None:  # noqa: ANN001
+            pass
+
+        def _page_session(self, _page: str, timeout_s: float):
+            calls.append(("page_session", timeout_s))
+            clock.advance(50.0)
+            return "target", "session", page_path
+
+        def _call(
+            self,
+            method: str,
+            _params=None,  # noqa: ANN001
+            *,
+            session_id: str,
+            timeout_s: float,
+        ):
+            assert session_id == "session"
+            calls.append((method, timeout_s))
+            if method == "Page.navigate":
+                clock.advance(60.0)
+                return {}
+            return {"result": {"value": "XY_OK"}}
+
+        def _wait_event(self, method: str, *, session_id: str, timeout_s: float) -> None:
+            assert (method, session_id) == ("Page.loadEventFired", "session")
+            calls.append((method, timeout_s))
+            clock.advance(70.0)
+
+    monkeypatch.setattr(render_smoke.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(render_smoke.time, "sleep", clock.sleep)
+    monkeypatch.setattr(render_smoke, "find_chromium", lambda: "/fake/chromium")
+    monkeypatch.setattr(render_smoke, "ChromiumSession", FakeSession)
+
+    assert render_smoke.run_probe("<title>pending</title>", timeout_s=300.0) == "XY_OK"
+    assert calls == [
+        ("launch", pytest.approx(300.0)),
+        ("page_session", pytest.approx(260.0)),
+        ("Page.navigate", pytest.approx(210.0)),
+        ("Page.loadEventFired", pytest.approx(150.0)),
+        ("Runtime.evaluate", pytest.approx(80.0)),
+    ]
+
+
+def test_run_probe_stops_setup_when_the_shared_deadline_expires(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    clock = _Clock()
+    calls: list[tuple[str, float]] = []
+    page_path = tmp_path / "probe.html"
+
+    class StallingSession:
+        def __init__(self, _executable: str, *, launch_timeout_s: float, **_kwargs) -> None:
+            calls.append(("launch", launch_timeout_s))
+            clock.advance(100.0)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, _exc_type, _exc, _tb) -> None:  # noqa: ANN001
+            pass
+
+        def _page_session(self, _page: str, timeout_s: float):
+            calls.append(("page_session", timeout_s))
+            clock.advance(100.0)
+            return "target", "session", page_path
+
+        def _call(
+            self,
+            method: str,
+            _params=None,  # noqa: ANN001
+            *,
+            session_id: str,
+            timeout_s: float,
+        ):
+            assert session_id == "session"
+            calls.append((method, timeout_s))
+            clock.advance(100.0)
+            return {}
+
+        def _wait_event(self, *_args, **_kwargs) -> None:  # noqa: ANN002, ANN003
+            raise AssertionError("load wait must not start after the deadline")
+
+    monkeypatch.setattr(render_smoke.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(render_smoke.time, "sleep", clock.sleep)
+    monkeypatch.setattr(render_smoke, "find_chromium", lambda: "/fake/chromium")
+    monkeypatch.setattr(render_smoke, "ChromiumSession", StallingSession)
+
+    with pytest.raises(TimeoutError, match="within 300 seconds"):
+        render_smoke.run_probe("<title>pending</title>", timeout_s=300.0)
+
+    assert calls == [
+        ("launch", pytest.approx(300.0)),
+        ("page_session", pytest.approx(200.0)),
+        ("Page.navigate", pytest.approx(100.0)),
+    ]


### PR DESCRIPTION
## What changed

- Replaced Chromium's raw `--dump-dom --virtual-time-budget` subprocess path with the repository's CDP-based `ChromiumSession` harness.
- Kept the 300-second overall deadline while polling the page sentinel without treating an individual poll as the entire run timeout.
- Close the browser context deterministically and document the runner behavior.

## Why

On macOS arm64, the raw headless Chrome process could stay alive until the five-minute timeout even after the page had completed. The CDP harness already provides bounded lifecycle control elsewhere in the repository.

## Impact

The no-NumPy standalone smoke completes reliably while preserving rendering, interaction, context-loss, DPR, and cleanup coverage.

## Validation

- `.venv/bin/python scripts/render_smoke_nonumpy.py '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'` — passed all assertions, including 3 context-loss cycles
- `.venv/bin/python scripts/check_python_floor.py`
- `.venv/bin/ruff check scripts/render_smoke_nonumpy.py`

Fixes #394

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Chromium startup, WebSocket communication, and page-session handling with consistent timeouts and deadline enforcement.
  * Ensured failed launches, connections, and page setup operations clean up resources reliably.
  * Improved recovery from browser, socket, and DevTools communication failures.
  * Browser shutdown and temporary-file cleanup are now bounded and more reliable.
  * Render smoke checks now use a deterministic page probe with clearer timeout and page-error reporting.

* **Documentation**
  * Clarified that render smoke checks stop the browser after the page reports its result.

* **Tests**
  * Expanded coverage for timeout handling, failure recovery, cleanup, and deterministic render smoke checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->