### PR TITLE
Enforce docs heading hierarchy

### DIFF
--- a/docs/app/scripts/check_heading_outline.py
+++ b/docs/app/scripts/check_heading_outline.py
@@ -1,0 +1,70 @@
+"""Validate semantic heading order on every public documentation route."""
+
+from collections.abc import Iterator, Sequence
+from itertools import pairwise
+from typing import Any
+
+from reflex_site_shared.docs.content import discover_docs
+from xy_docs.config import DOCS_CONFIG
+from xy_docs.markdown import render_xy_markdown_page
+
+
+def _static_string(value: Any) -> str | None:
+    """Return a Python string from a literal Reflex value."""
+    if isinstance(value, str):
+        return value
+    literal = getattr(value, "_var_value", None)
+    return literal if isinstance(literal, str) else None
+
+
+def _walk_component_tree(component: object) -> Iterator[object]:
+    """Yield a rendered Reflex component tree in document order."""
+    yield component
+    for child in getattr(component, "children", ()):
+        yield from _walk_component_tree(child)
+
+
+def _heading_level(component: object) -> int | None:
+    """Return the semantic heading level of a rendered Reflex component."""
+    tag = _static_string(getattr(component, "tag", None))
+    if tag == "Heading":
+        tag = _static_string(getattr(component, "as_", None))
+    if tag is not None and len(tag) == 2 and tag[0].lower() == "h":
+        level = int(tag[1]) if tag[1].isdigit() else 0
+        return level if 1 <= level <= 6 else None
+    return None
+
+
+def heading_jumps(components: Sequence[object]) -> tuple[tuple[int, int], ...]:
+    """Return adjacent heading levels that skip an outline level."""
+    levels = tuple(
+        level for component in components if (level := _heading_level(component)) is not None
+    )
+    # A public page must begin with its H1. Seeding with level 1 also makes a
+    # malformed first H3 fail if a future renderer accidentally omits H1.
+    return tuple(
+        (current, following)
+        for current, following in pairwise((1, *levels))
+        if following > current + 1
+    )
+
+
+def validate_public_page_headings() -> None:
+    """Raise when a public page skips a semantic heading level."""
+    failures: dict[str, tuple[tuple[int, int], ...]] = {}
+    for page in discover_docs(DOCS_CONFIG):
+        components = tuple(_walk_component_tree(render_xy_markdown_page(page)))
+        jumps = heading_jumps(components)
+        if jumps:
+            failures[page.route] = jumps
+    if failures:
+        raise RuntimeError(f"heading level jumps: {failures}")
+
+
+def main() -> None:
+    """Validate heading order on all public documentation pages."""
+    validate_public_page_headings()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/app/scripts/check_heading_outline.py
+++ b/docs/app/scripts/check_heading_outline.py
@@ -35,30 +35,35 @@ def _heading_level(component: object) -> int | None:
     return None
 
 
-def heading_jumps(components: Sequence[object]) -> tuple[tuple[int, int], ...]:
-    """Return adjacent heading levels that skip an outline level."""
+def heading_outline_errors(components: Sequence[object]) -> tuple[str, ...]:
+    """Return missing-H1 and adjacent heading-level errors."""
     levels = tuple(
         level for component in components if (level := _heading_level(component)) is not None
     )
-    # A public page must begin with its H1. Seeding with level 1 also makes a
-    # malformed first H3 fail if a future renderer accidentally omits H1.
-    return tuple(
-        (current, following)
-        for current, following in pairwise((1, *levels))
+    if not levels:
+        return ("missing H1 (page has no headings)",)
+
+    errors = []
+    if levels[0] != 1:
+        errors.append(f"first heading is H{levels[0]}, expected H1")
+    errors.extend(
+        f"heading level jumps from H{current} to H{following}"
+        for current, following in pairwise(levels)
         if following > current + 1
     )
+    return tuple(errors)
 
 
 def validate_public_page_headings() -> None:
-    """Raise when a public page skips a semantic heading level."""
-    failures: dict[str, tuple[tuple[int, int], ...]] = {}
+    """Raise when a public page omits H1 or skips a semantic heading level."""
+    failures: dict[str, tuple[str, ...]] = {}
     for page in discover_docs(DOCS_CONFIG):
         components = tuple(_walk_component_tree(render_xy_markdown_page(page)))
-        jumps = heading_jumps(components)
-        if jumps:
-            failures[page.route] = jumps
+        errors = heading_outline_errors(components)
+        if errors:
+            failures[page.route] = errors
     if failures:
-        raise RuntimeError(f"heading level jumps: {failures}")
+        raise RuntimeError(f"heading outline errors: {failures}")
 
 
 def main() -> None:

--- a/docs/app/tests/test_heading_outline.py
+++ b/docs/app/tests/test_heading_outline.py
@@ -19,6 +19,14 @@ check_heading_outline = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(check_heading_outline)
 
 
+def _heading(level: int) -> SimpleNamespace:
+    """Return one minimal rendered heading for validator unit tests."""
+    return SimpleNamespace(
+        tag="Heading",
+        as_=SimpleNamespace(_var_value=f"h{level}"),
+    )
+
+
 def test_public_docs_have_ordered_heading_levels() -> None:
     """Keep every rendered public route free of heading-level jumps."""
     result = subprocess.run(
@@ -33,15 +41,22 @@ def test_public_docs_have_ordered_heading_levels() -> None:
     assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
 
 
-def test_heading_outline_validator_rejects_first_h3() -> None:
-    """Reject a page whose first semantic section skips from H1 to H3."""
-    h3 = SimpleNamespace(
-        tag="Heading",
-        as_=SimpleNamespace(_var_value="h3"),
-    )
-    h4 = SimpleNamespace(
-        tag="Heading",
-        as_=SimpleNamespace(_var_value="h4"),
+def test_heading_outline_validator_rejects_no_headings() -> None:
+    """Reject a page with no semantic headings."""
+    assert check_heading_outline.heading_outline_errors(()) == (
+        "missing H1 (page has no headings)",
     )
 
-    assert check_heading_outline.heading_jumps((h3, h4)) == ((1, 3),)
+
+def test_heading_outline_validator_rejects_first_h2() -> None:
+    """Reject a page whose first semantic heading is not H1."""
+    assert check_heading_outline.heading_outline_errors((_heading(2),)) == (
+        "first heading is H2, expected H1",
+    )
+
+
+def test_heading_outline_validator_rejects_adjacent_jump() -> None:
+    """Reject adjacent headings that skip an outline level."""
+    assert check_heading_outline.heading_outline_errors((_heading(1), _heading(3))) == (
+        "heading level jumps from H1 to H3",
+    )

--- a/docs/app/tests/test_heading_outline.py
+++ b/docs/app/tests/test_heading_outline.py
@@ -1,0 +1,47 @@
+"""Regression coverage for public documentation heading outlines."""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+DOCS_APP_ROOT = Path(__file__).resolve().parent.parent
+CHECK_HEADING_OUTLINE_PATH = DOCS_APP_ROOT / "scripts" / "check_heading_outline.py"
+SPEC = importlib.util.spec_from_file_location(
+    "xy_docs_check_heading_outline",
+    CHECK_HEADING_OUTLINE_PATH,
+)
+if SPEC is None or SPEC.loader is None:
+    msg = f"Unable to load heading-outline validator: {CHECK_HEADING_OUTLINE_PATH}"
+    raise RuntimeError(msg)
+check_heading_outline = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(check_heading_outline)
+
+
+def test_public_docs_have_ordered_heading_levels() -> None:
+    """Keep every rendered public route free of heading-level jumps."""
+    result = subprocess.run(
+        [sys.executable, str(CHECK_HEADING_OUTLINE_PATH)],
+        cwd=DOCS_APP_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+
+
+def test_heading_outline_validator_rejects_first_h3() -> None:
+    """Reject a page whose first semantic section skips from H1 to H3."""
+    h3 = SimpleNamespace(
+        tag="Heading",
+        as_=SimpleNamespace(_var_value="h3"),
+    )
+    h4 = SimpleNamespace(
+        tag="Heading",
+        as_=SimpleNamespace(_var_value="h4"),
+    )
+
+    assert check_heading_outline.heading_jumps((h3, h4)) == ((1, 3),)

--- a/docs/app/xy_docs/demos/benchmark_charts.py
+++ b/docs/app/xy_docs/demos/benchmark_charts.py
@@ -188,7 +188,7 @@ def interactive_ux_demo() -> rx.Component:
     return rx.el.section(
         rx.el.div(
             rx.el.div(
-                rx.el.h3(
+                rx.el.h2(
                     "Live interactive render time",
                     class_name="text-xl font-semibold tracking-[-0.02em] text-secondary-12",
                 ),

--- a/docs/components/modebars-and-interaction-controls.md
+++ b/docs/components/modebars-and-interaction-controls.md
@@ -31,7 +31,7 @@ zoom, selection, brushing, and crosshairs do not yet have polar semantics and
 stay disabled even when a general interaction flag is enabled. The polar
 modebar therefore omits the Pan button.
 
-### The default toolbar
+## The default toolbar
 
 Every interactive chart gets the modebar for free — hover over the top-right
 corner of this chart to see the pan, zoom, reset, and export controls:
@@ -84,7 +84,7 @@ decimated or density-tier chart that is not necessarily every canonical source
 row; export the source table from Python when a complete data extract is
 required.
 
-### Styling or removing the toolbar
+## Styling or removing the toolbar
 
 The left chart restyles the toolbar surface and every button, while the right
 chart removes the toolbar entirely with `modebar(show=False)`:


### PR DESCRIPTION
## What changed

- Promoted the Modebars page's top-level sections from H3 to H2.
- Promoted the benchmark demo heading to H2 so visible demo content fits the page outline.
- Added an all-public-route heading-order validator plus a negative first-H3 regression test.

## Why

The two affected routes skipped directly from H1 to H3, weakening the semantic outline used by assistive technology and generated navigation.

## Impact

Public documentation headings now advance by at most one level, and future route-level heading jumps fail the docs suite.

## Validation

- `docs/app/.venv/bin/pytest -q docs/app/tests/test_heading_outline.py` — 2 passed
- `docs/app/.venv/bin/python docs/app/scripts/check_heading_outline.py`
- Ruff lint and format checks on changed Python files

Fixes #397

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

