### PR TITLE
Create GitHub Releases after publish

### DIFF
--- a/.github/workflows/deploy-docs-stg.yml
+++ b/.github/workflows/deploy-docs-stg.yml
@@ -118,10 +118,11 @@ jobs:
       - run: echo "Approved for production promotion"
 
   # No GitHub Release job here: on a `v*` tag release.yml owns the release
-  # (it gates tag == pyproject == CHANGELOG and attaches the Pyodide wheel with
-  # generated notes). A second creator would race it and could win, stamping a
-  # library release with docs-deployment notes. The flip side of not owning it
-  # is that this workflow must confirm it happened before promoting prod.
+  # (it gates tag == pyproject == CHANGELOG and attaches every verified wheel
+  # and sdist with generated notes). A second creator would race it and could
+  # win, stamping a library release with docs-deployment notes. The flip side
+  # of not owning it is that this workflow must confirm it happened before
+  # promoting prod.
   verify-library-release:
     name: Verify Library Release Published
     needs: [prepare, await-prod-approval]

--- a/.github/workflows/deploy-docs-stg.yml
+++ b/.github/workflows/deploy-docs-stg.yml
@@ -144,6 +144,7 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.version }}
           SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
           REPO: ${{ github.repository }}
+        shell: bash
         run: |
           shopt -s nullglob
           PYPI_VERSION="${VERSION#v}"

--- a/.github/workflows/deploy-docs-stg.yml
+++ b/.github/workflows/deploy-docs-stg.yml
@@ -127,7 +127,10 @@ jobs:
     name: Verify Library Release Published
     needs: [prepare, await-prod-approval]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # The poll loop has a 30-minute deadline. Its longest bounded network
+    # attempt is under six minutes, leaving at least nine more minutes for
+    # the final diagnostic and runner cleanup before the job timeout.
+    timeout-minutes: 45
     permissions:
       contents: read
       attestations: read
@@ -145,19 +148,39 @@ jobs:
           shopt -s nullglob
           PYPI_VERSION="${VERSION#v}"
           PROVENANCE_NAME="xy-release-provenance.json"
+          MAX_ATTEMPTS=30
+          POLL_INTERVAL_SECONDS=60
+          POLL_DEADLINE=$((SECONDS + 30 * 60))
+          verify_tag_source() {
+            local current_tag_sha
+            if ! current_tag_sha="$(
+              timeout --signal=TERM --kill-after=5s 30s \
+                gh api "repos/${REPO}/commits/${VERSION}" --jq '.sha'
+            )"; then
+              return 1
+            fi
+            [[ "$current_tag_sha" == "$SOURCE_SHA" ]]
+          }
           EXPECTED_PRERELEASE=false
           if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)[0-9]+$ ]]; then
             EXPECTED_PRERELEASE=true
           fi
-          for attempt in $(seq 1 30); do
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            if (( SECONDS >= POLL_DEADLINE )); then
+              echo "::warning::release-readiness polling deadline reached before attempt ${attempt}"
+              break
+            fi
             RELEASED=false
             PUBLISHED=false
             PROVENANCE_VALID=false
             ASSETS_MATCH=false
+            TAG_MATCH=false
             if release_json="$(
-              gh release view "$VERSION" \
-                --repo "$REPO" \
-                --json assets,body,isDraft,isPrerelease,name,publishedAt,tagName 2>/dev/null
+              timeout --signal=TERM --kill-after=5s 30s \
+                gh release view "$VERSION" \
+                  --repo "$REPO" \
+                  --json assets,body,isDraft,isPrerelease,name,publishedAt,tagName \
+                  2>/dev/null
             )"; then
               if jq -e \
                 --arg name "$VERSION" \
@@ -176,13 +199,21 @@ jobs:
               fi
             fi
             if pypi_json="$(
-              curl -fsS "https://pypi.org/pypi/xy/${PYPI_VERSION}/json" 2>/dev/null
+              curl -fsS \
+                --connect-timeout 5 \
+                --max-time 20 \
+                "https://pypi.org/pypi/xy/${PYPI_VERSION}/json" \
+                2>/dev/null
             )"; then
               # A yank is a withdrawal signal, not a usable release. Reject
-              # the entire version if any uploaded file has been yanked.
+              # the entire version if any uploaded file has been yanked or is
+              # not one of the signed wheel/sdist distribution formats.
               if jq -e \
                 '(.urls | length > 1) and
                  all(.urls[]; .yanked == false) and
+                 all(.urls[];
+                   .filename |
+                     endswith(".whl") or endswith(".tar.gz")) and
                  any(.urls[]; .filename | endswith(".whl")) and
                  ([.urls[] | select(.filename | endswith(".tar.gz"))] |
                    length) == 1' \
@@ -192,20 +223,22 @@ jobs:
             fi
             if [[ "$RELEASED" == true && "$PUBLISHED" == true ]]; then
               verify_dir="$(mktemp -d "${RUNNER_TEMP}/xy-promotion-verify.XXXXXX")"
-              if gh release download "$VERSION" \
-                --repo "$REPO" \
-                --dir "$verify_dir" \
-                --pattern '*.whl' \
-                --pattern '*.tar.gz' \
-                --pattern "$PROVENANCE_NAME"; then
+              if timeout --signal=TERM --kill-after=5s 180s \
+                gh release download "$VERSION" \
+                  --repo "$REPO" \
+                  --dir "$verify_dir" \
+                  --pattern '*.whl' \
+                  --pattern '*.tar.gz' \
+                  --pattern "$PROVENANCE_NAME"; then
                 provenance_file="${verify_dir}/${PROVENANCE_NAME}"
                 if [[ -s "$provenance_file" ]] &&
-                   gh attestation verify "$provenance_file" \
-                     --repo "$REPO" \
-                     --signer-workflow "${REPO}/.github/workflows/release.yml" \
-                     --source-ref "refs/tags/${VERSION}" \
-                     --source-digest "$SOURCE_SHA" \
-                     --deny-self-hosted-runners >/dev/null &&
+                   timeout --signal=TERM --kill-after=5s 60s \
+                     gh attestation verify "$provenance_file" \
+                       --repo "$REPO" \
+                       --signer-workflow "${REPO}/.github/workflows/release.yml" \
+                       --source-ref "refs/tags/${VERSION}" \
+                       --source-digest "$SOURCE_SHA" \
+                       --deny-self-hosted-runners >/dev/null &&
                    jq -e \
                      --arg tag "$VERSION" \
                      --arg source_sha "$SOURCE_SHA" \
@@ -263,8 +296,6 @@ jobs:
                   pypi_hashes_json="$(
                     jq -c \
                       '[.urls[] |
-                        select(.filename |
-                          endswith(".whl") or endswith(".tar.gz")) |
                         {name: .filename, sha256: .digests.sha256}] |
                        sort_by(.name)' \
                       <<<"$pypi_json"
@@ -283,21 +314,44 @@ jobs:
                   fi
                 fi
               fi
-              # A failed candidate can be retried up to 30 times. Remove the
-              # downloaded wheel set before polling again to bound disk use.
+              # A failed candidate can be attempted up to MAX_ATTEMPTS times.
+              # Remove the downloaded wheel set before polling again to bound
+              # disk use.
               rm -rf -- "$verify_dir"
             fi
             if [[ "$RELEASED" == true &&
                   "$PUBLISHED" == true &&
                   "$PROVENANCE_VALID" == true &&
-                  "$ASSETS_MATCH" == true ]]; then
+                  "$ASSETS_MATCH" == true ]] &&
+               verify_tag_source; then
+              TAG_MATCH=true
+            fi
+            if [[ "$RELEASED" == true &&
+                  "$PUBLISHED" == true &&
+                  "$PROVENANCE_VALID" == true &&
+                  "$ASSETS_MATCH" == true &&
+                  "$TAG_MATCH" == true ]]; then
               echo "::notice::${VERSION} has signed release provenance and byte-identical, non-yanked GitHub/PyPI distributions"
               exit 0
             fi
-            echo "attempt ${attempt}/30 — release=${RELEASED} pypi=${PUBLISHED} provenance=${PROVENANCE_VALID} assets=${ASSETS_MATCH}; retrying in 60s"
-            sleep 60
+            status="attempt ${attempt}/${MAX_ATTEMPTS} — tag=${TAG_MATCH} release=${RELEASED} pypi=${PUBLISHED} provenance=${PROVENANCE_VALID} assets=${ASSETS_MATCH}"
+            if (( attempt == MAX_ATTEMPTS )); then
+              echo "${status}; no retries remain"
+              break
+            fi
+            remaining_seconds=$((POLL_DEADLINE - SECONDS))
+            if (( remaining_seconds <= 0 )); then
+              echo "${status}; polling deadline reached"
+              break
+            fi
+            sleep_seconds=$POLL_INTERVAL_SECONDS
+            if (( sleep_seconds > remaining_seconds )); then
+              sleep_seconds=$remaining_seconds
+            fi
+            echo "${status}; retrying in ${sleep_seconds}s"
+            sleep "$sleep_seconds"
           done
-          echo "::error::${VERSION} did not become release-ready (metadata, signed notes provenance, non-yanked PyPI files, or exact asset hashes missing/mismatched) — refusing to promote prod"
+          echo "::error::${VERSION} did not become release-ready (current tag source, metadata, signed notes provenance, non-yanked PyPI files, or exact asset hashes missing/mismatched) — refusing to promote prod"
           exit 1
 
   helm-pr-prod:

--- a/.github/workflows/deploy-docs-stg.yml
+++ b/.github/workflows/deploy-docs-stg.yml
@@ -141,25 +141,66 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           PYPI_VERSION="${VERSION#v}"
+          EXPECTED_PRERELEASE=false
+          if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)[0-9]+$ ]]; then
+            EXPECTED_PRERELEASE=true
+          fi
           for attempt in $(seq 1 30); do
             RELEASED=false
             PUBLISHED=false
-            if gh release view "$VERSION" --repo "$REPO" >/dev/null 2>&1; then
-              RELEASED=true
+            ASSETS_MATCH=false
+            if release_json="$(
+              gh release view "$VERSION" \
+                --repo "$REPO" \
+                --json assets,body,isDraft,isPrerelease,name,publishedAt,tagName 2>/dev/null
+            )"; then
+              if jq -e \
+                --arg name "$VERSION" \
+                --argjson prerelease "$EXPECTED_PRERELEASE" \
+                '.isDraft == false and
+                 .name == $name and
+                 .tagName == $name and
+                 .publishedAt != null and
+                 .isPrerelease == $prerelease and
+                 (.body | endswith("<!-- xy-release-workflow:" + $name + " -->")) and
+                 any(.assets[]?; .name | endswith(".whl")) and
+                 ([.assets[]? | select(.name | endswith(".tar.gz"))] | length) == 1' \
+                <<<"$release_json" >/dev/null; then
+                RELEASED=true
+              fi
             fi
-            CODE=$(curl -fsS -o /dev/null -w '%{http_code}' \
-              "https://pypi.org/pypi/xy/${PYPI_VERSION}/json" 2>/dev/null || true)
-            if [[ "$CODE" == "200" ]]; then
+            if pypi_json="$(
+              curl -fsS "https://pypi.org/pypi/xy/${PYPI_VERSION}/json" 2>/dev/null
+            )"; then
               PUBLISHED=true
             fi
             if [[ "$RELEASED" == true && "$PUBLISHED" == true ]]; then
+              if github_assets="$(
+                   jq -c \
+                     '[.assets[]?.name |
+                       select(endswith(".whl") or endswith(".tar.gz"))] | sort' \
+                     <<<"$release_json"
+                 )" &&
+                 pypi_assets="$(
+                   jq -c \
+                     '[.urls[]?.filename |
+                       select(endswith(".whl") or endswith(".tar.gz"))] | sort' \
+                     <<<"$pypi_json"
+                 )" &&
+                 [[ "$github_assets" == "$pypi_assets" ]]; then
+                ASSETS_MATCH=true
+              fi
+            fi
+            if [[ "$RELEASED" == true &&
+                  "$PUBLISHED" == true &&
+                  "$ASSETS_MATCH" == true ]]; then
               echo "::notice::${VERSION} is on GitHub Releases and PyPI"
               exit 0
             fi
-            echo "attempt ${attempt}/30 — release=${RELEASED} pypi=${PUBLISHED}; retrying in 60s"
+            echo "attempt ${attempt}/30 — release=${RELEASED} pypi=${PUBLISHED} assets=${ASSETS_MATCH}; retrying in 60s"
             sleep 60
           done
-          echo "::error::${VERSION} did not publish (GitHub Release and/or PyPI missing) — refusing to promote prod"
+          echo "::error::${VERSION} did not become release-ready (metadata, notes, or GitHub/PyPI assets missing or mismatched) — refusing to promote prod"
           exit 1
 
   helm-pr-prod:

--- a/.github/workflows/deploy-docs-stg.yml
+++ b/.github/workflows/deploy-docs-stg.yml
@@ -130,6 +130,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      attestations: read
     steps:
       # release.yml runs in parallel on the same tag and its wheel matrix is
       # slow, so poll rather than sample once. Prod must never document a
@@ -138,9 +139,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.prepare.outputs.version }}
+          SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
           REPO: ${{ github.repository }}
         run: |
+          shopt -s nullglob
           PYPI_VERSION="${VERSION#v}"
+          PROVENANCE_NAME="xy-release-provenance.json"
           EXPECTED_PRERELEASE=false
           if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)[0-9]+$ ]]; then
             EXPECTED_PRERELEASE=true
@@ -148,6 +152,7 @@ jobs:
           for attempt in $(seq 1 30); do
             RELEASED=false
             PUBLISHED=false
+            PROVENANCE_VALID=false
             ASSETS_MATCH=false
             if release_json="$(
               gh release view "$VERSION" \
@@ -162,9 +167,10 @@ jobs:
                  .tagName == $name and
                  .publishedAt != null and
                  .isPrerelease == $prerelease and
-                 (.body | endswith("<!-- xy-release-workflow:" + $name + " -->")) and
                  any(.assets[]?; .name | endswith(".whl")) and
-                 ([.assets[]? | select(.name | endswith(".tar.gz"))] | length) == 1' \
+                 ([.assets[]? | select(.name | endswith(".tar.gz"))] | length) == 1 and
+                 ([.assets[]? | select(.name == "xy-release-provenance.json")] |
+                   length) == 1' \
                 <<<"$release_json" >/dev/null; then
                 RELEASED=true
               fi
@@ -172,35 +178,126 @@ jobs:
             if pypi_json="$(
               curl -fsS "https://pypi.org/pypi/xy/${PYPI_VERSION}/json" 2>/dev/null
             )"; then
-              PUBLISHED=true
+              # A yank is a withdrawal signal, not a usable release. Reject
+              # the entire version if any uploaded file has been yanked.
+              if jq -e \
+                '(.urls | length > 1) and
+                 all(.urls[]; .yanked == false) and
+                 any(.urls[]; .filename | endswith(".whl")) and
+                 ([.urls[] | select(.filename | endswith(".tar.gz"))] |
+                   length) == 1' \
+                <<<"$pypi_json" >/dev/null; then
+                PUBLISHED=true
+              fi
             fi
             if [[ "$RELEASED" == true && "$PUBLISHED" == true ]]; then
-              if github_assets="$(
-                   jq -c \
-                     '[.assets[]?.name |
-                       select(endswith(".whl") or endswith(".tar.gz"))] | sort' \
-                     <<<"$release_json"
-                 )" &&
-                 pypi_assets="$(
-                   jq -c \
-                     '[.urls[]?.filename |
-                       select(endswith(".whl") or endswith(".tar.gz"))] | sort' \
-                     <<<"$pypi_json"
-                 )" &&
-                 [[ "$github_assets" == "$pypi_assets" ]]; then
-                ASSETS_MATCH=true
+              verify_dir="$(mktemp -d "${RUNNER_TEMP}/xy-promotion-verify.XXXXXX")"
+              if gh release download "$VERSION" \
+                --repo "$REPO" \
+                --dir "$verify_dir" \
+                --pattern '*.whl' \
+                --pattern '*.tar.gz' \
+                --pattern "$PROVENANCE_NAME"; then
+                provenance_file="${verify_dir}/${PROVENANCE_NAME}"
+                if [[ -s "$provenance_file" ]] &&
+                   gh attestation verify "$provenance_file" \
+                     --repo "$REPO" \
+                     --signer-workflow "${REPO}/.github/workflows/release.yml" \
+                     --source-ref "refs/tags/${VERSION}" \
+                     --source-digest "$SOURCE_SHA" \
+                     --deny-self-hosted-runners >/dev/null &&
+                   jq -e \
+                     --arg tag "$VERSION" \
+                     --arg source_sha "$SOURCE_SHA" \
+                     '.schema == "xy-release-provenance/v1" and
+                      .tag == $tag and
+                      .source_sha == $source_sha and
+                      (.release_notes_sha256 |
+                        test("^[0-9a-f]{64}$")) and
+                      (.distributions | type == "array" and length > 1) and
+                      ([.distributions[].name] | length) ==
+                        ([.distributions[].name] | unique | length) and
+                      all(.distributions[];
+                        (.name |
+                          endswith(".whl") or endswith(".tar.gz")) and
+                        (.sha256 | test("^[0-9a-f]{64}$")))' \
+                     "$provenance_file" >/dev/null; then
+                  manifest_sha256="$(
+                    sha256sum "$provenance_file" | cut -d ' ' -f 1
+                  )"
+                  footer="<!-- xy-release-provenance:v1:${VERSION}:sha256:${manifest_sha256} -->"
+                  release_notes="$(jq -r '.body // ""' <<<"$release_json")"
+                  if [[ "$release_notes" == *$'\n\n'"$footer" ]]; then
+                    notes_body="${release_notes%$'\n\n'"$footer"}"
+                    actual_notes_sha256="$(
+                      printf '%s' "$notes_body" |
+                        sha256sum |
+                        cut -d ' ' -f 1
+                    )"
+                    manifest_notes_sha256="$(
+                      jq -r '.release_notes_sha256' "$provenance_file"
+                    )"
+                    if [[ "$actual_notes_sha256" == "$manifest_notes_sha256" ]]; then
+                      PROVENANCE_VALID=true
+                    fi
+                  fi
+                fi
+
+                if [[ "$PROVENANCE_VALID" == true ]]; then
+                  github_hashes_json="$(
+                    for artifact in "$verify_dir"/*.whl "$verify_dir"/*.tar.gz; do
+                      artifact_sha256="$(
+                        sha256sum "$artifact" | cut -d ' ' -f 1
+                      )"
+                      jq -cn \
+                        --arg name "${artifact##*/}" \
+                        --arg sha256 "$artifact_sha256" \
+                        '{name: $name, sha256: $sha256}'
+                    done | jq -sc 'sort_by(.name)'
+                  )"
+                  manifest_hashes_json="$(
+                    jq -c \
+                      '[.distributions[] | {name, sha256}] | sort_by(.name)' \
+                      "$provenance_file"
+                  )"
+                  pypi_hashes_json="$(
+                    jq -c \
+                      '[.urls[] |
+                        select(.filename |
+                          endswith(".whl") or endswith(".tar.gz")) |
+                        {name: .filename, sha256: .digests.sha256}] |
+                       sort_by(.name)' \
+                      <<<"$pypi_json"
+                  )"
+                  if jq -e \
+                       'length > 1 and
+                        ([.[].name] | length) ==
+                          ([.[].name] | unique | length) and
+                        all(.[]; .sha256 |
+                          type == "string" and
+                          test("^[0-9a-f]{64}$"))' \
+                       <<<"$pypi_hashes_json" >/dev/null &&
+                     [[ "$github_hashes_json" == "$manifest_hashes_json" &&
+                        "$github_hashes_json" == "$pypi_hashes_json" ]]; then
+                    ASSETS_MATCH=true
+                  fi
+                fi
               fi
+              # A failed candidate can be retried up to 30 times. Remove the
+              # downloaded wheel set before polling again to bound disk use.
+              rm -rf -- "$verify_dir"
             fi
             if [[ "$RELEASED" == true &&
                   "$PUBLISHED" == true &&
+                  "$PROVENANCE_VALID" == true &&
                   "$ASSETS_MATCH" == true ]]; then
-              echo "::notice::${VERSION} is on GitHub Releases and PyPI"
+              echo "::notice::${VERSION} has signed release provenance and byte-identical, non-yanked GitHub/PyPI distributions"
               exit 0
             fi
-            echo "attempt ${attempt}/30 — release=${RELEASED} pypi=${PUBLISHED} assets=${ASSETS_MATCH}; retrying in 60s"
+            echo "attempt ${attempt}/30 — release=${RELEASED} pypi=${PUBLISHED} provenance=${PROVENANCE_VALID} assets=${ASSETS_MATCH}; retrying in 60s"
             sleep 60
           done
-          echo "::error::${VERSION} did not become release-ready (metadata, notes, or GitHub/PyPI assets missing or mismatched) — refusing to promote prod"
+          echo "::error::${VERSION} did not become release-ready (metadata, signed notes provenance, non-yanked PyPI files, or exact asset hashes missing/mismatched) — refusing to promote prod"
           exit 1
 
   helm-pr-prod:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,6 +262,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
+      contents: read
       id-token: write # PyPI trusted publishing (OIDC) — no API token stored
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -292,6 +293,24 @@ jobs:
         run: |
           echo "::notice::Dry run — built and verified $(ls dist/*.whl dist/*.tar.gz 2>/dev/null | wc -l | tr -d ' ') artifacts across the full release matrix. Skipping PyPI publish."
           echo "Re-run this workflow with dry_run=false, or push a v* tag, to publish for real."
+      - name: Verify release tag source before PyPI
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if ! tag_source_sha="$(
+            timeout --signal=TERM --kill-after=5s 30s \
+              gh api "repos/${REPO}/commits/${TAG}" --jq '.sha'
+          )"; then
+            echo "::error::Could not resolve ${TAG} to its source commit"
+            exit 1
+          fi
+          if [[ "$tag_source_sha" != "$GITHUB_SHA" ]]; then
+            echo "::error::${TAG} resolves to ${tag_source_sha}, not workflow source ${GITHUB_SHA}"
+            exit 1
+          fi
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true'
         with:
@@ -307,6 +326,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: publish
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       # Keep repository write access out of every build and PyPI job.
       contents: write
@@ -330,10 +350,11 @@ jobs:
         run: |
           immutable=false
           if release_json="$(
-            gh release view "$TAG" \
-              --repo "$REPO" \
-              --json isImmutable \
-              2>/dev/null
+            timeout --signal=TERM --kill-after=5s 30s \
+              gh release view "$TAG" \
+                --repo "$REPO" \
+                --json isImmutable \
+                2>/dev/null
           )" && [[ "$(jq -r '.isImmutable' <<<"$release_json")" == "true" ]]; then
             immutable=true
           fi
@@ -373,12 +394,73 @@ jobs:
             exit 1
           fi
 
+          # Refuse to mint an attestation until both the mutable tag and
+          # PyPI's immutable file set agree with this workflow run.
+          verify_tag_source() {
+            local tag_source_sha
+            if ! tag_source_sha="$(
+              timeout --signal=TERM --kill-after=5s 30s \
+                gh api "repos/${REPO}/commits/${TAG}" --jq '.sha'
+            )"; then
+              echo "::error::Could not resolve ${TAG} to its source commit"
+              return 1
+            fi
+            if [[ "$tag_source_sha" != "$GITHUB_SHA" ]]; then
+              echo "::error::${TAG} resolves to ${tag_source_sha}, not workflow source ${GITHUB_SHA}"
+              return 1
+            fi
+          }
+          verify_tag_source
+
+          pypi_version="${TAG#v}"
+          pypi_matches=false
+          for attempt in $(seq 1 12); do
+            if pypi_json="$(
+              curl -fsS \
+                --connect-timeout 5 \
+                --max-time 20 \
+                "https://pypi.org/pypi/xy/${pypi_version}/json" \
+                2>/dev/null
+            )"; then
+              if pypi_hashes_json="$(
+                   jq -c \
+                     '[.urls[] |
+                       {name: .filename, sha256: .digests.sha256}] |
+                      sort_by(.name)' \
+                     <<<"$pypi_json"
+                 )" &&
+                 jq -e \
+                   '(.urls | length > 1) and
+                    all(.urls[];
+                      .yanked == false and
+                      (.filename |
+                        endswith(".whl") or endswith(".tar.gz")) and
+                      (.digests.sha256 |
+                        type == "string" and
+                        test("^[0-9a-f]{64}$")))' \
+                   <<<"$pypi_json" >/dev/null &&
+                 [[ "$pypi_hashes_json" == "$distributions_json" ]]; then
+                pypi_matches=true
+                break
+              fi
+            fi
+            if (( attempt < 12 )); then
+              echo "attempt ${attempt}/12 — waiting for exact, non-yanked PyPI files before attestation"
+              sleep 10
+            fi
+          done
+          if [[ "$pypi_matches" != true ]]; then
+            echo "::error::PyPI files for ${TAG} do not exactly match the verified build"
+            exit 1
+          fi
+
           notes_file="${RUNNER_TEMP}/xy-${TAG}-release-notes.md"
-          gh api \
-            --method POST \
-            "repos/${REPO}/releases/generate-notes" \
-            -f tag_name="$TAG" \
-            --jq '.body' > "$notes_file"
+          timeout --signal=TERM --kill-after=5s 30s \
+            gh api \
+              --method POST \
+              "repos/${REPO}/releases/generate-notes" \
+              -f tag_name="$TAG" \
+              --jq '.body' > "$notes_file"
           generated_notes="$(<"$notes_file")"
           if [[ -z "${generated_notes//[[:space:]]/}" ]]; then
             echo "::error::GitHub generated empty release notes for ${TAG}"
@@ -409,6 +491,9 @@ jobs:
           )"
           printf '%s\n\n<!-- xy-release-provenance:v1:%s:sha256:%s -->\n' \
             "$generated_notes" "$TAG" "$provenance_sha256" > "$notes_file"
+          # Close the tag-movement window before the immediately following
+          # attestation action persists a signature for this manifest.
+          verify_tag_source
 
       - name: Attest release provenance
         if: steps.release_state.outputs.immutable != 'true'
@@ -431,6 +516,41 @@ jobs:
             exit 1
           fi
 
+          verify_tag_source() {
+            local tag_source_sha
+            if ! tag_source_sha="$(
+              timeout --signal=TERM --kill-after=5s 30s \
+                gh api "repos/${REPO}/commits/${TAG}" --jq '.sha'
+            )"; then
+              echo "::error::Could not resolve ${TAG} to its source commit"
+              return 1
+            fi
+            if [[ "$tag_source_sha" != "$GITHUB_SHA" ]]; then
+              echo "::error::${TAG} resolves to ${tag_source_sha}, not workflow source ${GITHUB_SHA}"
+              return 1
+            fi
+          }
+          verify_tag_source
+
+          # Read the release before selecting the PyPI comparison source. An
+          # immutable release is already bound to its signed persisted
+          # manifest, so a same-source rebuild need not reproduce archive bytes
+          # exactly. Mutable and new releases still have to match this run's
+          # verified artifacts before any release write.
+          release_exists=false
+          release_json=""
+          is_immutable=false
+          if release_json="$(
+            timeout --signal=TERM --kill-after=5s 30s \
+              gh release view "$TAG" \
+                --repo "$REPO" \
+                --json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName \
+                2>/dev/null
+          )"; then
+            release_exists=true
+            is_immutable="$(jq -r '.isImmutable' <<<"$release_json")"
+          fi
+
           provenance_name="xy-release-provenance.json"
           provenance_file="${RUNNER_TEMP}/xy-${TAG}-release-provenance/${provenance_name}"
           notes_file="${RUNNER_TEMP}/xy-${TAG}-release-notes.md"
@@ -448,6 +568,54 @@ jobs:
                 '{name: $name, sha256: $sha256}'
             done | jq -sc 'sort_by(.name)'
           )"
+
+          # PyPI filenames are immutable. A retry may rebuild the same version
+          # after some files were already accepted by `skip-existing`; never
+          # clobber GitHub with candidate bytes that differ from those users
+          # can install. Poll briefly for PyPI's API cache to expose the full
+          # set after the publish job completes.
+          pypi_version="${TAG#v}"
+          pypi_matches=false
+          for attempt in $(seq 1 12); do
+            if pypi_json="$(
+              curl -fsS \
+                --connect-timeout 5 \
+                --max-time 20 \
+                "https://pypi.org/pypi/xy/${pypi_version}/json" \
+                2>/dev/null
+            )"; then
+              if pypi_hashes_json="$(
+                   jq -c \
+                     '[.urls[] |
+                       {name: .filename, sha256: .digests.sha256}] |
+                      sort_by(.name)' \
+                     <<<"$pypi_json"
+                 )" &&
+                 jq -e \
+                   '(.urls | length > 1) and
+                    all(.urls[];
+                      .yanked == false and
+                      (.filename |
+                        endswith(".whl") or endswith(".tar.gz")) and
+                      (.digests.sha256 |
+                        type == "string" and
+                        test("^[0-9a-f]{64}$")))' \
+                   <<<"$pypi_json" >/dev/null; then
+                if [[ "$is_immutable" == true || "$pypi_hashes_json" == "$expected_hashes_json" ]]; then
+                  pypi_matches=true
+                  break
+                fi
+              fi
+            fi
+            if (( attempt < 12 )); then
+              echo "attempt ${attempt}/12 — waiting for exact, non-yanked PyPI files"
+              sleep 10
+            fi
+          done
+          if [[ "$pypi_matches" != true ]]; then
+            echo "::error::PyPI files for ${TAG} do not exactly match the verified build"
+            exit 1
+          fi
 
           prerelease=()
           edit_prerelease=(--prerelease=false)
@@ -473,6 +641,7 @@ jobs:
 
           verify_release_payload() {
             local release_json="$1"
+            local reference_hashes_json="$2"
             local actual_assets_json
             local actual_hashes_json
             local actual_notes_sha256
@@ -481,31 +650,36 @@ jobs:
             local manifest_notes_sha256
             local manifest_sha256
             local notes_body
+            local reference_assets_json
             local release_notes
             local verify_dir
             local verified_provenance
 
+            reference_assets_json="$(
+              jq -c '[.[].name] | sort' <<<"$reference_hashes_json"
+            )"
             actual_assets_json="$(
               jq -c \
                 '[.assets[]?.name |
                   select(endswith(".whl") or endswith(".tar.gz"))] | sort' \
                 <<<"$release_json"
             )"
-            if [[ "$actual_assets_json" != "$expected_assets_json" ]] ||
+            if [[ "$actual_assets_json" != "$reference_assets_json" ]] ||
                ! jq -e --arg name "$provenance_name" \
                  '[.assets[]? | select(.name == $name)] | length == 1' \
                  <<<"$release_json" >/dev/null; then
-              echo "::error::${TAG} release asset names do not match the verified build"
+              echo "::error::${TAG} release asset names do not match the trusted distribution set"
               return 1
             fi
 
             verify_dir="$(mktemp -d "${RUNNER_TEMP}/xy-release-verify.XXXXXX")"
-            if ! gh release download "$TAG" \
-              --repo "$REPO" \
-              --dir "$verify_dir" \
-              --pattern '*.whl' \
-              --pattern '*.tar.gz' \
-              --pattern "$provenance_name"; then
+            if ! timeout --signal=TERM --kill-after=5s 180s \
+              gh release download "$TAG" \
+                --repo "$REPO" \
+                --dir "$verify_dir" \
+                --pattern '*.whl' \
+                --pattern '*.tar.gz' \
+                --pattern "$provenance_name"; then
               echo "::error::Could not download ${TAG} release assets for verification"
               return 1
             fi
@@ -515,12 +689,13 @@ jobs:
               return 1
             fi
 
-            if ! gh attestation verify "$verified_provenance" \
-              --repo "$REPO" \
-              --signer-workflow "${REPO}/.github/workflows/release.yml" \
-              --source-ref "refs/tags/${TAG}" \
-              --source-digest "$GITHUB_SHA" \
-              --deny-self-hosted-runners >/dev/null; then
+            if ! timeout --signal=TERM --kill-after=5s 60s \
+              gh attestation verify "$verified_provenance" \
+                --repo "$REPO" \
+                --signer-workflow "${REPO}/.github/workflows/release.yml" \
+                --source-ref "refs/tags/${TAG}" \
+                --source-digest "$GITHUB_SHA" \
+                --deny-self-hosted-runners >/dev/null; then
               echo "::error::${TAG} release provenance was not signed by this tag workflow"
               return 1
             fi
@@ -556,9 +731,9 @@ jobs:
                 '[.distributions[] | {name, sha256}] | sort_by(.name)' \
                 "$verified_provenance"
             )"
-            if [[ "$actual_hashes_json" != "$expected_hashes_json" ||
-                  "$manifest_hashes_json" != "$expected_hashes_json" ]]; then
-              echo "::error::${TAG} release bytes do not match the verified build"
+            if [[ "$actual_hashes_json" != "$reference_hashes_json" ||
+                  "$manifest_hashes_json" != "$reference_hashes_json" ]]; then
+              echo "::error::${TAG} release bytes do not match the trusted distribution set"
               return 1
             fi
 
@@ -589,19 +764,15 @@ jobs:
           # the verified files instead of failing an otherwise safe retry. A
           # manually created draft or mismatched prerelease is normalized and
           # then re-read before docs promotion is allowed to observe it.
-          if release_json="$(
-            gh release view "$TAG" \
-              --repo "$REPO" \
-              --json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName \
-              2>/dev/null
-          )"; then
-            is_immutable="$(jq -r '.isImmutable' <<<"$release_json")"
+          if [[ "$release_exists" == true ]]; then
             if [[ "$is_immutable" == "true" ]]; then
               # GitHub's generated-note inputs can change after publication.
               # Verify the persisted body against its signed manifest instead
-              # of comparing it with freshly regenerated notes.
+              # of comparing it with freshly regenerated notes or rebuilt
+              # archive bytes.
               if release_metadata_matches "$release_json" &&
-                 verify_release_payload "$release_json"; then
+                 verify_release_payload "$release_json" "$pypi_hashes_json"; then
+                verify_tag_source
                 echo "::notice::${TAG} is immutable and already matches the verified release"
                 exit 0
               fi
@@ -614,11 +785,13 @@ jobs:
               exit 1
             fi
             echo "::notice::${TAG} already exists; refreshing distribution assets"
+            verify_tag_source
             gh release upload "$TAG" "${artifacts[@]}" "$provenance_file" --repo "$REPO" --clobber
             release_json="$(
-              gh release view "$TAG" \
-                --repo "$REPO" \
-                --json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName
+              timeout --signal=TERM --kill-after=5s 30s \
+                gh release view "$TAG" \
+                  --repo "$REPO" \
+                  --json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName
             )"
 
             while IFS= read -r asset_json; do
@@ -631,6 +804,7 @@ jobs:
                   exit 1
                 fi
                 echo "::notice::Removing stale distribution asset ${asset_name}"
+                verify_tag_source
                 gh api \
                   --method DELETE \
                   "repos/${REPO}/releases/assets/${asset_id}"
@@ -642,6 +816,7 @@ jobs:
             )
 
             echo "::notice::Normalizing ${TAG} metadata and generated notes"
+            verify_tag_source
             gh release edit "$TAG" \
               --repo "$REPO" \
               --draft=false \
@@ -650,16 +825,18 @@ jobs:
               "${edit_prerelease[@]}"
 
             release_json="$(
-              gh release view "$TAG" \
-                --repo "$REPO" \
-                --json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName
+              timeout --signal=TERM --kill-after=5s 30s \
+                gh release view "$TAG" \
+                  --repo "$REPO" \
+                  --json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName
             )"
             if ! release_metadata_matches "$release_json" ||
-               ! verify_release_payload "$release_json"; then
+               ! verify_release_payload "$release_json" "$expected_hashes_json"; then
               echo "::error::${TAG} release metadata, notes, or assets are invalid after normalization"
               exit 1
             fi
 
+            verify_tag_source
             exit 0
           fi
 
@@ -667,14 +844,17 @@ jobs:
             echo "::error::Prepared release notes or provenance are missing"
             exit 1
           fi
+          verify_tag_source
           gh release create "$TAG" "${artifacts[@]}" "$provenance_file" --repo "$REPO" --verify-tag --title "$TAG" --notes-file "$notes_file" "${prerelease[@]}"
           release_json="$(
-            gh release view "$TAG" \
-              --repo "$REPO" \
-              --json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName
+            timeout --signal=TERM --kill-after=5s 30s \
+              gh release view "$TAG" \
+                --repo "$REPO" \
+                --json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName
           )"
           if ! release_metadata_matches "$release_json" ||
-             ! verify_release_payload "$release_json"; then
+             ! verify_release_payload "$release_json" "$expected_hashes_json"; then
             echo "::error::${TAG} release metadata, notes, or assets are invalid after creation"
             exit 1
           fi
+          verify_tag_source

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,15 +351,26 @@ jobs:
         shell: bash
         run: |
           immutable=false
+          release_lookup_error="$(mktemp "${RUNNER_TEMP}/xy-release-state-error.XXXXXX")"
           if release_json="$(
             timeout --signal=TERM --kill-after=5s 30s \
               gh release view "$TAG" \
                 --repo "$REPO" \
                 --json isImmutable \
-                2>/dev/null
-          )" && [[ "$(jq -r '.isImmutable' <<<"$release_json")" == "true" ]]; then
-            immutable=true
+                2>"$release_lookup_error"
+          )"; then
+            if ! immutable="$(jq -er '.isImmutable | if . == true then "true" elif . == false then "false" else error("invalid isImmutable") end' <<<"$release_json")"; then
+              rm -f "$release_lookup_error"
+              echo "::error::GitHub returned invalid release metadata for ${TAG}"
+              exit 1
+            fi
+          elif ! jq -eRs '. == "release not found\n"' "$release_lookup_error" >/dev/null; then
+            cat "$release_lookup_error" >&2
+            rm -f "$release_lookup_error"
+            echo "::error::Could not inspect existing GitHub Release ${TAG}; refusing to prepare provenance"
+            exit 1
           fi
+          rm -f "$release_lookup_error"
           echo "immutable=${immutable}" >> "$GITHUB_OUTPUT"
 
       - name: Prepare release provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,12 +310,112 @@ jobs:
     permissions:
       # Keep repository write access out of every build and PyPI job.
       contents: write
+      # Sign a manifest that binds the generated notes and every distribution
+      # byte to this exact tag workflow.
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           pattern: dist-*
           merge-multiple: true
+      - name: Inspect existing release
+        id: release_state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          immutable=false
+          if release_json="$(
+            gh release view "$TAG" \
+              --repo "$REPO" \
+              --json isImmutable \
+              2>/dev/null
+          )" && [[ "$(jq -r '.isImmutable' <<<"$release_json")" == "true" ]]; then
+            immutable=true
+          fi
+          echo "immutable=${immutable}" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare release provenance
+        if: steps.release_state.outputs.immutable != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          shopt -s nullglob
+          wheels=(dist/*.whl)
+          sdists=(dist/*.tar.gz)
+          artifacts=("${wheels[@]}" "${sdists[@]}")
+          if (( ${#wheels[@]} == 0 || ${#sdists[@]} != 1 )); then
+            echo "::error::Expected at least one wheel and exactly one sdist"
+            exit 1
+          fi
+
+          distributions_json="$(
+            for artifact in "${artifacts[@]}"; do
+              artifact_sha256="$(sha256sum "$artifact" | cut -d ' ' -f 1)"
+              jq -cn \
+                --arg name "${artifact##*/}" \
+                --arg sha256 "$artifact_sha256" \
+                '{name: $name, sha256: $sha256}'
+            done | jq -sc 'sort_by(.name)'
+          )"
+          if ! jq -e \
+            'length > 1 and
+             ([.[].name] | length) == ([.[].name] | unique | length) and
+             all(.[]; .sha256 | test("^[0-9a-f]{64}$"))' \
+            <<<"$distributions_json" >/dev/null; then
+            echo "::error::Distribution names or SHA-256 digests are invalid"
+            exit 1
+          fi
+
+          notes_file="${RUNNER_TEMP}/xy-${TAG}-release-notes.md"
+          gh api \
+            --method POST \
+            "repos/${REPO}/releases/generate-notes" \
+            -f tag_name="$TAG" \
+            --jq '.body' > "$notes_file"
+          generated_notes="$(<"$notes_file")"
+          if [[ -z "${generated_notes//[[:space:]]/}" ]]; then
+            echo "::error::GitHub generated empty release notes for ${TAG}"
+            exit 1
+          fi
+          notes_sha256="$(
+            printf '%s' "$generated_notes" | sha256sum | cut -d ' ' -f 1
+          )"
+
+          provenance_dir="${RUNNER_TEMP}/xy-${TAG}-release-provenance"
+          mkdir -p "$provenance_dir"
+          provenance_file="${provenance_dir}/xy-release-provenance.json"
+          jq -cS -n \
+            --arg schema "xy-release-provenance/v1" \
+            --arg tag "$TAG" \
+            --arg source_sha "$GITHUB_SHA" \
+            --arg release_notes_sha256 "$notes_sha256" \
+            --argjson distributions "$distributions_json" \
+            '{
+              schema: $schema,
+              tag: $tag,
+              source_sha: $source_sha,
+              release_notes_sha256: $release_notes_sha256,
+              distributions: $distributions
+            }' > "$provenance_file"
+          provenance_sha256="$(
+            sha256sum "$provenance_file" | cut -d ' ' -f 1
+          )"
+          printf '%s\n\n<!-- xy-release-provenance:v1:%s:sha256:%s -->\n' \
+            "$generated_notes" "$TAG" "$provenance_sha256" > "$notes_file"
+
+      - name: Attest release provenance
+        if: steps.release_state.outputs.immutable != 'true'
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-path: ${{ runner.temp }}/xy-${{ github.ref_name }}-release-provenance/xy-release-provenance.json
+
       - name: Create GitHub Release and attach distributions
         env:
           GH_TOKEN: ${{ github.token }}
@@ -331,6 +431,24 @@ jobs:
             exit 1
           fi
 
+          provenance_name="xy-release-provenance.json"
+          provenance_file="${RUNNER_TEMP}/xy-${TAG}-release-provenance/${provenance_name}"
+          notes_file="${RUNNER_TEMP}/xy-${TAG}-release-notes.md"
+
+          expected_assets_json="$(
+            printf '%s\n' "${artifacts[@]##*/}" |
+              jq -Rsc 'split("\n") | map(select(length > 0)) | sort'
+          )"
+          expected_hashes_json="$(
+            for artifact in "${artifacts[@]}"; do
+              artifact_sha256="$(sha256sum "$artifact" | cut -d ' ' -f 1)"
+              jq -cn \
+                --arg name "${artifact##*/}" \
+                --arg sha256 "$artifact_sha256" \
+                '{name: $name, sha256: $sha256}'
+            done | jq -sc 'sort_by(.name)'
+          )"
+
           prerelease=()
           edit_prerelease=(--prerelease=false)
           expected_prerelease=false
@@ -339,23 +457,132 @@ jobs:
             edit_prerelease=(--prerelease)
             expected_prerelease=true
           fi
-          expected_assets_json="$(
-            printf '%s\n' "${artifacts[@]##*/}" |
-              jq -Rsc 'split("\n") | map(select(length > 0)) | sort'
-          )"
-          notes_file="${RUNNER_TEMP}/xy-${TAG}-release-notes.md"
-          gh api \
-            --method POST \
-            "repos/${REPO}/releases/generate-notes" \
-            -f tag_name="$TAG" \
-            --jq '.body' > "$notes_file"
-          generated_notes="$(<"$notes_file")"
-          if [[ -z "${generated_notes//[[:space:]]/}" ]]; then
-            echo "::error::GitHub generated empty release notes for ${TAG}"
-            exit 1
-          fi
-          printf '\n<!-- xy-release-workflow:%s -->' "$TAG" >> "$notes_file"
-          expected_notes="$(<"$notes_file")"
+
+          release_metadata_matches() {
+            local release_json="$1"
+            jq -e \
+              --arg name "$TAG" \
+              --argjson prerelease "$expected_prerelease" \
+              '.isDraft == false and
+               .name == $name and
+               .tagName == $name and
+               .publishedAt != null and
+               .isPrerelease == $prerelease' \
+              <<<"$release_json" >/dev/null
+          }
+
+          verify_release_payload() {
+            local release_json="$1"
+            local actual_assets_json
+            local actual_hashes_json
+            local actual_notes_sha256
+            local footer
+            local manifest_hashes_json
+            local manifest_notes_sha256
+            local manifest_sha256
+            local notes_body
+            local release_notes
+            local verify_dir
+            local verified_provenance
+
+            actual_assets_json="$(
+              jq -c \
+                '[.assets[]?.name |
+                  select(endswith(".whl") or endswith(".tar.gz"))] | sort' \
+                <<<"$release_json"
+            )"
+            if [[ "$actual_assets_json" != "$expected_assets_json" ]] ||
+               ! jq -e --arg name "$provenance_name" \
+                 '[.assets[]? | select(.name == $name)] | length == 1' \
+                 <<<"$release_json" >/dev/null; then
+              echo "::error::${TAG} release asset names do not match the verified build"
+              return 1
+            fi
+
+            verify_dir="$(mktemp -d "${RUNNER_TEMP}/xy-release-verify.XXXXXX")"
+            if ! gh release download "$TAG" \
+              --repo "$REPO" \
+              --dir "$verify_dir" \
+              --pattern '*.whl' \
+              --pattern '*.tar.gz' \
+              --pattern "$provenance_name"; then
+              echo "::error::Could not download ${TAG} release assets for verification"
+              return 1
+            fi
+            verified_provenance="${verify_dir}/${provenance_name}"
+            if [[ ! -s "$verified_provenance" ]]; then
+              echo "::error::${TAG} release provenance asset is missing or empty"
+              return 1
+            fi
+
+            if ! gh attestation verify "$verified_provenance" \
+              --repo "$REPO" \
+              --signer-workflow "${REPO}/.github/workflows/release.yml" \
+              --source-ref "refs/tags/${TAG}" \
+              --source-digest "$GITHUB_SHA" \
+              --deny-self-hosted-runners >/dev/null; then
+              echo "::error::${TAG} release provenance was not signed by this tag workflow"
+              return 1
+            fi
+            if ! jq -e \
+              --arg tag "$TAG" \
+              --arg source_sha "$GITHUB_SHA" \
+              '.schema == "xy-release-provenance/v1" and
+               .tag == $tag and
+               .source_sha == $source_sha and
+               (.release_notes_sha256 | test("^[0-9a-f]{64}$")) and
+               (.distributions | type == "array" and length > 1) and
+               ([.distributions[].name] | length) ==
+                 ([.distributions[].name] | unique | length) and
+               all(.distributions[];
+                 (.name | endswith(".whl") or endswith(".tar.gz")) and
+                 (.sha256 | test("^[0-9a-f]{64}$")))' \
+              "$verified_provenance" >/dev/null; then
+              echo "::error::${TAG} release provenance content is invalid"
+              return 1
+            fi
+
+            actual_hashes_json="$(
+              for artifact in "$verify_dir"/*.whl "$verify_dir"/*.tar.gz; do
+                artifact_sha256="$(sha256sum "$artifact" | cut -d ' ' -f 1)"
+                jq -cn \
+                  --arg name "${artifact##*/}" \
+                  --arg sha256 "$artifact_sha256" \
+                  '{name: $name, sha256: $sha256}'
+              done | jq -sc 'sort_by(.name)'
+            )"
+            manifest_hashes_json="$(
+              jq -c \
+                '[.distributions[] | {name, sha256}] | sort_by(.name)' \
+                "$verified_provenance"
+            )"
+            if [[ "$actual_hashes_json" != "$expected_hashes_json" ||
+                  "$manifest_hashes_json" != "$expected_hashes_json" ]]; then
+              echo "::error::${TAG} release bytes do not match the verified build"
+              return 1
+            fi
+
+            manifest_sha256="$(
+              sha256sum "$verified_provenance" | cut -d ' ' -f 1
+            )"
+            footer="<!-- xy-release-provenance:v1:${TAG}:sha256:${manifest_sha256} -->"
+            release_notes="$(jq -r '.body // ""' <<<"$release_json")"
+            if [[ "$release_notes" != *$'\n\n'"$footer" ]]; then
+              echo "::error::${TAG} release notes are not bound to the signed provenance"
+              return 1
+            fi
+            notes_body="${release_notes%$'\n\n'"$footer"}"
+            actual_notes_sha256="$(
+              printf '%s' "$notes_body" | sha256sum | cut -d ' ' -f 1
+            )"
+            manifest_notes_sha256="$(
+              jq -r '.release_notes_sha256' "$verified_provenance"
+            )"
+            if [[ "$actual_notes_sha256" != "$manifest_notes_sha256" ]]; then
+              echo "::error::${TAG} release notes differ from the signed generated notes"
+              return 1
+            fi
+          }
 
           # `gh release create` publishes immediately. If a previous run made
           # the release but failed partway through uploading assets, refresh
@@ -368,26 +595,13 @@ jobs:
               --json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName \
               2>/dev/null
           )"; then
-            is_draft="$(jq -r '.isDraft' <<<"$release_json")"
             is_immutable="$(jq -r '.isImmutable' <<<"$release_json")"
-            is_prerelease="$(jq -r '.isPrerelease' <<<"$release_json")"
-            release_name="$(jq -r '.name' <<<"$release_json")"
-            release_notes="$(jq -r '.body' <<<"$release_json")"
-            published_at="$(jq -r '.publishedAt' <<<"$release_json")"
-            release_tag="$(jq -r '.tagName' <<<"$release_json")"
-            actual_assets_json="$(
-              jq -c \
-                '[.assets[].name | select(endswith(".whl") or endswith(".tar.gz"))] | sort' \
-                <<<"$release_json"
-            )"
             if [[ "$is_immutable" == "true" ]]; then
-              if [[ "$is_draft" == "false" &&
-                    "$is_prerelease" == "$expected_prerelease" &&
-                    "$release_name" == "$TAG" &&
-                    "$published_at" != "null" &&
-                    "$release_tag" == "$TAG" &&
-                    "$release_notes" == "$expected_notes" &&
-                    "$actual_assets_json" == "$expected_assets_json" ]]; then
+              # GitHub's generated-note inputs can change after publication.
+              # Verify the persisted body against its signed manifest instead
+              # of comparing it with freshly regenerated notes.
+              if release_metadata_matches "$release_json" &&
+                 verify_release_payload "$release_json"; then
                 echo "::notice::${TAG} is immutable and already matches the verified release"
                 exit 0
               fi
@@ -395,8 +609,12 @@ jobs:
               exit 1
             fi
 
+            if [[ ! -s "$provenance_file" || ! -s "$notes_file" ]]; then
+              echo "::error::Prepared release notes or provenance are missing"
+              exit 1
+            fi
             echo "::notice::${TAG} already exists; refreshing distribution assets"
-            gh release upload "$TAG" "${artifacts[@]}" --repo "$REPO" --clobber
+            gh release upload "$TAG" "${artifacts[@]}" "$provenance_file" --repo "$REPO" --clobber
             release_json="$(
               gh release view "$TAG" \
                 --repo "$REPO" \
@@ -436,25 +654,8 @@ jobs:
                 --repo "$REPO" \
                 --json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName
             )"
-            is_draft="$(jq -r '.isDraft' <<<"$release_json")"
-            is_prerelease="$(jq -r '.isPrerelease' <<<"$release_json")"
-            release_name="$(jq -r '.name' <<<"$release_json")"
-            release_notes="$(jq -r '.body' <<<"$release_json")"
-            published_at="$(jq -r '.publishedAt' <<<"$release_json")"
-            release_tag="$(jq -r '.tagName' <<<"$release_json")"
-            actual_assets_json="$(
-              jq -c \
-                '[.assets[].name | select(endswith(".whl") or endswith(".tar.gz"))] | sort' \
-                <<<"$release_json"
-            )"
-            if [[ "$is_draft" != "false" ||
-                  "$is_prerelease" != "$expected_prerelease" ||
-                  "$release_name" != "$TAG" ||
-                  "$published_at" == "null" ||
-                  "$release_tag" != "$TAG" ||
-                  -z "$release_notes" ||
-                  "$release_notes" != "$expected_notes" ||
-                  "$actual_assets_json" != "$expected_assets_json" ]]; then
+            if ! release_metadata_matches "$release_json" ||
+               ! verify_release_payload "$release_json"; then
               echo "::error::${TAG} release metadata, notes, or assets are invalid after normalization"
               exit 1
             fi
@@ -462,9 +663,18 @@ jobs:
             exit 0
           fi
 
-          gh release create "$TAG" "${artifacts[@]}" \
-            --repo "$REPO" \
-            --verify-tag \
-            --title "$TAG" \
-            --notes-file "$notes_file" \
-            "${prerelease[@]}"
+          if [[ ! -s "$provenance_file" || ! -s "$notes_file" ]]; then
+            echo "::error::Prepared release notes or provenance are missing"
+            exit 1
+          fi
+          gh release create "$TAG" "${artifacts[@]}" "$provenance_file" --repo "$REPO" --verify-tag --title "$TAG" --notes-file "$notes_file" "${prerelease[@]}"
+          release_json="$(
+            gh release view "$TAG" \
+              --repo "$REPO" \
+              --json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName
+          )"
+          if ! release_metadata_matches "$release_json" ||
+             ! verify_release_payload "$release_json"; then
+            echo "::error::${TAG} release metadata, notes, or assets are invalid after creation"
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release
 
-# Publish prebuilt wheels + sdist to PyPI on a version tag. This is what makes
-# `pip install xy` a no-toolchain install: each platform wheel carries
-# the compiled Rust core, so end users never see Rust or Node.
+# Publish prebuilt wheels + sdist to PyPI and GitHub Releases on a version tag.
+# This is what makes `pip install xy` a no-toolchain install: each platform
+# wheel carries the compiled Rust core, so end users never see Rust or Node.
 on:
   push:
     tags: ["v*"]
@@ -299,3 +299,52 @@ jobs:
           # A failed upload can leave a partial release on immutable PyPI.
           # Retrying the same tag should skip files that were already accepted.
           skip-existing: true
+
+  github-release:
+    name: Publish GitHub Release
+    # GitHub Releases are a tag-push side effect only. In particular, neither
+    # the default dry run nor a manually requested PyPI publish may create one.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      # Keep repository write access out of every build and PyPI job.
+      contents: write
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+          pattern: dist-*
+          merge-multiple: true
+      - name: Create GitHub Release and attach distributions
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          shopt -s nullglob
+          artifacts=(dist/*.whl dist/*.tar.gz)
+          if (( ${#artifacts[@]} == 0 )); then
+            echo "::error::No wheel or sdist artifacts were downloaded"
+            exit 1
+          fi
+
+          # `gh release create` publishes immediately. If a previous run made
+          # the release but failed partway through uploading assets, refresh
+          # the verified files instead of failing an otherwise safe retry.
+          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            echo "::notice::${TAG} already exists; refreshing distribution assets"
+            gh release upload "$TAG" "${artifacts[@]}" --repo "$REPO" --clobber
+            exit 0
+          fi
+
+          prerelease=()
+          if [[ "$TAG" =~ (a|b|rc)[0-9]+ ]]; then
+            prerelease=(--prerelease)
+          fi
+          gh release create "$TAG" "${artifacts[@]}" \
+            --repo "$REPO" \
+            --verify-tag \
+            --generate-notes \
+            --title "$TAG" \
+            "${prerelease[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,19 +329,60 @@ jobs:
             exit 1
           fi
 
+          prerelease=()
+          edit_prerelease=(--prerelease=false)
+          expected_prerelease=false
+          if [[ "$TAG" =~ (a|b|rc)[0-9]+ ]]; then
+            prerelease=(--prerelease)
+            edit_prerelease=(--prerelease)
+            expected_prerelease=true
+          fi
+
           # `gh release create` publishes immediately. If a previous run made
           # the release but failed partway through uploading assets, refresh
-          # the verified files instead of failing an otherwise safe retry.
-          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+          # the verified files instead of failing an otherwise safe retry. A
+          # manually created draft or mismatched prerelease is normalized and
+          # then re-read before docs promotion is allowed to observe it.
+          if release_json="$(
+            gh release view "$TAG" \
+              --repo "$REPO" \
+              --json isDraft,isPrerelease,name 2>/dev/null
+          )"; then
+            is_draft="$(jq -r '.isDraft' <<<"$release_json")"
+            is_prerelease="$(jq -r '.isPrerelease' <<<"$release_json")"
+            release_name="$(jq -r '.name' <<<"$release_json")"
             echo "::notice::${TAG} already exists; refreshing distribution assets"
             gh release upload "$TAG" "${artifacts[@]}" --repo "$REPO" --clobber
+
+            if [[ "$is_draft" != "false" ||
+                  "$is_prerelease" != "$expected_prerelease" ||
+                  "$release_name" != "$TAG" ]]; then
+              echo "::notice::${TAG} exists with incomplete metadata; normalizing it"
+              gh release edit "$TAG" \
+                --repo "$REPO" \
+                --draft=false \
+                --title "$TAG" \
+                "${edit_prerelease[@]}"
+            fi
+
+            release_json="$(
+              gh release view "$TAG" \
+                --repo "$REPO" \
+                --json isDraft,isPrerelease,name
+            )"
+            is_draft="$(jq -r '.isDraft' <<<"$release_json")"
+            is_prerelease="$(jq -r '.isPrerelease' <<<"$release_json")"
+            release_name="$(jq -r '.name' <<<"$release_json")"
+            if [[ "$is_draft" != "false" ||
+                  "$is_prerelease" != "$expected_prerelease" ||
+                  "$release_name" != "$TAG" ]]; then
+              echo "::error::${TAG} release metadata is still invalid after normalization"
+              exit 1
+            fi
+
             exit 0
           fi
 
-          prerelease=()
-          if [[ "$TAG" =~ (a|b|rc)[0-9]+ ]]; then
-            prerelease=(--prerelease)
-          fi
           gh release create "$TAG" "${artifacts[@]}" \
             --repo "$REPO" \
             --verify-tag \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,6 +299,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
+        shell: bash
         run: |
           if ! tag_source_sha="$(
             timeout --signal=TERM --kill-after=5s 30s \
@@ -312,7 +313,7 @@ jobs:
             exit 1
           fi
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
-        if: github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true'
+        if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')
         with:
           packages-dir: dist/
           # A failed upload can leave a partial release on immutable PyPI.
@@ -347,6 +348,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
+        shell: bash
         run: |
           immutable=false
           if release_json="$(
@@ -366,6 +368,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
+        shell: bash
         run: |
           shopt -s nullglob
           wheels=(dist/*.whl)
@@ -506,6 +509,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
+        shell: bash
         run: |
           shopt -s nullglob
           wheels=(dist/*.whl)
@@ -540,16 +544,23 @@ jobs:
           release_exists=false
           release_json=""
           is_immutable=false
+          release_lookup_error="$(mktemp "${RUNNER_TEMP}/xy-release-view-error.XXXXXX")"
           if release_json="$(
             timeout --signal=TERM --kill-after=5s 30s \
               gh release view "$TAG" \
                 --repo "$REPO" \
                 --json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName \
-                2>/dev/null
+                2>"$release_lookup_error"
           )"; then
             release_exists=true
             is_immutable="$(jq -r '.isImmutable' <<<"$release_json")"
+          elif ! jq -eRs '. == "release not found\n"' "$release_lookup_error" >/dev/null; then
+            cat "$release_lookup_error" >&2
+            rm -f "$release_lookup_error"
+            echo "::error::Could not inspect existing GitHub Release ${TAG}; refusing to create it"
+            exit 1
           fi
+          rm -f "$release_lookup_error"
 
           provenance_name="xy-release-provenance.json"
           provenance_file="${RUNNER_TEMP}/xy-${TAG}-release-provenance/${provenance_name}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,20 +323,39 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           shopt -s nullglob
-          artifacts=(dist/*.whl dist/*.tar.gz)
-          if (( ${#artifacts[@]} == 0 )); then
-            echo "::error::No wheel or sdist artifacts were downloaded"
+          wheels=(dist/*.whl)
+          sdists=(dist/*.tar.gz)
+          artifacts=("${wheels[@]}" "${sdists[@]}")
+          if (( ${#wheels[@]} == 0 || ${#sdists[@]} != 1 )); then
+            echo "::error::Expected at least one wheel and exactly one sdist"
             exit 1
           fi
 
           prerelease=()
           edit_prerelease=(--prerelease=false)
           expected_prerelease=false
-          if [[ "$TAG" =~ (a|b|rc)[0-9]+ ]]; then
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)[0-9]+$ ]]; then
             prerelease=(--prerelease)
             edit_prerelease=(--prerelease)
             expected_prerelease=true
           fi
+          expected_assets_json="$(
+            printf '%s\n' "${artifacts[@]##*/}" |
+              jq -Rsc 'split("\n") | map(select(length > 0)) | sort'
+          )"
+          notes_file="${RUNNER_TEMP}/xy-${TAG}-release-notes.md"
+          gh api \
+            --method POST \
+            "repos/${REPO}/releases/generate-notes" \
+            -f tag_name="$TAG" \
+            --jq '.body' > "$notes_file"
+          generated_notes="$(<"$notes_file")"
+          if [[ -z "${generated_notes//[[:space:]]/}" ]]; then
+            echo "::error::GitHub generated empty release notes for ${TAG}"
+            exit 1
+          fi
+          printf '\n<!-- xy-release-workflow:%s -->' "$TAG" >> "$notes_file"
+          expected_notes="$(<"$notes_file")"
 
           # `gh release create` publishes immediately. If a previous run made
           # the release but failed partway through uploading assets, refresh
@@ -346,37 +365,97 @@ jobs:
           if release_json="$(
             gh release view "$TAG" \
               --repo "$REPO" \
-              --json isDraft,isPrerelease,name 2>/dev/null
+              --json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName \
+              2>/dev/null
           )"; then
             is_draft="$(jq -r '.isDraft' <<<"$release_json")"
+            is_immutable="$(jq -r '.isImmutable' <<<"$release_json")"
             is_prerelease="$(jq -r '.isPrerelease' <<<"$release_json")"
             release_name="$(jq -r '.name' <<<"$release_json")"
+            release_notes="$(jq -r '.body' <<<"$release_json")"
+            published_at="$(jq -r '.publishedAt' <<<"$release_json")"
+            release_tag="$(jq -r '.tagName' <<<"$release_json")"
+            actual_assets_json="$(
+              jq -c \
+                '[.assets[].name | select(endswith(".whl") or endswith(".tar.gz"))] | sort' \
+                <<<"$release_json"
+            )"
+            if [[ "$is_immutable" == "true" ]]; then
+              if [[ "$is_draft" == "false" &&
+                    "$is_prerelease" == "$expected_prerelease" &&
+                    "$release_name" == "$TAG" &&
+                    "$published_at" != "null" &&
+                    "$release_tag" == "$TAG" &&
+                    "$release_notes" == "$expected_notes" &&
+                    "$actual_assets_json" == "$expected_assets_json" ]]; then
+                echo "::notice::${TAG} is immutable and already matches the verified release"
+                exit 0
+              fi
+              echo "::error::${TAG} is immutable but does not match the verified release"
+              exit 1
+            fi
+
             echo "::notice::${TAG} already exists; refreshing distribution assets"
             gh release upload "$TAG" "${artifacts[@]}" --repo "$REPO" --clobber
-
-            if [[ "$is_draft" != "false" ||
-                  "$is_prerelease" != "$expected_prerelease" ||
-                  "$release_name" != "$TAG" ]]; then
-              echo "::notice::${TAG} exists with incomplete metadata; normalizing it"
-              gh release edit "$TAG" \
+            release_json="$(
+              gh release view "$TAG" \
                 --repo "$REPO" \
-                --draft=false \
-                --title "$TAG" \
-                "${edit_prerelease[@]}"
-            fi
+                --json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName
+            )"
+
+            while IFS= read -r asset_json; do
+              asset_name="$(jq -r '.name' <<<"$asset_json")"
+              if ! jq -e --arg name "$asset_name" \
+                'index($name) != null' <<<"$expected_assets_json" >/dev/null; then
+                asset_id="$(jq -r '.apiUrl | split("/")[-1]' <<<"$asset_json")"
+                if [[ ! "$asset_id" =~ ^[0-9]+$ ]]; then
+                  echo "::error::Invalid GitHub asset id for ${asset_name}"
+                  exit 1
+                fi
+                echo "::notice::Removing stale distribution asset ${asset_name}"
+                gh api \
+                  --method DELETE \
+                  "repos/${REPO}/releases/assets/${asset_id}"
+              fi
+            done < <(
+              jq -c \
+                '.assets[] | select(.name | endswith(".whl") or endswith(".tar.gz"))' \
+                <<<"$release_json"
+            )
+
+            echo "::notice::Normalizing ${TAG} metadata and generated notes"
+            gh release edit "$TAG" \
+              --repo "$REPO" \
+              --draft=false \
+              --title "$TAG" \
+              --notes-file "$notes_file" \
+              "${edit_prerelease[@]}"
 
             release_json="$(
               gh release view "$TAG" \
                 --repo "$REPO" \
-                --json isDraft,isPrerelease,name
+                --json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName
             )"
             is_draft="$(jq -r '.isDraft' <<<"$release_json")"
             is_prerelease="$(jq -r '.isPrerelease' <<<"$release_json")"
             release_name="$(jq -r '.name' <<<"$release_json")"
+            release_notes="$(jq -r '.body' <<<"$release_json")"
+            published_at="$(jq -r '.publishedAt' <<<"$release_json")"
+            release_tag="$(jq -r '.tagName' <<<"$release_json")"
+            actual_assets_json="$(
+              jq -c \
+                '[.assets[].name | select(endswith(".whl") or endswith(".tar.gz"))] | sort' \
+                <<<"$release_json"
+            )"
             if [[ "$is_draft" != "false" ||
                   "$is_prerelease" != "$expected_prerelease" ||
-                  "$release_name" != "$TAG" ]]; then
-              echo "::error::${TAG} release metadata is still invalid after normalization"
+                  "$release_name" != "$TAG" ||
+                  "$published_at" == "null" ||
+                  "$release_tag" != "$TAG" ||
+                  -z "$release_notes" ||
+                  "$release_notes" != "$expected_notes" ||
+                  "$actual_assets_json" != "$expected_assets_json" ]]; then
+              echo "::error::${TAG} release metadata, notes, or assets are invalid after normalization"
               exit 1
             fi
 
@@ -386,6 +465,6 @@ jobs:
           gh release create "$TAG" "${artifacts[@]}" \
             --repo "$REPO" \
             --verify-tag \
-            --generate-notes \
             --title "$TAG" \
+            --notes-file "$notes_file" \
             "${prerelease[@]}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,10 +98,11 @@ path = "hatch_build.py"
 include = [
     ".github/workflows/ci.yml",
     ".github/workflows/codspeed.yml",
+    ".github/workflows/deploy-docs-stg.yml",
     ".github/workflows/release.yml",
     # The adapter's release workflow rides along (repo infra, like release.yml)
     # even though the adapter *package* stays out of this sdist: the shipped
-    # test suite validates all four workflows via scripts/verify_ci_workflow.py.
+    # test suite validates all five workflows via scripts/verify_ci_workflow.py.
     ".github/workflows/release-reflex-xy.yml",
     # The xy package only — python/reflex-xy is its own distributable
     # (own pyproject, depends on reflex) and must not ride in this sdist;

--- a/scripts/verify_ci_workflow.py
+++ b/scripts/verify_ci_workflow.py
@@ -929,15 +929,12 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                 (
                     'gh release view "$TAG"',
                     "--json isImmutable",
-                    'immutable=true',
+                    "immutable=true",
                     'echo "immutable=${immutable}" >> "$GITHUB_OUTPUT"',
                 ),
             )
             if missing:
-                errors.append(
-                    "release immutable-release preflight is incomplete: "
-                    f"{missing}"
-                )
+                errors.append(f"release immutable-release preflight is incomplete: {missing}")
 
         immutable_skip = "steps.release_state.outputs.immutable != 'true'"
         prepare_block = step_blocks.get("Prepare release provenance")
@@ -1002,9 +999,7 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                 attest_block,
                 re.MULTILINE,
             ):
-                errors.append(
-                    "release provenance attestation must sign the prepared manifest path"
-                )
+                errors.append("release provenance attestation must sign the prepared manifest path")
 
         release_shell = _named_step_run(
             github_release,
@@ -1085,18 +1080,14 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
             upload_lines = [
                 line
                 for line in active_lines
-                if line.startswith(
-                    'gh release upload "$TAG" "${artifacts[@]}" "$provenance_file" '
-                )
+                if line.startswith('gh release upload "$TAG" "${artifacts[@]}" "$provenance_file" ')
                 and line.endswith(" --clobber")
             ]
             create_lines = [
                 line
                 for line in active_lines
-                if line.startswith(
-                    'gh release create "$TAG" "${artifacts[@]}" "$provenance_file" '
-                )
-                and '--verify-tag ' in line
+                if line.startswith('gh release create "$TAG" "${artifacts[@]}" "$provenance_file" ')
+                and "--verify-tag " in line
                 and '--notes-file "$notes_file" ' in line
             ]
             if len(upload_lines) != 1 or len(create_lines) != 1:
@@ -1193,9 +1184,7 @@ def validate_docs_deploy_workflow(path: Path = DEFAULT_DOCS_DEPLOY_WORKFLOW) -> 
             "docs deploy production Helm promotion must actively depend on verify-library-release"
         )
 
-    gate_step = _named_step_blocks(release_gate).get(
-        "Await GitHub Release and PyPI availability"
-    )
+    gate_step = _named_step_blocks(release_gate).get("Await GitHub Release and PyPI availability")
     gate_shell = _named_step_run(
         release_gate,
         "Await GitHub Release and PyPI availability",

--- a/scripts/verify_ci_workflow.py
+++ b/scripts/verify_ci_workflow.py
@@ -35,7 +35,7 @@ REQUIRED_CI_JOBS = {
     "install_without_rust",
 }
 REQUIRED_CODSPEED_JOBS = {"benchmarks"}
-REQUIRED_RELEASE_JOBS = {"wheels", "sdist", "publish", "wasm"}
+REQUIRED_RELEASE_JOBS = {"wheels", "sdist", "publish", "wasm", "github-release"}
 REQUIRED_REFLEX_XY_RELEASE_JOBS = {"build", "publish"}
 
 
@@ -823,6 +823,31 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
             "unrelated condition (e.g. `if: always()`) would let a manual "
             "dispatch publish unintentionally"
         )
+    _require_job_contains(
+        errors,
+        jobs,
+        "github-release",
+        "release",
+        "tag-only, least-privilege GitHub Release creation after PyPI, using "
+        "the verified distribution artifacts with retry-safe uploads",
+        "if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')",
+        "needs: publish",
+        "permissions:",
+        "contents: write",
+        "actions/download-artifact@",
+        "pattern: dist-*",
+        "merge-multiple: true",
+        "GH_TOKEN: ${{ github.token }}",
+        "dist/*.whl",
+        "dist/*.tar.gz",
+        "gh release view",
+        "gh release upload",
+        "--clobber",
+        "gh release create",
+        "--verify-tag",
+        "--generate-notes",
+        "--prerelease",
+    )
     return errors
 
 

--- a/scripts/verify_ci_workflow.py
+++ b/scripts/verify_ci_workflow.py
@@ -118,6 +118,12 @@ def _job_scalar(job_text: str, key: str) -> str | None:
     return None if match is None else match.group(1)
 
 
+def _step_scalar(step_text: str, key: str) -> str | None:
+    """Return an active named-step scalar, ignoring comments and nested keys."""
+    match = re.search(rf"^        {re.escape(key)}:\s*(.*?)\s*$", step_text, re.MULTILINE)
+    return None if match is None else match.group(1)
+
+
 def _job_mapping(job_text: str, key: str) -> dict[str, str] | None:
     """Return an active job-level mapping with direct scalar children."""
     lines = job_text.splitlines()
@@ -149,11 +155,16 @@ def _named_step_run(job_text: str, step: str) -> str | None:
         start = lines.index("        run: |")
     except ValueError:
         return None
-    shell_lines = [
-        line[10:] if line.startswith("          ") else line.lstrip()
-        for line in lines[start + 1 :]
-        if not line.lstrip().startswith("#")
-    ]
+    shell_lines: list[str] = []
+    for line in lines[start + 1 :]:
+        # A step key may legally follow `run:` (for example `shell:` or
+        # `timeout-minutes:`). It is metadata, not part of the block scalar.
+        # Stop at the first non-empty line indented no deeper than `run:`.
+        if line.strip() and len(line) - len(line.lstrip()) <= 8:
+            break
+        if line.lstrip().startswith("#"):
+            continue
+        shell_lines.append(line[10:] if line.startswith("          ") else line.lstrip())
     return "\n".join(shell_lines)
 
 
@@ -880,6 +891,9 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
         "pattern: dist-*",
         "merge-multiple: true",
         "GH_TOKEN: ${{ github.token }}",
+        "Inspect existing release",
+        "Prepare release provenance",
+        "Attest release provenance",
         "Create GitHub Release and attach distributions",
     )
     github_release = jobs.get("github-release")
@@ -893,11 +907,104 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
         if _job_scalar(github_release, "needs") != "publish":
             errors.append("release github-release job must actively declare `needs: publish`")
         permissions = _job_mapping(github_release, "permissions")
-        if permissions != {"contents": "write"}:
+        expected_permissions = {
+            "attestations": "write",
+            "artifact-metadata": "write",
+            "contents": "write",
+            "id-token": "write",
+        }
+        if permissions != expected_permissions:
             errors.append(
                 "release github-release job permissions must be exactly "
-                f"`contents: write`, found {permissions!r}"
+                f"{expected_permissions!r}, found {permissions!r}"
             )
+
+        step_blocks = _named_step_blocks(github_release)
+        inspect_shell = _named_step_run(github_release, "Inspect existing release")
+        if inspect_shell is None:
+            errors.append("release github-release job is missing immutable-release preflight")
+        else:
+            missing = _missing_needles(
+                inspect_shell,
+                (
+                    'gh release view "$TAG"',
+                    "--json isImmutable",
+                    'immutable=true',
+                    'echo "immutable=${immutable}" >> "$GITHUB_OUTPUT"',
+                ),
+            )
+            if missing:
+                errors.append(
+                    "release immutable-release preflight is incomplete: "
+                    f"{missing}"
+                )
+
+        immutable_skip = "steps.release_state.outputs.immutable != 'true'"
+        prepare_block = step_blocks.get("Prepare release provenance")
+        prepare_shell = _named_step_run(github_release, "Prepare release provenance")
+        if prepare_block is None or prepare_shell is None:
+            errors.append("release github-release job is missing active provenance preparation")
+        else:
+            if _step_scalar(prepare_block, "if") != immutable_skip:
+                errors.append(
+                    "release provenance preparation must skip pre-existing immutable releases"
+                )
+            required_prepare_shell = (
+                "shopt -s nullglob",
+                "wheels=(dist/*.whl)",
+                "sdists=(dist/*.tar.gz)",
+                'artifacts=("${wheels[@]}" "${sdists[@]}")',
+                "if (( ${#wheels[@]} == 0 || ${#sdists[@]} != 1 )); then\n"
+                '  echo "::error::Expected at least one wheel and exactly one sdist"\n'
+                "  exit 1\n"
+                "fi",
+                "distributions_json=",
+                'sha256sum "$artifact"',
+                '"repos/${REPO}/releases/generate-notes"',
+                '-f tag_name="$TAG"',
+                'generated_notes="$(<"$notes_file")"',
+                'if [[ -z "${generated_notes//[[:space:]]/}" ]]; then\n'
+                '  echo "::error::GitHub generated empty release notes for ${TAG}"\n'
+                "  exit 1\n"
+                "fi",
+                '"xy-release-provenance/v1"',
+                '--arg source_sha "$GITHUB_SHA"',
+                "release_notes_sha256:",
+                "distributions:",
+                "xy-release-provenance.json",
+                "<!-- xy-release-provenance:v1:%s:sha256:%s -->",
+            )
+            missing = _missing_needles(prepare_shell, required_prepare_shell)
+            if missing:
+                errors.append(
+                    "release provenance preparation must bind generated notes and exact "
+                    f"distribution hashes to the tag source: {missing}"
+                )
+
+        attest_block = step_blocks.get("Attest release provenance")
+        attest_pin = "actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d"
+        if attest_block is None:
+            errors.append("release github-release job is missing provenance attestation")
+        else:
+            if _step_scalar(attest_block, "if") != immutable_skip:
+                errors.append(
+                    "release provenance attestation must skip pre-existing immutable releases"
+                )
+            attest_uses = _step_scalar(attest_block, "uses")
+            if attest_uses is None or attest_uses.split(" #", 1)[0] != attest_pin:
+                errors.append(
+                    "release provenance attestation must use the pinned actions/attest v4 action"
+                )
+            if not re.search(
+                r"^          subject-path:\s*"
+                r"\$\{\{ runner\.temp \}\}/xy-\$\{\{ github\.ref_name \}\}"
+                r"-release-provenance/xy-release-provenance\.json\s*$",
+                attest_block,
+                re.MULTILINE,
+            ):
+                errors.append(
+                    "release provenance attestation must sign the prepared manifest path"
+                )
 
         release_shell = _named_step_run(
             github_release,
@@ -924,24 +1031,32 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                 '"${edit_prerelease[@]}"',
                 '"${prerelease[@]}"',
                 "expected_assets_json=",
-                'gh release upload "$TAG" "${artifacts[@]}"',
-                'gh release create "$TAG" "${artifacts[@]}"',
+                "expected_hashes_json=",
+                'provenance_name="xy-release-provenance.json"',
+                'gh release upload "$TAG" "${artifacts[@]}" "$provenance_file"',
+                'gh release create "$TAG" "${artifacts[@]}" "$provenance_file"',
                 "--verify-tag",
                 "--prerelease=false",
                 "index($name) != null",
                 '.assets[] | select(.name | endswith(".whl") or endswith(".tar.gz"))',
                 '"repos/${REPO}/releases/assets/${asset_id}"',
-                '"repos/${REPO}/releases/generate-notes"',
-                '-f tag_name="$TAG"',
                 '--notes-file "$notes_file"',
-                "<!-- xy-release-workflow:%s -->",
-                'generated_notes="$(<"$notes_file")"',
-                'if [[ -z "${generated_notes//[[:space:]]/}" ]]; then',
                 "isImmutable",
                 "publishedAt",
                 "tagName",
                 "actual_assets_json=",
-                '"$actual_assets_json" != "$expected_assets_json"',
+                'gh release download "$TAG"',
+                'gh attestation verify "$verified_provenance"',
+                '--signer-workflow "${REPO}/.github/workflows/release.yml"',
+                '--source-ref "refs/tags/${TAG}"',
+                '--source-digest "$GITHUB_SHA"',
+                "--deny-self-hosted-runners",
+                "actual_hashes_json=",
+                "manifest_hashes_json=",
+                '"$actual_hashes_json" != "$expected_hashes_json"',
+                '"$manifest_hashes_json" != "$expected_hashes_json"',
+                "<!-- xy-release-provenance:v1:${TAG}:sha256:${manifest_sha256} -->",
+                '"$actual_notes_sha256" != "$manifest_notes_sha256"',
                 "--draft=false",
                 "--clobber",
             )
@@ -949,7 +1064,7 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
             if missing:
                 errors.append(
                     "release github-release job missing retry-safe artifact, metadata, "
-                    f"prerelease, or generated-notes behavior: {missing}"
+                    f"prerelease, hash, or signed-provenance behavior: {missing}"
                 )
 
             active_lines = [
@@ -961,25 +1076,34 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
             release_json_fields = (
                 "--json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName"
             )
-            if active_lines.count(release_view) < 3 or active_lines.count(release_json_fields) < 3:
+            if active_lines.count(release_view) < 4 or active_lines.count(release_json_fields) < 4:
                 errors.append(
                     "release github-release job must inspect full release metadata and "
-                    "assets before recovery, after upload, and after normalization"
+                    "assets before recovery, after upload, after normalization, "
+                    "and after creation"
                 )
             upload_lines = [
                 line
                 for line in active_lines
-                if line.startswith('gh release upload "$TAG" "${artifacts[@]}" ')
+                if line.startswith(
+                    'gh release upload "$TAG" "${artifacts[@]}" "$provenance_file" '
+                )
+                and line.endswith(" --clobber")
             ]
             create_lines = [
                 line
                 for line in active_lines
-                if line == 'gh release create "$TAG" "${artifacts[@]}"'
+                if line.startswith(
+                    'gh release create "$TAG" "${artifacts[@]}" "$provenance_file" '
+                )
+                and '--verify-tag ' in line
+                and '--notes-file "$notes_file" ' in line
             ]
             if len(upload_lines) != 1 or len(create_lines) != 1:
                 errors.append(
-                    "release github-release job must pass the verified artifact array "
-                    "directly to one active upload command and one active create command"
+                    "release github-release job must pass verified distributions and "
+                    "provenance directly to one active upload command (with --clobber) "
+                    "and one active create command"
                 )
 
             classifier = f'if [[ "$TAG" =~ {CORE_PRERELEASE_TAG_PATTERN} ]]; then'
@@ -1052,9 +1176,11 @@ def validate_docs_deploy_workflow(path: Path = DEFAULT_DOCS_DEPLOY_WORKFLOW) -> 
             "docs deploy verify-library-release job must actively depend on "
             "prepare and production approval"
         )
-    if _job_mapping(release_gate, "permissions") != {"contents": "read"}:
+    expected_permissions = {"attestations": "read", "contents": "read"}
+    if _job_mapping(release_gate, "permissions") != expected_permissions:
         errors.append(
-            "docs deploy verify-library-release permissions must be exactly `contents: read`"
+            "docs deploy verify-library-release permissions must be exactly "
+            f"{expected_permissions!r}"
         )
 
     production = jobs.get("helm-pr-prod")
@@ -1067,15 +1193,27 @@ def validate_docs_deploy_workflow(path: Path = DEFAULT_DOCS_DEPLOY_WORKFLOW) -> 
             "docs deploy production Helm promotion must actively depend on verify-library-release"
         )
 
+    gate_step = _named_step_blocks(release_gate).get(
+        "Await GitHub Release and PyPI availability"
+    )
     gate_shell = _named_step_run(
         release_gate,
         "Await GitHub Release and PyPI availability",
     )
-    if gate_shell is None:
+    if gate_step is None or gate_shell is None:
         errors.append("docs deploy release gate is missing its active polling shell step")
         return errors
+    if not re.search(
+        r"^          SOURCE_SHA:\s*"
+        r"\$\{\{ needs\.prepare\.outputs\.source_sha \}\}\s*$",
+        gate_step,
+        re.MULTILINE,
+    ):
+        errors.append("docs deploy release gate must use the prepared exact source SHA")
 
     required = (
+        "shopt -s nullglob",
+        'PROVENANCE_NAME="xy-release-provenance.json"',
         "EXPECTED_PRERELEASE=false",
         f'if [[ "$VERSION" =~ {CORE_PRERELEASE_TAG_PATTERN} ]]; then',
         "EXPECTED_PRERELEASE=true",
@@ -1086,21 +1224,37 @@ def validate_docs_deploy_workflow(path: Path = DEFAULT_DOCS_DEPLOY_WORKFLOW) -> 
         ".tagName == $name",
         ".publishedAt != null",
         ".isPrerelease == $prerelease",
-        '(.body | endswith("<!-- xy-release-workflow:" + $name + " -->"))',
         'any(.assets[]?; .name | endswith(".whl"))',
         '([.assets[]? | select(.name | endswith(".tar.gz"))] | length) == 1',
-        "[.assets[]?.name |",
-        "[.urls[]?.filename |",
-        '[[ "$github_assets" == "$pypi_assets" ]]; then',
+        'select(.name == "xy-release-provenance.json")',
+        "all(.urls[]; .yanked == false)",
+        'gh release download "$VERSION"',
+        'gh attestation verify "$provenance_file"',
+        '--signer-workflow "${REPO}/.github/workflows/release.yml"',
+        '--source-ref "refs/tags/${VERSION}"',
+        '--source-digest "$SOURCE_SHA"',
+        "--deny-self-hosted-runners",
+        "xy-release-provenance/v1",
+        "release_notes_sha256",
+        "manifest_sha256=",
+        "<!-- xy-release-provenance:v1:${VERSION}:sha256:${manifest_sha256} -->",
+        "github_hashes_json=",
+        "manifest_hashes_json=",
+        "pypi_hashes_json=",
+        ".digests.sha256",
+        '"$github_hashes_json" == "$manifest_hashes_json"',
+        '"$github_hashes_json" == "$pypi_hashes_json"',
         'if [[ "$RELEASED" == true &&',
         '"$PUBLISHED" == true &&',
+        '"$PROVENANCE_VALID" == true &&',
         '"$ASSETS_MATCH" == true ]]; then',
+        'rm -rf -- "$verify_dir"',
     )
     missing = _missing_needles(gate_shell, required)
     if missing:
         errors.append(
             "docs deploy release gate must require expected non-draft metadata, "
-            f"generated notes, wheel/sdist assets, and PyPI: {missing}"
+            f"signed notes provenance, non-yanked PyPI files, and exact asset hashes: {missing}"
         )
     return errors
 

--- a/scripts/verify_ci_workflow.py
+++ b/scripts/verify_ci_workflow.py
@@ -136,14 +136,26 @@ def _step_name(step_text: str) -> str | None:
 
 
 def _step_run(step_text: str) -> str | None:
-    """Return one step's shell, supporting block and one-line ``run`` values."""
+    """Return one step's shell from a literal block or one-line ``run`` value.
+
+    Folded YAML scalars replace source newlines with spaces according to YAML
+    folding rules. Treating their indented source as separate shell commands
+    validates different code from what Actions executes, so protected callers
+    must fail closed instead of attempting to reconstruct folded semantics.
+    """
     lines = step_text.splitlines()
     for start, line in enumerate(lines):
         match = re.match(r"^        run:\s*(.*?)\s*$", line)
         if match is None:
             continue
         value = _strip_yaml_inline_comment(match.group(1))
-        if not re.fullmatch(r"[|>][+-]?", value):
+        block_scalar = re.fullmatch(
+            r"[|>](?:(?:[1-9][+-]?)|(?:[+-][1-9]?))?",
+            value,
+        )
+        if block_scalar is not None and not re.fullmatch(r"\|[+-]?", value):
+            return None
+        if not re.fullmatch(r"\|[+-]?", value):
             return value or None
         shell_lines: list[str] = []
         for body_line in lines[start + 1 :]:
@@ -156,6 +168,16 @@ def _step_run(step_text: str) -> str | None:
             )
         return "\n".join(shell_lines)
     return None
+
+
+def _step_uses_uninspectable_run(step_text: str) -> bool:
+    """Return whether a shell step is not a supported literal YAML block."""
+    for line in step_text.splitlines():
+        match = re.match(r"^        run:\s*(.*?)\s*$", line)
+        if match is not None:
+            value = _strip_yaml_inline_comment(match.group(1))
+            return re.fullmatch(r"\|[+-]?", value) is None
+    return False
 
 
 def _job_scalar(job_text: str, key: str) -> str | None:
@@ -266,6 +288,213 @@ def _shell_command_records(shell: str) -> list[tuple[int, str, list[str]]]:
     return records
 
 
+_SHELL_COMMAND_BOUNDARIES = {
+    "&",
+    "&&",
+    "(",
+    ")",
+    ";",
+    ";;",
+    "do",
+    "elif",
+    "else",
+    "if",
+    "then",
+    "until",
+    "while",
+    "|",
+    "||",
+    "{",
+    "}",
+    "!",
+}
+_SHELL_ASSIGNMENT_TOKEN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def _shell_prefix_is_wrappers(prefix: list[str]) -> bool:
+    """Return whether ``prefix`` only wraps the command that follows it."""
+    index = 0
+    while index < len(prefix) and _SHELL_ASSIGNMENT_TOKEN.match(prefix[index]):
+        index += 1
+
+    while index < len(prefix):
+        wrapper = prefix[index].rsplit("/", 1)[-1]
+        index += 1
+        if wrapper in {"builtin", "command"}:
+            while index < len(prefix) and (prefix[index] == "--" or prefix[index].startswith("-")):
+                index += 1
+            continue
+        if wrapper == "env":
+            value_options = {
+                "--argv0",
+                "--chdir",
+                "--split-string",
+                "--unset",
+                "-C",
+                "-S",
+                "-a",
+                "-u",
+            }
+            while index < len(prefix):
+                token = prefix[index]
+                if _SHELL_ASSIGNMENT_TOKEN.match(token):
+                    index += 1
+                elif token == "--":
+                    index += 1
+                    break
+                elif token in value_options:
+                    index += 2
+                elif token.startswith("-"):
+                    index += 1
+                else:
+                    break
+            continue
+        if wrapper == "time":
+            while index < len(prefix) and (prefix[index] == "--" or prefix[index].startswith("-")):
+                index += 1
+            continue
+        if wrapper == "nohup":
+            while index < len(prefix) and prefix[index].startswith("-"):
+                index += 1
+            continue
+        if wrapper == "nice":
+            while index < len(prefix):
+                token = prefix[index]
+                if token in {"--adjustment", "-n"}:
+                    index += 2
+                elif token.startswith("-"):
+                    index += 1
+                else:
+                    break
+            continue
+        if wrapper == "stdbuf":
+            value_options = {"--error", "--input", "--output", "-e", "-i", "-o"}
+            while index < len(prefix):
+                token = prefix[index]
+                if token in value_options:
+                    index += 2
+                elif token.startswith("-"):
+                    index += 1
+                else:
+                    break
+            continue
+        if wrapper == "timeout":
+            value_options = {"--kill-after", "--signal", "-k", "-s"}
+            while index < len(prefix):
+                token = prefix[index]
+                if token == "--":
+                    index += 1
+                    continue
+                if token in value_options:
+                    index += 2
+                elif token.startswith("-"):
+                    index += 1
+                else:
+                    # The first positional value is timeout's duration.
+                    index += 1
+                    break
+            continue
+        return False
+    return True
+
+
+def _shell_token_starts_command(tokens: list[str], token_position: int) -> bool:
+    """Return whether one token is executable at a shell command boundary."""
+    command_start = 0
+    for prefix_position in range(token_position - 1, -1, -1):
+        if tokens[prefix_position] in _SHELL_COMMAND_BOUNDARIES:
+            command_start = prefix_position + 1
+            break
+    return _shell_prefix_is_wrappers(tokens[command_start:token_position])
+
+
+def _shell_command_arguments(tokens: list[str], token_position: int) -> list[str]:
+    """Return arguments up to the next shell control boundary."""
+    command_end = len(tokens)
+    for suffix_position in range(token_position + 1, len(tokens)):
+        if tokens[suffix_position] in _SHELL_COMMAND_BOUNDARIES:
+            command_end = suffix_position
+            break
+    return tokens[token_position + 1 : command_end]
+
+
+def _has_indirect_shell_execution(shell: str) -> bool:
+    """Reject commands that can hide unparsed shell from protected validators."""
+    shell_interpreters = {
+        "$SHELL",
+        "${SHELL}",
+        "ash",
+        "bash",
+        "dash",
+        "fish",
+        "ksh",
+        "mksh",
+        "sh",
+        "zsh",
+    }
+    double_bracket_open = False
+    for _, line, tokens in _shell_command_records(shell):
+        expression_positions: set[int] = set()
+        arithmetic_open = False
+        for position, token in enumerate(tokens):
+            if token == "[[":
+                double_bracket_open = True
+            elif token == "((":
+                arithmetic_open = True
+            if double_bracket_open or arithmetic_open:
+                expression_positions.add(position)
+            if token == "]]":
+                double_bracket_open = False
+            elif token == "))":
+                arithmetic_open = False
+
+        function_definition = re.match(
+            r"^(?:function\s+)?([A-Za-z_][A-Za-z0-9_]*)"
+            r"(?:\s*\(\))?\s*\{(?:\s|$)",
+            line,
+        )
+        if function_definition is not None and function_definition.group(1) not in {
+            "release_metadata_matches",
+            "verify_release_payload",
+            "verify_tag_source",
+        }:
+            return True
+        for token_position, token in enumerate(tokens):
+            if token_position in expression_positions:
+                continue
+            if not _shell_token_starts_command(tokens, token_position):
+                continue
+            command = token.rsplit("/", 1)[-1]
+            dynamic_command = token.startswith(("$", "`")) and not (
+                len(tokens) > 1 and _SHELL_ASSIGNMENT_TOKEN.match(tokens[0]) and tokens[1] == "("
+            )
+            if (
+                command
+                in {
+                    ".",
+                    "alias",
+                    "enable",
+                    "eval",
+                    "find",
+                    "hash",
+                    "parallel",
+                    "source",
+                    "trap",
+                    "xargs",
+                }
+                or command in shell_interpreters
+                or dynamic_command
+            ):
+                return True
+            if command == "env" and any(
+                argument in {"-S", "--split-string"}
+                or argument.startswith(("-S", "--split-string="))
+                for argument in _shell_command_arguments(tokens, token_position)
+            ):
+                return True
+    return False
+
+
 def _shell_maybe_successful_terminations(
     logical_lines: list[str],
 ) -> list[tuple[int, int, str, str | None]]:
@@ -283,29 +512,6 @@ def _shell_maybe_successful_terminations(
     ``command``/``builtin`` wrappers without mistaking text such as
     ``printf '%s' exit`` for an active termination.
     """
-    boundary_tokens = {
-        "&",
-        "&&",
-        "(",
-        ")",
-        ";",
-        ";;",
-        "do",
-        "elif",
-        "else",
-        "if",
-        "then",
-        "until",
-        "while",
-        "|",
-        "||",
-        "{",
-        "}",
-        "!",
-    }
-    command_wrappers = {"builtin", "command", "time"}
-    executing_wrapper_options = {"--", "-p"}
-    assignment = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
     explicit_status = re.compile(r"^[+-]?[0-9]+$")
     terminations: list[tuple[int, int, str, str | None]] = []
 
@@ -316,26 +522,9 @@ def _shell_maybe_successful_terminations(
         for token_position, token in enumerate(tokens):
             if token not in {"exec", "exit", "return"}:
                 continue
-
-            command_start = 0
-            for prefix_position in range(token_position - 1, -1, -1):
-                if tokens[prefix_position] in boundary_tokens:
-                    command_start = prefix_position + 1
-                    break
-            prefix = tokens[command_start:token_position]
-            while prefix and assignment.match(prefix[0]):
-                prefix = prefix[1:]
-            if prefix and not all(
-                item in command_wrappers or item in executing_wrapper_options for item in prefix
-            ):
+            if not _shell_token_starts_command(tokens, token_position):
                 continue
-
-            command_end = len(tokens)
-            for suffix_position in range(token_position + 1, len(tokens)):
-                if tokens[suffix_position] in boundary_tokens:
-                    command_end = suffix_position
-                    break
-            arguments = tokens[token_position + 1 : command_end]
+            arguments = _shell_command_arguments(tokens, token_position)
             status = arguments[0] if len(arguments) == 1 else None
             if (
                 token != "exec"
@@ -355,48 +544,157 @@ def _shell_function_definition_count(shell: str, name: str) -> int:
     return sum(bool(pattern.match(line)) for line in _shell_logical_lines(shell))
 
 
+def _normalized_api_endpoint(endpoint: str) -> str:
+    """Normalize one REST/GraphQL endpoint without inspecting option values."""
+    endpoint = endpoint.split("#", 1)[0].split("?", 1)[0].rstrip("/")
+    endpoint = re.sub(r"^https://[^/]+/(?:api/v3/)?", "", endpoint)
+    return endpoint.lstrip("/")
+
+
+def _normalized_release_api_endpoint(endpoint: str) -> tuple[bool, bool]:
+    """Return ``(is_release_endpoint, is_generate_notes_endpoint)``."""
+    endpoint = _normalized_api_endpoint(endpoint)
+    release_path = re.fullmatch(
+        r"repos/(?:\$\{REPO\}|\$REPO|[^/]+/[^/]+)/releases(?:/(.*))?",
+        endpoint,
+    )
+    if release_path is None:
+        return False, False
+    return True, release_path.group(1) == "generate-notes"
+
+
+def _gh_api_request(api_tokens: list[str]) -> tuple[str, str | None]:
+    """Return the effective method and positional endpoint of ``gh api``."""
+    method: str | None = None
+    has_payload = False
+    endpoint: str | None = None
+    value_options = {
+        "--cache",
+        "--header",
+        "--hostname",
+        "--jq",
+        "--preview",
+        "--template",
+        "-H",
+        "-p",
+        "-q",
+        "-t",
+    }
+    payload_options = {"--field", "--input", "--raw-field", "-F", "-f"}
+    index = 0
+    while index < len(api_tokens):
+        token = api_tokens[index]
+        if token in {"--method", "-X"}:
+            method = api_tokens[index + 1] if index + 1 < len(api_tokens) else ""
+            index += 2
+            continue
+        if token.startswith("--method="):
+            method = token.split("=", 1)[1]
+            index += 1
+            continue
+        if token.startswith("-X") and len(token) > 2:
+            method = token[2:].removeprefix("=")
+            index += 1
+            continue
+        if token in payload_options:
+            has_payload = True
+            index += 2
+            continue
+        if (
+            token.startswith("--field=")
+            or token.startswith("--input=")
+            or token.startswith("--raw-field=")
+            or (token.startswith("-F") and len(token) > 2)
+            or (token.startswith("-f") and len(token) > 2)
+        ):
+            has_payload = True
+            index += 1
+            continue
+        if token in value_options:
+            index += 2
+            continue
+        if any(
+            token.startswith(f"{option}=") for option in value_options if option.startswith("--")
+        ):
+            index += 1
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        if endpoint is None:
+            endpoint = token
+        index += 1
+    return (method.upper() if method is not None else ("POST" if has_payload else "GET")), endpoint
+
+
+def _gh_subcommand(arguments: list[str]) -> tuple[str | None, list[str]]:
+    """Return the first positional gh command after persistent options."""
+    value_options = {"--config-dir", "--hostname", "--repo", "-R"}
+    index = 0
+    while index < len(arguments):
+        token = arguments[index]
+        if token == "--":
+            index += 1
+            break
+        if token in value_options:
+            index += 2
+            continue
+        if token.startswith(("--config-dir=", "--hostname=", "--repo=")):
+            index += 1
+            continue
+        if token.startswith("-R") and len(token) > 2:
+            index += 1
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        return token, arguments[index + 1 :]
+    if index < len(arguments):
+        return arguments[index], arguments[index + 1 :]
+    return None, []
+
+
 def _has_gh_release_mutation(shell: str) -> bool:
     """Return whether shell directly invokes a GitHub Release write command."""
-    mutations = {"create", "delete", "edit", "upload"}
-    write_methods = {"DELETE", "PATCH", "POST", "PUT"}
+    mutations = {"create", "delete", "delete-asset", "edit", "new", "upload"}
     for _, _, tokens in _shell_command_records(shell):
-        for index in range(len(tokens) - 2):
-            if tokens[index : index + 2] == ["gh", "release"] and tokens[index + 2] in mutations:
+        for index, token in enumerate(tokens):
+            if token.rsplit("/", 1)[-1] != "gh" or not _shell_token_starts_command(tokens, index):
+                continue
+            gh_arguments = _shell_command_arguments(tokens, index)
+            subcommand, subcommand_arguments = _gh_subcommand(gh_arguments)
+            if subcommand == "release":
+                release_command, _ = _gh_subcommand(subcommand_arguments)
+                if release_command in mutations or (
+                    release_command is not None and release_command.startswith(("$", "`"))
+                ):
+                    return True
+                continue
+            if subcommand != "api":
+                continue
+            method, endpoint = _gh_api_request(subcommand_arguments)
+            if method in {"GET", "HEAD"}:
+                continue
+            if endpoint is None:
                 return True
-            if tokens[index : index + 2] != ["gh", "api"]:
-                continue
-            api_tokens = tokens[index + 2 :]
-            methods = [
-                api_tokens[position + 1].upper()
-                for position, token in enumerate(api_tokens[:-1])
-                if token in {"--method", "-X"}
-            ]
-            if not any(method in write_methods for method in methods):
-                continue
-            release_endpoints = [
-                token for token in api_tokens if re.search(r"(?:^|/)releases(?:/|$)", token)
-            ]
-            if any(
-                not endpoint.endswith("/releases/generate-notes") for endpoint in release_endpoints
-            ):
+            normalized_endpoint = _normalized_api_endpoint(endpoint)
+            if normalized_endpoint == "graphql":
+                return True
+            is_release, is_generate_notes = _normalized_release_api_endpoint(endpoint)
+            if is_release and not (is_generate_notes and method == "POST"):
+                return True
+            endpoint_without_repo = normalized_endpoint.replace("${REPO}", "REPO").replace(
+                "$REPO", "REPO"
+            )
+            if "$" in endpoint_without_repo or "`" in endpoint_without_repo:
+                # A computed write endpoint can resolve to Releases at runtime.
+                return True
+            if normalized_endpoint.startswith("graphql/"):
+                # Fail closed on non-canonical GraphQL spellings as well.
+                return True
+            if endpoint.startswith(("$", "`")):
                 return True
     return False
-
-
-def _option_values(tokens: list[str], option: str) -> list[str | None]:
-    """Return every value supplied to an exact long option token."""
-    values: list[str | None] = []
-    for index, token in enumerate(tokens):
-        if token == option:
-            values.append(tokens[index + 1] if index + 1 < len(tokens) else None)
-        elif token.startswith(f"{option}="):
-            values.append(token.removeprefix(f"{option}="))
-    return values
-
-
-def _has_exact_option(tokens: list[str], option: str, value: str) -> bool:
-    """Require one unambiguous long option whose value is exactly expected."""
-    return _option_values(tokens, option) == [value]
 
 
 def _is_release_metadata_read(tokens: list[str]) -> bool:
@@ -476,10 +774,154 @@ def _has_guarded_release_validation(logical_lines: list[str], metadata_position:
     )
 
 
+def _assignment_target_is(token: str, name: str) -> bool:
+    """Return whether an assignment/declaration token targets ``name``."""
+    target = token.split("=", 1)[0].removesuffix("+")
+    target = target.split("[", 1)[0]
+    return target == name
+
+
+def _assignment_target_is_dynamic(token: str) -> bool:
+    """Return whether a variable-writing command computes its target name."""
+    target = token.split("=", 1)[0]
+    return "$" in target or "`" in target
+
+
+def _shell_command_writes_variable(tokens: list[str], position: int, name: str) -> bool:
+    """Recognize shell builtins that can overwrite a protected variable."""
+    if not _shell_token_starts_command(tokens, position):
+        return False
+    command = tokens[position]
+    arguments = _shell_command_arguments(tokens, position)
+
+    if command in {"declare", "export", "local", "readonly", "typeset", "unset"}:
+        nameref = any(argument.startswith("-") and "n" in argument[1:] for argument in arguments)
+        if nameref:
+            # A nameref can redirect later ordinary assignments to a protected
+            # variable, including when its target name is computed indirectly.
+            return True
+        for argument in arguments:
+            if argument == "--" or argument.startswith("-"):
+                continue
+            if _assignment_target_is(argument, name) or _assignment_target_is_dynamic(argument):
+                return True
+        return False
+
+    if command == "printf":
+        for index, argument in enumerate(arguments):
+            if argument == "-v" and index + 1 < len(arguments):
+                target = arguments[index + 1]
+                return _assignment_target_is(target, name) or _assignment_target_is_dynamic(target)
+            if argument.startswith("-v") and len(argument) > 2:
+                target = argument[2:]
+                return _assignment_target_is(target, name) or _assignment_target_is_dynamic(target)
+        return False
+
+    if command == "read":
+        value_options = {"-d", "-i", "-n", "-N", "-p", "-t", "-u"}
+        index = 0
+        while index < len(arguments):
+            argument = arguments[index]
+            if argument == "--":
+                return any(
+                    _assignment_target_is(target, name) or _assignment_target_is_dynamic(target)
+                    for target in arguments[index + 1 :]
+                )
+            if argument == "-a" and index + 1 < len(arguments):
+                target = arguments[index + 1]
+                if _assignment_target_is(target, name) or _assignment_target_is_dynamic(target):
+                    return True
+                index += 2
+                continue
+            if argument.startswith("-a") and len(argument) > 2:
+                target = argument[2:]
+                if _assignment_target_is(target, name) or _assignment_target_is_dynamic(target):
+                    return True
+                index += 1
+                continue
+            if argument in value_options:
+                index += 2
+                continue
+            if argument.startswith("-"):
+                index += 1
+                continue
+            return any(
+                _assignment_target_is(target, name) or _assignment_target_is_dynamic(target)
+                for target in arguments[index:]
+            )
+        return False
+
+    if command in {"mapfile", "readarray"}:
+        value_options = {"-C", "-O", "-c", "-n", "-s", "-u"}
+        index = 0
+        while index < len(arguments):
+            argument = arguments[index]
+            if argument in value_options:
+                index += 2
+                continue
+            if argument.startswith("-"):
+                index += 1
+                continue
+            if re.match(r"^(?:[0-9]*)[<>]", argument):
+                redirection_only = re.fullmatch(
+                    r"[0-9]*(?:<<<|<<|<>|<&|>>|>&|>\||<|>)",
+                    argument,
+                )
+                index += 2 if redirection_only is not None else 1
+                continue
+            return _assignment_target_is(argument, name) or _assignment_target_is_dynamic(argument)
+        return name == "MAPFILE"
+
+    if command == "let":
+        if any("$" in argument or "`" in argument for argument in arguments):
+            return True
+        arithmetic_write = re.compile(
+            rf"^{re.escape(name)}(?:\[[^]]+\])?\s*"
+            r"(?:\+\+|--|(?:<<|>>|[+\-*/%&|^])?=(?!=))"
+        )
+        return any(arithmetic_write.search(argument) for argument in arguments)
+
+    if command == "getopts" and len(arguments) >= 2:
+        target = arguments[1]
+        return _assignment_target_is(target, name) or _assignment_target_is_dynamic(target)
+
+    return False
+
+
 def _assignment_lines(logical_lines: list[str], name: str) -> list[str]:
-    """Return active direct assignments to one protected shell variable."""
-    pattern = re.compile(rf"^(?:if (?:! )?)?{re.escape(name)}=")
-    return [line for line in logical_lines if pattern.match(line)]
+    """Return every direct or builtin write to a protected shell variable."""
+    pattern = re.compile(rf"^(?:if (?:! )?)?{re.escape(name)}(?:\[[^]]+\])?\+?=")
+    arithmetic_write = re.compile(
+        rf"(?<![A-Za-z0-9_]){re.escape(name)}(?:\[[^]]+\])?\s*"
+        r"(?:\+\+|--|(?:<<|>>|[+\-*/%&|^])?=(?!=))"
+    )
+    parameter_write = re.compile(rf"\$\{{{re.escape(name)}(?::?=)")
+    iteration_write = re.compile(
+        rf"(?:^|[;&|{{}}()]\s*|\b(?:do|then)\s+)"
+        rf"(?:for|select)\s+{re.escape(name)}\b"
+    )
+    dynamic_arithmetic_write = re.compile(
+        r"\(\([^)]*\$(?:\{[^}]+\}|[A-Za-z_][A-Za-z0-9_]*)\s*"
+        r"(?:\+\+|--|(?:<<|>>|[+\-*/%&|^])?=(?!=))"
+    )
+    assignments: list[str] = []
+    for line in logical_lines:
+        if (
+            pattern.match(line)
+            or arithmetic_write.search(line)
+            or parameter_write.search(line)
+            or iteration_write.search(line)
+            or dynamic_arithmetic_write.search(line)
+        ):
+            assignments.append(line)
+            continue
+        tokens = _shell_tokens(line)
+        if tokens is not None and any(
+            _shell_command_writes_variable(tokens, position, name)
+            for position in range(len(tokens))
+        ):
+            assignments.append(line)
+    return assignments
 
 
 def _logical_line_is(logical_lines: list[str], position: int, expected: str) -> bool:
@@ -1387,6 +1829,8 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
     if publish_tag_block is None or publish_tag_shell is None:
         errors.append("release publish job must verify the current tag source before PyPI")
     else:
+        if _has_indirect_shell_execution(publish_tag_shell):
+            errors.append("release publish tag guard must not use indirect shell execution")
         publish_tag_lines = _shell_logical_lines(publish_tag_shell)
         lookup_tokens = [
             "timeout",
@@ -1463,6 +1907,27 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                 "release github-release job must declare each protected step exactly once: "
                 f"{duplicate_protected_steps}"
             )
+        uninspectable_run_steps = [
+            _step_name(step) or "<unnamed>"
+            for step in job_steps
+            if _step_uses_uninspectable_run(step)
+        ]
+        if uninspectable_run_steps:
+            errors.append(
+                "release github-release job must use literal `run: |` blocks so every "
+                "shell step can be inspected for release mutations; found unsupported "
+                f"`run` scalars in {uninspectable_run_steps}"
+            )
+        indirect_shell_steps = [
+            _step_name(step) or "<unnamed>"
+            for step in job_steps
+            if (shell := _step_run(step)) is not None and _has_indirect_shell_execution(shell)
+        ]
+        if indirect_shell_steps:
+            errors.append(
+                "release github-release job must not hide release behavior behind "
+                f"indirect shell execution; found it in {indirect_shell_steps}"
+            )
         sibling_release_mutations = [
             _step_name(step) or "<unnamed>"
             for step in job_steps
@@ -1507,6 +1972,10 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
         if inspect_shell is None:
             errors.append("release github-release job is missing immutable-release preflight")
         else:
+            if _has_indirect_shell_execution(inspect_shell):
+                errors.append(
+                    "release immutable-release preflight must not use indirect shell execution"
+                )
             missing = _missing_needles(
                 inspect_shell,
                 (
@@ -1548,6 +2017,10 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
         if prepare_block is None or prepare_shell is None:
             errors.append("release github-release job is missing active provenance preparation")
         else:
+            if _has_indirect_shell_execution(prepare_shell):
+                errors.append(
+                    "release provenance preparation must not use indirect shell execution"
+                )
             if _step_scalar(prepare_block, "if") != immutable_skip:
                 errors.append(
                     "release provenance preparation must skip pre-existing immutable releases"
@@ -1655,7 +2128,8 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                 if line == "verify_tag_source"
             ]
             if not (
-                _assignment_lines(prepare_lines, "tag_source_sha") == ['if ! tag_source_sha="$(']
+                _assignment_lines(prepare_lines, "tag_source_sha")
+                == ["local tag_source_sha", 'if ! tag_source_sha="$(']
                 and _shell_function_definition_count(prepare_shell, "verify_tag_source") == 1
                 and len(tag_lookup_positions) == 1
                 and _has_exact_tag_source_function(
@@ -1725,6 +2199,8 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                 "release github-release job is missing the active release publication shell step"
             )
         else:
+            if _has_indirect_shell_execution(release_shell):
+                errors.append("release publication step must not use indirect shell execution")
             required_shell = (
                 "shopt -s nullglob",
                 "wheels=(dist/*.whl)",
@@ -2178,8 +2654,10 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
             if not (
                 len(tag_resolution_positions) == 1
                 and _assignment_lines(logical_lines, "tag_source_sha")
-                == ['if ! tag_source_sha="$(']
+                == ["local tag_source_sha", 'if ! tag_source_sha="$(']
                 and _shell_function_definition_count(release_shell, "verify_tag_source") == 1
+                and _shell_function_definition_count(release_shell, "release_metadata_matches") == 1
+                and _shell_function_definition_count(release_shell, "verify_release_payload") == 1
                 and _has_exact_tag_source_function(
                     logical_lines,
                     tag_resolution_positions[0] if tag_resolution_positions else -1,
@@ -2270,6 +2748,8 @@ def validate_docs_deploy_workflow(path: Path = DEFAULT_DOCS_DEPLOY_WORKFLOW) -> 
     if gate_step is None or gate_shell is None:
         errors.append("docs deploy release gate is missing its active polling shell step")
         return errors
+    if _has_indirect_shell_execution(gate_shell):
+        errors.append("docs deploy release gate must not use indirect shell execution")
     if not re.search(
         r"^          SOURCE_SHA:\s*"
         r"\$\{\{ needs\.prepare\.outputs\.source_sha \}\}\s*$",

--- a/scripts/verify_ci_workflow.py
+++ b/scripts/verify_ci_workflow.py
@@ -4,8 +4,8 @@
 The workflows are YAML, but this checker intentionally stays stdlib-only so it
 can run before the dev environment is installed. It does not try to be a full
 YAML parser; it checks stable, high-value invariants that are easy to lose when
-editing `.github/workflows/ci.yml`, `.github/workflows/release.yml`, or
-`.github/workflows/release-reflex-xy.yml`.
+editing `.github/workflows/ci.yml`, `.github/workflows/release.yml`,
+`.github/workflows/release-reflex-xy.yml`, or the production docs release gate.
 """
 
 from __future__ import annotations
@@ -21,6 +21,7 @@ DEFAULT_CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 DEFAULT_CODSPEED_WORKFLOW = ROOT / ".github" / "workflows" / "codspeed.yml"
 DEFAULT_RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 DEFAULT_REFLEX_XY_RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-reflex-xy.yml"
+DEFAULT_DOCS_DEPLOY_WORKFLOW = ROOT / ".github" / "workflows" / "deploy-docs-stg.yml"
 DEFAULT_WORKFLOW = DEFAULT_CI_WORKFLOW
 REQUIRED_CI_JOBS = {
     "browser_conformance",
@@ -111,6 +112,51 @@ def _named_step_blocks(job_text: str) -> dict[str, str]:
     return {name: "\n".join(lines) for name, lines in blocks.items()}
 
 
+def _job_scalar(job_text: str, key: str) -> str | None:
+    """Return an active job-level scalar, ignoring comments and nested keys."""
+    match = re.search(rf"^    {re.escape(key)}:\s*(.*?)\s*$", job_text, re.MULTILINE)
+    return None if match is None else match.group(1)
+
+
+def _job_mapping(job_text: str, key: str) -> dict[str, str] | None:
+    """Return an active job-level mapping with direct scalar children."""
+    lines = job_text.splitlines()
+    try:
+        start = lines.index(f"    {key}:")
+    except ValueError:
+        return None
+
+    mapping: dict[str, str] = {}
+    for line in lines[start + 1 :]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent <= 4:
+            break
+        match = re.fullmatch(r"      ([A-Za-z0-9_-]+):\s*(.*?)\s*", line)
+        if match:
+            mapping[match.group(1)] = match.group(2)
+    return mapping
+
+
+def _named_step_run(job_text: str, step: str) -> str | None:
+    """Return one named step's active shell body without comment-only lines."""
+    block = _named_step_blocks(job_text).get(step)
+    if block is None:
+        return None
+    lines = block.splitlines()
+    try:
+        start = lines.index("        run: |")
+    except ValueError:
+        return None
+    shell_lines = [
+        line[10:] if line.startswith("          ") else line.lstrip()
+        for line in lines[start + 1 :]
+        if not line.lstrip().startswith("#")
+    ]
+    return "\n".join(shell_lines)
+
+
 def _require_step_contains(
     errors: list[str], job_text: str, step: str, description: str, *needles: str
 ) -> None:
@@ -171,6 +217,7 @@ def _step_is_conditioned(job_text: str, step_needle: str) -> bool:
 PYPI_PUBLISH_GATE = (
     "if: github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true'"
 )
+CORE_PRERELEASE_TAG_PATTERN = r"^v[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)[0-9]+$"
 
 
 def _step_carries_publish_gate(job_text: str, step_needle: str) -> bool:
@@ -828,36 +875,233 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
         jobs,
         "github-release",
         "release",
-        "tag-only, least-privilege GitHub Release creation after PyPI, using "
-        "the verified distribution artifacts with retry-safe uploads",
-        "if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')",
-        "needs: publish",
-        "permissions:",
-        "contents: write",
+        "GitHub Release creation from downloaded verified distributions",
         "actions/download-artifact@",
         "pattern: dist-*",
         "merge-multiple: true",
         "GH_TOKEN: ${{ github.token }}",
-        "shopt -s nullglob",
-        "artifacts=(dist/*.whl dist/*.tar.gz)",
-        "if (( ${#artifacts[@]} == 0 )); then\n"
-        '            echo "::error::No wheel or sdist artifacts were downloaded"\n'
-        "            exit 1\n"
-        "          fi",
-        "dist/*.whl",
-        "dist/*.tar.gz",
-        "gh release view",
-        "--json isDraft,isPrerelease,name",
-        "gh release edit",
-        "--draft=false",
-        "--prerelease=false",
-        "gh release upload",
-        "--clobber",
-        "gh release create",
-        "--verify-tag",
-        "--generate-notes",
-        "--prerelease",
+        "Create GitHub Release and attach distributions",
     )
+    github_release = jobs.get("github-release")
+    if github_release is not None:
+        expected_gate = "github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')"
+        if _job_scalar(github_release, "if") != expected_gate:
+            errors.append(
+                "release github-release job must use the active tag-only gate "
+                f"`if: {expected_gate}`"
+            )
+        if _job_scalar(github_release, "needs") != "publish":
+            errors.append("release github-release job must actively declare `needs: publish`")
+        permissions = _job_mapping(github_release, "permissions")
+        if permissions != {"contents": "write"}:
+            errors.append(
+                "release github-release job permissions must be exactly "
+                f"`contents: write`, found {permissions!r}"
+            )
+
+        release_shell = _named_step_run(
+            github_release,
+            "Create GitHub Release and attach distributions",
+        )
+        if release_shell is None:
+            errors.append(
+                "release github-release job is missing the active release publication shell step"
+            )
+        else:
+            required_shell = (
+                "shopt -s nullglob",
+                "wheels=(dist/*.whl)",
+                "sdists=(dist/*.tar.gz)",
+                'artifacts=("${wheels[@]}" "${sdists[@]}")',
+                "if (( ${#wheels[@]} == 0 || ${#sdists[@]} != 1 )); then\n"
+                '  echo "::error::Expected at least one wheel and exactly one sdist"\n'
+                "  exit 1\n"
+                "fi",
+                f'if [[ "$TAG" =~ {CORE_PRERELEASE_TAG_PATTERN} ]]; then',
+                "prerelease=(--prerelease)",
+                "edit_prerelease=(--prerelease)",
+                "expected_prerelease=true",
+                '"${edit_prerelease[@]}"',
+                '"${prerelease[@]}"',
+                "expected_assets_json=",
+                'gh release upload "$TAG" "${artifacts[@]}"',
+                'gh release create "$TAG" "${artifacts[@]}"',
+                "--verify-tag",
+                "--prerelease=false",
+                "index($name) != null",
+                '.assets[] | select(.name | endswith(".whl") or endswith(".tar.gz"))',
+                '"repos/${REPO}/releases/assets/${asset_id}"',
+                '"repos/${REPO}/releases/generate-notes"',
+                '-f tag_name="$TAG"',
+                '--notes-file "$notes_file"',
+                "<!-- xy-release-workflow:%s -->",
+                'generated_notes="$(<"$notes_file")"',
+                'if [[ -z "${generated_notes//[[:space:]]/}" ]]; then',
+                "isImmutable",
+                "publishedAt",
+                "tagName",
+                "actual_assets_json=",
+                '"$actual_assets_json" != "$expected_assets_json"',
+                "--draft=false",
+                "--clobber",
+            )
+            missing = _missing_needles(release_shell, required_shell)
+            if missing:
+                errors.append(
+                    "release github-release job missing retry-safe artifact, metadata, "
+                    f"prerelease, or generated-notes behavior: {missing}"
+                )
+
+            active_lines = [
+                line.strip().removesuffix("\\").rstrip()
+                for line in release_shell.splitlines()
+                if line.strip()
+            ]
+            release_view = 'gh release view "$TAG"'
+            release_json_fields = (
+                "--json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName"
+            )
+            if active_lines.count(release_view) < 3 or active_lines.count(release_json_fields) < 3:
+                errors.append(
+                    "release github-release job must inspect full release metadata and "
+                    "assets before recovery, after upload, and after normalization"
+                )
+            upload_lines = [
+                line
+                for line in active_lines
+                if line.startswith('gh release upload "$TAG" "${artifacts[@]}" ')
+            ]
+            create_lines = [
+                line
+                for line in active_lines
+                if line == 'gh release create "$TAG" "${artifacts[@]}"'
+            ]
+            if len(upload_lines) != 1 or len(create_lines) != 1:
+                errors.append(
+                    "release github-release job must pass the verified artifact array "
+                    "directly to one active upload command and one active create command"
+                )
+
+            classifier = f'if [[ "$TAG" =~ {CORE_PRERELEASE_TAG_PATTERN} ]]; then'
+            for assignment in (
+                classifier,
+                "prerelease=(--prerelease)",
+                "edit_prerelease=(--prerelease)",
+                "expected_prerelease=true",
+            ):
+                if assignment not in active_lines:
+                    errors.append(
+                        "release github-release job must actively classify canonical "
+                        f"alpha/beta/RC tags; missing {assignment!r}"
+                    )
+
+            initial_view_position = release_shell.find(release_view)
+            upload_position = release_shell.find('gh release upload "$TAG"')
+            uploaded_view_position = release_shell.find(
+                release_view,
+                upload_position + 1 if upload_position >= 0 else 0,
+            )
+            prune_position = release_shell.find('"repos/${REPO}/releases/assets/${asset_id}"')
+            edit_position = release_shell.find('gh release edit "$TAG"')
+            final_view_position = release_shell.find(
+                release_view,
+                edit_position + 1 if edit_position >= 0 else 0,
+            )
+            if not (
+                0
+                <= initial_view_position
+                < upload_position
+                < uploaded_view_position
+                < prune_position
+                < edit_position
+                < final_view_position
+            ):
+                errors.append(
+                    "release github-release recovery must inspect, upload, re-read, "
+                    "prune stale assets by id, edit metadata last, and validate again"
+                )
+    return errors
+
+
+def validate_docs_deploy_workflow(path: Path = DEFAULT_DOCS_DEPLOY_WORKFLOW) -> list[str]:
+    """Keep production promotion behind a complete, published library release."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"cannot read docs deploy workflow {path}: {exc}"]
+
+    jobs = _job_blocks(text)
+    errors: list[str] = []
+    _require_job_contains(
+        errors,
+        jobs,
+        "verify-library-release",
+        "docs deploy",
+        "published GitHub Release metadata, generated notes, distribution assets, "
+        "and PyPI availability before production promotion",
+        "needs: [prepare, await-prod-approval]",
+        "permissions:",
+        "contents: read",
+        "Await GitHub Release and PyPI availability",
+    )
+    release_gate = jobs.get("verify-library-release")
+    if release_gate is None:
+        return errors
+    if _job_scalar(release_gate, "needs") != "[prepare, await-prod-approval]":
+        errors.append(
+            "docs deploy verify-library-release job must actively depend on "
+            "prepare and production approval"
+        )
+    if _job_mapping(release_gate, "permissions") != {"contents": "read"}:
+        errors.append(
+            "docs deploy verify-library-release permissions must be exactly `contents: read`"
+        )
+
+    production = jobs.get("helm-pr-prod")
+    if production is None:
+        errors.append("docs deploy workflow is missing the production Helm promotion job")
+    elif _job_scalar(production, "needs") != (
+        "[prepare, await-prod-approval, verify-library-release]"
+    ):
+        errors.append(
+            "docs deploy production Helm promotion must actively depend on verify-library-release"
+        )
+
+    gate_shell = _named_step_run(
+        release_gate,
+        "Await GitHub Release and PyPI availability",
+    )
+    if gate_shell is None:
+        errors.append("docs deploy release gate is missing its active polling shell step")
+        return errors
+
+    required = (
+        "EXPECTED_PRERELEASE=false",
+        f'if [[ "$VERSION" =~ {CORE_PRERELEASE_TAG_PATTERN} ]]; then',
+        "EXPECTED_PRERELEASE=true",
+        'gh release view "$VERSION"',
+        "--json assets,body,isDraft,isPrerelease,name,publishedAt,tagName",
+        ".isDraft == false",
+        ".name == $name",
+        ".tagName == $name",
+        ".publishedAt != null",
+        ".isPrerelease == $prerelease",
+        '(.body | endswith("<!-- xy-release-workflow:" + $name + " -->"))',
+        'any(.assets[]?; .name | endswith(".whl"))',
+        '([.assets[]? | select(.name | endswith(".tar.gz"))] | length) == 1',
+        "[.assets[]?.name |",
+        "[.urls[]?.filename |",
+        '[[ "$github_assets" == "$pypi_assets" ]]; then',
+        'if [[ "$RELEASED" == true &&',
+        '"$PUBLISHED" == true &&',
+        '"$ASSETS_MATCH" == true ]]; then',
+    )
+    missing = _missing_needles(gate_shell, required)
+    if missing:
+        errors.append(
+            "docs deploy release gate must require expected non-draft metadata, "
+            f"generated notes, wheel/sdist assets, and PyPI: {missing}"
+        )
     return errors
 
 
@@ -959,12 +1203,14 @@ def validate_all_workflows(
     codspeed_path: Path = DEFAULT_CODSPEED_WORKFLOW,
     release_path: Path = DEFAULT_RELEASE_WORKFLOW,
     reflex_xy_release_path: Path = DEFAULT_REFLEX_XY_RELEASE_WORKFLOW,
+    docs_deploy_path: Path = DEFAULT_DOCS_DEPLOY_WORKFLOW,
 ) -> list[str]:
     return [
         *validate_ci_workflow(ci_path),
         *validate_codspeed_workflow(codspeed_path),
         *validate_release_workflow(release_path),
         *validate_reflex_xy_release_workflow(reflex_xy_release_path),
+        *validate_docs_deploy_workflow(docs_deploy_path),
     ]
 
 
@@ -982,10 +1228,16 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument(
         "--reflex-xy-release-workflow", type=Path, default=DEFAULT_REFLEX_XY_RELEASE_WORKFLOW
     )
+    parser.add_argument(
+        "--docs-deploy-workflow",
+        type=Path,
+        default=DEFAULT_DOCS_DEPLOY_WORKFLOW,
+    )
     parser.add_argument("--ci-only", action="store_true")
     parser.add_argument("--codspeed-only", action="store_true")
     parser.add_argument("--release-only", action="store_true")
     parser.add_argument("--reflex-xy-release-only", action="store_true")
+    parser.add_argument("--docs-deploy-only", action="store_true")
     args = parser.parse_args(argv)
 
     selected_modes = [
@@ -993,11 +1245,12 @@ def main(argv: Optional[list[str]] = None) -> int:
         args.codspeed_only,
         args.release_only,
         args.reflex_xy_release_only,
+        args.docs_deploy_only,
     ]
     if sum(1 for selected in selected_modes if selected) > 1:
         parser.error(
-            "--ci-only, --codspeed-only, --release-only, and "
-            "--reflex-xy-release-only are mutually exclusive"
+            "--ci-only, --codspeed-only, --release-only, "
+            "--reflex-xy-release-only, and --docs-deploy-only are mutually exclusive"
         )
 
     if args.workflow is not None:
@@ -1015,18 +1268,23 @@ def main(argv: Optional[list[str]] = None) -> int:
     elif args.reflex_xy_release_only:
         errors = validate_reflex_xy_release_workflow(args.reflex_xy_release_workflow)
         checked = [args.reflex_xy_release_workflow]
+    elif args.docs_deploy_only:
+        errors = validate_docs_deploy_workflow(args.docs_deploy_workflow)
+        checked = [args.docs_deploy_workflow]
     else:
         errors = validate_all_workflows(
             args.ci_workflow,
             args.codspeed_workflow,
             args.release_workflow,
             args.reflex_xy_release_workflow,
+            args.docs_deploy_workflow,
         )
         checked = [
             args.ci_workflow,
             args.codspeed_workflow,
             args.release_workflow,
             args.reflex_xy_release_workflow,
+            args.docs_deploy_workflow,
         ]
 
     if errors:

--- a/scripts/verify_ci_workflow.py
+++ b/scripts/verify_ci_workflow.py
@@ -3110,39 +3110,41 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                 errors.append(
                     "release immutable-release preflight must not use indirect shell execution"
                 )
-            missing = _missing_needles(
-                inspect_shell,
+            expected_inspect_shell = "\n".join(
                 (
-                    'gh release view "$TAG"',
-                    "--json isImmutable",
-                    "immutable=true",
+                    "immutable=false",
+                    'release_lookup_error="$(mktemp '
+                    '"${RUNNER_TEMP}/xy-release-state-error.XXXXXX")"',
+                    'if release_json="$(',
+                    "  timeout --signal=TERM --kill-after=5s 30s \\",
+                    '    gh release view "$TAG" \\',
+                    '      --repo "$REPO" \\',
+                    "      --json isImmutable \\",
+                    '      2>"$release_lookup_error"',
+                    ')"; then',
+                    "  if ! immutable=\"$(jq -er '.isImmutable | "
+                    'if . == true then "true" elif . == false then "false" '
+                    'else error("invalid isImmutable") end\' <<<"$release_json")"; then',
+                    '    rm -f "$release_lookup_error"',
+                    '    echo "::error::GitHub returned invalid release metadata for ${TAG}"',
+                    "    exit 1",
+                    "  fi",
+                    "elif ! jq -eRs '. == \"release not found\\n\"' "
+                    '"$release_lookup_error" >/dev/null; then',
+                    '  cat "$release_lookup_error" >&2',
+                    '  rm -f "$release_lookup_error"',
+                    '  echo "::error::Could not inspect existing GitHub Release '
+                    '${TAG}; refusing to prepare provenance"',
+                    "  exit 1",
+                    "fi",
+                    'rm -f "$release_lookup_error"',
                     'echo "immutable=${immutable}" >> "$GITHUB_OUTPUT"',
-                ),
+                )
             )
-            if missing:
-                errors.append(f"release immutable-release preflight is incomplete: {missing}")
-            inspect_tokens = [
-                "timeout",
-                "--signal=TERM",
-                "--kill-after=5s",
-                "30s",
-                "gh",
-                "release",
-                "view",
-                "$TAG",
-                "--repo",
-                "$REPO",
-                "--json",
-                "isImmutable",
-                "2>/dev/null",
-            ]
-            inspect_commands = [
-                tokens for _, _, tokens in _shell_command_records(inspect_shell) if "gh" in tokens
-            ]
-            if inspect_commands != [inspect_tokens]:
+            if inspect_shell != expected_inspect_shell:
                 errors.append(
-                    "release immutable-release preflight must use one exact "
-                    "30-second timeout-bounded metadata read"
+                    "release immutable-release preflight must use the exact fail-closed, "
+                    "timeout-bounded metadata probe and accept only a boolean immutable state"
                 )
 
         immutable_skip = "steps.release_state.outputs.immutable != 'true'"

--- a/scripts/verify_ci_workflow.py
+++ b/scripts/verify_ci_workflow.py
@@ -838,9 +838,19 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
         "pattern: dist-*",
         "merge-multiple: true",
         "GH_TOKEN: ${{ github.token }}",
+        "shopt -s nullglob",
+        "artifacts=(dist/*.whl dist/*.tar.gz)",
+        "if (( ${#artifacts[@]} == 0 )); then\n"
+        '            echo "::error::No wheel or sdist artifacts were downloaded"\n'
+        "            exit 1\n"
+        "          fi",
         "dist/*.whl",
         "dist/*.tar.gz",
         "gh release view",
+        "--json isDraft,isPrerelease,name",
+        "gh release edit",
+        "--draft=false",
+        "--prerelease=false",
         "gh release upload",
         "--clobber",
         "gh release create",

--- a/scripts/verify_ci_workflow.py
+++ b/scripts/verify_ci_workflow.py
@@ -39,6 +39,10 @@ REQUIRED_CI_JOBS = {
 REQUIRED_CODSPEED_JOBS = {"benchmarks"}
 REQUIRED_RELEASE_JOBS = {"wheels", "sdist", "publish", "wasm", "github-release"}
 REQUIRED_REFLEX_XY_RELEASE_JOBS = {"build", "publish"}
+RELEASE_DOWNLOAD_ACTION = "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
+RELEASE_ATTEST_ACTION = "actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d"
+RELEASE_CHECKOUT_ACTION = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+PYPI_PUBLISH_ACTION = "pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b"
 
 
 def _job_blocks(text: str) -> dict[str, str]:
@@ -135,6 +139,169 @@ def _step_name(step_text: str) -> str | None:
     return None if match is None else match.group(1)
 
 
+def _step_uses(step_text: str) -> list[str]:
+    """Return every active action reference declared by one step."""
+    uses: list[str] = []
+    for line in step_text.splitlines():
+        match = re.match(r"^      -\s+uses\s*:\s*(.*?)\s*$", line)
+        if match is None:
+            match = re.match(r"^        uses\s*:\s*(.*?)\s*$", line)
+        if match is not None:
+            uses.append(_strip_yaml_inline_comment(match.group(1)))
+    return uses
+
+
+def _step_declares_run(step_text: str) -> bool:
+    """Return whether a step declares an active ``run`` key."""
+    return bool(_step_scalar_values(step_text, "run"))
+
+
+def _step_scalar_values(step_text: str, key: str) -> list[str]:
+    """Return every direct scalar value for one step key."""
+    values: list[str] = []
+    for match in re.finditer(
+        rf"^        {re.escape(key)}\s*:\s*(.*?)\s*$",
+        step_text,
+        re.MULTILINE,
+    ):
+        values.append(_strip_yaml_inline_comment(match.group(1)))
+    return values
+
+
+def _step_direct_keys(step_text: str) -> list[str]:
+    """Return every direct step key, preserving duplicates and source order."""
+    keys: list[str] = []
+    for line in step_text.splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent == 6 and line.startswith("      -"):
+            match = re.fullmatch(r"      -\s+([^:]+?)\s*:.*", line)
+        elif indent == 8:
+            match = re.fullmatch(r"        ([^#\s][^:]*?)\s*:.*", line)
+        else:
+            continue
+        keys.append("<unsupported>" if match is None else match.group(1).strip())
+    return keys
+
+
+def _step_mapping(step_text: str, key: str) -> dict[str, str] | None:
+    """Return one direct step mapping with unique plain-scalar children."""
+    lines = step_text.splitlines()
+    starts = [
+        index
+        for index, line in enumerate(lines)
+        if re.fullmatch(rf"        {re.escape(key)}\s*:\s*", line)
+    ]
+    if len(starts) != 1:
+        return None
+
+    mapping: dict[str, str] = {}
+    for line in lines[starts[0] + 1 :]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent <= 8:
+            break
+        match = re.fullmatch(r"          ([A-Za-z0-9_-]+)\s*:\s*(.*?)\s*", line)
+        if match is None or match.group(1) in mapping:
+            return None
+        mapping[match.group(1)] = _strip_yaml_inline_comment(match.group(2))
+    return mapping
+
+
+def _job_direct_keys(job_text: str) -> list[str]:
+    """Return active job-level keys, preserving duplicates and source order."""
+    keys: list[str] = []
+    for line in job_text.splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if len(line) - len(line.lstrip()) != 4:
+            continue
+        match = re.fullmatch(r"    ([^#\s][^:]*?)\s*:.*", line)
+        keys.append("<unsupported>" if match is None else match.group(1).strip())
+    return keys
+
+
+def _workflow_direct_keys(workflow_text: str) -> list[str]:
+    """Return active workflow-level keys, preserving duplicates and order."""
+    keys: list[str] = []
+    for line in workflow_text.splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if len(line) - len(line.lstrip()) != 0:
+            continue
+        match = re.fullmatch(r"([^#\s][^:]*?)\s*:.*", line)
+        keys.append("<unsupported>" if match is None else match.group(1).strip())
+    return keys
+
+
+def _workflow_mapping(workflow_text: str, key: str) -> dict[str, str] | None:
+    """Return one canonical flat workflow-level mapping."""
+    lines = workflow_text.splitlines()
+    starts = [index for index, line in enumerate(lines) if line == f"{key}:"]
+    if len(starts) != 1:
+        return None
+
+    mapping: dict[str, str] = {}
+    for line in lines[starts[0] + 1 :]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent == 0:
+            break
+        match = re.fullmatch(r"  ([A-Za-z0-9_-]+):\s*(.*?)\s*", line)
+        if match is None or match.group(1) in mapping:
+            return None
+        mapping[match.group(1)] = _strip_yaml_inline_comment(match.group(2))
+    return mapping
+
+
+def _release_trigger_is_exact(workflow_text: str) -> bool:
+    """Return whether core releases have only the canonical tag/manual triggers."""
+    lines = workflow_text.splitlines()
+    starts = [position for position, line in enumerate(lines) if line == "on:"]
+    if len(starts) != 1:
+        return False
+
+    entries: list[tuple[int, str]] = []
+    for line in lines[starts[0] + 1 :]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent == 0:
+            break
+        entries.append((indent, line.strip()))
+
+    fixed_prefix = [
+        (2, "push:"),
+        (4, 'tags: ["v*"]'),
+        (2, "workflow_dispatch:"),
+        (4, "inputs:"),
+        (6, "dry_run:"),
+        (8, "description: >-"),
+    ]
+    if entries[: len(fixed_prefix)] != fixed_prefix:
+        return False
+
+    position = len(fixed_prefix)
+    description_lines = 0
+    while position < len(entries) and entries[position][0] >= 10:
+        description_lines += 1
+        position += 1
+    return description_lines > 0 and entries[position:] == [
+        (8, "type: boolean"),
+        (8, "default: true"),
+    ]
+
+
+def _step_has_exact_bash_run(step_text: str) -> bool:
+    """Return whether a step has one direct run and one exact Bash shell."""
+    return len(_step_scalar_values(step_text, "run")) == 1 and _step_scalar_values(
+        step_text, "shell"
+    ) == ["bash"]
+
+
 def _step_run(step_text: str) -> str | None:
     """Return one step's shell from a literal block or one-line ``run`` value.
 
@@ -173,8 +340,10 @@ def _step_run(step_text: str) -> str | None:
 def _step_uses_uninspectable_run(step_text: str) -> bool:
     """Return whether a shell step is not a supported literal YAML block."""
     for line in step_text.splitlines():
-        match = re.match(r"^        run:\s*(.*?)\s*$", line)
+        match = re.match(r"^        run\s*:\s*(.*?)\s*$", line)
         if match is not None:
+            if not line.startswith("        run:"):
+                return True
             value = _strip_yaml_inline_comment(match.group(1))
             return re.fullmatch(r"\|[+-]?", value) is None
     return False
@@ -188,8 +357,8 @@ def _job_scalar(job_text: str, key: str) -> str | None:
 
 def _step_scalar(step_text: str, key: str) -> str | None:
     """Return an active named-step scalar, ignoring comments and nested keys."""
-    match = re.search(rf"^        {re.escape(key)}:\s*(.*?)\s*$", step_text, re.MULTILINE)
-    return None if match is None else _strip_yaml_inline_comment(match.group(1))
+    values = _step_scalar_values(step_text, key)
+    return values[0] if len(values) == 1 else None
 
 
 def _strip_yaml_inline_comment(value: str) -> str:
@@ -223,21 +392,21 @@ def _strip_yaml_inline_comment(value: str) -> str:
 def _job_mapping(job_text: str, key: str) -> dict[str, str] | None:
     """Return an active job-level mapping with direct scalar children."""
     lines = job_text.splitlines()
-    try:
-        start = lines.index(f"    {key}:")
-    except ValueError:
+    starts = [index for index, line in enumerate(lines) if line == f"    {key}:"]
+    if len(starts) != 1:
         return None
 
     mapping: dict[str, str] = {}
-    for line in lines[start + 1 :]:
+    for line in lines[starts[0] + 1 :]:
         if not line.strip() or line.lstrip().startswith("#"):
             continue
         indent = len(line) - len(line.lstrip())
         if indent <= 4:
             break
         match = re.fullmatch(r"      ([A-Za-z0-9_-]+):\s*(.*?)\s*", line)
-        if match:
-            mapping[match.group(1)] = _strip_yaml_inline_comment(match.group(2))
+        if match is None or match.group(1) in mapping:
+            return None
+        mapping[match.group(1)] = _strip_yaml_inline_comment(match.group(2))
     return mapping
 
 
@@ -309,10 +478,77 @@ _SHELL_COMMAND_BOUNDARIES = {
     "!",
 }
 _SHELL_ASSIGNMENT_TOKEN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+_SHELL_REDIRECTION_TOKEN = re.compile(
+    r"^(?:[0-9]+|\{[A-Za-z_][A-Za-z0-9_]*\})?"
+    r"(?:<<<|<<-|<<|<>|>>|>|<)(.*)$"
+)
+_ALLOWED_PROTECTED_ARITHMETIC_LINES = {
+    "POLL_DEADLINE=$((SECONDS + 30 * 60))",
+    "if (( SECONDS >= POLL_DEADLINE )); then",
+    "if (( ${#wheels[@]} == 0 || ${#sdists[@]} != 1 )); then",
+    "if (( attempt < 12 )); then",
+    "if (( attempt == MAX_ATTEMPTS )); then",
+    "remaining_seconds=$((POLL_DEADLINE - SECONDS))",
+    "if (( remaining_seconds <= 0 )); then",
+    "if (( sleep_seconds > remaining_seconds )); then",
+}
+_ALLOWED_PYPI_CURL_COMMANDS = {
+    (
+        "curl",
+        "-fsS",
+        "--connect-timeout",
+        "5",
+        "--max-time",
+        "20",
+        f"https://pypi.org/pypi/xy/${{{version_variable}}}/json",
+        "2>/dev/null",
+    )
+    for version_variable in ("pypi_version", "PYPI_VERSION")
+}
+
+
+def _shell_control_joins_redirection(tokens: list[str], position: int) -> bool:
+    """Return whether ``&`` or ``|`` completes the preceding redirect."""
+    if tokens[position] not in {"&", "|"} or position == 0 or position + 1 >= len(tokens):
+        return False
+    return (
+        re.fullmatch(
+            r"(?:[0-9]+|\{[A-Za-z_][A-Za-z0-9_]*\})?[<>]",
+            tokens[position - 1],
+        )
+        is not None
+    )
+
+
+def _shell_prefix_without_redirections(prefix: list[str]) -> list[str] | None:
+    """Remove complete Bash redirections from a simple-command prefix."""
+    cleaned: list[str] = []
+    index = 0
+    while index < len(prefix):
+        match = _SHELL_REDIRECTION_TOKEN.fullmatch(prefix[index])
+        if match is None:
+            cleaned.append(prefix[index])
+            index += 1
+            continue
+        if match.group(1):
+            index += 1
+            continue
+        if index + 1 >= len(prefix):
+            return None
+        if prefix[index + 1] in {"&", "|"}:
+            if index + 2 >= len(prefix):
+                return None
+            index += 3
+        else:
+            index += 2
+    return cleaned
 
 
 def _shell_prefix_is_wrappers(prefix: list[str]) -> bool:
     """Return whether ``prefix`` only wraps the command that follows it."""
+    prefix = _shell_prefix_without_redirections(prefix)
+    if prefix is None:
+        return False
     index = 0
     while index < len(prefix) and _SHELL_ASSIGNMENT_TOKEN.match(prefix[index]):
         index += 1
@@ -402,7 +638,9 @@ def _shell_token_starts_command(tokens: list[str], token_position: int) -> bool:
     """Return whether one token is executable at a shell command boundary."""
     command_start = 0
     for prefix_position in range(token_position - 1, -1, -1):
-        if tokens[prefix_position] in _SHELL_COMMAND_BOUNDARIES:
+        if tokens[prefix_position] in _SHELL_COMMAND_BOUNDARIES and not (
+            _shell_control_joins_redirection(tokens, prefix_position)
+        ):
             command_start = prefix_position + 1
             break
     return _shell_prefix_is_wrappers(tokens[command_start:token_position])
@@ -412,14 +650,578 @@ def _shell_command_arguments(tokens: list[str], token_position: int) -> list[str
     """Return arguments up to the next shell control boundary."""
     command_end = len(tokens)
     for suffix_position in range(token_position + 1, len(tokens)):
-        if tokens[suffix_position] in _SHELL_COMMAND_BOUNDARIES:
+        if tokens[suffix_position] in _SHELL_COMMAND_BOUNDARIES and not (
+            _shell_control_joins_redirection(tokens, suffix_position)
+        ):
             command_end = suffix_position
             break
     return tokens[token_position + 1 : command_end]
 
 
+def _shell_backtick_end(shell: str, start: int) -> int | None:
+    """Return the closing backtick after ``start``, honoring escapes."""
+    position = start
+    while position < len(shell):
+        if shell[position] == "\\":
+            position += 2
+            continue
+        if shell[position] == "`":
+            return position
+        position += 1
+    return None
+
+
+def _shell_command_substitution_end(shell: str, start: int) -> int | None:
+    """Return the closing parenthesis for a command substitution body."""
+    depth = 1
+    quote: str | None = None
+    position = start
+    while position < len(shell):
+        character = shell[position]
+        if quote == "'":
+            if character == "'":
+                quote = None
+            position += 1
+            continue
+        if quote == '"':
+            if character == "\\":
+                position += 2
+                continue
+            if character == '"':
+                quote = None
+                position += 1
+                continue
+            if shell.startswith("$(", position) and not shell.startswith("$((", position):
+                nested_end = _shell_command_substitution_end(shell, position + 2)
+                if nested_end is None:
+                    return None
+                position = nested_end + 1
+                continue
+            if character == "`":
+                nested_end = _shell_backtick_end(shell, position + 1)
+                if nested_end is None:
+                    return None
+                position = nested_end + 1
+                continue
+            position += 1
+            continue
+        if character == "\\":
+            position += 2
+            continue
+        if character in {"'", '"'}:
+            quote = character
+            position += 1
+            continue
+        if character == "#" and (
+            position == 0 or shell[position - 1].isspace() or shell[position - 1] in ";|&()"
+        ):
+            newline = shell.find("\n", position)
+            if newline < 0:
+                return None
+            position = newline + 1
+            continue
+        if shell.startswith("$(", position) and not shell.startswith("$((", position):
+            nested_end = _shell_command_substitution_end(shell, position + 2)
+            if nested_end is None:
+                return None
+            position = nested_end + 1
+            continue
+        if character == "`":
+            nested_end = _shell_backtick_end(shell, position + 1)
+            if nested_end is None:
+                return None
+            position = nested_end + 1
+            continue
+        if character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            if depth == 0:
+                return position
+        position += 1
+    return None
+
+
+def _shell_substitution_scan(shell: str) -> tuple[list[str], str] | None:
+    """Extract active substitution bodies and mask them in the outer shell."""
+    bodies: list[str] = []
+    masked: list[str] = []
+    quote: str | None = None
+    position = 0
+    while position < len(shell):
+        character = shell[position]
+        if quote == "'":
+            if character == "'":
+                quote = None
+            masked.append(character)
+            position += 1
+            continue
+        if character == "\\":
+            if position + 1 < len(shell) and shell[position + 1] == "\n":
+                position += 2
+                continue
+            masked.append(shell[position : position + 2])
+            position += 2
+            continue
+        if character == '"':
+            quote = None if quote == '"' else '"'
+            masked.append(character)
+            position += 1
+            continue
+        if quote is None and character == "'":
+            quote = "'"
+            masked.append(character)
+            position += 1
+            continue
+        if (
+            quote is None
+            and character == "#"
+            and (position == 0 or shell[position - 1].isspace() or shell[position - 1] in ";|&()")
+        ):
+            newline = shell.find("\n", position)
+            if newline < 0:
+                break
+            masked.append(shell[position:newline])
+            masked.append("\n")
+            position = newline + 1
+            continue
+        if shell.startswith("$(", position) and not shell.startswith("$((", position):
+            end = _shell_command_substitution_end(shell, position + 2)
+            if end is None:
+                return None
+            bodies.append(shell[position + 2 : end])
+            masked.append("__SHELL_SUBSTITUTION__")
+            position = end + 1
+            continue
+        if quote is None and shell.startswith(("<(", ">("), position):
+            end = _shell_command_substitution_end(shell, position + 2)
+            if end is None:
+                return None
+            bodies.append(shell[position + 2 : end])
+            masked.append("__SHELL_SUBSTITUTION__")
+            position = end + 1
+            continue
+        if character == "`":
+            end = _shell_backtick_end(shell, position + 1)
+            if end is None:
+                return None
+            bodies.append(shell[position + 1 : end])
+            masked.append("__SHELL_SUBSTITUTION__")
+            position = end + 1
+            continue
+        masked.append(character)
+        position += 1
+    return None if quote is not None else (bodies, "".join(masked))
+
+
+def _shell_command_substitutions(shell: str) -> list[str] | None:
+    """Extract active command- and process-substitution bodies from shell source."""
+    scan = _shell_substitution_scan(shell)
+    return None if scan is None else scan[0]
+
+
+def _strip_active_shell_comments(shell: str) -> str | None:
+    """Strip active Bash comments without treating parameter ``#`` as one."""
+    stripped: list[str] = []
+    quote: str | None = None
+    position = 0
+    while position < len(shell):
+        character = shell[position]
+        if quote == "'":
+            stripped.append(character)
+            if character == "'":
+                quote = None
+            position += 1
+            continue
+        if character == "\\":
+            if position + 1 < len(shell) and shell[position + 1] == "\n":
+                position += 2
+                continue
+            stripped.append(shell[position : position + 2])
+            position += 2
+            continue
+        if character == '"':
+            quote = None if quote == '"' else '"'
+            stripped.append(character)
+            position += 1
+            continue
+        if quote is None and character == "'":
+            quote = "'"
+            stripped.append(character)
+            position += 1
+            continue
+        if (
+            quote is None
+            and character == "#"
+            and (position == 0 or shell[position - 1].isspace() or shell[position - 1] in ";|&()")
+        ):
+            newline = shell.find("\n", position)
+            if newline < 0:
+                break
+            stripped.append("\n")
+            position = newline + 1
+            continue
+        stripped.append(character)
+        position += 1
+    return None if quote is not None else "".join(stripped)
+
+
+def _shell_script_tokens(shell: str) -> list[str] | None:
+    """Tokenize a complete Bash script while preserving command newlines.
+
+    Keeping the script intact prevents multiline quoted jq programs from being
+    mistaken for shell commands. Active substitutions are checked recursively
+    and masked before this outer lexical pass.
+    """
+    scan = _shell_substitution_scan(shell)
+    if scan is None:
+        return None
+    _, masked = scan
+    uncommented = _strip_active_shell_comments(masked)
+    if uncommented is None:
+        return None
+    lexer = shlex.shlex(uncommented, posix=True, punctuation_chars=";&|()\n")
+    lexer.commenters = ""
+    lexer.whitespace = " \t\r"
+    lexer.whitespace_split = True
+    try:
+        raw_tokens = list(lexer)
+    except ValueError:
+        return None
+
+    tokens: list[str] = []
+    two_character_operators = {"&&", "||", ";;", "((", "))"}
+    punctuation = set(";&|()\n")
+    for token in raw_tokens:
+        if not token or any(character not in punctuation for character in token):
+            tokens.append(token)
+            continue
+        position = 0
+        while position < len(token):
+            pair = token[position : position + 2]
+            if pair in two_character_operators:
+                tokens.append(pair)
+                position += 2
+            else:
+                tokens.append(token[position])
+                position += 1
+    return tokens
+
+
+def _shell_command_end(tokens: list[str], start: int) -> int:
+    """Return the first unambiguous simple-command boundary after ``start``."""
+    for position in range(start, len(tokens)):
+        if tokens[position] in {"\n", ";", ";;", "&", "&&", "|", "||"} and not (
+            _shell_control_joins_redirection(tokens, position)
+        ):
+            return position
+    return len(tokens)
+
+
+def _skip_balanced_shell_tokens(
+    tokens: list[str],
+    start: int,
+    opening: str,
+    closing: str,
+) -> int | None:
+    """Return the position after one balanced token expression."""
+    depth = 0
+    for position in range(start, len(tokens)):
+        if tokens[position] == opening:
+            depth += 1
+        elif tokens[position] == closing:
+            depth -= 1
+            if depth == 0:
+                return position + 1
+    return None
+
+
+_ALLOWED_PROTECTED_COMMANDS = {
+    ":",
+    "break",
+    "cat",
+    "curl",
+    "cut",
+    "diff",
+    "echo",
+    "exit",
+    "gh",
+    "jq",
+    "local",
+    "mkdir",
+    "mktemp",
+    "printf",
+    "read",
+    "release_metadata_matches",
+    "return",
+    "rm",
+    "seq",
+    "sha256sum",
+    "shopt",
+    "sleep",
+    "timeout",
+    "verify_release_payload",
+    "verify_tag_source",
+}
+_ALLOWED_PROTECTED_FUNCTIONS = {
+    "release_metadata_matches",
+    "verify_release_payload",
+    "verify_tag_source",
+}
+
+
+def _has_unapproved_shell_command(shell: str) -> bool:
+    """Reject every executable command head outside a small positive allowlist."""
+    scan = _shell_substitution_scan(shell)
+    if scan is None:
+        return True
+    substitutions, _ = scan
+    if any(_has_unapproved_shell_command(body) for body in substitutions):
+        return True
+
+    tokens = _shell_script_tokens(shell)
+    if tokens is None:
+        return True
+
+    command_expected = True
+    for_header = False
+    position = 0
+    while position < len(tokens):
+        token = tokens[position]
+
+        if for_header:
+            if token == "do":
+                for_header = False
+                command_expected = True
+            position += 1
+            continue
+
+        if token in {"\n", ";", ";;", "&", "&&", "|", "||"}:
+            if not _shell_control_joins_redirection(tokens, position):
+                command_expected = True
+            position += 1
+            continue
+
+        if not command_expected:
+            position += 1
+            continue
+
+        if token in {"if", "elif", "while", "until", "!", "then", "else", "do", "{"}:
+            command_expected = True
+            position += 1
+            continue
+        if token in {"fi", "done", "esac", "}"}:
+            command_expected = False
+            position += 1
+            continue
+        if token in {"for", "select"}:
+            for_header = True
+            command_expected = False
+            position += 1
+            continue
+        if token == "[[":
+            try:
+                position = tokens.index("]]", position + 1) + 1
+            except ValueError:
+                return True
+            command_expected = False
+            continue
+        if token == "((":
+            end = _skip_balanced_shell_tokens(tokens, position, "((", "))")
+            if end is None:
+                return True
+            position = end
+            command_expected = False
+            continue
+        if token == "(":
+            command_expected = True
+            position += 1
+            continue
+        if token == ")":
+            command_expected = False
+            position += 1
+            continue
+
+        redirection = _SHELL_REDIRECTION_TOKEN.fullmatch(token)
+        if redirection is not None:
+            if redirection.group(1):
+                position += 1
+            elif position + 2 < len(tokens) and tokens[position + 1] in {"&", "|"}:
+                position += 3
+            elif position + 1 < len(tokens):
+                position += 2
+            else:
+                return True
+            continue
+
+        if _SHELL_ASSIGNMENT_TOKEN.match(token):
+            if position + 1 < len(tokens) and tokens[position + 1] in {"(", "(("}:
+                opening = tokens[position + 1]
+                closing = ")" if opening == "(" else "))"
+                end = _skip_balanced_shell_tokens(tokens, position + 1, opening, closing)
+                if end is None:
+                    return True
+                position = end
+                command_expected = False
+            else:
+                position += 1
+            continue
+
+        if token in _ALLOWED_PROTECTED_FUNCTIONS and tokens[position + 1 : position + 4] == [
+            "(",
+            ")",
+            "{",
+        ]:
+            position += 4
+            command_expected = True
+            continue
+
+        # Trust exact raw command names only. A generated `/tmp/gh`, dynamic
+        # path, or other executable must not inherit trust from its basename.
+        if token not in _ALLOWED_PROTECTED_COMMANDS:
+            return True
+        if token == "timeout":
+            end = _shell_command_end(tokens, position + 1)
+            arguments = tokens[position + 1 : end]
+            if not (
+                len(arguments) >= 5
+                and arguments[:2] == ["--signal=TERM", "--kill-after=5s"]
+                and arguments[2] in {"30s", "60s", "180s"}
+                and arguments[3] == "gh"
+            ):
+                return True
+
+        command_expected = False
+        position += 1
+
+    return for_header
+
+
+def _has_deferred_shell_execution(shell: str) -> bool:
+    """Reject inert-looking text that Bash can later reevaluate as arithmetic.
+
+    Bash recursively interprets variable values used by arithmetic commands.
+    Consequently, a single-quoted assignment such as
+    ``payload='index[$(command)]'`` becomes executable when a later
+    ``(( payload ))`` evaluates it. Treat executable substitution syntax in a
+    single-quoted value as indirect execution instead of trying to prove every
+    later arithmetic data flow safe.
+    """
+    in_single_quote = False
+    position = 0
+    while position < len(shell):
+        character = shell[position]
+        if character == "\\" and not in_single_quote:
+            position += 2
+            continue
+        if character == "'":
+            in_single_quote = not in_single_quote
+            position += 1
+            continue
+        if in_single_quote and (shell.startswith(("$(", "<(", ">("), position) or character == "`"):
+            return True
+        position += 1
+    return False
+
+
+def _has_unapproved_shell_arithmetic(shell: str) -> bool:
+    """Reject arithmetic evaluation outside the exact protected gate expressions."""
+    return any(
+        "((" in tokens and line not in _ALLOWED_PROTECTED_ARITHMETIC_LINES
+        for _, line, tokens in _shell_command_records(shell)
+    )
+
+
+def _has_unapproved_network_access(shell: str) -> bool:
+    """Reject network-capable commands outside the exact PyPI/GitHub surface."""
+    substitutions = _shell_command_substitutions(shell)
+    if substitutions is None or any(_has_unapproved_network_access(body) for body in substitutions):
+        return True
+    if re.search(r"/dev/(?:tcp|udp)/", shell):
+        return True
+
+    network_tools = {
+        "aria2c",
+        "busybox",
+        "ftp",
+        "http",
+        "httpie",
+        "nc",
+        "ncat",
+        "netcat",
+        "openssl",
+        "sftp",
+        "socat",
+        "ssh",
+        "telnet",
+        "wget",
+    }
+    sensitive_assignments = {
+        "CURL_HOME",
+        "GH_CONFIG_DIR",
+        "HOME",
+        "PATH",
+        "XDG_CONFIG_HOME",
+    }
+    logical_lines = _shell_logical_lines(shell)
+    if any(_assignment_lines(logical_lines, name) for name in sensitive_assignments):
+        return True
+    allowed_gh_commands = {"api", "attestation", "release"}
+    for _, _, tokens in _shell_command_records(shell):
+        if any(
+            "=" in token and _assignment_target_is(token, name)
+            for token in tokens
+            for name in sensitive_assignments
+        ):
+            return True
+        for position, token in enumerate(tokens):
+            command = token.rsplit("/", 1)[-1]
+            command_position = _shell_token_starts_command(tokens, position)
+            if command in {"curl", "gh", *network_tools} and not command_position:
+                # Unknown wrappers such as strace/taskset can execute a later
+                # network-capable token. Fail closed instead of assuming the
+                # token is inert merely because the prefix is unsupported.
+                return True
+            if not command_position:
+                continue
+            arguments = _shell_command_arguments(tokens, position)
+            if command == "curl":
+                if token != "curl" or tuple([command, *arguments]) not in (
+                    _ALLOWED_PYPI_CURL_COMMANDS
+                ):
+                    return True
+            elif command in network_tools:
+                return True
+            elif command == "gh":
+                subcommand, _ = _gh_subcommand(arguments)
+                if (
+                    subcommand not in allowed_gh_commands
+                    or subcommand is None
+                    or any(marker in subcommand for marker in ("$", "`", "*", "?", "[", "{"))
+                ):
+                    return True
+    return False
+
+
 def _has_indirect_shell_execution(shell: str) -> bool:
     """Reject commands that can hide unparsed shell from protected validators."""
+    substitutions = _shell_command_substitutions(shell)
+    active_shell = _strip_active_shell_comments(shell)
+    if (
+        substitutions is None
+        or active_shell is None
+        or _has_deferred_shell_execution(shell)
+        or _has_unapproved_shell_arithmetic(shell)
+        or _has_unapproved_network_access(shell)
+        or _has_unapproved_shell_command(shell)
+        or re.search(r"\$(?:GITHUB_ENV|GITHUB_PATH)\b", shell)
+        or re.search(r"\$\{(?:GITHUB_ENV|GITHUB_PATH)\}", shell)
+        or any(
+            marker in active_shell for marker in ("_runner_file_commands", "set_env_", "add_path_")
+        )
+        or any(_has_indirect_shell_execution(body) for body in substitutions)
+    ):
+        return True
     shell_interpreters = {
         "$SHELL",
         "${SHELL}",
@@ -432,6 +1234,55 @@ def _has_indirect_shell_execution(shell: str) -> bool:
         "sh",
         "zsh",
     }
+    code_interpreters = {
+        "awk",
+        "bun",
+        "deno",
+        "gawk",
+        "lua",
+        "mawk",
+        "node",
+        "perl",
+        "php",
+        "ruby",
+        "sed",
+    }
+    indirect_commands = {
+        ".",
+        "alias",
+        "chroot",
+        "chrt",
+        "coproc",
+        "enable",
+        "eval",
+        "exec",
+        "find",
+        "hash",
+        "ionice",
+        "let",
+        "parallel",
+        "script",
+        "setsid",
+        "source",
+        "strace",
+        "sudo",
+        "systemd-run",
+        "taskset",
+        "trap",
+        "unshare",
+        "watch",
+        "xargs",
+    }
+    dangerous_shell_environment = {
+        "BASH_ENV",
+        "CDPATH",
+        "ENV",
+        "PROMPT_COMMAND",
+    }
+    if any(
+        _assignment_lines(_shell_logical_lines(shell), name) for name in dangerous_shell_environment
+    ):
+        return True
     double_bracket_open = False
     for _, line, tokens in _shell_command_records(shell):
         expression_positions: set[int] = set()
@@ -462,33 +1313,36 @@ def _has_indirect_shell_execution(shell: str) -> bool:
         for token_position, token in enumerate(tokens):
             if token_position in expression_positions:
                 continue
-            if not _shell_token_starts_command(tokens, token_position):
-                continue
             command = token.rsplit("/", 1)[-1]
             dynamic_command = token.startswith(("$", "`")) and not (
                 len(tokens) > 1 and _SHELL_ASSIGNMENT_TOKEN.match(tokens[0]) and tokens[1] == "("
             )
-            if (
-                command
-                in {
-                    ".",
-                    "alias",
-                    "enable",
-                    "eval",
-                    "find",
-                    "hash",
-                    "parallel",
-                    "source",
-                    "trap",
-                    "xargs",
-                }
+            command_position = _shell_token_starts_command(tokens, token_position)
+            potentially_executable = (
+                command in indirect_commands
                 or command in shell_interpreters
+                or command in code_interpreters
+                or command.startswith(("pypy", "python"))
                 or dynamic_command
-            ):
+            )
+            if not command_position:
+                if (
+                    command in shell_interpreters
+                    or command in code_interpreters
+                    or command.startswith(("pypy", "python"))
+                ):
+                    return True
+                continue
+            if potentially_executable:
                 return True
             if command == "env" and any(
                 argument in {"-S", "--split-string"}
                 or argument.startswith(("-S", "--split-string="))
+                for argument in _shell_command_arguments(tokens, token_position)
+            ):
+                return True
+            if command in {"declare", "local", "readonly", "typeset"} and any(
+                argument.startswith(("-i", "+i"))
                 for argument in _shell_command_arguments(tokens, token_position)
             ):
                 return True
@@ -654,6 +1508,11 @@ def _gh_subcommand(arguments: list[str]) -> tuple[str | None, list[str]]:
     return None, []
 
 
+def _shell_token_is_dynamic(token: str) -> bool:
+    """Return whether a shell token's value is computed at runtime."""
+    return any(marker in token for marker in ("$", "`", "*", "?", "[", "]", "{", "}"))
+
+
 def _has_gh_release_mutation(shell: str) -> bool:
     """Return whether shell directly invokes a GitHub Release write command."""
     mutations = {"create", "delete", "delete-asset", "edit", "new", "upload"}
@@ -663,10 +1522,13 @@ def _has_gh_release_mutation(shell: str) -> bool:
                 continue
             gh_arguments = _shell_command_arguments(tokens, index)
             subcommand, subcommand_arguments = _gh_subcommand(gh_arguments)
+            if subcommand is not None and _shell_token_is_dynamic(subcommand):
+                # A computed top-level command can become `release` or `api`.
+                return True
             if subcommand == "release":
                 release_command, _ = _gh_subcommand(subcommand_arguments)
                 if release_command in mutations or (
-                    release_command is not None and release_command.startswith(("$", "`"))
+                    release_command is not None and _shell_token_is_dynamic(release_command)
                 ):
                     return True
                 continue
@@ -697,6 +1559,24 @@ def _has_gh_release_mutation(shell: str) -> bool:
     return False
 
 
+def _gh_api_write_requests(shell: str) -> list[tuple[str, str | None]]:
+    """Return every non-read ``gh api`` request declared by a shell body."""
+    requests: list[tuple[str, str | None]] = []
+    for _, _, tokens in _shell_command_records(shell):
+        for index, token in enumerate(tokens):
+            if token != "gh" or not _shell_token_starts_command(tokens, index):
+                continue
+            subcommand, subcommand_arguments = _gh_subcommand(
+                _shell_command_arguments(tokens, index)
+            )
+            if subcommand != "api":
+                continue
+            method, endpoint = _gh_api_request(subcommand_arguments)
+            if method not in {"GET", "HEAD"}:
+                requests.append((method, endpoint))
+    return requests
+
+
 def _is_release_metadata_read(tokens: list[str]) -> bool:
     """Recognize the complete GitHub Release metadata read used by the gate."""
     fields = "assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName"
@@ -714,7 +1594,11 @@ def _is_release_metadata_read(tokens: list[str]) -> bool:
         "--json",
         fields,
     ]
-    return tokens in (command, [*command, "2>/dev/null"])
+    return tokens in (
+        command,
+        [*command, "2>/dev/null"],
+        [*command, "2>$release_lookup_error"],
+    )
 
 
 def _is_release_payload_verification(tokens: list[str]) -> bool:
@@ -1171,12 +2055,20 @@ def _step_is_conditioned(job_text: str, step_needle: str) -> bool:
 PYPI_PUBLISH_GATE = (
     "if: github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true'"
 )
+CORE_PYPI_PUBLISH_GATE = (
+    "if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || "
+    "(github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'false')"
+)
 CORE_PRERELEASE_TAG_PATTERN = r"^v[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)[0-9]+$"
 
 
-def _step_carries_publish_gate(job_text: str, step_needle: str) -> bool:
+def _step_carries_publish_gate(
+    job_text: str,
+    step_needle: str,
+    expected_gate: str = PYPI_PUBLISH_GATE,
+) -> bool:
     block = _step_block(job_text, step_needle)
-    return block is not None and PYPI_PUBLISH_GATE in block
+    return block is not None and expected_gate in block
 
 
 def _require_workflow_contains(
@@ -1688,6 +2580,18 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
 
     jobs = _job_blocks(text)
     errors: list[str] = []
+    if _workflow_direct_keys(text) != ["name", "on", "permissions", "jobs"]:
+        errors.append(
+            "release workflow must use exact top-level controls with no inherited "
+            "environment or run defaults"
+        )
+    if not _release_trigger_is_exact(text):
+        errors.append(
+            "release workflow triggers must be exactly v* tag pushes plus a "
+            "boolean workflow_dispatch dry_run input defaulting to true"
+        )
+    if _workflow_mapping(text, "permissions") != {"contents": "read"}:
+        errors.append("release workflow top-level permissions must be exactly contents: read")
     _require_unshallow_checkouts(errors, text, "release")
     missing_jobs = sorted(REQUIRED_RELEASE_JOBS - set(jobs))
     if missing_jobs:
@@ -1815,6 +2719,26 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
         "default: true",
     )
     publish = jobs.get("publish", "")
+    if _job_direct_keys(publish) != [
+        "name",
+        "needs",
+        "runs-on",
+        "environment",
+        "permissions",
+        "steps",
+    ]:
+        errors.append(
+            "release publish job must use exact control keys with no inherited "
+            "environment, defaults, or continue-on-error bypass"
+        )
+    if _job_scalar(publish, "runs-on") != "ubuntu-latest":
+        errors.append("release publish job must run on the exact trusted ubuntu-latest runner")
+    if _job_scalar(publish, "needs") != "[wheels, sdist, wasm]":
+        errors.append(
+            "release publish job must depend on the exact wheel, sdist, and wasm build jobs"
+        )
+    if _job_scalar(publish, "environment") != "pypi":
+        errors.append("release publish job must use the exact protected pypi environment")
     if "password:" in publish or "api-token" in publish:
         errors.append("release publish job should use trusted publishing, not a PyPI token")
     expected_publish_permissions = {"contents": "read", "id-token": "write"}
@@ -1824,13 +2748,93 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
         )
     publish_tag_block = _named_step_blocks(publish).get("Verify release tag source before PyPI")
     publish_tag_shell = _named_step_run(publish, "Verify release tag source before PyPI")
+    publish_steps = _job_step_blocks(publish)
+    expected_publish_step_names = [
+        None,
+        "Release version gate (tag == CHANGELOG)",
+        None,
+        "List artifacts",
+        "Dry run summary (no PyPI publish)",
+        "Verify release tag source before PyPI",
+        None,
+    ]
+    publish_step_names = [_step_name(step) for step in publish_steps]
+    publish_step_uses = [_step_uses(step) for step in publish_steps]
+    publish_steps_are_exact = (
+        publish_step_names == expected_publish_step_names
+        and publish_step_uses
+        == [
+            [RELEASE_CHECKOUT_ACTION],
+            [],
+            [RELEASE_DOWNLOAD_ACTION],
+            [],
+            [],
+            [],
+            [PYPI_PUBLISH_ACTION],
+        ]
+        and [_step_direct_keys(step) for step in publish_steps]
+        == [
+            ["uses", "with"],
+            ["name", "if", "run"],
+            ["uses", "with"],
+            ["name", "run"],
+            ["name", "if", "run"],
+            ["name", "if", "env", "shell", "run"],
+            ["uses", "if", "with"],
+        ]
+        and _step_mapping(publish_steps[0], "with") == {"fetch-depth": "0"}
+        and _step_scalar(publish_steps[1], "if") == "github.event_name == 'push'"
+        and _step_run(publish_steps[1]) == "python3 scripts/check_release_version.py"
+        and _step_mapping(publish_steps[2], "with")
+        == {"merge-multiple": "true", "path": "dist", "pattern": "dist-*"}
+        and _step_run(publish_steps[3]) == "ls -la dist/"
+        and _step_scalar(publish_steps[4], "if")
+        == "github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'"
+        and _step_run(publish_steps[4])
+        == (
+            'echo "::notice::Dry run — built and verified '
+            "$(ls dist/*.whl dist/*.tar.gz 2>/dev/null | wc -l | tr -d ' ') "
+            'artifacts across the full release matrix. Skipping PyPI publish."\n'
+            'echo "Re-run this workflow with dry_run=false, or push a v* tag, '
+            'to publish for real."'
+        )
+        and _step_scalar(publish_steps[6], "if")
+        == (
+            "(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || "
+            "(github.event_name == 'workflow_dispatch' && "
+            "github.event.inputs.dry_run == 'false')"
+        )
+        and _step_mapping(publish_steps[6], "with")
+        == {"packages-dir": "dist/", "skip-existing": "true"}
+    )
+    if not publish_steps_are_exact:
+        errors.append(
+            "release publish job must contain exactly the pinned artifact download, "
+            "fixed diagnostics, verified tag guard, and pinned PyPI publisher steps"
+        )
     publish_action_position = publish.find("pypa/gh-action-pypi-publish@")
     publish_tag_position = publish.find("- name: Verify release tag source before PyPI")
     if publish_tag_block is None or publish_tag_shell is None:
         errors.append("release publish job must verify the current tag source before PyPI")
     else:
+        expected_release_env = {
+            "GH_TOKEN": "${{ github.token }}",
+            "REPO": "${{ github.repository }}",
+            "TAG": "${{ github.ref_name }}",
+        }
+        if not (
+            _step_has_exact_bash_run(publish_tag_block)
+            and _step_direct_keys(publish_tag_block) == ["name", "if", "env", "shell", "run"]
+            and _step_mapping(publish_tag_block, "env") == expected_release_env
+        ):
+            errors.append(
+                "release publish tag guard must use exact step controls, environment, "
+                "one direct `run`, and exact step-local `shell: bash`"
+            )
         if _has_indirect_shell_execution(publish_tag_shell):
             errors.append("release publish tag guard must not use indirect shell execution")
+        if _gh_api_write_requests(publish_tag_shell):
+            errors.append("release publish tag guard must not make write-mode gh api requests")
         publish_tag_lines = _shell_logical_lines(publish_tag_shell)
         lookup_tokens = [
             "timeout",
@@ -1865,11 +2869,13 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                 "guard immediately before the PyPI publisher"
             )
     if "pypa/gh-action-pypi-publish@" in publish and not _step_carries_publish_gate(
-        publish, "pypa/gh-action-pypi-publish@"
+        publish,
+        "pypa/gh-action-pypi-publish@",
+        CORE_PYPI_PUBLISH_GATE,
     ):
         errors.append(
             "release publish job's PyPI upload step is not gated by the dry-run "
-            f"predicate on the step itself (`{PYPI_PUBLISH_GATE}`) — a missing or "
+            f"predicate on the step itself (`{CORE_PYPI_PUBLISH_GATE}`) — a missing or "
             "unrelated condition (e.g. `if: always()`) would let a manual "
             "dispatch publish unintentionally"
         )
@@ -1891,6 +2897,24 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
     github_release = jobs.get("github-release")
     if github_release is not None:
         job_steps = _job_step_blocks(github_release)
+        expected_job_keys = [
+            "name",
+            "if",
+            "needs",
+            "runs-on",
+            "timeout-minutes",
+            "permissions",
+            "steps",
+        ]
+        if _job_direct_keys(github_release) != expected_job_keys:
+            errors.append(
+                "release github-release job must use exact control keys with no defaults, "
+                "environment overrides, or continue-on-error bypass"
+            )
+        if _job_scalar(github_release, "runs-on") != "ubuntu-latest":
+            errors.append(
+                "release github-release job must run on the exact trusted ubuntu-latest runner"
+            )
         protected_step_names = (
             "Inspect existing release",
             "Prepare release provenance",
@@ -1906,6 +2930,97 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
             errors.append(
                 "release github-release job must declare each protected step exactly once: "
                 f"{duplicate_protected_steps}"
+            )
+        step_identities = [
+            (
+                _step_name(step),
+                tuple(_step_uses(step)),
+                _step_declares_run(step),
+            )
+            for step in job_steps
+        ]
+        expected_step_identities = [
+            (None, (RELEASE_DOWNLOAD_ACTION,), False),
+            ("Inspect existing release", (), True),
+            ("Prepare release provenance", (), True),
+            ("Attest release provenance", (RELEASE_ATTEST_ACTION,), False),
+            ("Create GitHub Release and attach distributions", (), True),
+        ]
+        if step_identities != expected_step_identities:
+            errors.append(
+                "release github-release job must contain exactly the pinned download, "
+                "immutable preflight, provenance preparation, pinned attestation, and "
+                f"publication steps in that order; found {step_identities!r}"
+            )
+        expected_step_keys = [
+            ["uses", "with"],
+            ["name", "id", "env", "shell", "run"],
+            ["name", "if", "env", "shell", "run"],
+            ["name", "if", "uses", "with"],
+            ["name", "env", "shell", "run"],
+        ]
+        if [_step_direct_keys(step) for step in job_steps] != expected_step_keys:
+            errors.append(
+                "release github-release steps must use exact control keys; explicit "
+                "`if`, `continue-on-error`, working-directory, or duplicate keys are forbidden"
+            )
+        expected_release_env = {
+            "GH_TOKEN": "${{ github.token }}",
+            "REPO": "${{ github.repository }}",
+            "TAG": "${{ github.ref_name }}",
+        }
+        step_mappings_are_exact = len(job_steps) == 5 and (
+            _step_mapping(job_steps[0], "with")
+            == {
+                "path": "dist",
+                "pattern": "dist-*",
+                "merge-multiple": "true",
+            }
+            and _step_scalar(job_steps[1], "id") == "release_state"
+            and _step_mapping(job_steps[1], "env") == expected_release_env
+            and _step_mapping(job_steps[2], "env") == expected_release_env
+            and _step_mapping(job_steps[3], "with")
+            == {
+                "subject-path": (
+                    "${{ runner.temp }}/xy-${{ github.ref_name }}"
+                    "-release-provenance/xy-release-provenance.json"
+                )
+            }
+            and _step_mapping(job_steps[4], "env") == expected_release_env
+        )
+        if not step_mappings_are_exact:
+            errors.append(
+                "release github-release steps must use exact environments, action inputs, "
+                "and immutable-state output identity"
+            )
+        invalid_step_shapes = [
+            _step_name(step) or "<unnamed>"
+            for step in job_steps
+            if _step_declares_run(step) == bool(_step_uses(step))
+        ]
+        if invalid_step_shapes:
+            errors.append(
+                "release github-release job steps must declare exactly one inspectable "
+                f"`run` or allowlisted `uses` action; found {invalid_step_shapes}"
+            )
+        action_uses = [uses for step in job_steps for uses in _step_uses(step)]
+        expected_action_uses = [RELEASE_DOWNLOAD_ACTION, RELEASE_ATTEST_ACTION]
+        if action_uses != expected_action_uses:
+            errors.append(
+                "release github-release job action steps must be exactly the pinned "
+                "download and provenance-attestation actions; found "
+                f"{action_uses!r}"
+            )
+        unsupported_shell_steps = [
+            _step_name(step) or "<unnamed>"
+            for step in job_steps
+            if _step_declares_run(step) and not _step_has_exact_bash_run(step)
+        ]
+        if unsupported_shell_steps:
+            errors.append(
+                "release github-release job must give every inspected shell step exactly "
+                "one direct `run` and one exact step-local `shell: bash`; found "
+                f"{unsupported_shell_steps}"
             )
         uninspectable_run_steps = [
             _step_name(step) or "<unnamed>"
@@ -1927,6 +3042,25 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
             errors.append(
                 "release github-release job must not hide release behavior behind "
                 f"indirect shell execution; found it in {indirect_shell_steps}"
+            )
+        expected_api_writes = {
+            "Inspect existing release": [],
+            "Prepare release provenance": [("POST", "repos/${REPO}/releases/generate-notes")],
+            "Create GitHub Release and attach distributions": [
+                ("DELETE", "repos/${REPO}/releases/assets/${asset_id}")
+            ],
+        }
+        unexpected_api_write_steps = [
+            _step_name(step) or "<unnamed>"
+            for step in job_steps
+            if (shell := _step_run(step)) is not None
+            and _gh_api_write_requests(shell) != expected_api_writes.get(_step_name(step), [])
+        ]
+        if unexpected_api_write_steps:
+            errors.append(
+                "release github-release shell steps may declare only the exact "
+                "generated-notes POST and release-asset DELETE API writes; found "
+                f"unexpected writes in {unexpected_api_write_steps}"
             )
         sibling_release_mutations = [
             _step_name(step) or "<unnamed>"
@@ -2154,7 +3288,7 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                 )
 
         attest_block = step_blocks.get("Attest release provenance")
-        attest_pin = "actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d"
+        attest_pin = RELEASE_ATTEST_ACTION
         if attest_block is None:
             errors.append("release github-release job is missing provenance attestation")
         else:
@@ -2623,6 +3757,52 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                 and sum(tokens == attestation_tokens for _, _, tokens in command_records) == 1
                 and len(metadata_read_positions) == 4
             )
+            release_lookup_is_fail_closed = (
+                _assignment_lines(logical_lines, "release_lookup_error")
+                == [
+                    'release_lookup_error="$(mktemp "${RUNNER_TEMP}/xy-release-view-error.XXXXXX")"'
+                ]
+                and _logical_line_is(
+                    logical_lines,
+                    initial_view_position - 2,
+                    'release_lookup_error="$(mktemp '
+                    '"${RUNNER_TEMP}/xy-release-view-error.XXXXXX")"',
+                )
+                and _logical_line_is(
+                    logical_lines,
+                    initial_view_position + 4,
+                    "elif ! jq -eRs '. == \"release not found\\n\"' "
+                    '"$release_lookup_error" >/dev/null; then',
+                )
+                and _logical_line_is(
+                    logical_lines,
+                    initial_view_position + 5,
+                    'cat "$release_lookup_error" >&2',
+                )
+                and _logical_line_is(
+                    logical_lines,
+                    initial_view_position + 6,
+                    'rm -f "$release_lookup_error"',
+                )
+                and _logical_line_is(
+                    logical_lines,
+                    initial_view_position + 7,
+                    'echo "::error::Could not inspect existing GitHub Release '
+                    '${TAG}; refusing to create it"',
+                )
+                and _logical_line_is(logical_lines, initial_view_position + 8, "exit 1")
+                and _logical_line_is(logical_lines, initial_view_position + 9, "fi")
+                and _logical_line_is(
+                    logical_lines,
+                    initial_view_position + 10,
+                    'rm -f "$release_lookup_error"',
+                )
+            )
+            if not release_lookup_is_fail_closed:
+                errors.append(
+                    "release github-release job must treat only an exact `release not found` "
+                    "lookup result as absent and fail closed on every other metadata-read error"
+                )
             immutable_state_is_exact = (
                 _assignment_lines(logical_lines, "release_exists")
                 == ["release_exists=false", "release_exists=true"]
@@ -2631,6 +3811,7 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                     "is_immutable=false",
                     'is_immutable="$(jq -r \'.isImmutable\' <<<"$release_json")"',
                 ]
+                and release_lookup_is_fail_closed
                 and _logical_line_is(
                     logical_lines,
                     initial_view_position - 1,
@@ -2647,7 +3828,6 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                     initial_view_position + 3,
                     'is_immutable="$(jq -r \'.isImmutable\' <<<"$release_json")"',
                 )
-                and _logical_line_is(logical_lines, initial_view_position + 4, "fi")
                 and logical_lines.count('if [[ "$release_exists" == true ]]; then') == 1
                 and logical_lines.count('if [[ "$is_immutable" == "true" ]]; then') == 1
             )
@@ -2703,6 +3883,19 @@ def validate_docs_deploy_workflow(path: Path = DEFAULT_DOCS_DEPLOY_WORKFLOW) -> 
 
     jobs = _job_blocks(text)
     errors: list[str] = []
+    if _workflow_direct_keys(text) != [
+        "name",
+        "on",
+        "permissions",
+        "concurrency",
+        "jobs",
+    ]:
+        errors.append(
+            "docs deploy workflow must use exact top-level controls with no inherited "
+            "environment or run defaults"
+        )
+    if _workflow_mapping(text, "permissions") != {"contents": "read"}:
+        errors.append("docs deploy workflow top-level permissions must be exactly contents: read")
     _require_job_contains(
         errors,
         jobs,
@@ -2718,6 +3911,22 @@ def validate_docs_deploy_workflow(path: Path = DEFAULT_DOCS_DEPLOY_WORKFLOW) -> 
     release_gate = jobs.get("verify-library-release")
     if release_gate is None:
         return errors
+    if _job_direct_keys(release_gate) != [
+        "name",
+        "needs",
+        "runs-on",
+        "timeout-minutes",
+        "permissions",
+        "steps",
+    ]:
+        errors.append(
+            "docs deploy release gate job must use exact control keys with no inherited "
+            "environment, defaults, or continue-on-error bypass"
+        )
+    if _job_scalar(release_gate, "runs-on") != "ubuntu-latest":
+        errors.append(
+            "docs deploy release gate job must run on the exact trusted ubuntu-latest runner"
+        )
     if _job_scalar(release_gate, "needs") != "[prepare, await-prod-approval]":
         errors.append(
             "docs deploy verify-library-release job must actively depend on "
@@ -2733,14 +3942,30 @@ def validate_docs_deploy_workflow(path: Path = DEFAULT_DOCS_DEPLOY_WORKFLOW) -> 
     production = jobs.get("helm-pr-prod")
     if production is None:
         errors.append("docs deploy workflow is missing the production Helm promotion job")
-    elif _job_scalar(production, "needs") != (
-        "[prepare, await-prod-approval, verify-library-release]"
-    ):
-        errors.append(
-            "docs deploy production Helm promotion must actively depend on verify-library-release"
-        )
+    else:
+        expected_production_needs = "[prepare, await-prod-approval, verify-library-release]"
+        expected_production_with = {
+            "auto_merge": "true",
+            "environment": "prod",
+            "image_tag": "${{ needs.prepare.outputs.version }}",
+            "source_ref": "${{ needs.prepare.outputs.source_sha }}",
+        }
+        if not (
+            _job_direct_keys(production)
+            == ["name", "needs", "permissions", "uses", "with", "secrets"]
+            and _job_scalar(production, "needs") == expected_production_needs
+            and _job_mapping(production, "permissions") == {"contents": "read"}
+            and _job_scalar(production, "uses") == "./.github/workflows/_helm-docs-pr.yml"
+            and _job_mapping(production, "with") == expected_production_with
+            and _job_scalar(production, "secrets") == "inherit"
+        ):
+            errors.append(
+                "docs deploy production Helm promotion must use the exact reusable "
+                "workflow controls and depend on verify-library-release without bypasses"
+            )
 
     gate_step = _named_step_blocks(release_gate).get("Await GitHub Release and PyPI availability")
+    gate_steps = _job_step_blocks(release_gate)
     gate_shell = _named_step_run(
         release_gate,
         "Await GitHub Release and PyPI availability",
@@ -2748,8 +3973,29 @@ def validate_docs_deploy_workflow(path: Path = DEFAULT_DOCS_DEPLOY_WORKFLOW) -> 
     if gate_step is None or gate_shell is None:
         errors.append("docs deploy release gate is missing its active polling shell step")
         return errors
+    if len(gate_steps) != 1 or gate_steps[0] != gate_step:
+        errors.append(
+            "docs deploy release gate job must contain exactly its one verified polling step"
+        )
+    expected_gate_env = {
+        "GH_TOKEN": "${{ github.token }}",
+        "VERSION": "${{ needs.prepare.outputs.version }}",
+        "SOURCE_SHA": "${{ needs.prepare.outputs.source_sha }}",
+        "REPO": "${{ github.repository }}",
+    }
+    if not (
+        _step_has_exact_bash_run(gate_step)
+        and _step_direct_keys(gate_step) == ["name", "env", "shell", "run"]
+        and _step_mapping(gate_step, "env") == expected_gate_env
+    ):
+        errors.append(
+            "docs deploy release gate must use exact step controls, environment, "
+            "one direct `run`, and exact step-local `shell: bash`"
+        )
     if _has_indirect_shell_execution(gate_shell):
         errors.append("docs deploy release gate must not use indirect shell execution")
+    if _gh_api_write_requests(gate_shell):
+        errors.append("docs deploy release gate must not make write-mode gh api requests")
     if not re.search(
         r"^          SOURCE_SHA:\s*"
         r"\$\{\{ needs\.prepare\.outputs\.source_sha \}\}\s*$",

--- a/scripts/verify_ci_workflow.py
+++ b/scripts/verify_ci_workflow.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import shlex
 import sys
 from pathlib import Path
 from typing import Optional
@@ -112,6 +113,51 @@ def _named_step_blocks(job_text: str) -> dict[str, str]:
     return {name: "\n".join(lines) for name, lines in blocks.items()}
 
 
+def _job_step_blocks(job_text: str) -> list[str]:
+    """Return every active job step, including unnamed ``uses``/``run`` steps."""
+    blocks: list[list[str]] = []
+    current: list[str] | None = None
+    for line in job_text.splitlines():
+        if re.match(r"^      -(?:\s|$)", line):
+            if current is not None:
+                blocks.append(current)
+            current = [line]
+        elif current is not None:
+            current.append(line)
+    if current is not None:
+        blocks.append(current)
+    return ["\n".join(block) for block in blocks]
+
+
+def _step_name(step_text: str) -> str | None:
+    """Return an active step name, if the step declares one."""
+    match = re.search(r"^      - name:\s*(.+?)\s*$", step_text, re.MULTILINE)
+    return None if match is None else match.group(1)
+
+
+def _step_run(step_text: str) -> str | None:
+    """Return one step's shell, supporting block and one-line ``run`` values."""
+    lines = step_text.splitlines()
+    for start, line in enumerate(lines):
+        match = re.match(r"^        run:\s*(.*?)\s*$", line)
+        if match is None:
+            continue
+        value = _strip_yaml_inline_comment(match.group(1))
+        if not re.fullmatch(r"[|>][+-]?", value):
+            return value or None
+        shell_lines: list[str] = []
+        for body_line in lines[start + 1 :]:
+            if body_line.strip() and len(body_line) - len(body_line.lstrip()) <= 8:
+                break
+            if body_line.lstrip().startswith("#"):
+                continue
+            shell_lines.append(
+                body_line[10:] if body_line.startswith("          ") else body_line.lstrip()
+            )
+        return "\n".join(shell_lines)
+    return None
+
+
 def _job_scalar(job_text: str, key: str) -> str | None:
     """Return an active job-level scalar, ignoring comments and nested keys."""
     match = re.search(rf"^    {re.escape(key)}:\s*(.*?)\s*$", job_text, re.MULTILINE)
@@ -121,7 +167,35 @@ def _job_scalar(job_text: str, key: str) -> str | None:
 def _step_scalar(step_text: str, key: str) -> str | None:
     """Return an active named-step scalar, ignoring comments and nested keys."""
     match = re.search(rf"^        {re.escape(key)}:\s*(.*?)\s*$", step_text, re.MULTILINE)
-    return None if match is None else match.group(1)
+    return None if match is None else _strip_yaml_inline_comment(match.group(1))
+
+
+def _strip_yaml_inline_comment(value: str) -> str:
+    """Strip a plain-scalar YAML comment without touching quoted ``#`` text."""
+    quote: str | None = None
+    escaped = False
+    index = 0
+    while index < len(value):
+        character = value[index]
+        if quote == '"':
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = None
+        elif quote == "'":
+            if character == quote:
+                if index + 1 < len(value) and value[index + 1] == quote:
+                    index += 1
+                else:
+                    quote = None
+        elif character in {'"', "'"}:
+            quote = character
+        elif character == "#" and (index == 0 or value[index - 1].isspace()):
+            return value[:index].rstrip()
+        index += 1
+    return value.rstrip()
 
 
 def _job_mapping(job_text: str, key: str) -> dict[str, str] | None:
@@ -141,31 +215,458 @@ def _job_mapping(job_text: str, key: str) -> dict[str, str] | None:
             break
         match = re.fullmatch(r"      ([A-Za-z0-9_-]+):\s*(.*?)\s*", line)
         if match:
-            mapping[match.group(1)] = match.group(2)
+            mapping[match.group(1)] = _strip_yaml_inline_comment(match.group(2))
     return mapping
 
 
 def _named_step_run(job_text: str, step: str) -> str | None:
     """Return one named step's active shell body without comment-only lines."""
     block = _named_step_blocks(job_text).get(step)
-    if block is None:
-        return None
-    lines = block.splitlines()
+    return None if block is None else _step_run(block)
+
+
+def _shell_logical_lines(shell: str) -> list[str]:
+    """Join backslash-continued shell lines while preserving command order."""
+    logical_lines: list[str] = []
+    pending = ""
+    for raw_line in shell.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        pending = f"{pending} {line}".strip() if pending else line
+        trailing_backslashes = len(pending) - len(pending.rstrip("\\"))
+        if trailing_backslashes % 2:
+            pending = pending[:-1].rstrip()
+            continue
+        logical_lines.append(pending)
+        pending = ""
+    if pending:
+        logical_lines.append(pending)
+    return logical_lines
+
+
+def _shell_tokens(command: str) -> list[str] | None:
+    """Tokenize one logical shell line, including control-operator tokens."""
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
+    lexer.commenters = "#"
+    lexer.whitespace_split = True
     try:
-        start = lines.index("        run: |")
+        return list(lexer)
     except ValueError:
         return None
-    shell_lines: list[str] = []
-    for line in lines[start + 1 :]:
-        # A step key may legally follow `run:` (for example `shell:` or
-        # `timeout-minutes:`). It is metadata, not part of the block scalar.
-        # Stop at the first non-empty line indented no deeper than `run:`.
-        if line.strip() and len(line) - len(line.lstrip()) <= 8:
-            break
-        if line.lstrip().startswith("#"):
+
+
+def _shell_command_records(shell: str) -> list[tuple[int, str, list[str]]]:
+    """Return successfully tokenized logical shell lines in source order."""
+    records: list[tuple[int, str, list[str]]] = []
+    for position, command in enumerate(_shell_logical_lines(shell)):
+        tokens = _shell_tokens(command)
+        if tokens is not None:
+            records.append((position, command, tokens))
+    return records
+
+
+def _shell_maybe_successful_terminations(
+    logical_lines: list[str],
+) -> list[tuple[int, int, str, str | None]]:
+    """Return active shell termination commands that may report success.
+
+    A release gate must enumerate every successful termination, not merely
+    prove that its expected success path exists: an earlier ``exit 0`` leaves
+    all of the later guarded shell present but dead. ``exec`` can replace the
+    gate with a successful command. Bare exit/return commands inherit the
+    preceding status, and dynamic statuses can evaluate to zero. Bash also
+    reduces numeric statuses modulo 256, so only an explicit integer whose
+    reduced status is nonzero is unambiguously a failure.
+
+    The command-start check recognizes normal shell control boundaries and the
+    ``command``/``builtin`` wrappers without mistaking text such as
+    ``printf '%s' exit`` for an active termination.
+    """
+    boundary_tokens = {
+        "&",
+        "&&",
+        "(",
+        ")",
+        ";",
+        ";;",
+        "do",
+        "elif",
+        "else",
+        "if",
+        "then",
+        "until",
+        "while",
+        "|",
+        "||",
+        "{",
+        "}",
+        "!",
+    }
+    command_wrappers = {"builtin", "command", "time"}
+    executing_wrapper_options = {"--", "-p"}
+    assignment = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+    explicit_status = re.compile(r"^[+-]?[0-9]+$")
+    terminations: list[tuple[int, int, str, str | None]] = []
+
+    for position, line in enumerate(logical_lines):
+        tokens = _shell_tokens(line)
+        if tokens is None:
             continue
-        shell_lines.append(line[10:] if line.startswith("          ") else line.lstrip())
-    return "\n".join(shell_lines)
+        for token_position, token in enumerate(tokens):
+            if token not in {"exec", "exit", "return"}:
+                continue
+
+            command_start = 0
+            for prefix_position in range(token_position - 1, -1, -1):
+                if tokens[prefix_position] in boundary_tokens:
+                    command_start = prefix_position + 1
+                    break
+            prefix = tokens[command_start:token_position]
+            while prefix and assignment.match(prefix[0]):
+                prefix = prefix[1:]
+            if prefix and not all(
+                item in command_wrappers or item in executing_wrapper_options for item in prefix
+            ):
+                continue
+
+            command_end = len(tokens)
+            for suffix_position in range(token_position + 1, len(tokens)):
+                if tokens[suffix_position] in boundary_tokens:
+                    command_end = suffix_position
+                    break
+            arguments = tokens[token_position + 1 : command_end]
+            status = arguments[0] if len(arguments) == 1 else None
+            if (
+                token != "exec"
+                and status is not None
+                and explicit_status.fullmatch(status)
+                and int(status, 10) % 256 != 0
+            ):
+                continue
+            terminations.append((position, token_position, token, status))
+
+    return terminations
+
+
+def _shell_function_definition_count(shell: str, name: str) -> int:
+    """Count active Bash definitions of ``name``, including one-line overrides."""
+    pattern = re.compile(rf"^(?:function\s+)?{re.escape(name)}(?:\s*\(\))?\s*\{{(?:\s|$)")
+    return sum(bool(pattern.match(line)) for line in _shell_logical_lines(shell))
+
+
+def _has_gh_release_mutation(shell: str) -> bool:
+    """Return whether shell directly invokes a GitHub Release write command."""
+    mutations = {"create", "delete", "edit", "upload"}
+    write_methods = {"DELETE", "PATCH", "POST", "PUT"}
+    for _, _, tokens in _shell_command_records(shell):
+        for index in range(len(tokens) - 2):
+            if tokens[index : index + 2] == ["gh", "release"] and tokens[index + 2] in mutations:
+                return True
+            if tokens[index : index + 2] != ["gh", "api"]:
+                continue
+            api_tokens = tokens[index + 2 :]
+            methods = [
+                api_tokens[position + 1].upper()
+                for position, token in enumerate(api_tokens[:-1])
+                if token in {"--method", "-X"}
+            ]
+            if not any(method in write_methods for method in methods):
+                continue
+            release_endpoints = [
+                token for token in api_tokens if re.search(r"(?:^|/)releases(?:/|$)", token)
+            ]
+            if any(
+                not endpoint.endswith("/releases/generate-notes") for endpoint in release_endpoints
+            ):
+                return True
+    return False
+
+
+def _option_values(tokens: list[str], option: str) -> list[str | None]:
+    """Return every value supplied to an exact long option token."""
+    values: list[str | None] = []
+    for index, token in enumerate(tokens):
+        if token == option:
+            values.append(tokens[index + 1] if index + 1 < len(tokens) else None)
+        elif token.startswith(f"{option}="):
+            values.append(token.removeprefix(f"{option}="))
+    return values
+
+
+def _has_exact_option(tokens: list[str], option: str, value: str) -> bool:
+    """Require one unambiguous long option whose value is exactly expected."""
+    return _option_values(tokens, option) == [value]
+
+
+def _is_release_metadata_read(tokens: list[str]) -> bool:
+    """Recognize the complete GitHub Release metadata read used by the gate."""
+    fields = "assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName"
+    command = [
+        "timeout",
+        "--signal=TERM",
+        "--kill-after=5s",
+        "30s",
+        "gh",
+        "release",
+        "view",
+        "$TAG",
+        "--repo",
+        "$REPO",
+        "--json",
+        fields,
+    ]
+    return tokens in (command, [*command, "2>/dev/null"])
+
+
+def _is_release_payload_verification(tokens: list[str]) -> bool:
+    """Recognize a direct call that validates the current release payload."""
+    return tokens in (
+        [
+            "verify_release_payload",
+            "$release_json",
+            "$pypi_hashes_json",
+            ";",
+            "then",
+        ],
+        [
+            "!",
+            "verify_release_payload",
+            "$release_json",
+            "$expected_hashes_json",
+            ";",
+            "then",
+        ],
+    )
+
+
+def _has_guarded_release_validation(logical_lines: list[str], metadata_position: int) -> bool:
+    """Bind a metadata assignment to payload verification and a failing guard."""
+    if metadata_position < 1 or metadata_position + 6 >= len(logical_lines):
+        return False
+    if logical_lines[metadata_position - 1] != 'release_json="$(':
+        return False
+    if logical_lines[metadata_position + 1] != ')"':
+        return False
+    if _shell_tokens(logical_lines[metadata_position + 2]) != [
+        "if",
+        "!",
+        "release_metadata_matches",
+        "$release_json",
+        "||",
+    ]:
+        return False
+    if _shell_tokens(logical_lines[metadata_position + 3]) != [
+        "!",
+        "verify_release_payload",
+        "$release_json",
+        "$expected_hashes_json",
+        ";",
+        "then",
+    ]:
+        return False
+    expected_errors = {
+        'echo "::error::${TAG} release metadata, notes, or assets are invalid after creation"',
+        'echo "::error::${TAG} release metadata, notes, or assets are invalid after normalization"',
+    }
+    return (
+        logical_lines[metadata_position + 4] in expected_errors
+        and _shell_tokens(logical_lines[metadata_position + 5]) == ["exit", "1"]
+        and _shell_tokens(logical_lines[metadata_position + 6]) == ["fi"]
+    )
+
+
+def _assignment_lines(logical_lines: list[str], name: str) -> list[str]:
+    """Return active direct assignments to one protected shell variable."""
+    pattern = re.compile(rf"^(?:if (?:! )?)?{re.escape(name)}=")
+    return [line for line in logical_lines if pattern.match(line)]
+
+
+def _logical_line_is(logical_lines: list[str], position: int, expected: str) -> bool:
+    """Compare one logical shell line without allowing negative indexing."""
+    return 0 <= position < len(logical_lines) and logical_lines[position] == expected
+
+
+def _has_exact_tag_source_gate(
+    logical_lines: list[str],
+    lookup_position: int,
+    *,
+    failure_statement: str,
+) -> bool:
+    """Require an adjacent, timeout-bounded tag lookup and failing SHA guard."""
+    if lookup_position < 1 or lookup_position + 8 >= len(logical_lines):
+        return False
+    return logical_lines[lookup_position - 1 : lookup_position + 9] == [
+        'if ! tag_source_sha="$(',
+        "timeout --signal=TERM --kill-after=5s 30s "
+        "gh api \"repos/${REPO}/commits/${TAG}\" --jq '.sha'",
+        ')"; then',
+        'echo "::error::Could not resolve ${TAG} to its source commit"',
+        failure_statement,
+        "fi",
+        'if [[ "$tag_source_sha" != "$GITHUB_SHA" ]]; then',
+        'echo "::error::${TAG} resolves to ${tag_source_sha}, not workflow source ${GITHUB_SHA}"',
+        failure_statement,
+        "fi",
+    ]
+
+
+def _has_exact_tag_source_function(
+    logical_lines: list[str],
+    lookup_position: int,
+) -> bool:
+    """Require the reusable tag guard to fail on lookup or SHA mismatch."""
+    if lookup_position < 3 or lookup_position + 9 >= len(logical_lines):
+        return False
+    return logical_lines[lookup_position - 3 : lookup_position + 10] == [
+        "verify_tag_source() {",
+        "local tag_source_sha",
+        'if ! tag_source_sha="$(',
+        "timeout --signal=TERM --kill-after=5s 30s "
+        "gh api \"repos/${REPO}/commits/${TAG}\" --jq '.sha'",
+        ')"; then',
+        'echo "::error::Could not resolve ${TAG} to its source commit"',
+        "return 1",
+        "fi",
+        'if [[ "$tag_source_sha" != "$GITHUB_SHA" ]]; then',
+        'echo "::error::${TAG} resolves to ${tag_source_sha}, not workflow source ${GITHUB_SHA}"',
+        "return 1",
+        "fi",
+        "}",
+    ]
+
+
+def _has_exact_docs_tag_source_function(
+    logical_lines: list[str],
+    lookup_position: int,
+) -> bool:
+    """Require the docs gate's bounded current-tag/source comparison."""
+    if lookup_position < 3 or lookup_position + 5 >= len(logical_lines):
+        return False
+    return logical_lines[lookup_position - 3 : lookup_position + 6] == [
+        "verify_tag_source() {",
+        "local current_tag_sha",
+        'if ! current_tag_sha="$(',
+        "timeout --signal=TERM --kill-after=5s 30s "
+        "gh api \"repos/${REPO}/commits/${VERSION}\" --jq '.sha'",
+        ')"; then',
+        "return 1",
+        "fi",
+        '[[ "$current_tag_sha" == "$SOURCE_SHA" ]]',
+        "}",
+    ]
+
+
+def _has_exact_pypi_gate_flow(
+    logical_lines: list[str],
+    *,
+    version_variable: str,
+    expected_hashes_variable: str,
+    immutable_variable: str | None = None,
+) -> tuple[bool, int]:
+    """Bind one bounded PyPI response to an exact all-file equality guard."""
+    url = f"https://pypi.org/pypi/xy/${{{version_variable}}}/json"
+    fetch_tokens = [
+        "curl",
+        "-fsS",
+        "--connect-timeout",
+        "5",
+        "--max-time",
+        "20",
+        url,
+        "2>/dev/null",
+    ]
+    fetch_positions = [
+        position
+        for position, _, tokens in _shell_command_records("\n".join(logical_lines))
+        if tokens == fetch_tokens
+    ]
+    equality_tokens = (
+        [
+            "if",
+            "[[",
+            immutable_variable,
+            "==",
+            "true",
+            "||",
+            "$pypi_hashes_json",
+            "==",
+            expected_hashes_variable,
+            "]]",
+            ";",
+            "then",
+        ]
+        if immutable_variable is not None
+        else [
+            "[[",
+            "$pypi_hashes_json",
+            "==",
+            expected_hashes_variable,
+            "]]",
+            ";",
+            "then",
+        ]
+    )
+    equality_positions = [
+        position
+        for position, line in enumerate(logical_lines)
+        if _shell_tokens(line) == equality_tokens
+    ]
+    guard_tokens = ["if", "[[", "$pypi_matches", "!=", "true", "]]", ";", "then"]
+    guard_positions = [
+        position
+        for position, line in enumerate(logical_lines)
+        if _shell_tokens(line) == guard_tokens
+    ]
+    if len(fetch_positions) != 1 or len(equality_positions) != 1 or len(guard_positions) != 1:
+        return False, -1
+
+    fetch_position = fetch_positions[0]
+    equality_position = equality_positions[0]
+    guard_position = guard_positions[0]
+    hash_assignment_positions = [
+        position for position, line in enumerate(logical_lines) if line == 'if pypi_hashes_json="$('
+    ]
+    assignments_are_exact = (
+        _assignment_lines(logical_lines, "pypi_json") == ['if pypi_json="$(']
+        and _assignment_lines(logical_lines, "pypi_hashes_json") == ['if pypi_hashes_json="$(']
+        and _assignment_lines(logical_lines, "pypi_matches")
+        == ["pypi_matches=false", "pypi_matches=true"]
+    )
+    fetch_is_direct = (
+        fetch_position >= 1
+        and fetch_position + 1 < len(logical_lines)
+        and logical_lines[fetch_position - 1] == 'if pypi_json="$('
+        and logical_lines[fetch_position + 1] == ')"; then'
+    )
+    malformed_response_retries = (
+        len(hash_assignment_positions) == 1
+        and hash_assignment_positions[0] == fetch_position + 2
+        and ')" &&' in logical_lines[hash_assignment_positions[0] + 1 : equality_position]
+    )
+    equality_sets_match = equality_position + 3 < len(logical_lines) and logical_lines[
+        equality_position + 1 : equality_position + 4
+    ] == ["pypi_matches=true", "break", "fi"]
+    guard_fails_closed = (
+        guard_position >= 1
+        and guard_position + 3 < len(logical_lines)
+        and logical_lines[guard_position - 1] == "done"
+        and logical_lines[guard_position + 1 : guard_position + 4]
+        == [
+            'echo "::error::PyPI files for ${TAG} do not exactly match the verified build"',
+            "exit 1",
+            "fi",
+        ]
+    )
+    return (
+        assignments_are_exact
+        and fetch_is_direct
+        and malformed_response_retries
+        and fetch_position < equality_position < guard_position
+        and equality_sets_match
+        and guard_fails_closed,
+        guard_position,
+    )
 
 
 def _require_step_contains(
@@ -848,12 +1349,14 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
         "and a tag/version/CHANGELOG agreement gate",
         "needs: [wheels, sdist, wasm]",
         "environment: pypi",
+        "contents: read",
         "id-token: write",
         "scripts/check_release_version.py",
         "actions/download-artifact@",
         "pattern: dist-*",
         "merge-multiple: true",
         "dry_run",
+        "Verify release tag source before PyPI",
         "pypa/gh-action-pypi-publish@",
         "packages-dir: dist/",
         "skip-existing: true",
@@ -872,6 +1375,51 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
     publish = jobs.get("publish", "")
     if "password:" in publish or "api-token" in publish:
         errors.append("release publish job should use trusted publishing, not a PyPI token")
+    expected_publish_permissions = {"contents": "read", "id-token": "write"}
+    if _job_mapping(publish, "permissions") != expected_publish_permissions:
+        errors.append(
+            f"release publish job permissions must be exactly {expected_publish_permissions!r}"
+        )
+    publish_tag_block = _named_step_blocks(publish).get("Verify release tag source before PyPI")
+    publish_tag_shell = _named_step_run(publish, "Verify release tag source before PyPI")
+    publish_action_position = publish.find("pypa/gh-action-pypi-publish@")
+    publish_tag_position = publish.find("- name: Verify release tag source before PyPI")
+    if publish_tag_block is None or publish_tag_shell is None:
+        errors.append("release publish job must verify the current tag source before PyPI")
+    else:
+        publish_tag_lines = _shell_logical_lines(publish_tag_shell)
+        lookup_tokens = [
+            "timeout",
+            "--signal=TERM",
+            "--kill-after=5s",
+            "30s",
+            "gh",
+            "api",
+            "repos/${REPO}/commits/${TAG}",
+            "--jq",
+            ".sha",
+        ]
+        lookup_positions = [
+            position
+            for position, _, tokens in _shell_command_records(publish_tag_shell)
+            if tokens == lookup_tokens
+        ]
+        if not (
+            _step_scalar(publish_tag_block, "if") == "github.event_name == 'push'"
+            and _assignment_lines(publish_tag_lines, "tag_source_sha")
+            == ['if ! tag_source_sha="$(']
+            and len(lookup_positions) == 1
+            and _has_exact_tag_source_gate(
+                publish_tag_lines,
+                lookup_positions[0],
+                failure_statement="exit 1",
+            )
+            and 0 <= publish_tag_position < publish_action_position
+        ):
+            errors.append(
+                "release publish job must use one timeout-bounded, failing tag/SHA "
+                "guard immediately before the PyPI publisher"
+            )
     if "pypa/gh-action-pypi-publish@" in publish and not _step_carries_publish_gate(
         publish, "pypa/gh-action-pypi-publish@"
     ):
@@ -898,6 +1446,37 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
     )
     github_release = jobs.get("github-release")
     if github_release is not None:
+        job_steps = _job_step_blocks(github_release)
+        protected_step_names = (
+            "Inspect existing release",
+            "Prepare release provenance",
+            "Attest release provenance",
+            "Create GitHub Release and attach distributions",
+        )
+        duplicate_protected_steps = [
+            name
+            for name in protected_step_names
+            if sum(_step_name(step) == name for step in job_steps) != 1
+        ]
+        if duplicate_protected_steps:
+            errors.append(
+                "release github-release job must declare each protected step exactly once: "
+                f"{duplicate_protected_steps}"
+            )
+        sibling_release_mutations = [
+            _step_name(step) or "<unnamed>"
+            for step in job_steps
+            if _step_name(step) != "Create GitHub Release and attach distributions"
+            and (shell := _step_run(step)) is not None
+            and _has_gh_release_mutation(shell)
+        ]
+        if sibling_release_mutations:
+            errors.append(
+                "release github-release job must keep every GitHub Release mutation "
+                "inside the structurally verified publication step; found writes in "
+                f"{sibling_release_mutations}"
+            )
+
         expected_gate = "github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')"
         if _job_scalar(github_release, "if") != expected_gate:
             errors.append(
@@ -906,6 +1485,10 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
             )
         if _job_scalar(github_release, "needs") != "publish":
             errors.append("release github-release job must actively declare `needs: publish`")
+        if _job_scalar(github_release, "timeout-minutes") != "30":
+            errors.append(
+                "release github-release job must retain its 30-minute network-failure timeout"
+            )
         permissions = _job_mapping(github_release, "permissions")
         expected_permissions = {
             "attestations": "write",
@@ -935,6 +1518,29 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
             )
             if missing:
                 errors.append(f"release immutable-release preflight is incomplete: {missing}")
+            inspect_tokens = [
+                "timeout",
+                "--signal=TERM",
+                "--kill-after=5s",
+                "30s",
+                "gh",
+                "release",
+                "view",
+                "$TAG",
+                "--repo",
+                "$REPO",
+                "--json",
+                "isImmutable",
+                "2>/dev/null",
+            ]
+            inspect_commands = [
+                tokens for _, _, tokens in _shell_command_records(inspect_shell) if "gh" in tokens
+            ]
+            if inspect_commands != [inspect_tokens]:
+                errors.append(
+                    "release immutable-release preflight must use one exact "
+                    "30-second timeout-bounded metadata read"
+                )
 
         immutable_skip = "steps.release_state.outputs.immutable != 'true'"
         prepare_block = step_blocks.get("Prepare release provenance")
@@ -957,6 +1563,13 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                 "fi",
                 "distributions_json=",
                 'sha256sum "$artifact"',
+                "timeout --signal=TERM --kill-after=5s 30s",
+                "gh api \"repos/${REPO}/commits/${TAG}\" --jq '.sha'",
+                '"$tag_source_sha" != "$GITHUB_SHA"',
+                "pypi_hashes_json=",
+                "{name: .filename, sha256: .digests.sha256}",
+                ".yanked == false",
+                '"$pypi_hashes_json" == "$distributions_json"',
                 '"repos/${REPO}/releases/generate-notes"',
                 '-f tag_name="$TAG"',
                 'generated_notes="$(<"$notes_file")"',
@@ -976,6 +1589,94 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                 errors.append(
                     "release provenance preparation must bind generated notes and exact "
                     f"distribution hashes to the tag source: {missing}"
+                )
+            prepare_lines = _shell_logical_lines(prepare_shell)
+            prepare_records = _shell_command_records(prepare_shell)
+            tag_lookup_tokens = [
+                "timeout",
+                "--signal=TERM",
+                "--kill-after=5s",
+                "30s",
+                "gh",
+                "api",
+                "repos/${REPO}/commits/${TAG}",
+                "--jq",
+                ".sha",
+            ]
+            tag_lookup_positions = [
+                position for position, _, tokens in prepare_records if tokens == tag_lookup_tokens
+            ]
+            pypi_flow_valid, pypi_guard_position = _has_exact_pypi_gate_flow(
+                prepare_lines,
+                version_variable="pypi_version",
+                expected_hashes_variable="$distributions_json",
+            )
+            pypi_projection = re.search(
+                r"\[\s*\.urls\[\]\s*\|\s*"
+                r"\{name:\s*\.filename,\s*sha256:\s*\.digests\.sha256\}\s*\]\s*"
+                r"\|\s*sort_by\(\.name\)",
+                prepare_shell,
+            )
+            pypi_policy = re.search(
+                r"all\(\.urls\[\];\s*"
+                r"\.yanked\s*==\s*false\s+and\s*"
+                r"\(\.filename\s*\|\s*"
+                r"endswith\(\"\.whl\"\)\s+or\s+endswith\(\"\.tar\.gz\"\)\)\s+and\s*"
+                r"\(\.digests\.sha256\s*\|\s*"
+                r"type\s*==\s*\"string\"\s+and\s*"
+                r"test\(\"\^\[0-9a-f\]\{64\}\$\"\)\)\)",
+                prepare_shell,
+            )
+            generated_notes_tokens = [
+                "timeout",
+                "--signal=TERM",
+                "--kill-after=5s",
+                "30s",
+                "gh",
+                "api",
+                "--method",
+                "POST",
+                "repos/${REPO}/releases/generate-notes",
+                "-f",
+                "tag_name=$TAG",
+                "--jq",
+                ".body",
+                ">",
+                "$notes_file",
+            ]
+            generated_notes_positions = [
+                position
+                for position, _, tokens in prepare_records
+                if tokens == generated_notes_tokens
+            ]
+            tag_guard_call_positions = [
+                position
+                for position, line in enumerate(prepare_lines)
+                if line == "verify_tag_source"
+            ]
+            if not (
+                _assignment_lines(prepare_lines, "tag_source_sha") == ['if ! tag_source_sha="$(']
+                and _shell_function_definition_count(prepare_shell, "verify_tag_source") == 1
+                and len(tag_lookup_positions) == 1
+                and _has_exact_tag_source_function(
+                    prepare_lines,
+                    tag_lookup_positions[0],
+                )
+                and tag_guard_call_positions
+                == [tag_lookup_positions[0] + 10, len(prepare_lines) - 1]
+                and pypi_flow_valid
+                and pypi_projection is not None
+                and pypi_policy is not None
+                and len(generated_notes_positions) == 1
+                and tag_guard_call_positions[0]
+                < pypi_guard_position
+                < generated_notes_positions[0]
+                < tag_guard_call_positions[1]
+            ):
+                errors.append(
+                    "release provenance preparation must independently bind one reusable, "
+                    "timeout-bounded tag guard before PyPI, a malformed-response-safe exact "
+                    "all-file PyPI gate, and a fresh final tag guard before attesting"
                 )
 
         attest_block = step_blocks.get("Attest release provenance")
@@ -1000,6 +1701,20 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                 re.MULTILINE,
             ):
                 errors.append("release provenance attestation must sign the prepared manifest path")
+        protected_step_order = [
+            "Prepare release provenance",
+            "Attest release provenance",
+            "Create GitHub Release and attach distributions",
+        ]
+        named_step_order = list(step_blocks)
+        if not all(name in named_step_order for name in protected_step_order) or not (
+            named_step_order.index(protected_step_order[0])
+            < named_step_order.index(protected_step_order[1])
+            < named_step_order.index(protected_step_order[2])
+        ):
+            errors.append(
+                "release provenance must be prepared and gated before attestation, then published"
+            )
 
         release_shell = _named_step_run(
             github_release,
@@ -1019,6 +1734,11 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                 '  echo "::error::Expected at least one wheel and exactly one sdist"\n'
                 "  exit 1\n"
                 "fi",
+                "verify_tag_source() {",
+                "timeout --signal=TERM --kill-after=5s 30s",
+                "gh api \"repos/${REPO}/commits/${TAG}\" --jq '.sha'",
+                '"$tag_source_sha" != "$GITHUB_SHA"',
+                "return 1",
                 f'if [[ "$TAG" =~ {CORE_PRERELEASE_TAG_PATTERN} ]]; then',
                 "prerelease=(--prerelease)",
                 "edit_prerelease=(--prerelease)",
@@ -1027,6 +1747,14 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                 '"${prerelease[@]}"',
                 "expected_assets_json=",
                 "expected_hashes_json=",
+                "pypi_hashes_json=",
+                "{name: .filename, sha256: .digests.sha256}",
+                ".yanked == false",
+                '"$pypi_hashes_json" == "$expected_hashes_json"',
+                'if [[ "$pypi_matches" != true ]]; then\n'
+                '  echo "::error::PyPI files for ${TAG} do not exactly match the verified build"\n'
+                "  exit 1\n"
+                "fi",
                 'provenance_name="xy-release-provenance.json"',
                 'gh release upload "$TAG" "${artifacts[@]}" "$provenance_file"',
                 'gh release create "$TAG" "${artifacts[@]}" "$provenance_file"',
@@ -1041,15 +1769,21 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                 "tagName",
                 "actual_assets_json=",
                 'gh release download "$TAG"',
+                "timeout --signal=TERM --kill-after=5s 180s",
                 'gh attestation verify "$verified_provenance"',
+                "timeout --signal=TERM --kill-after=5s 60s",
                 '--signer-workflow "${REPO}/.github/workflows/release.yml"',
                 '--source-ref "refs/tags/${TAG}"',
                 '--source-digest "$GITHUB_SHA"',
                 "--deny-self-hosted-runners",
                 "actual_hashes_json=",
                 "manifest_hashes_json=",
-                '"$actual_hashes_json" != "$expected_hashes_json"',
-                '"$manifest_hashes_json" != "$expected_hashes_json"',
+                "reference_assets_json=",
+                '"$actual_assets_json" != "$reference_assets_json"',
+                '"$actual_hashes_json" != "$reference_hashes_json"',
+                '"$manifest_hashes_json" != "$reference_hashes_json"',
+                'verify_release_payload "$release_json" "$pypi_hashes_json"',
+                'verify_release_payload "$release_json" "$expected_hashes_json"',
                 "<!-- xy-release-provenance:v1:${TAG}:sha256:${manifest_sha256} -->",
                 '"$actual_notes_sha256" != "$manifest_notes_sha256"',
                 "--draft=false",
@@ -1062,42 +1796,60 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                     f"prerelease, hash, or signed-provenance behavior: {missing}"
                 )
 
+            logical_lines = _shell_logical_lines(release_shell)
+            command_records = _shell_command_records(release_shell)
+            upload_commands = [
+                (position, tokens)
+                for position, _, tokens in command_records
+                if tokens[:3] == ["gh", "release", "upload"]
+            ]
+            create_commands = [
+                (position, tokens)
+                for position, _, tokens in command_records
+                if tokens[:3] == ["gh", "release", "create"]
+            ]
+            valid_upload = len(upload_commands) == 1 and upload_commands[0][1] == [
+                "gh",
+                "release",
+                "upload",
+                "$TAG",
+                "${artifacts[@]}",
+                "$provenance_file",
+                "--repo",
+                "$REPO",
+                "--clobber",
+            ]
+            valid_create = len(create_commands) == 1 and create_commands[0][1] == [
+                "gh",
+                "release",
+                "create",
+                "$TAG",
+                "${artifacts[@]}",
+                "$provenance_file",
+                "--repo",
+                "$REPO",
+                "--verify-tag",
+                "--title",
+                "$TAG",
+                "--notes-file",
+                "$notes_file",
+                "${prerelease[@]}",
+            ]
+            if not valid_upload or not valid_create:
+                errors.append(
+                    "release github-release job must pass verified distributions and "
+                    "provenance directly to one active upload command (with exact "
+                    '`--repo "$REPO"` and `--clobber` arguments) and one active '
+                    'create command (with exact `--repo "$REPO"`, `--verify-tag`, '
+                    'and `--notes-file "$notes_file"` arguments)'
+                )
+
+            classifier = f'if [[ "$TAG" =~ {CORE_PRERELEASE_TAG_PATTERN} ]]; then'
             active_lines = [
                 line.strip().removesuffix("\\").rstrip()
                 for line in release_shell.splitlines()
                 if line.strip()
             ]
-            release_view = 'gh release view "$TAG"'
-            release_json_fields = (
-                "--json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName"
-            )
-            if active_lines.count(release_view) < 4 or active_lines.count(release_json_fields) < 4:
-                errors.append(
-                    "release github-release job must inspect full release metadata and "
-                    "assets before recovery, after upload, after normalization, "
-                    "and after creation"
-                )
-            upload_lines = [
-                line
-                for line in active_lines
-                if line.startswith('gh release upload "$TAG" "${artifacts[@]}" "$provenance_file" ')
-                and line.endswith(" --clobber")
-            ]
-            create_lines = [
-                line
-                for line in active_lines
-                if line.startswith('gh release create "$TAG" "${artifacts[@]}" "$provenance_file" ')
-                and "--verify-tag " in line
-                and '--notes-file "$notes_file" ' in line
-            ]
-            if len(upload_lines) != 1 or len(create_lines) != 1:
-                errors.append(
-                    "release github-release job must pass verified distributions and "
-                    "provenance directly to one active upload command (with --clobber) "
-                    "and one active create command"
-                )
-
-            classifier = f'if [[ "$TAG" =~ {CORE_PRERELEASE_TAG_PATTERN} ]]; then'
             for assignment in (
                 classifier,
                 "prerelease=(--prerelease)",
@@ -1110,17 +1862,90 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                         f"alpha/beta/RC tags; missing {assignment!r}"
                     )
 
-            initial_view_position = release_shell.find(release_view)
-            upload_position = release_shell.find('gh release upload "$TAG"')
-            uploaded_view_position = release_shell.find(
-                release_view,
-                upload_position + 1 if upload_position >= 0 else 0,
+            metadata_read_positions = [
+                position
+                for position, _, tokens in command_records
+                if _is_release_metadata_read(tokens)
+            ]
+            payload_verification_positions = [
+                position
+                for position, _, tokens in command_records
+                if _is_release_payload_verification(tokens)
+            ]
+            upload_position = upload_commands[0][0] if len(upload_commands) == 1 else -1
+            create_position = create_commands[0][0] if len(create_commands) == 1 else -1
+            edit_positions = [
+                position
+                for position, _, tokens in command_records
+                if tokens
+                == [
+                    "gh",
+                    "release",
+                    "edit",
+                    "$TAG",
+                    "--repo",
+                    "$REPO",
+                    "--draft=false",
+                    "--title",
+                    "$TAG",
+                    "--notes-file",
+                    "$notes_file",
+                    "${edit_prerelease[@]}",
+                ]
+            ]
+            edit_position = edit_positions[0] if len(edit_positions) == 1 else -1
+            prune_positions = [
+                position
+                for position, _, tokens in command_records
+                if tokens
+                == [
+                    "gh",
+                    "api",
+                    "--method",
+                    "DELETE",
+                    "repos/${REPO}/releases/assets/${asset_id}",
+                ]
+            ]
+            prune_position = prune_positions[0] if len(prune_positions) == 1 else -1
+            initial_view_positions = [
+                position for position in metadata_read_positions if position < upload_position
+            ]
+            initial_view_position = initial_view_positions[-1] if initial_view_positions else -1
+            uploaded_view_position = next(
+                (
+                    position
+                    for position in metadata_read_positions
+                    if upload_position < position < prune_position
+                ),
+                -1,
             )
-            prune_position = release_shell.find('"repos/${REPO}/releases/assets/${asset_id}"')
-            edit_position = release_shell.find('gh release edit "$TAG"')
-            final_view_position = release_shell.find(
-                release_view,
-                edit_position + 1 if edit_position >= 0 else 0,
+            normalized_view_position = next(
+                (
+                    position
+                    for position in metadata_read_positions
+                    if edit_position < position < create_position
+                ),
+                -1,
+            )
+            normalized_verify_position = next(
+                (
+                    position
+                    for position in payload_verification_positions
+                    if normalized_view_position < position < create_position
+                ),
+                -1,
+            )
+            created_view_position = next(
+                (position for position in metadata_read_positions if position > create_position),
+                -1,
+            )
+            created_verify_position = next(
+                (
+                    position
+                    for position in payload_verification_positions
+                    if position > created_view_position
+                ),
+                -1,
             )
             if not (
                 0
@@ -1129,11 +1954,264 @@ def validate_release_workflow(path: Path = DEFAULT_RELEASE_WORKFLOW) -> list[str
                 < uploaded_view_position
                 < prune_position
                 < edit_position
-                < final_view_position
+                < normalized_view_position
+                < normalized_verify_position
+                < create_position
+                and _has_guarded_release_validation(logical_lines, normalized_view_position)
             ):
                 errors.append(
-                    "release github-release recovery must inspect, upload, re-read, "
-                    "prune stale assets by id, edit metadata last, and validate again"
+                    "release github-release job recovery must inspect, upload, re-read, "
+                    "prune stale assets by id, edit metadata last, re-read, and validate again"
+                )
+            if not (
+                0 <= create_position < created_view_position < created_verify_position
+                and _has_guarded_release_validation(logical_lines, created_view_position)
+            ):
+                errors.append(
+                    "release github-release job creation must re-read complete metadata "
+                    "and validate again with the active signed-payload check"
+                )
+
+            tag_lookup_tokens = [
+                "timeout",
+                "--signal=TERM",
+                "--kill-after=5s",
+                "30s",
+                "gh",
+                "api",
+                "repos/${REPO}/commits/${TAG}",
+                "--jq",
+                ".sha",
+            ]
+            tag_resolution_positions = [
+                position for position, _, tokens in command_records if tokens == tag_lookup_tokens
+            ]
+            pypi_flow_valid, pypi_guard_position = _has_exact_pypi_gate_flow(
+                logical_lines,
+                version_variable="pypi_version",
+                expected_hashes_variable="$expected_hashes_json",
+                immutable_variable="$is_immutable",
+            )
+            pypi_projection = re.search(
+                r"\[\s*\.urls\[\]\s*\|\s*"
+                r"\{name:\s*\.filename,\s*sha256:\s*\.digests\.sha256\}\s*\]\s*"
+                r"\|\s*sort_by\(\.name\)",
+                release_shell,
+            )
+            pypi_policy = re.search(
+                r"all\(\.urls\[\];\s*"
+                r"\.yanked\s*==\s*false\s+and\s*"
+                r"\(\.filename\s*\|\s*"
+                r"endswith\(\"\.whl\"\)\s+or\s+endswith\(\"\.tar\.gz\"\)\)\s+and\s*"
+                r"\(\.digests\.sha256\s*\|\s*"
+                r"type\s*==\s*\"string\"\s+and\s*"
+                r"test\(\"\^\[0-9a-f\]\{64\}\$\"\)\)\)",
+                release_shell,
+            )
+            mutation_positions = [
+                position
+                for position in (
+                    upload_position,
+                    prune_position,
+                    edit_position,
+                    create_position,
+                )
+                if position >= 0
+            ]
+            first_mutation_position = min(mutation_positions, default=-1)
+            pre_guard_github_commands = [
+                (position, tokens)
+                for position, _, tokens in command_records
+                if position < pypi_guard_position and any(token == "gh" for token in tokens)
+            ]
+            allowed_release_subcommands = {"create", "download", "edit", "upload", "view"}
+            unknown_release_commands = [
+                tokens
+                for _, _, tokens in command_records
+                for index in range(len(tokens) - 2)
+                if tokens[index : index + 2] == ["gh", "release"]
+                and tokens[index + 2] not in allowed_release_subcommands
+            ]
+            immutable_payload_positions = [
+                position
+                for position in payload_verification_positions
+                if position < upload_position
+                and _shell_tokens(logical_lines[position])
+                == [
+                    "verify_release_payload",
+                    "$release_json",
+                    "$pypi_hashes_json",
+                    ";",
+                    "then",
+                ]
+            ]
+            download_tokens = [
+                "if",
+                "!",
+                "timeout",
+                "--signal=TERM",
+                "--kill-after=5s",
+                "180s",
+                "gh",
+                "release",
+                "download",
+                "$TAG",
+                "--repo",
+                "$REPO",
+                "--dir",
+                "$verify_dir",
+                "--pattern",
+                "*.whl",
+                "--pattern",
+                "*.tar.gz",
+                "--pattern",
+                "$provenance_name",
+                ";",
+                "then",
+            ]
+            attestation_tokens = [
+                "if",
+                "!",
+                "timeout",
+                "--signal=TERM",
+                "--kill-after=5s",
+                "60s",
+                "gh",
+                "attestation",
+                "verify",
+                "$verified_provenance",
+                "--repo",
+                "$REPO",
+                "--signer-workflow",
+                "${REPO}/.github/workflows/release.yml",
+                "--source-ref",
+                "refs/tags/${TAG}",
+                "--source-digest",
+                "$GITHUB_SHA",
+                "--deny-self-hosted-runners",
+                ">/dev/null",
+                ";",
+                "then",
+            ]
+            guarded_mutations = len(mutation_positions) == 4 and all(
+                _logical_line_is(logical_lines, position - 1, "verify_tag_source")
+                for position in mutation_positions
+            )
+            successful_terminations_are_exact = (
+                len(immutable_payload_positions) == 1
+                and normalized_view_position >= 0
+                and _shell_maybe_successful_terminations(logical_lines)
+                == [
+                    (immutable_payload_positions[0] + 3, 0, "exit", "0"),
+                    (normalized_view_position + 8, 0, "exit", "0"),
+                ]
+            )
+            if not successful_terminations_are_exact:
+                errors.append(
+                    "release github-release job must allow only its two exact "
+                    "tag-guarded `exit 0` sites and no additional potentially "
+                    "successful termination commands"
+                )
+            guarded_successes = (
+                len(immutable_payload_positions) == 1
+                and _logical_line_is(
+                    logical_lines,
+                    immutable_payload_positions[0] + 1,
+                    "verify_tag_source",
+                )
+                and _logical_line_is(
+                    logical_lines,
+                    immutable_payload_positions[0] + 3,
+                    "exit 0",
+                )
+                and _logical_line_is(
+                    logical_lines,
+                    normalized_view_position + 7,
+                    "verify_tag_source",
+                )
+                and _logical_line_is(
+                    logical_lines,
+                    normalized_view_position + 8,
+                    "exit 0",
+                )
+                and _logical_line_is(
+                    logical_lines,
+                    created_view_position + 7,
+                    "verify_tag_source",
+                )
+                and logical_lines[-1:] == ["verify_tag_source"]
+                and successful_terminations_are_exact
+            )
+            network_verification_is_bounded = (
+                sum(tokens == download_tokens for _, _, tokens in command_records) == 1
+                and sum(tokens == attestation_tokens for _, _, tokens in command_records) == 1
+                and len(metadata_read_positions) == 4
+            )
+            immutable_state_is_exact = (
+                _assignment_lines(logical_lines, "release_exists")
+                == ["release_exists=false", "release_exists=true"]
+                and _assignment_lines(logical_lines, "is_immutable")
+                == [
+                    "is_immutable=false",
+                    'is_immutable="$(jq -r \'.isImmutable\' <<<"$release_json")"',
+                ]
+                and _logical_line_is(
+                    logical_lines,
+                    initial_view_position - 1,
+                    'if release_json="$(',
+                )
+                and _logical_line_is(logical_lines, initial_view_position + 1, ')"; then')
+                and _logical_line_is(
+                    logical_lines,
+                    initial_view_position + 2,
+                    "release_exists=true",
+                )
+                and _logical_line_is(
+                    logical_lines,
+                    initial_view_position + 3,
+                    'is_immutable="$(jq -r \'.isImmutable\' <<<"$release_json")"',
+                )
+                and _logical_line_is(logical_lines, initial_view_position + 4, "fi")
+                and logical_lines.count('if [[ "$release_exists" == true ]]; then') == 1
+                and logical_lines.count('if [[ "$is_immutable" == "true" ]]; then') == 1
+            )
+            if not (
+                len(tag_resolution_positions) == 1
+                and _assignment_lines(logical_lines, "tag_source_sha")
+                == ['if ! tag_source_sha="$(']
+                and _shell_function_definition_count(release_shell, "verify_tag_source") == 1
+                and _has_exact_tag_source_function(
+                    logical_lines,
+                    tag_resolution_positions[0] if tag_resolution_positions else -1,
+                )
+                and pypi_flow_valid
+                and pypi_projection is not None
+                and pypi_policy is not None
+                and _assignment_lines(logical_lines, "expected_hashes_json")
+                == ['expected_hashes_json="$(']
+                and pre_guard_github_commands
+                == [
+                    (tag_resolution_positions[0], tag_lookup_tokens),
+                    (initial_view_position, _shell_tokens(logical_lines[initial_view_position])),
+                ]
+                and not unknown_release_commands
+                and 0 <= pypi_guard_position < first_mutation_position
+                and _logical_line_is(
+                    logical_lines,
+                    tag_resolution_positions[0] + 10,
+                    "verify_tag_source",
+                )
+                and tag_resolution_positions[0] + 10 < initial_view_position
+                and guarded_mutations
+                and guarded_successes
+                and network_verification_is_bounded
+                and immutable_state_is_exact
+            ):
+                errors.append(
+                    "release github-release job must define one timeout-bounded tag guard, "
+                    "require a malformed-response-safe exact non-yanked all-file PyPI gate, "
+                    "reject pre-gate API writes, recheck the tag at every mutation/success "
+                    "boundary, and bound every release read/verification"
                 )
     return errors
 
@@ -1203,6 +2281,11 @@ def validate_docs_deploy_workflow(path: Path = DEFAULT_DOCS_DEPLOY_WORKFLOW) -> 
     required = (
         "shopt -s nullglob",
         'PROVENANCE_NAME="xy-release-provenance.json"',
+        "MAX_ATTEMPTS=30",
+        "POLL_INTERVAL_SECONDS=60",
+        "POLL_DEADLINE=$((SECONDS + 30 * 60))",
+        "verify_tag_source() {",
+        "timeout --signal=TERM --kill-after=5s 30s",
         "EXPECTED_PRERELEASE=false",
         f'if [[ "$VERSION" =~ {CORE_PRERELEASE_TAG_PATTERN} ]]; then',
         "EXPECTED_PRERELEASE=true",
@@ -1217,6 +2300,9 @@ def validate_docs_deploy_workflow(path: Path = DEFAULT_DOCS_DEPLOY_WORKFLOW) -> 
         '([.assets[]? | select(.name | endswith(".tar.gz"))] | length) == 1',
         'select(.name == "xy-release-provenance.json")',
         "all(.urls[]; .yanked == false)",
+        "all(.urls[];",
+        ".filename |",
+        'endswith(".whl") or endswith(".tar.gz")',
         'gh release download "$VERSION"',
         'gh attestation verify "$provenance_file"',
         '--signer-workflow "${REPO}/.github/workflows/release.yml"',
@@ -1236,14 +2322,333 @@ def validate_docs_deploy_workflow(path: Path = DEFAULT_DOCS_DEPLOY_WORKFLOW) -> 
         'if [[ "$RELEASED" == true &&',
         '"$PUBLISHED" == true &&',
         '"$PROVENANCE_VALID" == true &&',
-        '"$ASSETS_MATCH" == true ]]; then',
+        '"$ASSETS_MATCH" == true ]] &&',
+        "verify_tag_source; then",
+        "TAG_MATCH=true",
+        '"$TAG_MATCH" == true ]]; then',
         'rm -rf -- "$verify_dir"',
+        "if (( attempt == MAX_ATTEMPTS )); then",
+        'echo "${status}; no retries remain"',
+        "remaining_seconds=$((POLL_DEADLINE - SECONDS))",
+        'sleep "$sleep_seconds"',
     )
     missing = _missing_needles(gate_shell, required)
     if missing:
         errors.append(
             "docs deploy release gate must require expected non-draft metadata, "
             f"signed notes provenance, non-yanked PyPI files, and exact asset hashes: {missing}"
+        )
+
+    logical_lines = _shell_logical_lines(gate_shell)
+    command_records = _shell_command_records(gate_shell)
+    timeout = _job_scalar(release_gate, "timeout-minutes")
+    deadline_matches = re.findall(
+        r"^POLL_DEADLINE=\$\(\(SECONDS \+ ([0-9]+) \* 60\)\)$",
+        gate_shell,
+        re.MULTILINE,
+    )
+    timeout_minutes = int(timeout) if timeout is not None and timeout.isdigit() else 0
+    deadline_minutes = int(deadline_matches[0]) if len(deadline_matches) == 1 else 0
+    gross_headroom_seconds = (timeout_minutes - deadline_minutes) * 60
+    # Include each timeout's five-second TERM→KILL grace plus the final fresh
+    # tag lookup after release/asset/attestation verification.
+    worst_case_attempt_seconds = 35 + 20 + 185 + 65 + 35
+    protected_timing_assignments = (
+        _assignment_lines(logical_lines, "MAX_ATTEMPTS") == ["MAX_ATTEMPTS=30"]
+        and _assignment_lines(logical_lines, "POLL_INTERVAL_SECONDS")
+        == ["POLL_INTERVAL_SECONDS=60"]
+        and _assignment_lines(logical_lines, "POLL_DEADLINE")
+        == ["POLL_DEADLINE=$((SECONDS + 30 * 60))"]
+    )
+    if not (
+        timeout_minutes == 45
+        and deadline_minutes == 30
+        and protected_timing_assignments
+        and gross_headroom_seconds >= 10 * 60
+        and gross_headroom_seconds - worst_case_attempt_seconds >= 5 * 60
+    ):
+        errors.append(
+            "docs deploy verify-library-release job must retain one 30-minute polling "
+            "deadline inside its 45-minute timeout, with ten minutes gross and five "
+            "minutes beyond a worst-case bounded network attempt"
+        )
+
+    pypi_supported_policy = re.search(
+        r"all\(\.urls\[\];\s*"
+        r"\.filename\s*\|\s*"
+        r"endswith\(\"\.whl\"\)\s+or\s+endswith\(\"\.tar\.gz\"\)\)",
+        gate_shell,
+    )
+    pypi_all_files_projection = re.search(
+        r"\[\s*\.urls\[\]\s*\|\s*"
+        r"\{name:\s*\.filename,\s*sha256:\s*\.digests\.sha256\}\s*\]\s*"
+        r"\|\s*sort_by\(\.name\)",
+        gate_shell,
+    )
+    if pypi_supported_policy is None or pypi_all_files_projection is None:
+        errors.append(
+            "docs deploy release gate must reject unsupported PyPI filenames and "
+            "compare an unfiltered all-file `.urls[]` filename/digest projection"
+        )
+
+    tag_lookup_tokens = [
+        "timeout",
+        "--signal=TERM",
+        "--kill-after=5s",
+        "30s",
+        "gh",
+        "api",
+        "repos/${REPO}/commits/${VERSION}",
+        "--jq",
+        ".sha",
+    ]
+    release_view_tokens = [
+        "timeout",
+        "--signal=TERM",
+        "--kill-after=5s",
+        "30s",
+        "gh",
+        "release",
+        "view",
+        "$VERSION",
+        "--repo",
+        "$REPO",
+        "--json",
+        "assets,body,isDraft,isPrerelease,name,publishedAt,tagName",
+        "2>/dev/null",
+    ]
+    pypi_fetch_tokens = [
+        "curl",
+        "-fsS",
+        "--connect-timeout",
+        "5",
+        "--max-time",
+        "20",
+        "https://pypi.org/pypi/xy/${PYPI_VERSION}/json",
+        "2>/dev/null",
+    ]
+    release_download_tokens = [
+        "if",
+        "timeout",
+        "--signal=TERM",
+        "--kill-after=5s",
+        "180s",
+        "gh",
+        "release",
+        "download",
+        "$VERSION",
+        "--repo",
+        "$REPO",
+        "--dir",
+        "$verify_dir",
+        "--pattern",
+        "*.whl",
+        "--pattern",
+        "*.tar.gz",
+        "--pattern",
+        "$PROVENANCE_NAME",
+        ";",
+        "then",
+    ]
+    attestation_tokens = [
+        "timeout",
+        "--signal=TERM",
+        "--kill-after=5s",
+        "60s",
+        "gh",
+        "attestation",
+        "verify",
+        "$provenance_file",
+        "--repo",
+        "$REPO",
+        "--signer-workflow",
+        "${REPO}/.github/workflows/release.yml",
+        "--source-ref",
+        "refs/tags/${VERSION}",
+        "--source-digest",
+        "$SOURCE_SHA",
+        "--deny-self-hosted-runners",
+        ">/dev/null",
+        "&&",
+    ]
+    network_positions = {
+        "tag": [position for position, _, tokens in command_records if tokens == tag_lookup_tokens],
+        "view": [
+            position for position, _, tokens in command_records if tokens == release_view_tokens
+        ],
+        "pypi": [
+            position for position, _, tokens in command_records if tokens == pypi_fetch_tokens
+        ],
+        "download": [
+            position for position, _, tokens in command_records if tokens == release_download_tokens
+        ],
+        "attest": [
+            position for position, _, tokens in command_records if tokens == attestation_tokens
+        ],
+    }
+    pypi_fetch_position = (
+        network_positions["pypi"][0] if len(network_positions["pypi"]) == 1 else -1
+    )
+    pypi_flow_is_direct = (
+        _assignment_lines(logical_lines, "pypi_json") == ['if pypi_json="$(']
+        and _assignment_lines(logical_lines, "pypi_hashes_json") == ['pypi_hashes_json="$(']
+        and _logical_line_is(
+            logical_lines,
+            pypi_fetch_position - 1,
+            'if pypi_json="$(',
+        )
+        and _logical_line_is(logical_lines, pypi_fetch_position + 1, ')"; then')
+    )
+    tag_lookup_position = network_positions["tag"][0] if len(network_positions["tag"]) == 1 else -1
+    tag_function_is_exact = (
+        _has_exact_docs_tag_source_function(
+            logical_lines,
+            tag_lookup_position,
+        )
+        and _shell_function_definition_count(gate_shell, "verify_tag_source") == 1
+    )
+    tag_verification_positions = [
+        position for position, line in enumerate(logical_lines) if line == "verify_tag_source; then"
+    ]
+    tag_verification_position = (
+        tag_verification_positions[0] if len(tag_verification_positions) == 1 else -1
+    )
+    tag_state_is_fresh = (
+        _assignment_lines(logical_lines, "TAG_MATCH") == ["TAG_MATCH=false", "TAG_MATCH=true"]
+        and _logical_line_is(
+            logical_lines,
+            tag_verification_position - 4,
+            'if [[ "$RELEASED" == true &&',
+        )
+        and _logical_line_is(
+            logical_lines,
+            tag_verification_position - 3,
+            '"$PUBLISHED" == true &&',
+        )
+        and _logical_line_is(
+            logical_lines,
+            tag_verification_position - 2,
+            '"$PROVENANCE_VALID" == true &&',
+        )
+        and _logical_line_is(
+            logical_lines,
+            tag_verification_position - 1,
+            '"$ASSETS_MATCH" == true ]] &&',
+        )
+        and _logical_line_is(
+            logical_lines,
+            tag_verification_position + 1,
+            "TAG_MATCH=true",
+        )
+        and _logical_line_is(logical_lines, tag_verification_position + 2, "fi")
+    )
+    readiness_success_block = [
+        'if [[ "$RELEASED" == true &&',
+        '"$PUBLISHED" == true &&',
+        '"$PROVENANCE_VALID" == true &&',
+        '"$ASSETS_MATCH" == true &&',
+        '"$TAG_MATCH" == true ]]; then',
+        'echo "::notice::${VERSION} has signed release provenance and '
+        'byte-identical, non-yanked GitHub/PyPI distributions"',
+        "exit 0",
+        "fi",
+    ]
+    readiness_success_positions = [
+        position
+        for position in range(len(logical_lines) - len(readiness_success_block) + 1)
+        if logical_lines[position : position + len(readiness_success_block)]
+        == readiness_success_block
+    ]
+    readiness_success_is_exact = len(
+        readiness_success_positions
+    ) == 1 and _shell_maybe_successful_terminations(logical_lines) == [
+        (readiness_success_positions[0] + 6, 0, "exit", "0")
+    ]
+    if not readiness_success_is_exact:
+        errors.append(
+            "docs deploy release gate must have exactly one readiness-bound "
+            "`exit 0` and no other potentially successful termination commands"
+        )
+    readiness_assignments_are_exact = all(
+        _assignment_lines(logical_lines, name) == [f"{name}=false", f"{name}=true"]
+        for name in (
+            "RELEASED",
+            "PUBLISHED",
+            "PROVENANCE_VALID",
+            "ASSETS_MATCH",
+            "TAG_MATCH",
+        )
+    )
+    network_calls_are_bounded = all(
+        len(network_positions[name]) == 1 for name in ("tag", "view", "pypi", "download", "attest")
+    )
+    if not (
+        pypi_flow_is_direct
+        and tag_function_is_exact
+        and tag_state_is_fresh
+        and readiness_success_is_exact
+        and readiness_assignments_are_exact
+        and network_calls_are_bounded
+    ):
+        errors.append(
+            "docs deploy release gate must bind one unfiltered bounded PyPI response, "
+            "use exact timeout-bounded release/tag/attestation calls, and derive every "
+            "fresh readiness flag only through its protected control flow"
+        )
+
+    early_deadline_position = gate_shell.find("if (( SECONDS >= POLL_DEADLINE )); then")
+    release_poll_position = gate_shell.find('gh release view "$VERSION"')
+    final_attempt_position = gate_shell.find("if (( attempt == MAX_ATTEMPTS )); then")
+    remaining_position = gate_shell.find("remaining_seconds=$((POLL_DEADLINE - SECONDS))")
+    exhausted_deadline_position = gate_shell.find("if (( remaining_seconds <= 0 )); then")
+    bounded_sleep_position = gate_shell.find('sleep "$sleep_seconds"')
+    final_error_position = gate_shell.find('echo "::error::${VERSION} did not become release-ready')
+    early_deadline_guard = re.search(
+        r"if \(\( SECONDS >= POLL_DEADLINE \)\); then\s*"
+        r'echo "::warning::release-readiness polling deadline reached '
+        r'before attempt \$\{attempt\}"\s*'
+        r"break\s*fi",
+        gate_shell,
+    )
+    final_attempt_guard = re.search(
+        r"if \(\( attempt == MAX_ATTEMPTS \)\); then\s*"
+        r'echo "\$\{status\}; no retries remain"\s*'
+        r"break\s*fi",
+        gate_shell,
+    )
+    exhausted_deadline_guard = re.search(
+        r"if \(\( remaining_seconds <= 0 \)\); then\s*"
+        r'echo "\$\{status\}; polling deadline reached"\s*'
+        r"break\s*fi",
+        gate_shell,
+    )
+    sleep_lines = [
+        line for line in logical_lines if re.search(r"(?<![A-Za-z0-9_])sleep(?![A-Za-z0-9_])", line)
+    ]
+    final_error = (
+        'echo "::error::${VERSION} did not become release-ready (current tag source, '
+        "metadata, signed notes provenance, non-yanked PyPI files, or exact asset hashes "
+        'missing/mismatched) — refusing to promote prod"'
+    )
+    if not (
+        0
+        <= early_deadline_position
+        < release_poll_position
+        < final_attempt_position
+        < remaining_position
+        < exhausted_deadline_position
+        < bounded_sleep_position
+        < final_error_position
+        and early_deadline_guard is not None
+        and final_attempt_guard is not None
+        and exhausted_deadline_guard is not None
+        and sleep_lines == ['sleep "$sleep_seconds"']
+        and logical_lines[-3:] == ["done", final_error, "exit 1"]
+    ):
+        errors.append(
+            "docs deploy release gate must use a deadline-aware retry loop, "
+            "break before its only bounded sleep after the final attempt, and end "
+            "immediately with the final diagnostic"
         )
     return errors
 

--- a/scripts/verify_sdist.py
+++ b/scripts/verify_sdist.py
@@ -12,12 +12,14 @@ before installing anything.
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import re
 import sys
 import tarfile
+import tempfile
 from email.parser import Parser
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Optional
 
 REQUIRED_FILES = {
@@ -257,6 +259,37 @@ def _require_file_contains(path: str, root: str, member: str, needles: set[str])
         raise AssertionError(f"{member} missing expected markers: {missing}")
 
 
+def _require_valid_docs_deploy_workflow(path: str, root: str) -> None:
+    """Structurally validate the archived production-release gate.
+
+    Raw substring checks accept commented-out jobs and shell commands. Load the
+    trusted verifier beside this script and run it against the workflow bytes
+    from the archive instead.
+    """
+    member = ".github/workflows/deploy-docs-stg.yml"
+    with tarfile.open(path, "r:gz") as tf:
+        data = tf.extractfile(f"{root}/{member}")
+        if data is None:
+            raise AssertionError(f"{member} is missing")
+        workflow = data.read().decode("utf-8")
+    if len(workflow) < 1000:
+        raise AssertionError(f"{member} is suspiciously small")
+
+    verifier_path = Path(__file__).with_name("verify_ci_workflow.py")
+    spec = importlib.util.spec_from_file_location("_xy_sdist_ci_verifier", verifier_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"cannot load workflow verifier from {verifier_path}")
+    verifier = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(verifier)
+
+    with tempfile.TemporaryDirectory(prefix="xy-sdist-workflow-") as temp_dir:
+        archived_path = Path(temp_dir) / "deploy-docs-stg.yml"
+        archived_path.write_text(workflow, encoding="utf-8")
+        errors = verifier.validate_docs_deploy_workflow(archived_path)
+    if errors:
+        raise AssertionError(f"{member} fails structural release-gate validation: {errors}")
+
+
 def _require_exact_file(path: str, root: str, member: str, expected: bytes) -> None:
     with tarfile.open(path, "r:gz") as tf:
         data = tf.extractfile(f"{root}/{member}")
@@ -412,18 +445,7 @@ def verify_sdist(path: str) -> None:
         ".github/workflows/codspeed.yml",
         {"CodSpeedHQ/action@", "pytest-codspeed", 'k.BACKEND == "native"'},
     )
-    _require_file_contains(
-        path,
-        root,
-        ".github/workflows/deploy-docs-stg.yml",
-        {
-            "verify-library-release",
-            "--json assets,body,isDraft,isPrerelease,name,publishedAt,tagName",
-            "xy-release-workflow:",
-            "pypi.org/pypi/xy/",
-            "verify-library-release]",
-        },
-    )
+    _require_valid_docs_deploy_workflow(path, root)
     _require_file_contains(
         path,
         root,

--- a/scripts/verify_sdist.py
+++ b/scripts/verify_sdist.py
@@ -280,12 +280,23 @@ def _require_valid_docs_deploy_workflow(path: str, root: str) -> None:
     if spec is None or spec.loader is None:
         raise AssertionError(f"cannot load workflow verifier from {verifier_path}")
     verifier = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(verifier)
+    had_previous = spec.name in sys.modules
+    previous = sys.modules.get(spec.name)
+    sys.modules[spec.name] = verifier
+    try:
+        spec.loader.exec_module(verifier)
+        with tempfile.TemporaryDirectory(prefix="xy-sdist-workflow-") as temp_dir:
+            archived_path = Path(temp_dir) / "deploy-docs-stg.yml"
+            archived_path.write_text(workflow, encoding="utf-8")
+            errors = verifier.validate_docs_deploy_workflow(archived_path)
+    finally:
+        if had_previous:
+            # Preserve an existing import rather than leaking this one-off
+            # archive validator into global interpreter state.
+            sys.modules[spec.name] = previous  # type: ignore[assignment]
+        else:
+            sys.modules.pop(spec.name, None)
 
-    with tempfile.TemporaryDirectory(prefix="xy-sdist-workflow-") as temp_dir:
-        archived_path = Path(temp_dir) / "deploy-docs-stg.yml"
-        archived_path.write_text(workflow, encoding="utf-8")
-        errors = verifier.validate_docs_deploy_workflow(archived_path)
     if errors:
         raise AssertionError(f"{member} fails structural release-gate validation: {errors}")
 

--- a/scripts/verify_sdist.py
+++ b/scripts/verify_sdist.py
@@ -23,6 +23,7 @@ from typing import Optional
 REQUIRED_FILES = {
     ".github/workflows/ci.yml",
     ".github/workflows/codspeed.yml",
+    ".github/workflows/deploy-docs-stg.yml",
     ".github/workflows/release.yml",
     ".github/workflows/release-reflex-xy.yml",
     "CHANGELOG.md",
@@ -410,6 +411,18 @@ def verify_sdist(path: str) -> None:
         root,
         ".github/workflows/codspeed.yml",
         {"CodSpeedHQ/action@", "pytest-codspeed", 'k.BACKEND == "native"'},
+    )
+    _require_file_contains(
+        path,
+        root,
+        ".github/workflows/deploy-docs-stg.yml",
+        {
+            "verify-library-release",
+            "--json assets,body,isDraft,isPrerelease,name,publishedAt,tagName",
+            "xy-release-workflow:",
+            "pypi.org/pypi/xy/",
+            "verify-library-release]",
+        },
     )
     _require_file_contains(
         path,

--- a/spec/process/production-readiness.md
+++ b/spec/process/production-readiness.md
@@ -400,11 +400,25 @@ Before tagging a release:
   publishing succeeded. `release.yml` downloads the same verified wheel and
   sdist batch into a least-privilege `contents: write` job, attaches every
   distribution with generated notes, and marks canonical alpha, beta, and
-  release-candidate tags as prereleases. The job is retry-safe: an existing
-  release has its assets refreshed with `--clobber`, while every
-  `workflow_dispatch` run (including `dry_run=false`) skips GitHub Release
-  creation. The production docs workflow polls for both this release and the
-  matching PyPI version before promotion.
+  release-candidate tags as prereleases. It also publishes a signed
+  `xy-release-provenance.json` manifest whose attestation is bound to
+  `release.yml`, the release tag, and the exact source commit. The manifest
+  binds the generated release-note body by SHA-256, and a hidden footer in the
+  release body binds those notes back to the exact manifest. The workflow
+  re-resolves the tag to the triggering commit before PyPI publication, before
+  attestation, at every GitHub Release mutation/success boundary, and again
+  after production approval; network probes are time-bounded so the release
+  gates fail closed instead of hanging past their diagnostic deadline. The job
+  is retry-safe: an existing mutable release has its assets refreshed with
+  `--clobber`, while an immutable release is re-verified as-is against its
+  signed manifest and PyPI bytes instead of requiring a later rebuild to be
+  archive-byte-identical. Every `workflow_dispatch` run (including
+  `dry_run=false`) skips GitHub Release creation. Before production promotion,
+  the docs workflow verifies that
+  signed provenance and note binding, rejects yanked or unsupported PyPI
+  uploads, and requires the exact distribution filename set and SHA-256
+  digests to agree across the downloaded GitHub Release assets, manifest, and
+  PyPI metadata.
 
 ### reflex-xy releases
 

--- a/spec/process/production-readiness.md
+++ b/spec/process/production-readiness.md
@@ -357,8 +357,8 @@ Before tagging a release:
 - Run `make check-full` locally or confirm the equivalent
   CI gates passed on the release commit.
 - Run `make check-ci` to confirm CI and release workflow
-  gates still include artifact verification, upload/download, and trusted PyPI
-  publishing.
+  gates still include artifact verification, upload/download, trusted PyPI
+  publishing, and tag-only GitHub Release creation.
 - Before the first release after a change to the wheel matrix (new target,
   cross-compile toolchain, or tagging scheme), manually run the release
   workflow (`workflow_dispatch`, `dry_run` defaults to `true`) and confirm
@@ -396,6 +396,16 @@ Before tagging a release:
   are sdist-only.
 - Confirm the wheel size budget is still below 15 MB.
 - Confirm `spec/api/api-examples.md` runs against the tagged API.
+- Confirm the tag run created a public GitHub Release only after PyPI
+  publishing succeeded. `release.yml` downloads the same verified wheel and
+  sdist batch into a least-privilege `contents: write` job, attaches every
+  distribution with generated notes, and marks canonical alpha, beta, and
+  release-candidate tags as prereleases. The job is retry-safe: an existing
+  release has its assets refreshed with `--clobber`, while every
+  `workflow_dispatch` run (including `dry_run=false`) skips GitHub Release
+  creation. The production docs workflow polls for both this release and the
+  matching PyPI version before promotion.
+
 ### reflex-xy releases
 
 The adapter is a pure-Python distribution — no native core, no JS build, no

--- a/spec/process/production-readiness.md
+++ b/spec/process/production-readiness.md
@@ -414,11 +414,10 @@ Before tagging a release:
   signed manifest and PyPI bytes instead of requiring a later rebuild to be
   archive-byte-identical. Every `workflow_dispatch` run (including
   `dry_run=false`) skips GitHub Release creation. Before production promotion,
-  the docs workflow verifies that
-  signed provenance and note binding, rejects yanked or unsupported PyPI
-  uploads, and requires the exact distribution filename set and SHA-256
-  digests to agree across the downloaded GitHub Release assets, manifest, and
-  PyPI metadata.
+  the docs workflow verifies signed provenance and note binding, rejects
+  yanked or unsupported PyPI uploads, and requires the exact distribution
+  filename set and SHA-256 digests to agree across the downloaded GitHub
+  Release assets, manifest, and PyPI metadata.
 
 ### reflex-xy releases
 

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -790,6 +790,56 @@ def test_release_workflow_rejects_unsafe_github_release_job(tmp_path: Path) -> N
     )
 
 
+def test_release_workflow_rejects_missing_github_release_artifact_guard(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    guard = """\
+          shopt -s nullglob
+          artifacts=(dist/*.whl dist/*.tar.gz)
+          if (( ${#artifacts[@]} == 0 )); then
+            echo "::error::No wheel or sdist artifacts were downloaded"
+            exit 1
+          fi
+
+"""
+    path = tmp_path / "release.yml"
+    path.write_text(workflow.replace(guard, ""), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any(
+        "github-release job" in error
+        and "shopt -s nullglob" in error
+        and "artifacts=(dist/*.whl dist/*.tar.gz)" in error
+        and "No wheel or sdist artifacts were downloaded" in error
+        for error in errors
+    )
+
+
+def test_release_workflow_rejects_unvalidated_existing_github_release(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace("--json isDraft,isPrerelease,name", "--json name")
+        .replace('              gh release edit "$TAG" \\\n', '              echo "$TAG" \\\n')
+        .replace("                --draft=false \\\n", ""),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any(
+        "github-release job" in error
+        and "--json isDraft,isPrerelease,name" in error
+        and "gh release edit" in error
+        and "--draft=false" in error
+        for error in errors
+    )
+
+
 def test_release_workflow_rejects_shallow_checkout(tmp_path: Path) -> None:
     """A depth-1 checkout fetches no tags, and the version is derived from them.
 

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -58,6 +58,125 @@ def test_named_step_run_stops_before_following_step_metadata() -> None:
     assert verify_ci_workflow._named_step_run(job, "Guard") == 'echo "$VALUE"'
 
 
+@pytest.mark.parametrize("indicator", ["|", "|-", "|+"])
+def test_step_run_accepts_literal_yaml_blocks(indicator: str) -> None:
+    step = f"""\
+      - name: Guard
+        run: {indicator}
+          first
+          second
+"""
+
+    assert verify_ci_workflow._step_run(step) == "first\nsecond"
+
+
+@pytest.mark.parametrize("indicator", [">", ">-", ">+"])
+def test_step_run_rejects_folded_yaml_blocks(indicator: str) -> None:
+    step = f"""\
+      - name: Guard
+        run: {indicator}
+          first
+          second
+"""
+
+    assert verify_ci_workflow._step_run(step) is None
+
+
+@pytest.mark.parametrize("indicator", [">2-", ">-2", "|2-", "|-2"])
+def test_step_run_rejects_explicit_indentation_blocks(indicator: str) -> None:
+    step = f"""\
+      - name: Guard
+        run: {indicator}
+          first
+          second
+"""
+
+    assert verify_ci_workflow._step_run(step) is None
+
+
+@pytest.mark.parametrize(
+    "shell",
+    [
+        "eval 'exit 0'",
+        "command eval 'exit 0'",
+        "source hidden.sh",
+        ". hidden.sh",
+        "bash -c 'exit 0'",
+        "env bash hidden.sh",
+        "env -u UNUSED eval 'exit 0'",
+        "timeout 5s bash -c 'exit 0'",
+        "printf '%s\\n' true | xargs bash -c",
+        "find . -exec bash -c 'exit 0' \\;",
+        "trap 'exit 0' EXIT",
+        '$DYNAMIC_COMMAND "exit 0"',
+        "[[ x == x ]] && $DYNAMIC_COMMAND -c 'exit 0'",
+        'VALUE=1 $DYNAMIC_COMMAND "exit 0"',
+        "function exit { :; }",
+        "gh() { :; }",
+    ],
+)
+def test_indirect_shell_execution_is_detected(shell: str) -> None:
+    assert verify_ci_workflow._has_indirect_shell_execution(shell)
+
+
+@pytest.mark.parametrize("kind", ["eval", "source", "dot", "bash"])
+def test_indirect_shell_commands_execute_hidden_code(
+    tmp_path: Path,
+    kind: str,
+) -> None:
+    marker = tmp_path / "hidden"
+    hidden = tmp_path / "hidden.sh"
+    hidden.write_text(f'printf hidden > "{marker}"\nexit 0\n', encoding="utf-8")
+    commands = {
+        "eval": f"eval 'printf hidden > \"{marker}\"; exit 0'",
+        "source": f'source "{hidden}"',
+        "dot": f'. "{hidden}"',
+        "bash": f"bash -c 'printf hidden > \"{marker}\"'",
+    }
+
+    result = subprocess.run(
+        ["bash", "-c", f'{commands[kind]}\ntest -s "{marker}"'],
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert marker.read_text(encoding="utf-8") == "hidden"
+
+
+@pytest.mark.parametrize(
+    "write",
+    [
+        "declare TAG_MATCH=true",
+        "typeset TAG_MATCH=true",
+        "export TAG_MATCH=true",
+        "local TAG_MATCH=true",
+        "readonly TAG_MATCH=true",
+        "printf -v TAG_MATCH %s true",
+        "read TAG_MATCH",
+        "read -a TAG_MATCH",
+        "mapfile -t TAG_MATCH",
+        "mapfile -t TAG_MATCH < file",
+        "readarray TAG_MATCH",
+        "TAG_MATCH[0]=true",
+        "TAG_MATCH+=(true)",
+        "declare -n alias=TAG_MATCH",
+        "(( TAG_MATCH = 1 ))",
+        "target=TAG_MATCH; (( $target = 1 ))",
+        "let TAG_MATCH=1",
+        'target=TAG_MATCH; let "$target=1"',
+        'target=TAG_MATCH; printf -v "$target" %s true',
+        'target=TAG_MATCH; read "$target"',
+        "for TAG_MATCH in false true; do :; done",
+        "select TAG_MATCH in true; do break; done",
+        "{ select TAG_MATCH in true; do break; done; }",
+        "getopts x TAG_MATCH",
+        ': "${TAG_MATCH:=true}"',
+    ],
+)
+def test_assignment_scan_detects_builtin_and_array_writes(write: str) -> None:
+    assert verify_ci_workflow._assignment_lines([write], "TAG_MATCH") == [write]
+
+
 def test_shell_success_termination_scan_models_bash_status_wrapping() -> None:
     logical_lines = [
         "exit 1",
@@ -1163,6 +1282,217 @@ def test_release_workflow_rejects_sibling_release_api_mutation(tmp_path: Path) -
     )
 
 
+@pytest.mark.parametrize(
+    "api_command",
+    [
+        'gh api "repos/${REPO}/releases" -f tag_name="$TAG"',
+        'gh api "repos/${REPO}/releases" -F tag_name="$TAG"',
+        'gh api "repos/${REPO}/releases" --field tag_name="$TAG"',
+        'gh api "repos/${REPO}/releases" --raw-field tag_name="$TAG"',
+        'gh api "repos/${REPO}/releases" --input payload.json',
+        'gh api "repos/${REPO}/releases" --input=payload.json',
+        'gh api --method=DELETE "repos/${REPO}/releases/assets/42"',
+        'gh api -XDELETE "repos/${REPO}/releases/assets/42"',
+        'gh api -X=DELETE "repos/${REPO}/releases/assets/42"',
+        'gh api --method GET --method DELETE "repos/${REPO}/releases/assets/42"',
+        'gh --repo "$REPO" api "repos/${REPO}/releases" -f tag_name="$TAG"',
+        'timeout 5s /usr/bin/gh api "repos/${REPO}/releases" -f tag_name="$TAG"',
+        'nice -n 5 gh api "repos/${REPO}/releases" -f tag_name="$TAG"',
+        'nohup gh api "repos/${REPO}/releases" -f tag_name="$TAG"',
+        'stdbuf -oL gh api "repos/${REPO}/releases" -f tag_name="$TAG"',
+        'gh api "/graphql" -f query=mutation',
+        'gh api "https://api.github.com/graphql" -f query=mutation',
+        'gh api "repos/${REPO}/${RESOURCE}" -f tag_name="$TAG"',
+        'gh release --repo "$REPO" create "$TAG"',
+        'gh --repo "$REPO" release create "$TAG"',
+        'env -u UNUSED gh release create "$TAG"',
+        '/usr/bin/gh release new "$TAG"',
+        'gh release -R "$REPO" delete-asset "$TAG" 42 --yes',
+    ],
+)
+def test_release_workflow_rejects_sibling_mutation_forms(
+    tmp_path: Path,
+    api_command: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "      - name: Create GitHub Release and attach distributions\n"
+    sibling = f"""\
+      - name: Hidden release API write
+        run: {api_command}
+"""
+    path = tmp_path / "release.yml"
+    path.write_text(workflow.replace(marker, sibling + marker, 1), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("every GitHub Release mutation" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "api_command",
+    [
+        'gh api "repos/${REPO}/releases"',
+        'gh api --method GET "repos/${REPO}/releases" -f per_page=1',
+        'gh api --method DELETE --method GET "repos/${REPO}/releases" -f per_page=1',
+        'gh api "repos/${REPO}/releases/generate-notes" -f tag_name="$TAG"',
+        'gh api --method=POST "repos/${REPO}/releases/generate-notes?x=1" -f tag_name="$TAG"',
+        'gh api --method POST "repos/${REPO}/issues" -f body="/repos/${REPO}/releases/1"',
+        'echo gh api "repos/${REPO}/releases" -f tag_name="$TAG"',
+        'gh release view create --repo "$REPO"',
+    ],
+)
+def test_release_api_classifier_ignores_non_mutating_or_non_release_calls(
+    api_command: str,
+) -> None:
+    assert not verify_ci_workflow._has_gh_release_mutation(api_command)
+
+
+def test_release_workflow_rejects_folded_publication_run(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    step = "      - name: Create GitHub Release and attach distributions\n"
+    before, separator, after = workflow.partition(step)
+    assert separator and "        run: |\n" in after
+    path = tmp_path / "release.yml"
+    path.write_text(
+        before + separator + after.replace("        run: |\n", "        run: >\n", 1),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("missing the active release publication shell step" in error for error in errors)
+
+
+def test_release_workflow_rejects_folded_sibling_run(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "      - name: Create GitHub Release and attach distributions\n"
+    sibling = """\
+      - name: Hidden release API write
+        run: >-
+          gh api "repos/${REPO}/releases"
+          -f tag_name="$TAG"
+"""
+    path = tmp_path / "release.yml"
+    path.write_text(workflow.replace(marker, sibling + marker, 1), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("every shell step can be inspected" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "run",
+    [
+        """>2-
+          gh api "repos/${REPO}/releases"
+          -f tag_name="$TAG"
+""",
+        """'gh api "repos/${REPO}/releases" -f tag_name="$TAG"'
+""",
+    ],
+)
+def test_release_workflow_rejects_other_uninspectable_sibling_runs(
+    tmp_path: Path,
+    run: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "      - name: Create GitHub Release and attach distributions\n"
+    sibling = f"""\
+      - name: Hidden release API write
+        run: {run}"""
+    path = tmp_path / "release.yml"
+    path.write_text(workflow.replace(marker, sibling + marker, 1), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("every shell step can be inspected" in error for error in errors)
+
+
+def test_release_workflow_rejects_indirect_sibling_shell(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "      - name: Create GitHub Release and attach distributions\n"
+    sibling = """\
+      - name: Hidden release API write
+        run: bash -c 'gh api "repos/${REPO}/releases" -f tag_name="$TAG"'
+"""
+    path = tmp_path / "release.yml"
+    path.write_text(workflow.replace(marker, sibling + marker, 1), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("hide release behavior" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "indirect_command",
+    [
+        "eval 'exit 0'",
+        "source hidden.sh",
+        ". hidden.sh",
+        "bash -c 'exit 0'",
+        "timeout 5s bash -c 'exit 0'",
+        "printf '%s\\n' true | xargs bash -c",
+        "trap 'exit 0' EXIT",
+        '$DYNAMIC_COMMAND "exit 0"',
+        "[[ x == x ]] && $DYNAMIC_COMMAND -c 'exit 0'",
+    ],
+)
+def test_release_workflow_rejects_indirect_publication_shell(
+    tmp_path: Path,
+    indirect_command: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "          prerelease=()\n"
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(marker, f"          {indirect_command}\n{marker}", 1),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any(
+        "publication step must not use indirect shell execution" in error for error in errors
+    )
+
+
+@pytest.mark.parametrize(
+    "builtin_write",
+    [
+        "declare is_immutable=true",
+        "export is_immutable=true",
+        "printf -v is_immutable %s true",
+        "read is_immutable <<< true",
+        "mapfile is_immutable",
+        "mapfile -t is_immutable < file",
+        "(( is_immutable = 1 ))",
+        'target=is_immutable; printf -v "$target" %s true',
+        'target=is_immutable; read "$target" <<< true',
+        "target=is_immutable; (( $target = 1 ))",
+        "for is_immutable in true; do :; done",
+        "select is_immutable in true; do break; done <<< 1",
+        "{ select is_immutable in true; do break; done; } <<< 1",
+        "getopts x is_immutable",
+        ': "${is_immutable:=true}"',
+    ],
+)
+def test_release_workflow_rejects_builtin_security_state_writes(
+    tmp_path: Path,
+    builtin_write: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "          is_immutable=false\n"
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(marker, marker + f"          {builtin_write}\n", 1),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("exact non-yanked all-file PyPI gate" in error for error in errors)
+
+
 def test_release_workflow_rejects_forced_immutable_pypi_bypass(tmp_path: Path) -> None:
     workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
     marker = "          # PyPI filenames are immutable."
@@ -1594,6 +1924,94 @@ def test_release_workflow_rejects_non_failing_empty_notes_guard(
 
 def test_docs_deploy_workflow_accepts_release_contract() -> None:
     assert verify_ci_workflow.validate_docs_deploy_workflow() == []
+
+
+def test_docs_deploy_rejects_folded_release_gate_run(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    step = "      - name: Await GitHub Release and PyPI availability\n"
+    before, separator, after = workflow.partition(step)
+    assert separator and "        run: |\n" in after
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(
+        before + separator + after.replace("        run: |\n", "        run: >-\n", 1),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("missing its active polling shell step" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "indirect_command",
+    [
+        "eval 'exit 0'",
+        "source hidden.sh",
+        ". hidden.sh",
+        "bash -c 'exit 0'",
+        "timeout 5s bash -c 'exit 0'",
+        "printf '%s\\n' true | xargs bash -c",
+        "trap 'exit 0' EXIT",
+        '$DYNAMIC_COMMAND "exit 0"',
+        "[[ x == x ]] && $DYNAMIC_COMMAND -c 'exit 0'",
+    ],
+)
+def test_docs_deploy_rejects_indirect_release_gate_shell(
+    tmp_path: Path,
+    indirect_command: str,
+) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    marker = "          EXPECTED_PRERELEASE=false\n"
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(
+        workflow.replace(marker, f"          {indirect_command}\n{marker}", 1),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("release gate must not use indirect shell execution" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "builtin_write",
+    [
+        "declare TAG_MATCH=true",
+        "typeset TAG_MATCH=true",
+        "export TAG_MATCH=true",
+        "readonly TAG_MATCH=true",
+        "printf -v TAG_MATCH %s true",
+        "read TAG_MATCH <<< true",
+        "read -a TAG_MATCH <<< true",
+        "mapfile TAG_MATCH",
+        "mapfile -t TAG_MATCH < file",
+        "TAG_MATCH[0]=true",
+        "(( TAG_MATCH = 1 ))",
+        "target=TAG_MATCH; (( $target = 1 ))",
+        'target=TAG_MATCH; printf -v "$target" %s true',
+        'target=TAG_MATCH; read "$target" <<< true',
+        "for TAG_MATCH in true; do :; done",
+        "select TAG_MATCH in true; do break; done <<< 1",
+        "{ select TAG_MATCH in true; do break; done; } <<< 1",
+        "getopts x TAG_MATCH",
+        ': "${TAG_MATCH:=true}"',
+    ],
+)
+def test_docs_deploy_rejects_builtin_readiness_state_writes(
+    tmp_path: Path,
+    builtin_write: str,
+) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    marker = "            TAG_MATCH=false\n"
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(
+        workflow.replace(marker, marker + f"            {builtin_write}\n", 1),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("fresh readiness flag" in error for error in errors)
 
 
 def test_docs_deploy_rejects_existence_only_release_gate(tmp_path: Path) -> None:

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import hashlib
 import importlib.util
+import json
 import os
 import re
 import shutil
@@ -1138,10 +1140,15 @@ def test_release_workflow_reconciles_stale_assets_before_publishing(
 ) -> None:
     workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
     job = verify_ci_workflow._job_blocks(workflow)["github-release"]
+    prepare_shell = verify_ci_workflow._named_step_run(
+        job,
+        "Prepare release provenance",
+    )
     release_shell = verify_ci_workflow._named_step_run(
         job,
         "Create GitHub Release and attach distributions",
     )
+    assert prepare_shell is not None
     assert release_shell is not None
 
     fake_bin = tmp_path / "bin"
@@ -1149,26 +1156,100 @@ def test_release_workflow_reconciles_stale_assets_before_publishing(
     fake_gh = fake_bin / "gh"
     fake_gh.write_text(
         r"""#!/usr/bin/env bash
-set -eu
+set -euo pipefail
 printf '%s\n' "$*" >> "$GH_LOG"
 state="$(<"$GH_STATE")"
 if [[ "$1" == "api" && "$*" == *"/generate-notes"* ]]; then
   printf '## Changes\n\n- Generated\n'
 elif [[ "$1" == "api" && "$*" == *"/releases/assets/"* ]]; then
+  [[ "$state" == "uploaded" ]]
   [[ "$*" == *"/releases/assets/9003"* ]]
   printf 'deleted' > "$GH_STATE"
 elif [[ "$1" == "release" && "$2" == "upload" ]]; then
   [[ "$state" == "initial" ]]
+  for candidate in "$@"; do
+    case "$candidate" in
+      dist/*.whl|dist/*.tar.gz|*/xy-release-provenance.json)
+        cp "$candidate" "$GH_REMOTE/"
+        ;;
+    esac
+  done
+  [[ -s "$GH_REMOTE/xy-1.2.3-py3-none-any.whl" ]]
+  [[ -s "$GH_REMOTE/xy-1.2.3.tar.gz" ]]
+  [[ -s "$GH_REMOTE/xy-release-provenance.json" ]]
   printf 'uploaded' > "$GH_STATE"
 elif [[ "$1" == "release" && "$2" == "edit" ]]; then
   [[ "$state" == "deleted" ]]
+  notes_file=""
+  while (( $# > 0 )); do
+    if [[ "$1" == "--notes-file" ]]; then
+      shift
+      notes_file="$1"
+      break
+    fi
+    shift
+  done
+  [[ -s "$notes_file" ]]
+  cp "$notes_file" "$GH_NOTES"
   printf 'edited' > "$GH_STATE"
 elif [[ "$1" == "release" && "$2" == "view" ]]; then
   if [[ "$state" == "edited" ]]; then
-    printf '%s\n' '{"assets":[{"name":"xy-1.2.3-py3-none-any.whl","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9001"},{"name":"xy-1.2.3.tar.gz","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9002"},{"name":"checksums.txt","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9004"}],"body":"## Changes\n\n- Generated\n\n<!-- xy-release-workflow:v1.2.3 -->","isDraft":false,"isImmutable":false,"isPrerelease":false,"name":"v1.2.3","publishedAt":"2026-07-31T00:00:00Z","tagName":"v1.2.3"}'
+    body="$(<"$GH_NOTES")"
+    jq -cn --arg body "$body" '{
+      assets: [
+        {
+          name: "xy-1.2.3-py3-none-any.whl",
+          apiUrl: "https://api.github.com/repos/reflex-dev/xy/releases/assets/9001"
+        },
+        {
+          name: "xy-1.2.3.tar.gz",
+          apiUrl: "https://api.github.com/repos/reflex-dev/xy/releases/assets/9002"
+        },
+        {
+          name: "checksums.txt",
+          apiUrl: "https://api.github.com/repos/reflex-dev/xy/releases/assets/9004"
+        },
+        {
+          name: "xy-release-provenance.json",
+          apiUrl: "https://api.github.com/repos/reflex-dev/xy/releases/assets/9005"
+        }
+      ],
+      body: $body,
+      isDraft: false,
+      isImmutable: false,
+      isPrerelease: false,
+      name: "v1.2.3",
+      publishedAt: "2026-07-31T00:00:00Z",
+      tagName: "v1.2.3"
+    }'
+  elif [[ "$state" == "uploaded" ]]; then
+    printf '%s\n' '{"assets":[{"name":"xy-1.2.3-py3-none-any.whl","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9001"},{"name":"xy-1.2.3.tar.gz","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9002"},{"name":"stale.whl","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9003"},{"name":"checksums.txt","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9004"},{"name":"xy-release-provenance.json","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9005"}],"body":"manual","isDraft":true,"isImmutable":false,"isPrerelease":false,"name":"manual","publishedAt":null,"tagName":"v1.2.3"}'
   else
     printf '%s\n' '{"assets":[{"name":"xy-1.2.3-py3-none-any.whl","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9001"},{"name":"xy-1.2.3.tar.gz","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9002"},{"name":"stale.whl","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9003"},{"name":"checksums.txt","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9004"}],"body":"manual","isDraft":true,"isImmutable":false,"isPrerelease":false,"name":"manual","publishedAt":null,"tagName":"v1.2.3"}'
   fi
+elif [[ "$1" == "release" && "$2" == "download" ]]; then
+  [[ "$state" == "edited" ]]
+  download_dir=""
+  while (( $# > 0 )); do
+    if [[ "$1" == "--dir" ]]; then
+      shift
+      download_dir="$1"
+      break
+    fi
+    shift
+  done
+  [[ -n "$download_dir" ]]
+  mkdir -p "$download_dir"
+  cp "$GH_REMOTE/xy-1.2.3-py3-none-any.whl" "$download_dir/"
+  cp "$GH_REMOTE/xy-1.2.3.tar.gz" "$download_dir/"
+  cp "$GH_REMOTE/xy-release-provenance.json" "$download_dir/"
+elif [[ "$1" == "attestation" && "$2" == "verify" ]]; then
+  [[ "$state" == "edited" ]]
+  [[ -s "$3" ]]
+  [[ "$*" == *"--signer-workflow $REPO/.github/workflows/release.yml"* ]]
+  [[ "$*" == *"--source-ref refs/tags/$TAG"* ]]
+  [[ "$*" == *"--source-digest $GITHUB_SHA"* ]]
+  [[ "$*" == *"--deny-self-hosted-runners"* ]]
 else
   printf 'unexpected gh invocation: %s\n' "$*" >&2
   exit 97
@@ -1185,18 +1266,49 @@ fi
     log = tmp_path / "gh.log"
     runner_temp = tmp_path / "runner"
     runner_temp.mkdir()
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    notes = tmp_path / "release-notes.md"
+    source_sha = "0123456789abcdef0123456789abcdef01234567"
     env = {
         **os.environ,
         "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
         "GH_LOG": str(log),
+        "GH_NOTES": str(notes),
+        "GH_REMOTE": str(remote),
         "GH_STATE": str(state),
         "GH_TOKEN": "test",
+        "GITHUB_SHA": source_sha,
         "REPO": "reflex-dev/xy",
         "RUNNER_TEMP": str(runner_temp),
         "TAG": "v1.2.3",
     }
 
-    result = subprocess.run(
+    prepare_result = subprocess.run(
+        ["bash", "-e", "-o", "pipefail", "-c", prepare_shell],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert prepare_result.returncode == 0, f"{prepare_result.stdout}\n{prepare_result.stderr}"
+
+    provenance = runner_temp / "xy-v1.2.3-release-provenance" / "xy-release-provenance.json"
+    prepared_notes = runner_temp / "xy-v1.2.3-release-notes.md"
+    manifest = json.loads(provenance.read_text(encoding="utf-8"))
+    assert manifest["source_sha"] == source_sha
+    assert (
+        manifest["release_notes_sha256"] == hashlib.sha256(b"## Changes\n\n- Generated").hexdigest()
+    )
+    footer = (
+        "<!-- xy-release-provenance:v1:v1.2.3:sha256:"
+        f"{hashlib.sha256(provenance.read_bytes()).hexdigest()} -->"
+    )
+    assert prepared_notes.read_text(encoding="utf-8").endswith(f"\n\n{footer}\n")
+
+    release_result = subprocess.run(
         ["bash", "-e", "-o", "pipefail", "-c", release_shell],
         cwd=tmp_path,
         env=env,
@@ -1206,22 +1318,72 @@ fi
         check=False,
     )
 
-    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+    assert release_result.returncode == 0, f"{release_result.stdout}\n{release_result.stderr}"
     calls = log.read_text(encoding="utf-8")
-    assert "release upload v1.2.3 dist/xy-1.2.3-py3-none-any.whl dist/xy-1.2.3.tar.gz" in calls
+    assert ("release upload v1.2.3 dist/xy-1.2.3-py3-none-any.whl dist/xy-1.2.3.tar.gz") in calls
+    assert str(provenance) in calls
     assert "api --method DELETE repos/reflex-dev/xy/releases/assets/9003" in calls
     assert "releases/assets/9004" not in calls
     assert "release edit v1.2.3" in calls
+    assert "release download v1.2.3" in calls
+    assert "attestation verify" in calls
+    assert notes.read_text(encoding="utf-8").endswith(f"{footer}\n")
     assert state.read_text(encoding="utf-8") == "edited"
 
 
-@pytest.mark.skipif(
-    shutil.which("bash") is None or shutil.which("jq") is None,
-    reason="release workflow runtime simulation requires bash and jq",
-)
-def test_release_workflow_never_mutates_mismatched_immutable_release(
+def _write_signed_release_fixture(
+    remote: Path,
+    *,
+    source_sha: str,
+    notes: str,
+    github_wheel: bytes = b"wheel",
+    manifest_wheel: bytes = b"wheel",
+) -> dict[str, str]:
+    wheel_name = "xy-1.2.3-py3-none-any.whl"
+    sdist_name = "xy-1.2.3.tar.gz"
+    sdist = b"sdist"
+    remote.mkdir()
+    (remote / wheel_name).write_bytes(github_wheel)
+    (remote / sdist_name).write_bytes(sdist)
+    wheel_sha256 = hashlib.sha256(manifest_wheel).hexdigest()
+    sdist_sha256 = hashlib.sha256(sdist).hexdigest()
+    manifest = {
+        "distributions": sorted(
+            [
+                {"name": wheel_name, "sha256": wheel_sha256},
+                {"name": sdist_name, "sha256": sdist_sha256},
+            ],
+            key=lambda distribution: distribution["name"],
+        ),
+        "release_notes_sha256": hashlib.sha256(notes.encode()).hexdigest(),
+        "schema": "xy-release-provenance/v1",
+        "source_sha": source_sha,
+        "tag": "v1.2.3",
+    }
+    provenance = remote / "xy-release-provenance.json"
+    provenance.write_text(
+        json.dumps(manifest, separators=(",", ":"), sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    footer = (
+        "<!-- xy-release-provenance:v1:v1.2.3:sha256:"
+        f"{hashlib.sha256(provenance.read_bytes()).hexdigest()} -->"
+    )
+    return {
+        "body": f"{notes}\n\n{footer}",
+        "footer": footer,
+        "sdist_name": sdist_name,
+        "sdist_sha256": sdist_sha256,
+        "wheel_name": wheel_name,
+        "wheel_sha256": wheel_sha256,
+    }
+
+
+def _run_immutable_release(
     tmp_path: Path,
-) -> None:
+    *,
+    github_wheel: bytes,
+) -> tuple[subprocess.CompletedProcess[str], str, str, str]:
     workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
     release_shell = verify_ci_workflow._named_step_run(
         verify_ci_workflow._job_blocks(workflow)["github-release"],
@@ -1229,17 +1391,70 @@ def test_release_workflow_never_mutates_mismatched_immutable_release(
     )
     assert release_shell is not None
 
+    source_sha = "0123456789abcdef0123456789abcdef01234567"
+    persisted_notes = "## Changes\n\n- Persisted at publication"
+    current_notes = "## Changes\n\n- Generated after publication"
+    remote = tmp_path / "remote"
+    fixture = _write_signed_release_fixture(
+        remote,
+        source_sha=source_sha,
+        notes=persisted_notes,
+        github_wheel=github_wheel,
+    )
+    release_json = tmp_path / "release.json"
+    release_json.write_text(
+        json.dumps(
+            {
+                "assets": [
+                    {"name": fixture["wheel_name"]},
+                    {"name": fixture["sdist_name"]},
+                    {"name": "xy-release-provenance.json"},
+                ],
+                "body": fixture["body"],
+                "isDraft": False,
+                "isImmutable": True,
+                "isPrerelease": False,
+                "name": "v1.2.3",
+                "publishedAt": "2026-07-31T00:00:00Z",
+                "tagName": "v1.2.3",
+            },
+            separators=(",", ":"),
+        ),
+        encoding="utf-8",
+    )
+
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_gh = fake_bin / "gh"
     fake_gh.write_text(
         r"""#!/usr/bin/env bash
-set -eu
+set -euo pipefail
 printf '%s\n' "$*" >> "$GH_LOG"
-if [[ "$1" == "api" && "$*" == *"/generate-notes"* ]]; then
-  printf '## Changes\n\n- Generated\n'
-elif [[ "$1" == "release" && "$2" == "view" ]]; then
-  printf '%s\n' '{"assets":[{"name":"xy-1.2.3-py3-none-any.whl"},{"name":"xy-1.2.3.tar.gz"}],"body":"manual notes","isDraft":false,"isImmutable":true,"isPrerelease":false,"name":"v1.2.3","publishedAt":"2026-07-31T00:00:00Z","tagName":"v1.2.3"}'
+if [[ "$1" == "release" && "$2" == "view" ]]; then
+  cat "$GH_RELEASE_JSON"
+elif [[ "$1" == "release" && "$2" == "download" ]]; then
+  download_dir=""
+  while (( $# > 0 )); do
+    if [[ "$1" == "--dir" ]]; then
+      shift
+      download_dir="$1"
+      break
+    fi
+    shift
+  done
+  [[ -n "$download_dir" ]]
+  mkdir -p "$download_dir"
+  cp "$GH_REMOTE/xy-1.2.3-py3-none-any.whl" "$download_dir/"
+  cp "$GH_REMOTE/xy-1.2.3.tar.gz" "$download_dir/"
+  cp "$GH_REMOTE/xy-release-provenance.json" "$download_dir/"
+elif [[ "$1" == "attestation" && "$2" == "verify" ]]; then
+  [[ -s "$3" ]]
+  [[ "$*" == *"--signer-workflow $REPO/.github/workflows/release.yml"* ]]
+  [[ "$*" == *"--source-ref refs/tags/$TAG"* ]]
+  [[ "$*" == *"--source-digest $GITHUB_SHA"* ]]
+  [[ "$*" == *"--deny-self-hosted-runners"* ]]
+elif [[ "$1" == "api" && "$*" == *"/generate-notes"* ]]; then
+  printf '%s\n' "$CURRENT_NOTES"
 else
   printf 'mutation attempted: %s\n' "$*" >&2
   exit 98
@@ -1249,16 +1464,20 @@ fi
     )
     fake_gh.chmod(0o755)
     (tmp_path / "dist").mkdir()
-    (tmp_path / "dist" / "xy-1.2.3-py3-none-any.whl").write_bytes(b"wheel")
-    (tmp_path / "dist" / "xy-1.2.3.tar.gz").write_bytes(b"sdist")
+    (tmp_path / "dist" / fixture["wheel_name"]).write_bytes(b"wheel")
+    (tmp_path / "dist" / fixture["sdist_name"]).write_bytes(b"sdist")
     log = tmp_path / "gh.log"
     runner_temp = tmp_path / "runner"
     runner_temp.mkdir()
     env = {
         **os.environ,
         "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "CURRENT_NOTES": current_notes,
         "GH_LOG": str(log),
+        "GH_RELEASE_JSON": str(release_json),
+        "GH_REMOTE": str(remote),
         "GH_TOKEN": "test",
+        "GITHUB_SHA": source_sha,
         "REPO": "reflex-dev/xy",
         "RUNNER_TEMP": str(runner_temp),
         "TAG": "v1.2.3",
@@ -1273,10 +1492,27 @@ fi
         timeout=30,
         check=False,
     )
+    return result, log.read_text(encoding="utf-8"), fixture["body"], current_notes
 
-    assert result.returncode == 1
-    assert "immutable but does not match" in result.stdout
-    calls = log.read_text(encoding="utf-8")
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="release workflow runtime simulation requires bash and jq",
+)
+def test_release_workflow_accepts_persisted_signed_immutable_release(
+    tmp_path: Path,
+) -> None:
+    result, calls, persisted_body, current_notes = _run_immutable_release(
+        tmp_path,
+        github_wheel=b"wheel",
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+    assert "is immutable and already matches the verified release" in result.stdout
+    assert current_notes not in persisted_body
+    assert "generate-notes" not in calls
+    assert "release download v1.2.3" in calls
+    assert "attestation verify" in calls
     assert "release upload" not in calls
     assert "release edit" not in calls
     assert "/releases/assets/" not in calls
@@ -1285,11 +1521,33 @@ fi
 
 @pytest.mark.skipif(
     shutil.which("bash") is None or shutil.which("jq") is None,
-    reason="docs promotion runtime simulation requires bash and jq",
+    reason="release workflow runtime simulation requires bash and jq",
 )
-def test_docs_promotion_accepts_only_matching_ready_distribution_set(
+def test_release_workflow_rejects_mismatched_immutable_release_bytes(
     tmp_path: Path,
 ) -> None:
+    result, calls, _, _ = _run_immutable_release(
+        tmp_path,
+        github_wheel=b"altered GitHub wheel",
+    )
+
+    assert result.returncode == 1
+    assert "release bytes do not match the verified build" in result.stdout
+    assert "immutable but does not match" in result.stdout
+    assert "attestation verify" in calls
+    assert "release upload" not in calls
+    assert "release edit" not in calls
+    assert "/releases/assets/" not in calls
+    assert "release create" not in calls
+
+
+def _run_docs_promotion(
+    tmp_path: Path,
+    *,
+    release_notes: str | None = None,
+    github_wheel: bytes = b"wheel",
+    pypi_yanked: bool = False,
+) -> tuple[subprocess.CompletedProcess[str], str, str]:
     workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
     gate_shell = verify_ci_workflow._named_step_run(
         verify_ci_workflow._job_blocks(workflow)["verify-library-release"],
@@ -1297,13 +1555,94 @@ def test_docs_promotion_accepts_only_matching_ready_distribution_set(
     )
     assert gate_shell is not None
 
+    source_sha = "0123456789abcdef0123456789abcdef01234567"
+    signed_notes = "## Changes\n\n- Signed release"
+    remote = tmp_path / "remote"
+    fixture = _write_signed_release_fixture(
+        remote,
+        source_sha=source_sha,
+        notes=signed_notes,
+        github_wheel=github_wheel,
+    )
+    body = fixture["body"]
+    if release_notes is not None:
+        body = f"{release_notes}\n\n{fixture['footer']}"
+    release_json = tmp_path / "release.json"
+    release_json.write_text(
+        json.dumps(
+            {
+                "assets": [
+                    {"name": fixture["wheel_name"]},
+                    {"name": fixture["sdist_name"]},
+                    {"name": "xy-release-provenance.json"},
+                ],
+                "body": body,
+                "isDraft": False,
+                "isPrerelease": False,
+                "name": "v1.2.3",
+                "publishedAt": "2026-07-31T00:00:00Z",
+                "tagName": "v1.2.3",
+            },
+            separators=(",", ":"),
+        ),
+        encoding="utf-8",
+    )
+    pypi_json = tmp_path / "pypi.json"
+    pypi_json.write_text(
+        json.dumps(
+            {
+                "urls": [
+                    {
+                        "digests": {"sha256": fixture["sdist_sha256"]},
+                        "filename": fixture["sdist_name"],
+                        "yanked": False,
+                    },
+                    {
+                        "digests": {"sha256": fixture["wheel_sha256"]},
+                        "filename": fixture["wheel_name"],
+                        "yanked": pypi_yanked,
+                    },
+                ]
+            },
+            separators=(",", ":"),
+        ),
+        encoding="utf-8",
+    )
+
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_gh = fake_bin / "gh"
     fake_gh.write_text(
         r"""#!/usr/bin/env bash
-set -eu
-printf '%s\n' '{"assets":[{"name":"xy-1.2.3-py3-none-any.whl"},{"name":"xy-1.2.3.tar.gz"},{"name":"checksums.txt"}],"body":"## Changes\n\n<!-- xy-release-workflow:v1.2.3 -->","isDraft":false,"isPrerelease":false,"name":"v1.2.3","publishedAt":"2026-07-31T00:00:00Z","tagName":"v1.2.3"}'
+set -euo pipefail
+printf '%s\n' "$*" >> "$GH_LOG"
+if [[ "$1" == "release" && "$2" == "view" ]]; then
+  cat "$GH_RELEASE_JSON"
+elif [[ "$1" == "release" && "$2" == "download" ]]; then
+  download_dir=""
+  while (( $# > 0 )); do
+    if [[ "$1" == "--dir" ]]; then
+      shift
+      download_dir="$1"
+      break
+    fi
+    shift
+  done
+  [[ -n "$download_dir" ]]
+  mkdir -p "$download_dir"
+  cp "$GH_REMOTE/xy-1.2.3-py3-none-any.whl" "$download_dir/"
+  cp "$GH_REMOTE/xy-1.2.3.tar.gz" "$download_dir/"
+  cp "$GH_REMOTE/xy-release-provenance.json" "$download_dir/"
+elif [[ "$1" == "attestation" && "$2" == "verify" ]]; then
+  [[ -s "$3" ]]
+  [[ "$*" == *"--signer-workflow $REPO/.github/workflows/release.yml"* ]]
+  [[ "$*" == *"--source-ref refs/tags/$VERSION"* ]]
+  [[ "$*" == *"--source-digest $SOURCE_SHA"* ]]
+  [[ "$*" == *"--deny-self-hosted-runners"* ]]
+else
+  printf 'unexpected gh invocation: %s\n' "$*" >&2
+  exit 97
+fi
 """,
         encoding="utf-8",
     )
@@ -1311,8 +1650,9 @@ printf '%s\n' '{"assets":[{"name":"xy-1.2.3-py3-none-any.whl"},{"name":"xy-1.2.3
     fake_curl = fake_bin / "curl"
     fake_curl.write_text(
         r"""#!/usr/bin/env bash
-set -eu
-printf '%s\n' '{"urls":[{"filename":"xy-1.2.3.tar.gz"},{"filename":"xy-1.2.3-py3-none-any.whl"}]}'
+set -euo pipefail
+printf '%s\n' "$*" >> "$CURL_LOG"
+cat "$PYPI_JSON"
 """,
         encoding="utf-8",
     )
@@ -1320,11 +1660,22 @@ printf '%s\n' '{"urls":[{"filename":"xy-1.2.3.tar.gz"},{"filename":"xy-1.2.3-py3
     fake_sleep = fake_bin / "sleep"
     fake_sleep.write_text("#!/usr/bin/env bash\nexit 99\n", encoding="utf-8")
     fake_sleep.chmod(0o755)
+    gh_log = tmp_path / "gh.log"
+    curl_log = tmp_path / "curl.log"
+    runner_temp = tmp_path / "runner"
+    runner_temp.mkdir()
     env = {
         **os.environ,
         "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "CURL_LOG": str(curl_log),
+        "GH_LOG": str(gh_log),
+        "GH_RELEASE_JSON": str(release_json),
+        "GH_REMOTE": str(remote),
         "GH_TOKEN": "test",
+        "PYPI_JSON": str(pypi_json),
         "REPO": "reflex-dev/xy",
+        "RUNNER_TEMP": str(runner_temp),
+        "SOURCE_SHA": source_sha,
         "VERSION": "v1.2.3",
     }
 
@@ -1337,9 +1688,72 @@ printf '%s\n' '{"urls":[{"filename":"xy-1.2.3.tar.gz"},{"filename":"xy-1.2.3-py3
         timeout=30,
         check=False,
     )
+    return result, gh_log.read_text(encoding="utf-8"), source_sha
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="docs promotion runtime simulation requires bash and jq",
+)
+def test_docs_promotion_accepts_only_matching_ready_distribution_set(
+    tmp_path: Path,
+) -> None:
+    result, calls, source_sha = _run_docs_promotion(tmp_path)
 
     assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
-    assert "v1.2.3 is on GitHub Releases and PyPI" in result.stdout
+    assert "has signed release provenance and byte-identical" in result.stdout
+    assert "release download v1.2.3" in calls
+    assert "attestation verify" in calls
+    assert f"--source-digest {source_sha}" in calls
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="docs promotion runtime simulation requires bash and jq",
+)
+@pytest.mark.parametrize(
+    ("release_notes", "github_wheel", "pypi_yanked", "expected_state"),
+    [
+        pytest.param(
+            "## Changes\n\n- Altered after signing",
+            b"wheel",
+            False,
+            "provenance=false",
+            id="altered-notes",
+        ),
+        pytest.param(
+            None,
+            b"altered GitHub wheel",
+            False,
+            "provenance=true assets=false",
+            id="altered-github-bytes",
+        ),
+        pytest.param(
+            None,
+            b"wheel",
+            True,
+            "pypi=false provenance=false assets=false",
+            id="yanked-pypi-file",
+        ),
+    ],
+)
+def test_docs_promotion_fails_closed_on_unready_signed_release(
+    tmp_path: Path,
+    release_notes: str | None,
+    github_wheel: bytes,
+    pypi_yanked: bool,
+    expected_state: str,
+) -> None:
+    result, _, _ = _run_docs_promotion(
+        tmp_path,
+        release_notes=release_notes,
+        github_wheel=github_wheel,
+        pypi_yanked=pypi_yanked,
+    )
+
+    assert result.returncode == 99
+    assert expected_state in result.stdout
+    assert "has signed release provenance and byte-identical" not in result.stdout
 
 
 def test_release_workflow_rejects_shallow_checkout(tmp_path: Path) -> None:

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -15,6 +15,7 @@ import pytest
 # must not silently turn these negative tests into no-ops.
 _UPLOAD_ARTIFACT_USES = re.compile(r" *- uses: actions/upload-artifact@\S+.*\n")
 _NODE24_ACTION_PINS = {
+    "actions/attest": "508db95dd578ae2727ebd6217d5ba78e4fbda05d",
     "actions/cache": "55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
     "actions/checkout": "3d3c42e5aac5ba805825da76410c181273ba90b1",
     "actions/download-artifact": "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
@@ -36,6 +37,23 @@ def _load_verify_module():
 
 
 verify_ci_workflow = _load_verify_module()
+
+
+def test_named_step_run_stops_before_following_step_metadata() -> None:
+    job = """\
+  example:
+    steps:
+      - name: Guard
+        env:
+          VALUE: safe
+        run: |
+          echo "$VALUE"
+          # ignored shell comment
+        shell: echo "metadata is not shell"
+        timeout-minutes: 5
+"""
+
+    assert verify_ci_workflow._named_step_run(job, "Guard") == 'echo "$VALUE"'
 
 
 def test_ci_workflow_accepts_current_gates() -> None:
@@ -804,7 +822,7 @@ def test_release_workflow_rejects_unsafe_github_release_job(tmp_path: Path) -> N
     path.write_text(
         workflow.replace("      contents: write\n", "      contents: read\n", 1)
         .replace(" --clobber\n", "\n", 1)
-        .replace("            --verify-tag \\\n", "", 1),
+        .replace(" --verify-tag ", " --no-verify-tag ", 1),
         encoding="utf-8",
     )
 
@@ -914,25 +932,60 @@ def test_release_workflow_rejects_detached_release_artifacts(
     tmp_path: Path,
 ) -> None:
     workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
-    upload = '            gh release upload "$TAG" "${artifacts[@]}" --repo "$REPO" --clobber\n'
-    create = '          gh release create "$TAG" "${artifacts[@]}" \\\n'
+    upload = (
+        '            gh release upload "$TAG" "${artifacts[@]}" "$provenance_file" '
+        '--repo "$REPO" --clobber\n'
+    )
+    create = (
+        '          gh release create "$TAG" "${artifacts[@]}" "$provenance_file" '
+        '--repo "$REPO" --verify-tag --title "$TAG" --notes-file "$notes_file" '
+        '"${prerelease[@]}"\n'
+    )
     assert upload in workflow
     assert create in workflow
     path = tmp_path / "release.yml"
     path.write_text(
         workflow.replace(
             upload,
-            '            gh release upload "$TAG" --repo "$REPO" --clobber\n',
+            '            gh release upload "$TAG" "$provenance_file" '
+            '--repo "$REPO" --clobber\n',
         ).replace(
             create,
-            '          gh release create "$TAG" \\\n',
+            '          gh release create "$TAG" "$provenance_file" '
+            '--repo "$REPO" --verify-tag --title "$TAG" '
+            '--notes-file "$notes_file" "${prerelease[@]}"\n',
         ),
         encoding="utf-8",
     )
 
     errors = verify_ci_workflow.validate_release_workflow(path)
 
-    assert any("pass the verified artifact array directly" in error for error in errors)
+    assert any("pass verified distributions and provenance directly" in error for error in errors)
+
+
+def test_release_workflow_binds_clobber_to_artifact_upload(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    upload = (
+        '            gh release upload "$TAG" "${artifacts[@]}" "$provenance_file" '
+        '--repo "$REPO" --clobber\n'
+    )
+    assert upload in workflow
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(
+            upload,
+            '            gh release upload "$TAG" "${artifacts[@]}" "$provenance_file" '
+            '--repo "$REPO"\n'
+            '            unused_retry_flag="--clobber"\n',
+        ),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("pass verified distributions and provenance directly" in error for error in errors)
 
 
 def test_release_workflow_rejects_missing_stale_asset_reconciliation(
@@ -952,18 +1005,69 @@ def test_release_workflow_rejects_missing_stale_asset_reconciliation(
     )
 
 
-def test_release_workflow_rejects_missing_generated_notes_marker(
+def test_release_workflow_rejects_missing_signed_provenance_footer(
     tmp_path: Path,
 ) -> None:
     workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
-    marker = "<!-- xy-release-workflow:%s -->"
+    marker = "<!-- xy-release-provenance:v1:%s:sha256:%s -->"
     assert marker in workflow
     path = tmp_path / "release.yml"
     path.write_text(workflow.replace(marker, "<!-- marker removed -->"), encoding="utf-8")
 
     errors = verify_ci_workflow.validate_release_workflow(path)
 
-    assert any("generated-notes behavior" in error and marker in error for error in errors)
+    assert any("provenance preparation" in error and marker in error for error in errors)
+
+
+def test_release_workflow_rejects_unattested_provenance(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    action = (
+        "        uses: actions/attest@"
+        "508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1\n"
+    )
+    assert action in workflow
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(action, '        uses: example/untrusted-attest@v1\n'),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("pinned actions/attest" in error for error in errors)
+
+
+def test_release_workflow_rejects_non_failing_empty_notes_guard(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    guard = """\
+          if [[ -z "${generated_notes//[[:space:]]/}" ]]; then
+            echo "::error::GitHub generated empty release notes for ${TAG}"
+            exit 1
+          fi
+"""
+    assert guard in workflow
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(
+            guard,
+            """\
+          if [[ -z "${generated_notes//[[:space:]]/}" ]]; then
+            echo "::error::GitHub generated empty release notes for ${TAG}"
+            true
+          fi
+          unused_empty_notes_exit="exit 1"
+""",
+        ),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("provenance preparation" in error for error in errors)
 
 
 def test_docs_deploy_workflow_accepts_release_contract() -> None:
@@ -984,17 +1088,29 @@ def test_docs_deploy_rejects_existence_only_release_gate(tmp_path: Path) -> None
 
 def test_docs_deploy_rejects_asset_set_check_removal(tmp_path: Path) -> None:
     workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
-    comparison = '                 [[ "$github_assets" == "$pypi_assets" ]]; then\n'
+    comparison = '                     [[ "$github_hashes_json" == "$manifest_hashes_json" &&\n'
     assert comparison in workflow
     path = tmp_path / "deploy-docs-stg.yml"
     path.write_text(
-        workflow.replace(comparison, "                 [[ true == true ]]; then\n"),
+        workflow.replace(comparison, "                     [[ true == true &&\n"),
         encoding="utf-8",
     )
 
     errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
 
-    assert any("wheel/sdist assets" in error for error in errors)
+    assert any("exact asset hashes" in error for error in errors)
+
+
+def test_docs_deploy_rejects_yanked_file_guard_removal(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    guard = "                 all(.urls[]; .yanked == false) and\n"
+    assert guard in workflow
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(workflow.replace(guard, ""), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("non-yanked PyPI files" in error for error in errors)
 
 
 def test_docs_deploy_rejects_bypassed_production_release_gate(

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -58,6 +58,42 @@ def test_named_step_run_stops_before_following_step_metadata() -> None:
     assert verify_ci_workflow._named_step_run(job, "Guard") == 'echo "$VALUE"'
 
 
+def test_shell_success_termination_scan_models_bash_status_wrapping() -> None:
+    logical_lines = [
+        "exit 1",
+        "return -1",
+        "exit 256",
+        "return 512",
+        "exit",
+        'return "$status"',
+        "guard() { return 0; }",
+        "command -- exit 0",
+        "builtin -- return 256",
+        "command -p exit 512",
+        "time exit 0",
+        "time -p return 256",
+        "exec true",
+        "command -- exec true",
+    ]
+
+    records = verify_ci_workflow._shell_maybe_successful_terminations(logical_lines)
+
+    assert [(position, command, status) for position, _, command, status in records] == [
+        (2, "exit", "256"),
+        (3, "return", "512"),
+        (4, "exit", None),
+        (5, "return", "$status"),
+        (6, "return", "0"),
+        (7, "exit", "0"),
+        (8, "return", "256"),
+        (9, "exit", "512"),
+        (10, "exit", "0"),
+        (11, "return", "256"),
+        (12, "exec", "true"),
+        (13, "exec", "true"),
+    ]
+
+
 def test_ci_workflow_accepts_current_gates() -> None:
     assert verify_ci_workflow.validate_workflow() == []
     assert verify_ci_workflow.validate_ci_workflow() == []
@@ -834,6 +870,90 @@ def test_release_workflow_rejects_unsafe_github_release_job(tmp_path: Path) -> N
     assert any("--clobber" in error and "--verify-tag" in error for error in errors)
 
 
+def test_release_workflow_requires_publication_options_as_actual_tokens(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    upload = (
+        '            gh release upload "$TAG" "${artifacts[@]}" "$provenance_file" '
+        '--repo "$REPO" --clobber\n'
+    )
+    create = (
+        '          gh release create "$TAG" "${artifacts[@]}" "$provenance_file" '
+        '--repo "$REPO" --verify-tag --title "$TAG" --notes-file "$notes_file" '
+        '"${prerelease[@]}"\n'
+    )
+    assert upload in workflow
+    assert create in workflow
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(
+            upload,
+            '            gh release upload "$TAG" "${artifacts[@]}" "$provenance_file" '
+            "'--description=--repo \"$REPO\" --clobber'\n",
+        ).replace(
+            create,
+            '          gh release create "$TAG" "${artifacts[@]}" "$provenance_file" '
+            '\'--title=--repo "$REPO" --verify-tag --notes-file "$notes_file"\' '
+            '"${prerelease[@]}"\n',
+        ),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("exact `--repo" in error and "`--verify-tag`" in error for error in errors)
+
+
+def test_release_workflow_rejects_option_terminator_and_ignored_create_failure(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    upload = (
+        '            gh release upload "$TAG" "${artifacts[@]}" "$provenance_file" '
+        '--repo "$REPO" --clobber\n'
+    )
+    create = (
+        '          gh release create "$TAG" "${artifacts[@]}" "$provenance_file" '
+        '--repo "$REPO" --verify-tag --title "$TAG" --notes-file "$notes_file" '
+        '"${prerelease[@]}"\n'
+    )
+    assert upload in workflow
+    assert create in workflow
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(upload, upload.replace(" --repo", " -- --repo")).replace(
+            create,
+            create.rstrip() + " || true\n",
+        ),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any(
+        "one active upload command" in error and "one active create" in error for error in errors
+    )
+
+
+def test_release_workflow_allows_inline_comments_on_protected_step_gates(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    condition = "        if: steps.release_state.outputs.immutable != 'true'\n"
+    assert workflow.count(condition) == 2
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(
+            condition,
+            condition.rstrip() + " # immutable releases are already signed\n",
+        ),
+        encoding="utf-8",
+    )
+
+    assert verify_ci_workflow.validate_release_workflow(path) == []
+
+
 def test_release_workflow_rejects_missing_github_release_artifact_guard(
     tmp_path: Path,
 ) -> None:
@@ -868,16 +988,15 @@ def test_release_workflow_rejects_unvalidated_existing_github_release(
     tmp_path: Path,
 ) -> None:
     workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
-    final_view = """\
-              gh release view "$TAG" \\
-                --repo "$REPO" \\
-                --json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName
-"""
+    final_view = '                gh release view "$TAG" \\\n'
     assert workflow.count(final_view) == 2
     path = tmp_path / "release.yml"
     before, separator, after = workflow.rpartition(final_view)
     assert separator
-    path.write_text(before + '              echo "validation removed"\n' + after, encoding="utf-8")
+    path.write_text(
+        before + '                printf "%s\\n" "validation removed"\n' + after,
+        encoding="utf-8",
+    )
 
     errors = verify_ci_workflow.validate_release_workflow(path)
 
@@ -886,6 +1005,327 @@ def test_release_workflow_rejects_unvalidated_existing_github_release(
         and ("after normalization" in error or "validate again" in error)
         for error in errors
     )
+
+
+def test_release_workflow_rejects_missing_post_create_payload_validation(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    validation = (
+        '             ! verify_release_payload "$release_json" "$expected_hashes_json"; then\n'
+    )
+    before, separator, after = workflow.rpartition(validation)
+    assert separator
+    path = tmp_path / "release.yml"
+    path.write_text(
+        before + "             ! true; then\n" + after,
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("creation must re-read" in error and "signed-payload" in error for error in errors)
+
+
+def test_release_workflow_rejects_disabled_post_create_payload_condition(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    validation = (
+        '             ! verify_release_payload "$release_json" "$expected_hashes_json"; then\n'
+    )
+    before, separator, after = workflow.rpartition(validation)
+    assert separator
+    path = tmp_path / "release.yml"
+    path.write_text(
+        before + '             ! verify_release_payload "$release_json" '
+        '"$expected_hashes_json" && false; then\n' + after,
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("creation must re-read" in error and "signed-payload" in error for error in errors)
+
+
+def test_release_workflow_rejects_missing_tag_source_binding(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    resolution = "                gh api \"repos/${REPO}/commits/${TAG}\" --jq '.sha'\n"
+    assert resolution in workflow
+    before, separator, after = workflow.rpartition(resolution)
+    assert separator
+    path = tmp_path / "release.yml"
+    path.write_text(
+        before + '                printf "%s\\n" "$GITHUB_SHA"\n' + after,
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("timeout-bounded tag guard" in error for error in errors)
+
+
+def test_release_workflow_rejects_overwritten_tag_source_guard(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    guard = '            if [[ "$tag_source_sha" != "$GITHUB_SHA" ]]; then\n'
+    before, separator, after = workflow.rpartition(guard)
+    assert separator
+    path = tmp_path / "release.yml"
+    path.write_text(
+        before + '            tag_source_sha="$GITHUB_SHA"\n' + separator + after,
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("timeout-bounded tag guard" in error for error in errors)
+
+
+def test_release_workflow_rejects_redefined_tag_source_guard(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "          # PyPI filenames are immutable."
+    assert marker in workflow
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(
+            marker,
+            "          verify_tag_source() { return 0; }\n\n" + marker,
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("timeout-bounded tag guard" in error for error in errors)
+
+
+def test_release_workflow_rejects_redefined_preparation_tag_guard(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    boundary = '          verify_tag_source\n\n          pypi_version="${TAG#v}"\n'
+    assert boundary in workflow
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(
+            boundary,
+            "          verify_tag_source\n"
+            "          verify_tag_source() { return 0; }\n\n"
+            '          pypi_version="${TAG#v}"\n',
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("provenance preparation" in error for error in errors)
+
+
+def test_release_workflow_rejects_sibling_release_mutation(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "      - name: Create GitHub Release and attach distributions\n"
+    assert marker in workflow
+    sibling = """\
+      - name: Unverified release upload
+        run: gh release upload "$TAG" dist/*.whl --clobber
+"""
+    path = tmp_path / "release.yml"
+    path.write_text(workflow.replace(marker, sibling + marker, 1), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any(
+        "every GitHub Release mutation" in error and "Unverified release upload" in error
+        for error in errors
+    )
+
+
+def test_release_workflow_rejects_sibling_release_api_mutation(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "      - name: Create GitHub Release and attach distributions\n"
+    assert marker in workflow
+    sibling = """\
+      - name: Unverified release API write
+        run: gh api --method DELETE "repos/${REPO}/releases/assets/42"
+"""
+    path = tmp_path / "release.yml"
+    path.write_text(workflow.replace(marker, sibling + marker, 1), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any(
+        "every GitHub Release mutation" in error and "Unverified release API write" in error
+        for error in errors
+    )
+
+
+def test_release_workflow_rejects_forced_immutable_pypi_bypass(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "          # PyPI filenames are immutable."
+    assert marker in workflow
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(marker, "          is_immutable=true\n\n" + marker, 1),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("exact non-yanked all-file PyPI gate" in error for error in errors)
+
+
+def test_release_workflow_rejects_pre_mutation_pypi_equality_bypass(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    equality = (
+        '                if [[ "$is_immutable" == true || '
+        '"$pypi_hashes_json" == "$expected_hashes_json" ]]; then\n'
+    )
+    assert equality in workflow
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(equality, "                if [[ true == true ]]; then\n"),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("malformed-response-safe exact non-yanked" in error for error in errors)
+
+
+def test_release_workflow_rejects_forced_pypi_match_before_guard(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    guard = '          if [[ "$pypi_matches" != true ]]; then\n'
+    before, separator, after = workflow.rpartition(guard)
+    assert separator
+    path = tmp_path / "release.yml"
+    path.write_text(
+        before + "          pypi_matches=true\n" + separator + after,
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("malformed-response-safe exact non-yanked" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "termination",
+    [
+        "exit 0",
+        "exit",
+        "exit 256",
+        "command -- exit 0",
+        "exec true",
+        "time exit 0",
+    ],
+)
+def test_release_workflow_rejects_early_success_after_pypi_gate(
+    tmp_path: Path,
+    termination: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "          prerelease=()\n"
+    assert workflow.count(marker) == 1
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(marker, f"          {termination}\n{marker}", 1),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("two exact tag-guarded `exit 0` sites" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "termination",
+    ["return 0", "return", "builtin -- return 0"],
+)
+def test_release_workflow_rejects_payload_helper_early_success(
+    tmp_path: Path,
+    termination: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "          verify_release_payload() {\n"
+    assert workflow.count(marker) == 1
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(marker, f"{marker}            {termination}\n", 1),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("no additional potentially successful termination" in error for error in errors)
+
+
+@pytest.mark.parametrize("termination", ["return 0", "return"])
+def test_release_workflow_rejects_metadata_helper_early_success(
+    tmp_path: Path,
+    termination: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "          release_metadata_matches() {\n"
+    assert workflow.count(marker) == 1
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(marker, f"{marker}            {termination}\n", 1),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("no additional potentially successful termination" in error for error in errors)
+
+
+@pytest.mark.parametrize("termination", ["exit 0", "exit"])
+def test_release_workflow_rejects_immutable_branch_early_success(
+    tmp_path: Path,
+    termination: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = '            if [[ "$is_immutable" == "true" ]]; then\n'
+    assert workflow.count(marker) == 1
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(marker, f"{marker}              {termination}\n", 1),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("two exact tag-guarded `exit 0` sites" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "early_write",
+    [
+        '          gh api --method POST "repos/${REPO}/releases" -f tag_name="$TAG"\n',
+        '          gh release delete "$TAG" --repo "$REPO" --yes\n',
+    ],
+)
+def test_release_workflow_rejects_unclassified_pre_pypi_release_write(
+    tmp_path: Path,
+    early_write: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "          # PyPI filenames are immutable."
+    assert marker in workflow
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(marker, early_write + marker, 1),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("reject pre-gate API writes" in error for error in errors)
 
 
 def test_release_workflow_rejects_extra_github_release_write_scope(
@@ -907,6 +1347,90 @@ def test_release_workflow_rejects_extra_github_release_write_scope(
     errors = verify_ci_workflow.validate_release_workflow(path)
 
     assert any("permissions must be exactly" in error and "issues" in error for error in errors)
+
+
+def test_release_publish_requires_read_permission_and_tag_step(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    permission = (
+        "      contents: read\n"
+        "      id-token: write # PyPI trusted publishing (OIDC) — no API token stored\n"
+    )
+    step_name = "      - name: Verify release tag source before PyPI\n"
+    assert permission in workflow
+    assert step_name in workflow
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(
+            permission, permission.replace("contents: read", "contents: write")
+        ).replace(step_name, "      - name: Publish without tag verification\n"),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("publish job permissions must be exactly" in error for error in errors)
+    assert any("verify the current tag source before PyPI" in error for error in errors)
+
+
+def test_release_pre_attestation_gate_requires_final_tag_recheck(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    boundary = "          verify_tag_source\n\n      - name: Attest release provenance\n"
+    assert boundary in workflow
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(boundary, "\n      - name: Attest release provenance\n"),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("fresh final tag guard before attesting" in error for error in errors)
+
+
+def test_release_pypi_gate_retries_malformed_json_projection(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    guarded_projection = '              if pypi_hashes_json="$(\n'
+    before, separator, after = workflow.rpartition(guarded_projection)
+    assert separator
+    path = tmp_path / "release.yml"
+    path.write_text(
+        before + '              pypi_hashes_json="$(\n' + after,
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("malformed-response-safe exact non-yanked" in error for error in errors)
+
+
+def test_release_mutations_and_probes_require_adjacent_guards_and_timeouts(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    guarded_delete = """\
+                verify_tag_source
+                gh api \\
+                  --method DELETE \\
+"""
+    bounded_download = "            if ! timeout --signal=TERM --kill-after=5s 180s \\\n"
+    assert guarded_delete in workflow
+    assert bounded_download in workflow
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(
+            guarded_delete,
+            """\
+                gh api \\
+                  --method DELETE \\
+""",
+        ).replace(bounded_download, bounded_download.replace("180s", "181s")),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("every mutation/success boundary" in error for error in errors)
+    assert any("bound every release read/verification" in error for error in errors)
 
 
 def test_release_workflow_rejects_removed_prerelease_classifier(
@@ -1111,6 +1635,242 @@ def test_docs_deploy_rejects_yanked_file_guard_removal(tmp_path: Path) -> None:
     assert any("non-yanked PyPI files" in error for error in errors)
 
 
+def test_docs_deploy_rejects_polling_deadline_without_timeout_headroom(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    timeout = "    timeout-minutes: 45\n"
+    assert workflow.count(timeout) == 1
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(
+        workflow.replace(timeout, "    timeout-minutes: 35\n"),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any(
+        "30-minute polling deadline" in error and "45-minute timeout" in error for error in errors
+    )
+
+
+def test_docs_deploy_rejects_overwritten_polling_deadline(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    deadline = "          POLL_DEADLINE=$((SECONDS + 30 * 60))\n"
+    assert workflow.count(deadline) == 1
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(
+        workflow.replace(
+            deadline,
+            deadline + "          POLL_DEADLINE=$((SECONDS + 60 * 60))\n",
+        ),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("30-minute polling deadline" in error for error in errors)
+
+
+def test_docs_deploy_rejects_redefined_tag_source_guard(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    marker = "          EXPECTED_PRERELEASE=false\n"
+    assert marker in workflow
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(
+        workflow.replace(
+            marker,
+            "          verify_tag_source() { return 0; }\n" + marker,
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("timeout-bounded release/tag/attestation calls" in error for error in errors)
+
+
+def test_docs_deploy_rejects_sleep_after_final_poll_attempt(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    final_attempt_guard = """\
+            if (( attempt == MAX_ATTEMPTS )); then
+              echo "${status}; no retries remain"
+              break
+            fi
+"""
+    assert final_attempt_guard in workflow
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(
+        workflow.replace(
+            final_attempt_guard,
+            '            echo "${status}; retry budget not checked"\n',
+        ),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("break before its only bounded sleep" in error for error in errors)
+
+
+def test_docs_deploy_rejects_disguised_sleep_after_poll_loop(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    final_error = '          echo "::error::${VERSION} did not become release-ready'
+    assert final_error in workflow
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(
+        workflow.replace(
+            final_error,
+            "          command sleep 3600\n" + final_error,
+        ),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("only bounded sleep" in error and "final diagnostic" in error for error in errors)
+
+
+def test_docs_deploy_rejects_filtered_or_unsupported_pypi_file_sets(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    supported_policy = """\
+                 all(.urls[];
+                   .filename |
+                     endswith(".whl") or endswith(".tar.gz")) and
+"""
+    projection = """\
+                      '[.urls[] |
+                        {name: .filename, sha256: .digests.sha256}] |
+"""
+    assert supported_policy in workflow
+    assert projection in workflow
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(
+        workflow.replace(supported_policy, "").replace(
+            projection,
+            """\
+                      '[.urls[] |
+                        select(.filename | endswith(".whl")) |
+                        {name: .filename, sha256: .digests.sha256}] |
+""",
+        ),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("unsupported PyPI filenames" in error and "unfiltered" in error for error in errors)
+
+
+def test_docs_deploy_rejects_prefiltered_fetched_pypi_json(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    fetch = """\
+            if pypi_json="$(
+              curl -fsS \\
+                --connect-timeout 5 \\
+                --max-time 20 \\
+                "https://pypi.org/pypi/xy/${PYPI_VERSION}/json" \\
+                2>/dev/null
+            )"; then
+"""
+    assert fetch in workflow
+    filtered = """\
+              pypi_json="$(
+                jq -c '{urls: [.urls[] |
+                  select(.filename | endswith(".whl") or endswith(".tar.gz"))]}' \\
+                  <<<"$pypi_json"
+              )"
+"""
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(
+        workflow.replace(fetch, fetch + filtered),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("one unfiltered bounded PyPI response" in error for error in errors)
+
+
+def test_docs_deploy_rejects_unbounded_network_probe(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    max_time = "                --max-time 20 \\\n"
+    assert workflow.count(max_time) == 1
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(
+        workflow.replace(max_time, max_time.replace("20", "200")),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("timeout-bounded release/tag/attestation calls" in error for error in errors)
+
+
+def test_docs_deploy_rejects_forced_readiness_flags_before_success(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    success = '            if [[ "$RELEASED" == true &&\n'
+    assert workflow.count(success) == 2
+    before, separator, after = workflow.rpartition(success)
+    assert separator
+    forced = """\
+            RELEASED=true
+            PUBLISHED=true
+            PROVENANCE_VALID=true
+            ASSETS_MATCH=true
+            TAG_MATCH=true
+"""
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(before + forced + separator + after, encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("fresh readiness flag" in error for error in errors)
+
+
+@pytest.mark.parametrize("termination", ["exit 0", "exit", "exec true", "time exit 0"])
+def test_docs_deploy_rejects_early_success_before_poll_loop(
+    tmp_path: Path,
+    termination: str,
+) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    marker = "          EXPECTED_PRERELEASE=false\n"
+    assert workflow.count(marker) == 1
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(
+        workflow.replace(marker, f"          {termination}\n{marker}", 1),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("exactly one readiness-bound `exit 0`" in error for error in errors)
+
+
+@pytest.mark.parametrize("termination", ["exit 0", "exit", "exec true", "time exit 0"])
+def test_docs_deploy_rejects_early_success_in_poll_attempt(
+    tmp_path: Path,
+    termination: str,
+) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    marker = "            RELEASED=false\n"
+    assert workflow.count(marker) == 1
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(
+        workflow.replace(marker, f"            {termination}\n{marker}", 1),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("exactly one readiness-bound `exit 0`" in error for error in errors)
+
+
 def test_docs_deploy_rejects_bypassed_production_release_gate(
     tmp_path: Path,
 ) -> None:
@@ -1129,6 +1889,23 @@ def test_docs_deploy_rejects_bypassed_production_release_gate(
     errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
 
     assert any("production Helm promotion" in error for error in errors)
+
+
+def _write_passthrough_timeout(fake_bin: Path) -> None:
+    """Install a deterministic GNU-timeout stand-in for shell simulations."""
+    fake_timeout = fake_bin / "timeout"
+    fake_timeout.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+while [[ "$1" == --* ]]; do
+  shift
+done
+shift
+exec "$@"
+""",
+        encoding="utf-8",
+    )
+    fake_timeout.chmod(0o755)
 
 
 @pytest.mark.skipif(
@@ -1153,6 +1930,7 @@ def test_release_workflow_reconciles_stale_assets_before_publishing(
 
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
+    _write_passthrough_timeout(fake_bin)
     fake_gh = fake_bin / "gh"
     fake_gh.write_text(
         r"""#!/usr/bin/env bash
@@ -1161,6 +1939,8 @@ printf '%s\n' "$*" >> "$GH_LOG"
 state="$(<"$GH_STATE")"
 if [[ "$1" == "api" && "$*" == *"/generate-notes"* ]]; then
   printf '## Changes\n\n- Generated\n'
+elif [[ "$1" == "api" && "$*" == *"/commits/$TAG"* ]]; then
+  printf '%s\n' "$GITHUB_SHA"
 elif [[ "$1" == "api" && "$*" == *"/releases/assets/"* ]]; then
   [[ "$state" == "uploaded" ]]
   [[ "$*" == *"/releases/assets/9003"* ]]
@@ -1258,9 +2038,49 @@ fi
         encoding="utf-8",
     )
     fake_gh.chmod(0o755)
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text(
+        r"""#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$(<"$CURL_STATE")" == "malformed" ]]; then
+  printf 'valid' > "$CURL_STATE"
+  printf '{not-json\n'
+  exit 0
+fi
+cat "$PYPI_JSON"
+""",
+        encoding="utf-8",
+    )
+    fake_curl.chmod(0o755)
+    fake_sleep = fake_bin / "sleep"
+    fake_sleep.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    fake_sleep.chmod(0o755)
     (tmp_path / "dist").mkdir()
     (tmp_path / "dist" / "xy-1.2.3-py3-none-any.whl").write_bytes(b"wheel")
     (tmp_path / "dist" / "xy-1.2.3.tar.gz").write_bytes(b"sdist")
+    pypi_json = tmp_path / "pypi.json"
+    pypi_json.write_text(
+        json.dumps(
+            {
+                "urls": [
+                    {
+                        "digests": {"sha256": hashlib.sha256(b"wheel").hexdigest()},
+                        "filename": "xy-1.2.3-py3-none-any.whl",
+                        "yanked": False,
+                    },
+                    {
+                        "digests": {"sha256": hashlib.sha256(b"sdist").hexdigest()},
+                        "filename": "xy-1.2.3.tar.gz",
+                        "yanked": False,
+                    },
+                ]
+            },
+            separators=(",", ":"),
+        ),
+        encoding="utf-8",
+    )
+    curl_state = tmp_path / "curl-state"
+    curl_state.write_text("malformed", encoding="utf-8")
     state = tmp_path / "state"
     state.write_text("initial", encoding="utf-8")
     log = tmp_path / "gh.log"
@@ -1273,12 +2093,14 @@ fi
     env = {
         **os.environ,
         "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "CURL_STATE": str(curl_state),
         "GH_LOG": str(log),
         "GH_NOTES": str(notes),
         "GH_REMOTE": str(remote),
         "GH_STATE": str(state),
         "GH_TOKEN": "test",
         "GITHUB_SHA": source_sha,
+        "PYPI_JSON": str(pypi_json),
         "REPO": "reflex-dev/xy",
         "RUNNER_TEMP": str(runner_temp),
         "TAG": "v1.2.3",
@@ -1294,6 +2116,8 @@ fi
         check=False,
     )
     assert prepare_result.returncode == 0, f"{prepare_result.stdout}\n{prepare_result.stderr}"
+    assert "attempt 1/12" in prepare_result.stdout
+    assert curl_state.read_text(encoding="utf-8") == "valid"
 
     provenance = runner_temp / "xy-v1.2.3-release-provenance" / "xy-release-provenance.json"
     prepared_notes = runner_temp / "xy-v1.2.3-release-notes.md"
@@ -1329,6 +2153,107 @@ fi
     assert "attestation verify" in calls
     assert notes.read_text(encoding="utf-8").endswith(f"{footer}\n")
     assert state.read_text(encoding="utf-8") == "edited"
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="release workflow runtime simulation requires bash and jq",
+)
+def test_release_preparation_rechecks_tag_immediately_before_attestation(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    prepare_shell = verify_ci_workflow._named_step_run(
+        verify_ci_workflow._job_blocks(workflow)["github-release"],
+        "Prepare release provenance",
+    )
+    assert prepare_shell is not None
+
+    source_sha = "0123456789abcdef0123456789abcdef01234567"
+    moved_sha = "fedcba9876543210fedcba9876543210fedcba98"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_passthrough_timeout(fake_bin)
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text(
+        r"""#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "api" && "$*" == *"/commits/$TAG"* ]]; then
+  if [[ "$(<"$TAG_STATE")" == "initial" ]]; then
+    printf 'moved' > "$TAG_STATE"
+    printf '%s\n' "$GITHUB_SHA"
+  else
+    printf '%s\n' "$MOVED_SHA"
+  fi
+elif [[ "$1" == "api" && "$*" == *"/generate-notes"* ]]; then
+  printf '## Changes\n\n- Generated\n'
+else
+  exit 97
+fi
+""",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text(
+        '#!/usr/bin/env bash\nset -euo pipefail\ncat "$PYPI_JSON"\n',
+        encoding="utf-8",
+    )
+    fake_curl.chmod(0o755)
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / "xy-1.2.3-py3-none-any.whl").write_bytes(b"wheel")
+    (tmp_path / "dist" / "xy-1.2.3.tar.gz").write_bytes(b"sdist")
+    pypi_json = tmp_path / "pypi.json"
+    pypi_json.write_text(
+        json.dumps(
+            {
+                "urls": [
+                    {
+                        "digests": {"sha256": hashlib.sha256(b"wheel").hexdigest()},
+                        "filename": "xy-1.2.3-py3-none-any.whl",
+                        "yanked": False,
+                    },
+                    {
+                        "digests": {"sha256": hashlib.sha256(b"sdist").hexdigest()},
+                        "filename": "xy-1.2.3.tar.gz",
+                        "yanked": False,
+                    },
+                ]
+            },
+            separators=(",", ":"),
+        ),
+        encoding="utf-8",
+    )
+    tag_state = tmp_path / "tag-state"
+    tag_state.write_text("initial", encoding="utf-8")
+    runner_temp = tmp_path / "runner"
+    runner_temp.mkdir()
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "GH_TOKEN": "test",
+        "GITHUB_SHA": source_sha,
+        "MOVED_SHA": moved_sha,
+        "PYPI_JSON": str(pypi_json),
+        "REPO": "reflex-dev/xy",
+        "RUNNER_TEMP": str(runner_temp),
+        "TAG": "v1.2.3",
+        "TAG_STATE": str(tag_state),
+    }
+
+    result = subprocess.run(
+        ["bash", "-e", "-o", "pipefail", "-c", prepare_shell],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert f"resolves to {moved_sha}, not workflow source" in result.stdout
+    assert tag_state.read_text(encoding="utf-8") == "moved"
 
 
 def _write_signed_release_fixture(
@@ -1383,6 +2308,9 @@ def _run_immutable_release(
     tmp_path: Path,
     *,
     github_wheel: bytes,
+    local_wheel: bytes = b"wheel",
+    pypi_wheel: bytes = b"wheel",
+    tag_source_sha: str | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], str, str, str]:
     workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
     release_shell = verify_ci_workflow._named_step_run(
@@ -1425,12 +2353,15 @@ def _run_immutable_release(
 
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
+    _write_passthrough_timeout(fake_bin)
     fake_gh = fake_bin / "gh"
     fake_gh.write_text(
         r"""#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$GH_LOG"
-if [[ "$1" == "release" && "$2" == "view" ]]; then
+if [[ "$1" == "api" && "$*" == *"/commits/$TAG"* ]]; then
+  printf '%s\n' "$TAG_SOURCE_SHA"
+elif [[ "$1" == "release" && "$2" == "view" ]]; then
   cat "$GH_RELEASE_JSON"
 elif [[ "$1" == "release" && "$2" == "download" ]]; then
   download_dir=""
@@ -1463,8 +2394,41 @@ fi
         encoding="utf-8",
     )
     fake_gh.chmod(0o755)
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text(
+        r"""#!/usr/bin/env bash
+set -euo pipefail
+cat "$PYPI_JSON"
+""",
+        encoding="utf-8",
+    )
+    fake_curl.chmod(0o755)
+    fake_sleep = fake_bin / "sleep"
+    fake_sleep.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    fake_sleep.chmod(0o755)
+    pypi_json = tmp_path / "pypi.json"
+    pypi_json.write_text(
+        json.dumps(
+            {
+                "urls": [
+                    {
+                        "digests": {"sha256": hashlib.sha256(pypi_wheel).hexdigest()},
+                        "filename": fixture["wheel_name"],
+                        "yanked": False,
+                    },
+                    {
+                        "digests": {"sha256": fixture["sdist_sha256"]},
+                        "filename": fixture["sdist_name"],
+                        "yanked": False,
+                    },
+                ]
+            },
+            separators=(",", ":"),
+        ),
+        encoding="utf-8",
+    )
     (tmp_path / "dist").mkdir()
-    (tmp_path / "dist" / fixture["wheel_name"]).write_bytes(b"wheel")
+    (tmp_path / "dist" / fixture["wheel_name"]).write_bytes(local_wheel)
     (tmp_path / "dist" / fixture["sdist_name"]).write_bytes(b"sdist")
     log = tmp_path / "gh.log"
     runner_temp = tmp_path / "runner"
@@ -1478,9 +2442,11 @@ fi
         "GH_REMOTE": str(remote),
         "GH_TOKEN": "test",
         "GITHUB_SHA": source_sha,
+        "PYPI_JSON": str(pypi_json),
         "REPO": "reflex-dev/xy",
         "RUNNER_TEMP": str(runner_temp),
         "TAG": "v1.2.3",
+        "TAG_SOURCE_SHA": tag_source_sha or source_sha,
     }
 
     result = subprocess.run(
@@ -1492,7 +2458,8 @@ fi
         timeout=30,
         check=False,
     )
-    return result, log.read_text(encoding="utf-8"), fixture["body"], current_notes
+    calls = log.read_text(encoding="utf-8") if log.exists() else ""
+    return result, calls, fixture["body"], current_notes
 
 
 @pytest.mark.skipif(
@@ -1523,6 +2490,30 @@ def test_release_workflow_accepts_persisted_signed_immutable_release(
     shutil.which("bash") is None or shutil.which("jq") is None,
     reason="release workflow runtime simulation requires bash and jq",
 )
+def test_release_workflow_accepts_immutable_release_after_nonidentical_rebuild(
+    tmp_path: Path,
+) -> None:
+    result, calls, _, _ = _run_immutable_release(
+        tmp_path,
+        github_wheel=b"wheel",
+        local_wheel=b"same-source rebuild with different archive bytes",
+        pypi_wheel=b"wheel",
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+    assert "is immutable and already matches the verified release" in result.stdout
+    assert "release view v1.2.3" in calls
+    assert "release download v1.2.3" in calls
+    assert "attestation verify" in calls
+    assert "release upload" not in calls
+    assert "release edit" not in calls
+    assert "release create" not in calls
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="release workflow runtime simulation requires bash and jq",
+)
 def test_release_workflow_rejects_mismatched_immutable_release_bytes(
     tmp_path: Path,
 ) -> None:
@@ -1532,12 +2523,57 @@ def test_release_workflow_rejects_mismatched_immutable_release_bytes(
     )
 
     assert result.returncode == 1
-    assert "release bytes do not match the verified build" in result.stdout
+    assert "release bytes do not match the trusted distribution set" in result.stdout
     assert "immutable but does not match" in result.stdout
     assert "attestation verify" in calls
     assert "release upload" not in calls
     assert "release edit" not in calls
     assert "/releases/assets/" not in calls
+    assert "release create" not in calls
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="release workflow runtime simulation requires bash and jq",
+)
+def test_release_workflow_rejects_moved_tag_before_release_mutation(
+    tmp_path: Path,
+) -> None:
+    moved_sha = "fedcba9876543210fedcba9876543210fedcba98"
+    result, calls, _, _ = _run_immutable_release(
+        tmp_path,
+        github_wheel=b"wheel",
+        tag_source_sha=moved_sha,
+    )
+
+    assert result.returncode == 1
+    assert f"resolves to {moved_sha}, not workflow source" in result.stdout
+    assert "release view" not in calls
+    assert "release upload" not in calls
+    assert "release edit" not in calls
+    assert "release create" not in calls
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="release workflow runtime simulation requires bash and jq",
+)
+def test_release_workflow_rejects_pypi_mismatch_before_release_mutation(
+    tmp_path: Path,
+) -> None:
+    result, calls, _, _ = _run_immutable_release(
+        tmp_path,
+        github_wheel=b"wheel",
+        pypi_wheel=b"different immutable PyPI wheel",
+    )
+
+    assert result.returncode == 1
+    assert "release bytes do not match the trusted distribution set" in result.stdout
+    assert "release view v1.2.3" in calls
+    assert "release download v1.2.3" in calls
+    assert "attestation verify" in calls
+    assert "release upload" not in calls
+    assert "release edit" not in calls
     assert "release create" not in calls
 
 
@@ -1547,6 +2583,9 @@ def _run_docs_promotion(
     release_notes: str | None = None,
     github_wheel: bytes = b"wheel",
     pypi_yanked: bool = False,
+    pypi_extra_file: bool = False,
+    max_attempts: int | None = None,
+    tag_source_sha: str | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], str, str]:
     workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
     gate_shell = verify_ci_workflow._named_step_run(
@@ -1554,6 +2593,13 @@ def _run_docs_promotion(
         "Await GitHub Release and PyPI availability",
     )
     assert gate_shell is not None
+    if max_attempts is not None:
+        assert "MAX_ATTEMPTS=30" in gate_shell
+        gate_shell = gate_shell.replace(
+            "MAX_ATTEMPTS=30",
+            f"MAX_ATTEMPTS={max_attempts}",
+            1,
+        )
 
     source_sha = "0123456789abcdef0123456789abcdef01234567"
     signed_notes = "## Changes\n\n- Signed release"
@@ -1587,36 +2633,43 @@ def _run_docs_promotion(
         ),
         encoding="utf-8",
     )
+    pypi_urls = [
+        {
+            "digests": {"sha256": fixture["sdist_sha256"]},
+            "filename": fixture["sdist_name"],
+            "yanked": False,
+        },
+        {
+            "digests": {"sha256": fixture["wheel_sha256"]},
+            "filename": fixture["wheel_name"],
+            "yanked": pypi_yanked,
+        },
+    ]
+    if pypi_extra_file:
+        pypi_urls.append(
+            {
+                "digests": {"sha256": hashlib.sha256(b"extra").hexdigest()},
+                "filename": "xy-1.2.3.zip",
+                "yanked": False,
+            }
+        )
     pypi_json = tmp_path / "pypi.json"
     pypi_json.write_text(
-        json.dumps(
-            {
-                "urls": [
-                    {
-                        "digests": {"sha256": fixture["sdist_sha256"]},
-                        "filename": fixture["sdist_name"],
-                        "yanked": False,
-                    },
-                    {
-                        "digests": {"sha256": fixture["wheel_sha256"]},
-                        "filename": fixture["wheel_name"],
-                        "yanked": pypi_yanked,
-                    },
-                ]
-            },
-            separators=(",", ":"),
-        ),
+        json.dumps({"urls": pypi_urls}, separators=(",", ":")),
         encoding="utf-8",
     )
 
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
+    _write_passthrough_timeout(fake_bin)
     fake_gh = fake_bin / "gh"
     fake_gh.write_text(
         r"""#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$GH_LOG"
-if [[ "$1" == "release" && "$2" == "view" ]]; then
+if [[ "$1" == "api" && "$*" == *"/commits/$VERSION"* ]]; then
+  printf '%s\n' "$TAG_SOURCE_SHA"
+elif [[ "$1" == "release" && "$2" == "view" ]]; then
   cat "$GH_RELEASE_JSON"
 elif [[ "$1" == "release" && "$2" == "download" ]]; then
   download_dir=""
@@ -1676,6 +2729,7 @@ cat "$PYPI_JSON"
         "REPO": "reflex-dev/xy",
         "RUNNER_TEMP": str(runner_temp),
         "SOURCE_SHA": source_sha,
+        "TAG_SOURCE_SHA": tag_source_sha or source_sha,
         "VERSION": "v1.2.3",
     }
 
@@ -1712,11 +2766,18 @@ def test_docs_promotion_accepts_only_matching_ready_distribution_set(
     reason="docs promotion runtime simulation requires bash and jq",
 )
 @pytest.mark.parametrize(
-    ("release_notes", "github_wheel", "pypi_yanked", "expected_state"),
+    (
+        "release_notes",
+        "github_wheel",
+        "pypi_yanked",
+        "pypi_extra_file",
+        "expected_state",
+    ),
     [
         pytest.param(
             "## Changes\n\n- Altered after signing",
             b"wheel",
+            False,
             False,
             "provenance=false",
             id="altered-notes",
@@ -1725,6 +2786,7 @@ def test_docs_promotion_accepts_only_matching_ready_distribution_set(
             None,
             b"altered GitHub wheel",
             False,
+            False,
             "provenance=true assets=false",
             id="altered-github-bytes",
         ),
@@ -1732,8 +2794,17 @@ def test_docs_promotion_accepts_only_matching_ready_distribution_set(
             None,
             b"wheel",
             True,
+            False,
             "pypi=false provenance=false assets=false",
             id="yanked-pypi-file",
+        ),
+        pytest.param(
+            None,
+            b"wheel",
+            False,
+            True,
+            "pypi=false provenance=false assets=false",
+            id="unsupported-extra-pypi-file",
         ),
     ],
 )
@@ -1742,6 +2813,7 @@ def test_docs_promotion_fails_closed_on_unready_signed_release(
     release_notes: str | None,
     github_wheel: bytes,
     pypi_yanked: bool,
+    pypi_extra_file: bool,
     expected_state: str,
 ) -> None:
     result, _, _ = _run_docs_promotion(
@@ -1749,10 +2821,47 @@ def test_docs_promotion_fails_closed_on_unready_signed_release(
         release_notes=release_notes,
         github_wheel=github_wheel,
         pypi_yanked=pypi_yanked,
+        pypi_extra_file=pypi_extra_file,
     )
 
     assert result.returncode == 99
     assert expected_state in result.stdout
+    assert "has signed release provenance and byte-identical" not in result.stdout
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="docs promotion runtime simulation requires bash and jq",
+)
+def test_docs_promotion_does_not_sleep_after_final_attempt(tmp_path: Path) -> None:
+    result, _, _ = _run_docs_promotion(
+        tmp_path,
+        pypi_extra_file=True,
+        max_attempts=1,
+    )
+
+    assert result.returncode == 1
+    assert "attempt 1/1" in result.stdout
+    assert "no retries remain" in result.stdout
+    assert "did not become release-ready" in result.stdout
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="docs promotion runtime simulation requires bash and jq",
+)
+def test_docs_promotion_rejects_tag_moved_after_production_approval(
+    tmp_path: Path,
+) -> None:
+    moved_sha = "fedcba9876543210fedcba9876543210fedcba98"
+    result, _, _ = _run_docs_promotion(
+        tmp_path,
+        max_attempts=1,
+        tag_source_sha=moved_sha,
+    )
+
+    assert result.returncode == 1
+    assert "tag=false release=true pypi=true provenance=true assets=true" in result.stdout
     assert "has signed release provenance and byte-identical" not in result.stdout
 
 

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -1382,6 +1382,42 @@ def test_release_workflow_rejects_sibling_release_api_mutation(tmp_path: Path) -
 
 
 @pytest.mark.parametrize(
+    ("marker", "replacement"),
+    [
+        ('                2>"$release_lookup_error"\n', "                2>/dev/null\n"),
+        (
+            "          elif ! jq -eRs '. == \"release not found\\n\"' "
+            '"$release_lookup_error" >/dev/null; then\n',
+            "          else\n",
+        ),
+        ('else error("invalid isImmutable") end', 'else "false" end'),
+    ],
+)
+def test_release_workflow_rejects_fail_open_immutable_preflight(
+    tmp_path: Path,
+    marker: str,
+    replacement: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    before, inspect_marker, after = workflow.partition("      - name: Inspect existing release\n")
+    assert inspect_marker
+    inspect_step, next_marker, remainder = after.partition(
+        "      - name: Prepare release provenance\n"
+    )
+    assert next_marker
+    mutated_step = _replace_once(inspect_step, marker, replacement)
+    path = tmp_path / "release.yml"
+    path.write_text(
+        before + inspect_marker + mutated_step + next_marker + remainder,
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("exact fail-closed" in error for error in errors)
+
+
+@pytest.mark.parametrize(
     "shell_value",
     ["python", "pwsh", "bash {0}", "bash -c", "${{ matrix.release_shell }}"],
 )
@@ -3140,6 +3176,147 @@ exec "$@"
         encoding="utf-8",
     )
     fake_timeout.chmod(0o755)
+
+
+def _run_release_state_preflight(
+    tmp_path: Path,
+    *,
+    mode: str,
+    response: str = "",
+) -> tuple[subprocess.CompletedProcess[str], str, list[Path]]:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    inspect_shell = verify_ci_workflow._named_step_run(
+        verify_ci_workflow._job_blocks(workflow)["github-release"],
+        "Inspect existing release",
+    )
+    assert inspect_shell is not None
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_passthrough_timeout(fake_bin)
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+case "$GH_MODE" in
+  success)
+    printf '%s\\n' "$GH_RESPONSE"
+    ;;
+  not-found)
+    printf 'release not found\\n' >&2
+    exit 1
+    ;;
+  auth-error)
+    printf 'HTTP 401: Bad credentials\\n' >&2
+    exit 1
+    ;;
+  timeout)
+    exit 124
+    ;;
+  *)
+    exit 98
+    ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
+    github_output = tmp_path / "github-output"
+    env = os.environ | {
+        "GITHUB_OUTPUT": str(github_output),
+        "GH_MODE": mode,
+        "GH_RESPONSE": response,
+        "GH_TOKEN": "test-token",
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+        "REPO": "reflex-dev/xy",
+        "RUNNER_TEMP": str(runner_temp),
+        "TAG": "v1.2.3",
+    }
+    result = subprocess.run(
+        ["bash", "-e", "-o", "pipefail", "-c", inspect_shell],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    output = github_output.read_text(encoding="utf-8") if github_output.exists() else ""
+    return result, output, list(runner_temp.iterdir())
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="release workflow runtime simulation requires bash and jq",
+)
+@pytest.mark.parametrize(
+    ("response", "expected_output"),
+    [
+        ('{"isImmutable":true}', "immutable=true\n"),
+        ('{"isImmutable":false}', "immutable=false\n"),
+    ],
+)
+def test_release_state_preflight_reports_boolean_metadata(
+    tmp_path: Path,
+    response: str,
+    expected_output: str,
+) -> None:
+    result, output, leftovers = _run_release_state_preflight(
+        tmp_path,
+        mode="success",
+        response=response,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+    assert output == expected_output
+    assert leftovers == []
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="release workflow runtime simulation requires bash and jq",
+)
+def test_release_state_preflight_treats_only_exact_not_found_as_absent(
+    tmp_path: Path,
+) -> None:
+    result, output, leftovers = _run_release_state_preflight(tmp_path, mode="not-found")
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+    assert output == "immutable=false\n"
+    assert leftovers == []
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="release workflow runtime simulation requires bash and jq",
+)
+@pytest.mark.parametrize(
+    ("mode", "response"),
+    [
+        ("auth-error", ""),
+        ("timeout", ""),
+        ("success", "{"),
+        ("success", "{}"),
+        ("success", '{"isImmutable":"true"}'),
+    ],
+)
+def test_release_state_preflight_fails_closed_on_lookup_or_metadata_errors(
+    tmp_path: Path,
+    mode: str,
+    response: str,
+) -> None:
+    result, output, leftovers = _run_release_state_preflight(
+        tmp_path,
+        mode=mode,
+        response=response,
+    )
+
+    assert result.returncode != 0
+    assert output == ""
+    assert leftovers == []
 
 
 @pytest.mark.skipif(

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -41,6 +41,11 @@ def _load_verify_module():
 verify_ci_workflow = _load_verify_module()
 
 
+def _replace_once(text: str, marker: str, replacement: str) -> str:
+    assert text.count(marker) == 1, f"expected exactly one workflow marker: {marker!r}"
+    return text.replace(marker, replacement, 1)
+
+
 def test_named_step_run_stops_before_following_step_metadata() -> None:
     job = """\
   example:
@@ -110,6 +115,17 @@ def test_step_run_rejects_explicit_indentation_blocks(indicator: str) -> None:
         "trap 'exit 0' EXIT",
         '$DYNAMIC_COMMAND "exit 0"',
         "[[ x == x ]] && $DYNAMIC_COMMAND -c 'exit 0'",
+        'if [[ x &&\n  $(eval "$payload") ]]; then :; fi',
+        'if [[ "$(eval "$payload")" == x ]]; then :; fi',
+        'if [[ x && `eval "$payload"` ]]; then :; fi',
+        'if [[ -e <(eval "$payload") ]]; then :; fi',
+        'if [[ -e >(eval "$payload") ]]; then :; fi',
+        'value="$(printf %s "$(eval "$payload")")"',
+        "payload='index[$(eval \"$command\")]'; (( payload )) || :",
+        'payload="index[\\$(eval \\"$command\\")]"; (( payload )) || :',
+        'let "$payload"',
+        'declare -i result="$payload"',
+        'coproc gh release create "$TAG"; wait "$COPROC_PID"',
         'VALUE=1 $DYNAMIC_COMMAND "exit 0"',
         "function exit { :; }",
         "gh() { :; }",
@@ -117,6 +133,20 @@ def test_step_run_rejects_explicit_indentation_blocks(indicator: str) -> None:
 )
 def test_indirect_shell_execution_is_detected(shell: str) -> None:
     assert verify_ci_workflow._has_indirect_shell_execution(shell)
+
+
+@pytest.mark.parametrize(
+    "shell",
+    [
+        'if [[ x &&\n  "$value" == y ]]; then :; fi',
+        'value="$(jq -r .value <<<"$payload")"',
+        'digest="$(printf %s "$value" | sha256sum | cut -d " " -f 1)"',
+        'diff <(printf %s "$left") <(printf %s "$right")',
+        "if (( attempt < 12 )); then",
+    ],
+)
+def test_safe_shell_expressions_and_substitutions_are_not_indirect(shell: str) -> None:
+    assert not verify_ci_workflow._has_indirect_shell_execution(shell)
 
 
 @pytest.mark.parametrize("kind", ["eval", "source", "dot", "bash"])
@@ -911,6 +941,48 @@ def test_release_workflow_rejects_missing_dry_run_input(tmp_path: Path) -> None:
     assert any("dry-run input" in error for error in errors)
 
 
+@pytest.mark.parametrize(
+    "extra_trigger",
+    ["pull_request_target:", "schedule:", "workflow_call:"],
+)
+def test_release_workflow_rejects_additional_triggers(
+    tmp_path: Path,
+    extra_trigger: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "  workflow_dispatch:\n"
+    path = tmp_path / "release.yml"
+    path.write_text(
+        _replace_once(workflow, marker, f"  {extra_trigger}\n{marker}"),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("triggers must be exactly" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    ("marker", "replacement"),
+    [
+        ("        type: boolean\n", "        type: string # type: boolean\n"),
+        ("        default: true\n", "        default: false # default: true\n"),
+    ],
+)
+def test_release_workflow_rejects_commented_dry_run_control_spoofs(
+    tmp_path: Path,
+    marker: str,
+    replacement: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release.yml"
+    path.write_text(_replace_once(workflow, marker, replacement), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("triggers must be exactly" in error for error in errors)
+
+
 def test_release_workflow_rejects_ungated_pypi_publish_step(tmp_path: Path) -> None:
     """A sibling step's `if:` (the dry-run summary) must not mask a missing
     gate on the actual PyPI upload step — regression for a bug where the
@@ -919,8 +991,10 @@ def test_release_workflow_rejects_ungated_pypi_publish_step(tmp_path: Path) -> N
     path = tmp_path / "release.yml"
     path.write_text(
         workflow.replace(
-            "        if: github.event_name != 'workflow_dispatch' "
-            "|| github.event.inputs.dry_run != 'true'\n",
+            "        if: (github.event_name == 'push' && "
+            "startsWith(github.ref, 'refs/tags/v')) || "
+            "(github.event_name == 'workflow_dispatch' && "
+            "github.event.inputs.dry_run == 'false')\n",
             "",
         ),
         encoding="utf-8",
@@ -1126,6 +1200,31 @@ def test_release_workflow_rejects_unvalidated_existing_github_release(
     )
 
 
+def test_release_workflow_rejects_lookup_errors_falling_through_to_create(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    failure_guard = """\
+          elif ! jq -eRs '. == "release not found\\n"' "$release_lookup_error" >/dev/null; then
+            cat "$release_lookup_error" >&2
+            rm -f "$release_lookup_error"
+            echo "::error::Could not inspect existing GitHub Release ${TAG}; refusing to create it"
+            exit 1
+"""
+    assert workflow.count(failure_guard) == 1
+    path = tmp_path / "release.yml"
+    path.write_text(workflow.replace(failure_guard, "", 1), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any(
+        "only an exact `release not found`" in error
+        and "fail closed" in error
+        and "metadata-read error" in error
+        for error in errors
+    )
+
+
 def test_release_workflow_rejects_missing_post_create_payload_validation(
     tmp_path: Path,
 ) -> None:
@@ -1283,6 +1382,514 @@ def test_release_workflow_rejects_sibling_release_api_mutation(tmp_path: Path) -
 
 
 @pytest.mark.parametrize(
+    "shell_value",
+    ["python", "pwsh", "bash {0}", "bash -c", "${{ matrix.release_shell }}"],
+)
+def test_release_workflow_rejects_noncanonical_protected_shells(
+    tmp_path: Path,
+    shell_value: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = (
+        "          TAG: ${{ github.ref_name }}\n"
+        "        shell: bash\n"
+        "        run: |\n"
+        "          immutable=false\n"
+    )
+    replacement = marker.replace("shell: bash", f"shell: {shell_value}")
+    path = tmp_path / "release.yml"
+    path.write_text(_replace_once(workflow, marker, replacement), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("exact step-local `shell: bash`" in error for error in errors)
+
+
+def test_release_workflow_rejects_job_default_replacing_step_local_bash(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    job = "  github-release:\n"
+    before, separator, after = workflow.partition(job)
+    assert separator
+    after = _replace_once(
+        after,
+        "    runs-on: ubuntu-latest\n    timeout-minutes: 30\n",
+        "    runs-on: ubuntu-latest\n"
+        "    defaults:\n"
+        "      run:\n"
+        "        shell: python\n"
+        "    timeout-minutes: 30\n",
+    )
+    inspect_shell = (
+        "          TAG: ${{ github.ref_name }}\n"
+        "        shell: bash\n"
+        "        run: |\n"
+        "          immutable=false\n"
+    )
+    after = _replace_once(
+        after,
+        inspect_shell,
+        inspect_shell.replace("        shell: bash\n", ""),
+    )
+    path = tmp_path / "release.yml"
+    path.write_text(before + separator + after, encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("exact step-local `shell: bash`" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "duplicate_key",
+    ["        shell: python\n", "        run: python hidden_release_writer.py\n"],
+)
+def test_release_workflow_rejects_duplicate_run_or_shell_keys(
+    tmp_path: Path,
+    duplicate_key: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = (
+        "          TAG: ${{ github.ref_name }}\n"
+        "        shell: bash\n"
+        "        run: |\n"
+        "          immutable=false\n"
+    )
+    replacement = marker.replace("        run: |\n", duplicate_key + "        run: |\n")
+    path = tmp_path / "release.yml"
+    path.write_text(_replace_once(workflow, marker, replacement), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("exactly one direct `run`" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    ("marker", "replacement"),
+    [
+        (
+            "  github-release:\n    name: Publish GitHub Release\n",
+            "  github-release:\n    name: Publish GitHub Release\n    continue-on-error: true\n",
+        ),
+        (
+            "      - name: Attest release provenance\n"
+            "        if: steps.release_state.outputs.immutable != 'true'\n",
+            "      - name: Attest release provenance\n"
+            "        if: steps.release_state.outputs.immutable != 'true'\n"
+            "        continue-on-error: true\n",
+        ),
+        (
+            "      - name: Create GitHub Release and attach distributions\n        env:\n",
+            "      - name: Create GitHub Release and attach distributions\n"
+            "        if: always()\n"
+            "        env:\n",
+        ),
+        (
+            "      - name: Create GitHub Release and attach distributions\n        env:\n",
+            "      - name: Create GitHub Release and attach distributions\n"
+            "        continue-on-error: true\n"
+            "        env:\n",
+        ),
+        (
+            "      - name: Create GitHub Release and attach distributions\n        env:\n",
+            "      - name: Create GitHub Release and attach distributions\n"
+            "        ? continue-on-error\n"
+            "        : true\n"
+            "        env:\n",
+        ),
+    ],
+)
+def test_release_workflow_rejects_privileged_control_bypasses(
+    tmp_path: Path,
+    marker: str,
+    replacement: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release.yml"
+    path.write_text(_replace_once(workflow, marker, replacement), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("exact control keys" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "inherited_control",
+    [
+        "env:\n  BASH_ENV: ./hidden-release-writer.sh\n\n",
+        "defaults:\n  run:\n    working-directory: ./unverified-release\n\n",
+        "? env\n:\n  BASH_ENV: ./hidden-release-writer.sh\n\n",
+    ],
+)
+def test_release_workflow_rejects_inherited_workflow_controls(
+    tmp_path: Path,
+    inherited_control: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release.yml"
+    path.write_text(
+        _replace_once(workflow, "jobs:\n", inherited_control + "jobs:\n"),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("exact top-level controls" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "permissions",
+    [
+        "permissions:\n  contents: write\n",
+        'permissions:\n  contents: read\n  "packages": write\n',
+    ],
+)
+def test_release_workflow_rejects_broad_top_level_permissions(
+    tmp_path: Path,
+    permissions: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "permissions:\n  contents: read\n"
+    path = tmp_path / "release.yml"
+    path.write_text(_replace_once(workflow, marker, permissions), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("top-level permissions must be exactly" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    ("marker", "replacement"),
+    [
+        (
+            "          TAG: ${{ github.ref_name }}\n"
+            "        shell: bash\n"
+            "        run: |\n"
+            "          immutable=false\n",
+            "          TAG: ${{ github.ref_name }}\n"
+            "          BASH_ENV: ./hidden-release-writer.sh\n"
+            "        shell: bash\n"
+            "        run: |\n"
+            "          immutable=false\n",
+        ),
+        (
+            "          pattern: dist-*\n"
+            "          merge-multiple: true\n"
+            "      - name: Inspect existing release\n",
+            "          pattern: dist-*\n"
+            "          merge-multiple: true\n"
+            "          repository: attacker/unverified-artifacts\n"
+            "      - name: Inspect existing release\n",
+        ),
+    ],
+)
+def test_release_workflow_rejects_privileged_mapping_extensions(
+    tmp_path: Path,
+    marker: str,
+    replacement: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release.yml"
+    path.write_text(_replace_once(workflow, marker, replacement), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("exact environments, action inputs" in error for error in errors)
+
+
+def test_release_workflow_rejects_noncanonical_permission_keys(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = (
+        "    permissions:\n      # Keep repository write access out of every build and PyPI job.\n"
+    )
+    replacement = (
+        "    permissions:\n"
+        '      "packages": write\n'
+        "      # Keep repository write access out of every build and PyPI job.\n"
+    )
+    path = tmp_path / "release.yml"
+    path.write_text(_replace_once(workflow, marker, replacement), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("permissions must be exactly" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "unapproved_command",
+    [
+        'curl -fsS -X DELETE -H "Authorization: Bearer $GH_TOKEN" '
+        '"https://api.github.com/repos/${REPO}/releases/123"',
+        'wget -qO- "https://api.github.com/repos/${REPO}/releases"',
+        "python3 -c 'import urllib.request; urllib.request.urlopen(\"https://api.github.com\")'",
+        'gh extension exec release-writer -- "$TAG"',
+        'strace gh release create "$TAG" --repo "$REPO"',
+        'taskset -c 0 gh release create "$TAG" --repo "$REPO"',
+        'git -c alias.pwn=\'!gh release create "$TAG" --repo "$REPO"\' pwn',
+        'make --no-print-directory --eval=$\'all:\\n\\tgh release create "$TAG" --repo "$REPO"\'',
+        "printf '%s\\n' 'gh release create \"$TAG\" --repo \"$REPO\"' "
+        "> /tmp/xy-writer; chmod +x /tmp/xy-writer; /tmp/xy-writer",
+        "printf '%s\\n' 'gh release create \"$TAG\" --repo \"$REPO\"' "
+        "> /tmp/xy-env-writer; "
+        "echo 'BASH_ENV=/tmp/xy-env-writer' >> \"$GITHUB_ENV\"",
+        "printf '%s\\n' '/tmp/xy-bin' > \"$GITHUB_PATH\"",
+        "printf '%s\\n' 'gh release create \"$TAG\" --repo \"$REPO\"' "
+        "> /tmp/xy-env-writer; "
+        "printf 'BASH_%s=/tmp/xy-env-writer\\n' ENV >> "
+        "/home/runner/work/_temp/_runner_file_commands/set_env_*",
+        "printf '/tmp/xy-bin\\n' >> /home/runner/work/_temp/_runner_file_commands/add_path_*",
+        "BASH_ENV=/tmp/xy-env-writer",
+        "ENV=/tmp/xy-env-writer",
+        "CDPATH=/tmp/xy-path",
+        "PROMPT_COMMAND=/tmp/xy-writer",
+        'printf "DELETE / HTTP/1.1\\r\\n\\r\\n" > /dev/tcp/api.github.com/443',
+        "CURL_HOME=/tmp/unverified curl -fsS --connect-timeout 5 --max-time 20 "
+        '"https://pypi.org/pypi/xy/${pypi_version}/json" 2>/dev/null',
+    ],
+)
+def test_release_workflow_rejects_unapproved_clients_inside_trusted_steps(
+    tmp_path: Path,
+    unapproved_command: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "          immutable=false\n"
+    replacement = f"          {unapproved_command}\n{marker}"
+    path = tmp_path / "release.yml"
+    path.write_text(_replace_once(workflow, marker, replacement), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("indirect shell execution" in error for error in errors)
+
+
+@pytest.mark.parametrize("shell_value", ["python", "bash {0}", "${{ env.RELEASE_SHELL }}"])
+def test_release_workflow_rejects_noncanonical_publish_tag_guard_shell(
+    tmp_path: Path,
+    shell_value: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = (
+        "      - name: Verify release tag source before PyPI\n"
+        "        if: github.event_name == 'push'\n"
+        "        env:\n"
+        "          GH_TOKEN: ${{ github.token }}\n"
+        "          REPO: ${{ github.repository }}\n"
+        "          TAG: ${{ github.ref_name }}\n"
+        "        shell: bash\n"
+    )
+    replacement = marker.replace("shell: bash", f"shell: {shell_value}")
+    path = tmp_path / "release.yml"
+    path.write_text(_replace_once(workflow, marker, replacement), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("publish tag guard" in error and "exact step-local" in error for error in errors)
+
+
+def test_release_workflow_rejects_publish_tag_guard_control_bypass(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = (
+        "      - name: Verify release tag source before PyPI\n"
+        "        if: github.event_name == 'push'\n"
+    )
+    replacement = marker + "        continue-on-error: true\n"
+    path = tmp_path / "release.yml"
+    path.write_text(_replace_once(workflow, marker, replacement), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("publish tag guard" in error and "exact step controls" in error for error in errors)
+
+
+def test_release_workflow_rejects_publish_job_inherited_environment(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "  publish:\n    name: Publish to PyPI\n"
+    replacement = (
+        "  publish:\n"
+        "    name: Publish to PyPI\n"
+        "    env:\n"
+        "      BASH_ENV: ./hidden-release-writer.sh\n"
+    )
+    path = tmp_path / "release.yml"
+    path.write_text(_replace_once(workflow, marker, replacement), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("publish job must use exact control keys" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    ("marker", "replacement", "message"),
+    [
+        (
+            "    needs: [wheels, sdist, wasm]\n",
+            "    needs: [wheels, sdist]\n",
+            "exact wheel, sdist, and wasm",
+        ),
+        (
+            "    environment: pypi\n",
+            "    environment: unprotected\n",
+            "exact protected pypi environment",
+        ),
+    ],
+)
+def test_release_workflow_rejects_changed_publish_job_identity(
+    tmp_path: Path,
+    marker: str,
+    replacement: str,
+    message: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release.yml"
+    path.write_text(_replace_once(workflow, marker, replacement), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any(message in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    ("job_name", "next_job"),
+    [("publish", "github-release"), ("github-release", None)],
+)
+def test_release_workflow_rejects_self_hosted_privileged_jobs(
+    tmp_path: Path,
+    job_name: str,
+    next_job: str | None,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    job_marker = f"  {job_name}:\n"
+    before, separator, after = workflow.partition(job_marker)
+    assert separator
+    job_body, next_separator, remainder = (
+        after.partition(f"\n  {next_job}:\n") if next_job is not None else (after, "", "")
+    )
+    job_body = _replace_once(
+        job_body,
+        "    runs-on: ubuntu-latest\n",
+        "    runs-on: self-hosted\n",
+    )
+    path = tmp_path / "release.yml"
+    path.write_text(
+        before + separator + job_body + next_separator + remainder,
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("exact trusted ubuntu-latest runner" in error for error in errors)
+
+
+def test_release_workflow_rejects_sibling_step_in_pypi_oidc_job(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b"
+    sibling = (
+        "      - name: Unverified OIDC publisher\n"
+        "        uses: attacker/publish@0123456789012345678901234567890123456789\n"
+    )
+    path = tmp_path / "release.yml"
+    path.write_text(_replace_once(workflow, marker, sibling + marker), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("exactly the pinned artifact download" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "api_write",
+    [
+        'gh api --method PUT "repos/${REPO}/contents/SECURITY.md" -f message=pwn -f content=eA==',
+        'gh api --method POST "repos/${REPO}/git/refs" -f ref=refs/tags/pwn -f sha="$GITHUB_SHA"',
+    ],
+)
+def test_release_workflow_rejects_non_release_api_writes(
+    tmp_path: Path,
+    api_write: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    step = "      - name: Prepare release provenance\n"
+    before, separator, after = workflow.partition(step)
+    assert separator
+    prepare, next_step, remainder = after.partition("\n      - name: Attest release provenance\n")
+    assert next_step
+    prepare = _replace_once(
+        prepare,
+        "          shopt -s nullglob\n",
+        f"          shopt -s nullglob\n          {api_write}\n",
+    )
+    path = tmp_path / "release.yml"
+    path.write_text(
+        before + separator + prepare + next_step + remainder,
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("only the exact generated-notes POST" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "action_step",
+    [
+        "      - name: Unverified release action\n"
+        "        uses: owner/release-writer@0123456789012345678901234567890123456789\n",
+        "      - uses: ./release-writer\n",
+        "      - name: Container release action\n"
+        "        uses: docker://example/release-writer:latest\n",
+        "      - name: Dynamic release action\n"
+        "        uses: ${{ github.repository }}/release-writer@main\n",
+        "      - name: Unpinned download action\n        uses: actions/download-artifact@v8\n",
+        "      - name: Duplicate attest action\n"
+        "        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d\n",
+    ],
+)
+def test_release_workflow_rejects_non_allowlisted_action_steps(
+    tmp_path: Path,
+    action_step: str,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "      - name: Create GitHub Release and attach distributions\n"
+    path = tmp_path / "release.yml"
+    path.write_text(_replace_once(workflow, marker, action_step + marker), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any(
+        "exactly the pinned download and provenance-attestation actions" in error
+        for error in errors
+    )
+
+
+def test_release_workflow_rejects_unexpected_bash_sibling_step(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "      - name: Create GitHub Release and attach distributions\n"
+    sibling = """\
+      - name: Unverified network client
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          curl -X POST -H "Authorization: Bearer $GH_TOKEN" \\
+            "https://api.github.com/repos/${REPO}/releases"
+"""
+    path = tmp_path / "release.yml"
+    path.write_text(_replace_once(workflow, marker, sibling + marker), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any(
+        "must contain exactly" in error and "steps in that order" in error for error in errors
+    )
+
+
+@pytest.mark.parametrize(
     "api_command",
     [
         'gh api "repos/${REPO}/releases" -f tag_name="$TAG"',
@@ -1308,6 +1915,29 @@ def test_release_workflow_rejects_sibling_release_api_mutation(tmp_path: Path) -
         'env -u UNUSED gh release create "$TAG"',
         '/usr/bin/gh release new "$TAG"',
         'gh release -R "$REPO" delete-asset "$TAG" 42 --yes',
+        'gh "$command" create "$TAG"',
+        'gh "${command}" "repos/${REPO}/releases" -f tag_name="$TAG"',
+        'gh "$(printf release)" create "$TAG"',
+        'gh "rel${suffix}" create "$TAG"',
+        'gh releas? create "$TAG"',
+        'gh relea* create "$TAG"',
+        'gh {release,api} create "$TAG"',
+        'gh --repo "$REPO" "$command" create "$TAG"',
+        'gh release "cr${suffix}" "$TAG"',
+        'gh release cr* "$TAG"',
+        '>release.log gh release create "$TAG"',
+        '> release.log gh release create "$TAG"',
+        '1>release.log gh release create "$TAG"',
+        '2>>release.log gh release create "$TAG"',
+        '<payload.json gh api "repos/${REPO}/releases" -f tag_name="$TAG"',
+        '3>&1 gh release create "$TAG"',
+        '3>"$log_file" gh release create "$TAG"',
+        '{release_fd}>release.log gh release create "$TAG"',
+        '&>release.log gh release create "$TAG"',
+        '>|release.log gh release create "$TAG"',
+        '>| release.log gh release create "$TAG"',
+        '2>|release.log gh release create "$TAG"',
+        '2>| release.log gh release create "$TAG"',
     ],
 )
 def test_release_workflow_rejects_sibling_mutation_forms(
@@ -1321,7 +1951,7 @@ def test_release_workflow_rejects_sibling_mutation_forms(
         run: {api_command}
 """
     path = tmp_path / "release.yml"
-    path.write_text(workflow.replace(marker, sibling + marker, 1), encoding="utf-8")
+    path.write_text(_replace_once(workflow, marker, sibling + marker), encoding="utf-8")
 
     errors = verify_ci_workflow.validate_release_workflow(path)
 
@@ -1373,7 +2003,7 @@ def test_release_workflow_rejects_folded_sibling_run(tmp_path: Path) -> None:
           -f tag_name="$TAG"
 """
     path = tmp_path / "release.yml"
-    path.write_text(workflow.replace(marker, sibling + marker, 1), encoding="utf-8")
+    path.write_text(_replace_once(workflow, marker, sibling + marker), encoding="utf-8")
 
     errors = verify_ci_workflow.validate_release_workflow(path)
 
@@ -1401,22 +2031,39 @@ def test_release_workflow_rejects_other_uninspectable_sibling_runs(
       - name: Hidden release API write
         run: {run}"""
     path = tmp_path / "release.yml"
-    path.write_text(workflow.replace(marker, sibling + marker, 1), encoding="utf-8")
+    path.write_text(_replace_once(workflow, marker, sibling + marker), encoding="utf-8")
 
     errors = verify_ci_workflow.validate_release_workflow(path)
 
     assert any("every shell step can be inspected" in error for error in errors)
 
 
-def test_release_workflow_rejects_indirect_sibling_shell(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "indirect_command",
+    [
+        'bash -c \'gh api "repos/${REPO}/releases" -f tag_name="$TAG"\'',
+        'exec gh release create "$TAG"',
+        'exec -- gh release create "$TAG"',
+        'exec -a release-writer gh release create "$TAG"',
+        'command exec gh release create "$TAG"',
+        'coproc gh release create "$TAG"; wait "$COPROC_PID"',
+        'if [[ -e <(eval "$payload") ]]; then :; fi',
+        "payload='index[$(gh release create \"$TAG\")]'; (( payload )) || :",
+    ],
+)
+def test_release_workflow_rejects_indirect_sibling_shell(
+    tmp_path: Path,
+    indirect_command: str,
+) -> None:
     workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
     marker = "      - name: Create GitHub Release and attach distributions\n"
-    sibling = """\
+    sibling = f"""\
       - name: Hidden release API write
-        run: bash -c 'gh api "repos/${REPO}/releases" -f tag_name="$TAG"'
+        shell: bash
+        run: {indirect_command}
 """
     path = tmp_path / "release.yml"
-    path.write_text(workflow.replace(marker, sibling + marker, 1), encoding="utf-8")
+    path.write_text(_replace_once(workflow, marker, sibling + marker), encoding="utf-8")
 
     errors = verify_ci_workflow.validate_release_workflow(path)
 
@@ -1435,6 +2082,9 @@ def test_release_workflow_rejects_indirect_sibling_shell(tmp_path: Path) -> None
         "trap 'exit 0' EXIT",
         '$DYNAMIC_COMMAND "exit 0"',
         "[[ x == x ]] && $DYNAMIC_COMMAND -c 'exit 0'",
+        'if [[ x &&\n            $(eval "$payload") ]]; then :; fi',
+        'if [[ "$(eval "$payload")" == x ]]; then :; fi',
+        'if [[ x && `eval "$payload"` ]]; then :; fi',
     ],
 )
 def test_release_workflow_rejects_indirect_publication_shell(
@@ -1445,7 +2095,7 @@ def test_release_workflow_rejects_indirect_publication_shell(
     marker = "          prerelease=()\n"
     path = tmp_path / "release.yml"
     path.write_text(
-        workflow.replace(marker, f"          {indirect_command}\n{marker}", 1),
+        _replace_once(workflow, marker, f"          {indirect_command}\n{marker}"),
         encoding="utf-8",
     )
 
@@ -1484,7 +2134,7 @@ def test_release_workflow_rejects_builtin_security_state_writes(
     marker = "          is_immutable=false\n"
     path = tmp_path / "release.yml"
     path.write_text(
-        workflow.replace(marker, marker + f"          {builtin_write}\n", 1),
+        _replace_once(workflow, marker, marker + f"          {builtin_write}\n"),
         encoding="utf-8",
     )
 
@@ -1942,6 +2592,140 @@ def test_docs_deploy_rejects_folded_release_gate_run(tmp_path: Path) -> None:
     assert any("missing its active polling shell step" in error for error in errors)
 
 
+@pytest.mark.parametrize("shell_value", ["python", "pwsh", "bash {0}", "${{ env.SHELL }}"])
+def test_docs_deploy_rejects_noncanonical_release_gate_shell(
+    tmp_path: Path,
+    shell_value: str,
+) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    step = "      - name: Await GitHub Release and PyPI availability\n"
+    before, separator, after = workflow.partition(step)
+    assert separator
+    after = _replace_once(after, "        shell: bash\n", f"        shell: {shell_value}\n")
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(before + separator + after, encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("exact step-local `shell: bash`" in error for error in errors)
+
+
+def test_docs_deploy_rejects_release_gate_control_bypass(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    marker = "      - name: Await GitHub Release and PyPI availability\n        env:\n"
+    replacement = (
+        "      - name: Await GitHub Release and PyPI availability\n"
+        "        continue-on-error: true\n"
+        "        env:\n"
+    )
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(_replace_once(workflow, marker, replacement), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("exact step controls" in error for error in errors)
+
+
+def test_docs_deploy_rejects_release_gate_job_inherited_environment(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    marker = "  verify-library-release:\n    name: Verify Library Release Published\n"
+    replacement = (
+        "  verify-library-release:\n"
+        "    name: Verify Library Release Published\n"
+        "    env:\n"
+        "      BASH_ENV: ./hidden-release-writer.sh\n"
+    )
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(_replace_once(workflow, marker, replacement), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("release gate job must use exact control keys" in error for error in errors)
+
+
+def test_docs_deploy_rejects_self_hosted_release_gate(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    job = "  verify-library-release:\n"
+    before, separator, after = workflow.partition(job)
+    assert separator
+    after = _replace_once(
+        after,
+        "    runs-on: ubuntu-latest\n",
+        "    runs-on: self-hosted\n",
+    )
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(before + separator + after, encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("exact trusted ubuntu-latest runner" in error for error in errors)
+
+
+def test_docs_deploy_rejects_sibling_step_before_release_gate(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    marker = "      - name: Await GitHub Release and PyPI availability\n"
+    sibling = """\
+      - name: Poison following Bash step
+        shell: bash
+        run: |
+          printf '%s\\n' 'exit 0' > /tmp/xy-gate-bypass
+          echo 'BASH_ENV=/tmp/xy-gate-bypass' >> "$GITHUB_ENV"
+"""
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(_replace_once(workflow, marker, sibling + marker), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("exactly its one verified polling step" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "inherited_control",
+    [
+        "env:\n  BASH_ENV: ./hidden-release-writer.sh\n\n",
+        "defaults:\n  run:\n    working-directory: ./unverified-release\n\n",
+        "? env\n:\n  BASH_ENV: ./hidden-release-writer.sh\n\n",
+    ],
+)
+def test_docs_deploy_rejects_inherited_workflow_controls(
+    tmp_path: Path,
+    inherited_control: str,
+) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(
+        _replace_once(workflow, "jobs:\n", inherited_control + "jobs:\n"),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("exact top-level controls" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "permissions",
+    [
+        "permissions:\n  contents: write\n",
+        'permissions:\n  contents: read\n  "packages": write\n',
+    ],
+)
+def test_docs_deploy_rejects_broad_top_level_permissions(
+    tmp_path: Path,
+    permissions: str,
+) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    marker = "permissions:\n  contents: read\n"
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(_replace_once(workflow, marker, permissions), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("top-level permissions must be exactly" in error for error in errors)
+
+
 @pytest.mark.parametrize(
     "indirect_command",
     [
@@ -1954,6 +2738,11 @@ def test_docs_deploy_rejects_folded_release_gate_run(tmp_path: Path) -> None:
         "trap 'exit 0' EXIT",
         '$DYNAMIC_COMMAND "exit 0"',
         "[[ x == x ]] && $DYNAMIC_COMMAND -c 'exit 0'",
+        'if [[ x &&\n            $(eval "$payload") ]]; then :; fi',
+        'if [[ "$(eval "$payload")" == x ]]; then :; fi',
+        'if [[ x && `eval "$payload"` ]]; then :; fi',
+        "echo 'BASH_ENV=/tmp/xy-gate-bypass' >> \"$GITHUB_ENV\"",
+        "printf '%s\\n' '/tmp/xy-bin' > \"$GITHUB_PATH\"",
     ],
 )
 def test_docs_deploy_rejects_indirect_release_gate_shell(
@@ -1964,7 +2753,7 @@ def test_docs_deploy_rejects_indirect_release_gate_shell(
     marker = "          EXPECTED_PRERELEASE=false\n"
     path = tmp_path / "deploy-docs-stg.yml"
     path.write_text(
-        workflow.replace(marker, f"          {indirect_command}\n{marker}", 1),
+        _replace_once(workflow, marker, f"          {indirect_command}\n{marker}"),
         encoding="utf-8",
     )
 
@@ -2005,7 +2794,7 @@ def test_docs_deploy_rejects_builtin_readiness_state_writes(
     marker = "            TAG_MATCH=false\n"
     path = tmp_path / "deploy-docs-stg.yml"
     path.write_text(
-        workflow.replace(marker, marker + f"            {builtin_write}\n", 1),
+        _replace_once(workflow, marker, marker + f"            {builtin_write}\n"),
         encoding="utf-8",
     )
 
@@ -2307,6 +3096,33 @@ def test_docs_deploy_rejects_bypassed_production_release_gate(
     errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
 
     assert any("production Helm promotion" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "bypass",
+    [
+        "    needs: [prepare, await-prod-approval]\n",
+        '    "needs": [prepare, await-prod-approval]\n',
+        "    ? needs\n    : [prepare, await-prod-approval]\n",
+        "    if: always()\n",
+        "    continue-on-error: true\n",
+    ],
+)
+def test_docs_deploy_rejects_duplicate_or_conditional_production_gate(
+    tmp_path: Path,
+    bypass: str,
+) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    dependency = "    needs: [prepare, await-prod-approval, verify-library-release]\n"
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(
+        _replace_once(workflow, dependency, dependency + bypass),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("exact reusable workflow controls" in error for error in errors)
 
 
 def _write_passthrough_timeout(fake_bin: Path) -> None:
@@ -2728,6 +3544,7 @@ def _run_immutable_release(
     github_wheel: bytes,
     local_wheel: bytes = b"wheel",
     pypi_wheel: bytes = b"wheel",
+    release_lookup_error: str | None = None,
     tag_source_sha: str | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], str, str, str]:
     workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
@@ -2780,6 +3597,12 @@ printf '%s\n' "$*" >> "$GH_LOG"
 if [[ "$1" == "api" && "$*" == *"/commits/$TAG"* ]]; then
   printf '%s\n' "$TAG_SOURCE_SHA"
 elif [[ "$1" == "release" && "$2" == "view" ]]; then
+  if [[ "${GH_RELEASE_LOOKUP_FAIL:-}" == true ]]; then
+    if [[ -n "${GH_RELEASE_LOOKUP_ERROR:-}" ]]; then
+      printf '%s\n' "$GH_RELEASE_LOOKUP_ERROR" >&2
+    fi
+    exit 1
+  fi
   cat "$GH_RELEASE_JSON"
 elif [[ "$1" == "release" && "$2" == "download" ]]; then
   download_dir=""
@@ -2856,6 +3679,8 @@ cat "$PYPI_JSON"
         "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
         "CURRENT_NOTES": current_notes,
         "GH_LOG": str(log),
+        "GH_RELEASE_LOOKUP_FAIL": str(release_lookup_error is not None).lower(),
+        "GH_RELEASE_LOOKUP_ERROR": release_lookup_error or "",
         "GH_RELEASE_JSON": str(release_json),
         "GH_REMOTE": str(remote),
         "GH_TOKEN": "test",
@@ -2878,6 +3703,60 @@ cat "$PYPI_JSON"
     )
     calls = log.read_text(encoding="utf-8") if log.exists() else ""
     return result, calls, fixture["body"], current_notes
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="release workflow runtime simulation requires bash and jq",
+)
+@pytest.mark.parametrize(
+    "lookup_error",
+    [
+        "",
+        "request timed out",
+        "HTTP 429: rate limit exceeded",
+        "HTTP 401: authentication required",
+    ],
+)
+def test_release_workflow_fails_closed_on_existing_release_lookup_errors(
+    tmp_path: Path,
+    lookup_error: str,
+) -> None:
+    result, calls, _, _ = _run_immutable_release(
+        tmp_path,
+        github_wheel=b"wheel",
+        release_lookup_error=lookup_error,
+    )
+
+    assert result.returncode == 1
+    assert (
+        "Could not inspect existing GitHub Release v1.2.3; refusing to create it" in result.stdout
+    )
+    assert result.stderr == (f"{lookup_error}\n" if lookup_error else "")
+    assert "release view v1.2.3" in calls
+    assert "release download" not in calls
+    assert "release upload" not in calls
+    assert "release edit" not in calls
+    assert "release create" not in calls
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="release workflow runtime simulation requires bash and jq",
+)
+def test_release_workflow_treats_exact_not_found_lookup_as_absent(
+    tmp_path: Path,
+) -> None:
+    result, calls, _, _ = _run_immutable_release(
+        tmp_path,
+        github_wheel=b"wheel",
+        release_lookup_error="release not found",
+    )
+
+    assert result.returncode == 1
+    assert "Could not inspect existing GitHub Release" not in result.stdout
+    assert "Prepared release notes or provenance are missing" in result.stdout
+    assert "release view v1.2.3" in calls
 
 
 @pytest.mark.skipif(
@@ -3389,8 +4268,10 @@ def test_release_workflow_rejects_always_conditioned_pypi_publish(tmp_path: Path
     workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
     path = tmp_path / "release.yml"
     gate = (
-        "        if: github.event_name != 'workflow_dispatch' "
-        "|| github.event.inputs.dry_run != 'true'\n"
+        "        if: (github.event_name == 'push' && "
+        "startsWith(github.ref, 'refs/tags/v')) || "
+        "(github.event_name == 'workflow_dispatch' && "
+        "github.event.inputs.dry_run == 'false')\n"
     )
     assert gate in workflow
     path.write_text(workflow.replace(gate, "        if: always()\n"), encoding="utf-8")

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -947,8 +947,7 @@ def test_release_workflow_rejects_detached_release_artifacts(
     path.write_text(
         workflow.replace(
             upload,
-            '            gh release upload "$TAG" "$provenance_file" '
-            '--repo "$REPO" --clobber\n',
+            '            gh release upload "$TAG" "$provenance_file" --repo "$REPO" --clobber\n',
         ).replace(
             create,
             '          gh release create "$TAG" "$provenance_file" '
@@ -1023,14 +1022,11 @@ def test_release_workflow_rejects_unattested_provenance(
     tmp_path: Path,
 ) -> None:
     workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
-    action = (
-        "        uses: actions/attest@"
-        "508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1\n"
-    )
+    action = "        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1\n"
     assert action in workflow
     path = tmp_path / "release.yml"
     path.write_text(
-        workflow.replace(action, '        uses: example/untrusted-attest@v1\n'),
+        workflow.replace(action, "        uses: example/untrusted-attest@v1\n"),
         encoding="utf-8",
     )
 

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -742,6 +742,54 @@ def test_release_workflow_rejects_non_retryable_pypi_publish(tmp_path: Path) -> 
     assert any("release publish job" in error and "skip-existing" in error for error in errors)
 
 
+def test_release_workflow_rejects_missing_github_release_job(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release.yml"
+    path.write_text(workflow.split("\n  github-release:\n", 1)[0], encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("github-release" in error for error in errors)
+
+
+def test_release_workflow_rejects_manual_github_release_creation(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(
+            "    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')\n",
+            "    if: github.event_name != 'workflow_dispatch' "
+            "|| github.event.inputs.dry_run != 'true'\n",
+        ),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("github-release job" in error and "tag-only" in error for error in errors)
+
+
+def test_release_workflow_rejects_unsafe_github_release_job(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace("      contents: write\n", "      contents: read\n", 1)
+        .replace(" --clobber\n", "\n", 1)
+        .replace("            --verify-tag \\\n", "", 1),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any(
+        "github-release job" in error
+        and "contents: write" in error
+        and "--clobber" in error
+        and "--verify-tag" in error
+        for error in errors
+    )
+
+
 def test_release_workflow_rejects_shallow_checkout(tmp_path: Path) -> None:
     """A depth-1 checkout fetches no tags, and the version is derived from them.
 

--- a/tests/test_verify_ci_workflow.py
+++ b/tests/test_verify_ci_workflow.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import re
+import shutil
+import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 # Actions are pinned to full commit SHAs (`@<40-hex> # vX`) per the org policy,
 # so fixtures strip a step by its action *path*, not a version tag — a SHA bump
@@ -549,6 +554,25 @@ def test_release_workflow_accepts_current_gates() -> None:
     assert verify_ci_workflow.validate_release_workflow() == []
 
 
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    (
+        ("v1.2.3", False),
+        ("v1.2.3a1", True),
+        ("v1.2.3b2", True),
+        ("v1.2.3rc4", True),
+        ("v1.2.3.post1", False),
+        ("v1.2.3-rc1", False),
+        ("v1.2.3rc1-extra", False),
+        ("prefix-v1.2.3rc1", False),
+    ),
+)
+def test_release_prerelease_classifier_is_canonical(tag: str, expected: bool) -> None:
+    assert (
+        re.fullmatch(verify_ci_workflow.CORE_PRERELEASE_TAG_PATTERN, tag) is not None
+    ) is expected
+
+
 def test_release_workflow_rejects_missing_native_wheel_verifier(tmp_path: Path) -> None:
     workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
     path = tmp_path / "release.yml"
@@ -754,19 +778,24 @@ def test_release_workflow_rejects_missing_github_release_job(tmp_path: Path) -> 
 
 def test_release_workflow_rejects_manual_github_release_creation(tmp_path: Path) -> None:
     workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    gate = "    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')\n"
+    assert gate in workflow
     path = tmp_path / "release.yml"
     path.write_text(
         workflow.replace(
-            "    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')\n",
-            "    if: github.event_name != 'workflow_dispatch' "
-            "|| github.event.inputs.dry_run != 'true'\n",
+            gate,
+            "    # if: github.event_name == 'push' && "
+            "startsWith(github.ref, 'refs/tags/v')\n"
+            "    if: always()\n",
         ),
         encoding="utf-8",
     )
 
     errors = verify_ci_workflow.validate_release_workflow(path)
 
-    assert any("github-release job" in error and "tag-only" in error for error in errors)
+    assert any(
+        "github-release job" in error and "active tag-only gate" in error for error in errors
+    )
 
 
 def test_release_workflow_rejects_unsafe_github_release_job(tmp_path: Path) -> None:
@@ -781,13 +810,8 @@ def test_release_workflow_rejects_unsafe_github_release_job(tmp_path: Path) -> N
 
     errors = verify_ci_workflow.validate_release_workflow(path)
 
-    assert any(
-        "github-release job" in error
-        and "contents: write" in error
-        and "--clobber" in error
-        and "--verify-tag" in error
-        for error in errors
-    )
+    assert any("permissions must be exactly" in error and "contents" in error for error in errors)
+    assert any("--clobber" in error and "--verify-tag" in error for error in errors)
 
 
 def test_release_workflow_rejects_missing_github_release_artifact_guard(
@@ -796,13 +820,16 @@ def test_release_workflow_rejects_missing_github_release_artifact_guard(
     workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
     guard = """\
           shopt -s nullglob
-          artifacts=(dist/*.whl dist/*.tar.gz)
-          if (( ${#artifacts[@]} == 0 )); then
-            echo "::error::No wheel or sdist artifacts were downloaded"
+          wheels=(dist/*.whl)
+          sdists=(dist/*.tar.gz)
+          artifacts=("${wheels[@]}" "${sdists[@]}")
+          if (( ${#wheels[@]} == 0 || ${#sdists[@]} != 1 )); then
+            echo "::error::Expected at least one wheel and exactly one sdist"
             exit 1
           fi
 
 """
+    assert guard in workflow
     path = tmp_path / "release.yml"
     path.write_text(workflow.replace(guard, ""), encoding="utf-8")
 
@@ -811,8 +838,8 @@ def test_release_workflow_rejects_missing_github_release_artifact_guard(
     assert any(
         "github-release job" in error
         and "shopt -s nullglob" in error
-        and "artifacts=(dist/*.whl dist/*.tar.gz)" in error
-        and "No wheel or sdist artifacts were downloaded" in error
+        and "wheels=(dist/*.whl)" in error
+        and "exactly one sdist" in error
         for error in errors
     )
 
@@ -821,23 +848,386 @@ def test_release_workflow_rejects_unvalidated_existing_github_release(
     tmp_path: Path,
 ) -> None:
     workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    final_view = """\
+              gh release view "$TAG" \\
+                --repo "$REPO" \\
+                --json assets,body,isDraft,isImmutable,isPrerelease,name,publishedAt,tagName
+"""
+    assert workflow.count(final_view) == 2
     path = tmp_path / "release.yml"
-    path.write_text(
-        workflow.replace("--json isDraft,isPrerelease,name", "--json name")
-        .replace('              gh release edit "$TAG" \\\n', '              echo "$TAG" \\\n')
-        .replace("                --draft=false \\\n", ""),
-        encoding="utf-8",
-    )
+    before, separator, after = workflow.rpartition(final_view)
+    assert separator
+    path.write_text(before + '              echo "validation removed"\n' + after, encoding="utf-8")
 
     errors = verify_ci_workflow.validate_release_workflow(path)
 
     assert any(
         "github-release job" in error
-        and "--json isDraft,isPrerelease,name" in error
-        and "gh release edit" in error
-        and "--draft=false" in error
+        and ("after normalization" in error or "validate again" in error)
         for error in errors
     )
+
+
+def test_release_workflow_rejects_extra_github_release_write_scope(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    permission = "      contents: write\n"
+    assert permission in workflow
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(
+            permission,
+            permission + "      issues: write\n",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("permissions must be exactly" in error and "issues" in error for error in errors)
+
+
+def test_release_workflow_rejects_removed_prerelease_classifier(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    classifier = f"""\
+          if [[ "$TAG" =~ {verify_ci_workflow.CORE_PRERELEASE_TAG_PATTERN} ]]; then
+            prerelease=(--prerelease)
+            edit_prerelease=(--prerelease)
+            expected_prerelease=true
+          fi
+"""
+    assert classifier in workflow
+    path = tmp_path / "release.yml"
+    path.write_text(workflow.replace(classifier, ""), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert "--prerelease=false" in workflow
+    assert any("classify canonical alpha/beta/RC tags" in error for error in errors)
+
+
+def test_release_workflow_rejects_detached_release_artifacts(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    upload = '            gh release upload "$TAG" "${artifacts[@]}" --repo "$REPO" --clobber\n'
+    create = '          gh release create "$TAG" "${artifacts[@]}" \\\n'
+    assert upload in workflow
+    assert create in workflow
+    path = tmp_path / "release.yml"
+    path.write_text(
+        workflow.replace(
+            upload,
+            '            gh release upload "$TAG" --repo "$REPO" --clobber\n',
+        ).replace(
+            create,
+            '          gh release create "$TAG" \\\n',
+        ),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("pass the verified artifact array directly" in error for error in errors)
+
+
+def test_release_workflow_rejects_missing_stale_asset_reconciliation(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    endpoint = '"repos/${REPO}/releases/assets/${asset_id}"'
+    assert endpoint in workflow
+    path = tmp_path / "release.yml"
+    path.write_text(workflow.replace(endpoint, '"stale asset deletion removed"'), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any(
+        "prune stale assets by id" in error or "releases/assets/${asset_id}" in error
+        for error in errors
+    )
+
+
+def test_release_workflow_rejects_missing_generated_notes_marker(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    marker = "<!-- xy-release-workflow:%s -->"
+    assert marker in workflow
+    path = tmp_path / "release.yml"
+    path.write_text(workflow.replace(marker, "<!-- marker removed -->"), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_release_workflow(path)
+
+    assert any("generated-notes behavior" in error and marker in error for error in errors)
+
+
+def test_docs_deploy_workflow_accepts_release_contract() -> None:
+    assert verify_ci_workflow.validate_docs_deploy_workflow() == []
+
+
+def test_docs_deploy_rejects_existence_only_release_gate(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    fields = "--json assets,body,isDraft,isPrerelease,name,publishedAt,tagName"
+    assert fields in workflow
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(workflow.replace(fields, "--json name"), encoding="utf-8")
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("expected non-draft metadata" in error and fields in error for error in errors)
+
+
+def test_docs_deploy_rejects_asset_set_check_removal(tmp_path: Path) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    comparison = '                 [[ "$github_assets" == "$pypi_assets" ]]; then\n'
+    assert comparison in workflow
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(
+        workflow.replace(comparison, "                 [[ true == true ]]; then\n"),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("wheel/sdist assets" in error for error in errors)
+
+
+def test_docs_deploy_rejects_bypassed_production_release_gate(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    dependency = "    needs: [prepare, await-prod-approval, verify-library-release]\n"
+    assert dependency in workflow
+    path = tmp_path / "deploy-docs-stg.yml"
+    path.write_text(
+        workflow.replace(
+            dependency,
+            "    needs: [prepare, await-prod-approval]\n",
+        ),
+        encoding="utf-8",
+    )
+
+    errors = verify_ci_workflow.validate_docs_deploy_workflow(path)
+
+    assert any("production Helm promotion" in error for error in errors)
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="release workflow runtime simulation requires bash and jq",
+)
+def test_release_workflow_reconciles_stale_assets_before_publishing(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    job = verify_ci_workflow._job_blocks(workflow)["github-release"]
+    release_shell = verify_ci_workflow._named_step_run(
+        job,
+        "Create GitHub Release and attach distributions",
+    )
+    assert release_shell is not None
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text(
+        r"""#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$*" >> "$GH_LOG"
+state="$(<"$GH_STATE")"
+if [[ "$1" == "api" && "$*" == *"/generate-notes"* ]]; then
+  printf '## Changes\n\n- Generated\n'
+elif [[ "$1" == "api" && "$*" == *"/releases/assets/"* ]]; then
+  [[ "$*" == *"/releases/assets/9003"* ]]
+  printf 'deleted' > "$GH_STATE"
+elif [[ "$1" == "release" && "$2" == "upload" ]]; then
+  [[ "$state" == "initial" ]]
+  printf 'uploaded' > "$GH_STATE"
+elif [[ "$1" == "release" && "$2" == "edit" ]]; then
+  [[ "$state" == "deleted" ]]
+  printf 'edited' > "$GH_STATE"
+elif [[ "$1" == "release" && "$2" == "view" ]]; then
+  if [[ "$state" == "edited" ]]; then
+    printf '%s\n' '{"assets":[{"name":"xy-1.2.3-py3-none-any.whl","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9001"},{"name":"xy-1.2.3.tar.gz","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9002"},{"name":"checksums.txt","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9004"}],"body":"## Changes\n\n- Generated\n\n<!-- xy-release-workflow:v1.2.3 -->","isDraft":false,"isImmutable":false,"isPrerelease":false,"name":"v1.2.3","publishedAt":"2026-07-31T00:00:00Z","tagName":"v1.2.3"}'
+  else
+    printf '%s\n' '{"assets":[{"name":"xy-1.2.3-py3-none-any.whl","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9001"},{"name":"xy-1.2.3.tar.gz","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9002"},{"name":"stale.whl","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9003"},{"name":"checksums.txt","apiUrl":"https://api.github.com/repos/reflex-dev/xy/releases/assets/9004"}],"body":"manual","isDraft":true,"isImmutable":false,"isPrerelease":false,"name":"manual","publishedAt":null,"tagName":"v1.2.3"}'
+  fi
+else
+  printf 'unexpected gh invocation: %s\n' "$*" >&2
+  exit 97
+fi
+""",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / "xy-1.2.3-py3-none-any.whl").write_bytes(b"wheel")
+    (tmp_path / "dist" / "xy-1.2.3.tar.gz").write_bytes(b"sdist")
+    state = tmp_path / "state"
+    state.write_text("initial", encoding="utf-8")
+    log = tmp_path / "gh.log"
+    runner_temp = tmp_path / "runner"
+    runner_temp.mkdir()
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "GH_LOG": str(log),
+        "GH_STATE": str(state),
+        "GH_TOKEN": "test",
+        "REPO": "reflex-dev/xy",
+        "RUNNER_TEMP": str(runner_temp),
+        "TAG": "v1.2.3",
+    }
+
+    result = subprocess.run(
+        ["bash", "-e", "-o", "pipefail", "-c", release_shell],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+    calls = log.read_text(encoding="utf-8")
+    assert "release upload v1.2.3 dist/xy-1.2.3-py3-none-any.whl dist/xy-1.2.3.tar.gz" in calls
+    assert "api --method DELETE repos/reflex-dev/xy/releases/assets/9003" in calls
+    assert "releases/assets/9004" not in calls
+    assert "release edit v1.2.3" in calls
+    assert state.read_text(encoding="utf-8") == "edited"
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="release workflow runtime simulation requires bash and jq",
+)
+def test_release_workflow_never_mutates_mismatched_immutable_release(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    release_shell = verify_ci_workflow._named_step_run(
+        verify_ci_workflow._job_blocks(workflow)["github-release"],
+        "Create GitHub Release and attach distributions",
+    )
+    assert release_shell is not None
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text(
+        r"""#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$*" >> "$GH_LOG"
+if [[ "$1" == "api" && "$*" == *"/generate-notes"* ]]; then
+  printf '## Changes\n\n- Generated\n'
+elif [[ "$1" == "release" && "$2" == "view" ]]; then
+  printf '%s\n' '{"assets":[{"name":"xy-1.2.3-py3-none-any.whl"},{"name":"xy-1.2.3.tar.gz"}],"body":"manual notes","isDraft":false,"isImmutable":true,"isPrerelease":false,"name":"v1.2.3","publishedAt":"2026-07-31T00:00:00Z","tagName":"v1.2.3"}'
+else
+  printf 'mutation attempted: %s\n' "$*" >&2
+  exit 98
+fi
+""",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+    (tmp_path / "dist").mkdir()
+    (tmp_path / "dist" / "xy-1.2.3-py3-none-any.whl").write_bytes(b"wheel")
+    (tmp_path / "dist" / "xy-1.2.3.tar.gz").write_bytes(b"sdist")
+    log = tmp_path / "gh.log"
+    runner_temp = tmp_path / "runner"
+    runner_temp.mkdir()
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "GH_LOG": str(log),
+        "GH_TOKEN": "test",
+        "REPO": "reflex-dev/xy",
+        "RUNNER_TEMP": str(runner_temp),
+        "TAG": "v1.2.3",
+    }
+
+    result = subprocess.run(
+        ["bash", "-e", "-o", "pipefail", "-c", release_shell],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "immutable but does not match" in result.stdout
+    calls = log.read_text(encoding="utf-8")
+    assert "release upload" not in calls
+    assert "release edit" not in calls
+    assert "/releases/assets/" not in calls
+    assert "release create" not in calls
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="docs promotion runtime simulation requires bash and jq",
+)
+def test_docs_promotion_accepts_only_matching_ready_distribution_set(
+    tmp_path: Path,
+) -> None:
+    workflow = Path(".github/workflows/deploy-docs-stg.yml").read_text(encoding="utf-8")
+    gate_shell = verify_ci_workflow._named_step_run(
+        verify_ci_workflow._job_blocks(workflow)["verify-library-release"],
+        "Await GitHub Release and PyPI availability",
+    )
+    assert gate_shell is not None
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text(
+        r"""#!/usr/bin/env bash
+set -eu
+printf '%s\n' '{"assets":[{"name":"xy-1.2.3-py3-none-any.whl"},{"name":"xy-1.2.3.tar.gz"},{"name":"checksums.txt"}],"body":"## Changes\n\n<!-- xy-release-workflow:v1.2.3 -->","isDraft":false,"isPrerelease":false,"name":"v1.2.3","publishedAt":"2026-07-31T00:00:00Z","tagName":"v1.2.3"}'
+""",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text(
+        r"""#!/usr/bin/env bash
+set -eu
+printf '%s\n' '{"urls":[{"filename":"xy-1.2.3.tar.gz"},{"filename":"xy-1.2.3-py3-none-any.whl"}]}'
+""",
+        encoding="utf-8",
+    )
+    fake_curl.chmod(0o755)
+    fake_sleep = fake_bin / "sleep"
+    fake_sleep.write_text("#!/usr/bin/env bash\nexit 99\n", encoding="utf-8")
+    fake_sleep.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "GH_TOKEN": "test",
+        "REPO": "reflex-dev/xy",
+        "VERSION": "v1.2.3",
+    }
+
+    result = subprocess.run(
+        ["bash", "-e", "-o", "pipefail", "-c", gate_shell],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+    assert "v1.2.3 is on GitHub Releases and PyPI" in result.stdout
 
 
 def test_release_workflow_rejects_shallow_checkout(tmp_path: Path) -> None:

--- a/tests/test_verify_sdist.py
+++ b/tests/test_verify_sdist.py
@@ -4,6 +4,7 @@ import importlib.util
 import io
 import sys
 import tarfile
+import types
 from pathlib import Path
 from typing import Optional, Union
 
@@ -139,6 +140,52 @@ def _load_sdist_module():
 
 
 verify_sdist = _load_sdist_module()
+
+
+def test_archived_workflow_verifier_uses_normal_import_semantics(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "_xy_sdist_ci_verifier"
+    previous = types.ModuleType(module_name)
+    monkeypatch.setitem(sys.modules, module_name, previous)
+
+    class AssertingLoader:
+        def create_module(self, spec):  # noqa: ANN001
+            return None
+
+        def exec_module(self, module):  # noqa: ANN001
+            assert sys.modules.get(module_name) is module
+
+            def validate_docs_deploy_workflow(path: Path) -> list[str]:
+                assert path.name == "deploy-docs-stg.yml"
+                assert sys.modules.get(module_name) is module
+                return []
+
+            module.validate_docs_deploy_workflow = validate_docs_deploy_workflow
+
+    def fake_spec_from_file_location(name: str, path: Path):  # noqa: ARG001
+        return importlib.util.spec_from_loader(name, AssertingLoader())
+
+    monkeypatch.setattr(
+        verify_sdist.importlib.util,
+        "spec_from_file_location",
+        fake_spec_from_file_location,
+    )
+    archive = tmp_path / "fixture.tar.gz"
+    with tarfile.open(archive, "w:gz") as tf:
+        _add_file(
+            tf,
+            "xy-0.0.1/.github/workflows/deploy-docs-stg.yml",
+            b"# workflow\n" + b"x" * 1100,
+        )
+
+    verify_sdist._require_valid_docs_deploy_workflow(
+        str(archive),
+        "xy-0.0.1",
+    )
+
+    assert sys.modules[module_name] is previous
 
 
 def _add_file(tf: tarfile.TarFile, name: str, data: bytes = b"") -> None:

--- a/tests/test_verify_sdist.py
+++ b/tests/test_verify_sdist.py
@@ -83,17 +83,8 @@ CODSPEED_YML = (
     + ("codspeed workflow padding\n" * 100)
 )
 DOCS_DEPLOY_YML = (
-    "name: Deploy docs\n"
-    "jobs:\n"
-    "  verify-library-release:\n"
-    "    steps:\n"
-    "      - run: gh release view --json assets,body,isDraft,isPrerelease,name,publishedAt,tagName\n"
-    "      - run: curl https://pypi.org/pypi/xy/version/json\n"
-    "      - run: echo '<!-- xy-release-workflow:tag -->'\n"
-    "  helm-pr-prod:\n"
-    "    needs: [prepare, await-prod-approval, verify-library-release]\n"
-    + ("docs deploy workflow padding\n" * 100)
-)
+    Path(__file__).resolve().parents[1] / ".github" / "workflows" / "deploy-docs-stg.yml"
+).read_text(encoding="utf-8")
 RELEASE_YML = (
     "name: Release\n"
     "jobs:\n"
@@ -464,6 +455,26 @@ def test_verify_sdist_rejects_missing_docs_deploy_workflow(tmp_path: Path) -> No
     _write_sdist(sdist, omit={".github/workflows/deploy-docs-stg.yml"})
 
     with pytest.raises(AssertionError, match=r"deploy-docs-stg\.yml"):
+        verify_sdist.verify_sdist(str(sdist))
+
+
+def test_verify_sdist_rejects_commented_out_docs_release_gate(tmp_path: Path) -> None:
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
+    active_command = '              gh release view "$VERSION" \\\n'
+    assert active_command in DOCS_DEPLOY_YML
+    commented_workflow = DOCS_DEPLOY_YML.replace(
+        active_command,
+        '              # gh release view "$VERSION" \\\n',
+        1,
+    )
+    # The legacy raw-substring check would still see every marker.
+    assert 'gh release view "$VERSION"' in commented_workflow
+    _write_sdist(
+        sdist,
+        replacements={".github/workflows/deploy-docs-stg.yml": commented_workflow},
+    )
+
+    with pytest.raises(AssertionError, match=r"structural release-gate validation"):
         verify_sdist.verify_sdist(str(sdist))
 
 

--- a/tests/test_verify_sdist.py
+++ b/tests/test_verify_sdist.py
@@ -82,6 +82,18 @@ CODSPEED_YML = (
     "      - run: python -c 'import xy.kernels as k; assert k.BACKEND == \"native\"'\n"
     + ("codspeed workflow padding\n" * 100)
 )
+DOCS_DEPLOY_YML = (
+    "name: Deploy docs\n"
+    "jobs:\n"
+    "  verify-library-release:\n"
+    "    steps:\n"
+    "      - run: gh release view --json assets,body,isDraft,isPrerelease,name,publishedAt,tagName\n"
+    "      - run: curl https://pypi.org/pypi/xy/version/json\n"
+    "      - run: echo '<!-- xy-release-workflow:tag -->'\n"
+    "  helm-pr-prod:\n"
+    "    needs: [prepare, await-prod-approval, verify-library-release]\n"
+    + ("docs deploy workflow padding\n" * 100)
+)
 RELEASE_YML = (
     "name: Release\n"
     "jobs:\n"
@@ -186,6 +198,8 @@ def _write_sdist(
                 data = CI_YML.encode("utf-8")
             elif name == ".github/workflows/codspeed.yml":
                 data = CODSPEED_YML.encode("utf-8")
+            elif name == ".github/workflows/deploy-docs-stg.yml":
+                data = DOCS_DEPLOY_YML.encode("utf-8")
             elif name == ".github/workflows/release.yml":
                 data = RELEASE_YML.encode("utf-8")
             elif name == ".github/workflows/release-reflex-xy.yml":
@@ -442,6 +456,14 @@ def test_verify_sdist_rejects_missing_release_workflow(tmp_path: Path) -> None:
     _write_sdist(sdist, omit={".github/workflows/release.yml"})
 
     with pytest.raises(AssertionError, match=r"release\.yml"):
+        verify_sdist.verify_sdist(str(sdist))
+
+
+def test_verify_sdist_rejects_missing_docs_deploy_workflow(tmp_path: Path) -> None:
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
+    _write_sdist(sdist, omit={".github/workflows/deploy-docs-stg.yml"})
+
+    with pytest.raises(AssertionError, match=r"deploy-docs-stg\.yml"):
         verify_sdist.verify_sdist(str(sdist))
 
 


### PR DESCRIPTION
## What changed

- Added a tag-only `github-release` job after the verified PyPI publish job.
- Download the already-verified distribution artifacts and create the GitHub Release with generated notes and attached wheels/sdist.
- Mark alpha, beta, and release-candidate tags as prereleases and make reruns replace assets safely.
- Kept all `workflow_dispatch` runs, including dry runs, unable to create a release.
- Aligned docs-promotion comments/runbook text and added workflow invariants.

## Why

Docs promotion requires both the PyPI version and a GitHub Release, but the core release workflow previously created only the PyPI publication. No automated owner completed the second half of that contract.

## Impact

A real `v*` tag now produces the GitHub Release only after publication succeeds, while manual validation remains non-publishing.

## Validation

- `.venv/bin/pytest -q tests/test_verify_ci_workflow.py` — 59 passed
- `.venv/bin/python scripts/verify_ci_workflow.py`
- Ruff lint and format checks on verifier code/tests

Fixes #398

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub Releases are created automatically after successful PyPI publication.
  * Verified packages and signed provenance are attached to releases.
  * Release assets, metadata, notes, and PyPI packages are cross-checked for consistency.
  * Pre-release tags are detected automatically, with safe retry handling for updates.
  * Documentation deployments undergo bounded readiness and integrity checks before promotion.

* **Documentation**
  * Updated release and production-readiness guidance.

* **Tests**
  * Expanded validation for releases, documentation deployment, package contents, and promotion safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->