### PR TITLE
Trim source distribution to build inputs by 88%

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="spec/assets/xy-sdf-binned-scatter.png" alt="XY-shaped probability field shown as a binned scatter chart." width="521">
+  <img src="https://raw.githubusercontent.com/reflex-dev/xy/main/spec/assets/xy-sdf-binned-scatter.png" alt="XY-shaped probability field shown as a binned scatter chart." width="521">
 </p>
 
 <p align="center">
@@ -62,8 +62,8 @@ The same API scales to a hundred million points as a density surface:
 
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="spec/assets/xy-density-100m-dark.gif">
-    <img src="spec/assets/xy-density-100m-light.gif" alt="A hundred-million-point spiral rendered as a density surface, then zoomed until the surface resolves into individual points." width="780">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/reflex-dev/xy/main/spec/assets/xy-density-100m-dark.gif">
+    <img src="https://raw.githubusercontent.com/reflex-dev/xy/main/spec/assets/xy-density-100m-light.gif" alt="A hundred-million-point spiral rendered as a density surface, then zoomed until the surface resolves into individual points." width="780">
   </picture>
 </p>
 
@@ -115,7 +115,7 @@ ax.legend()
 plt.show()
 ```
 
-See the [compatibility guide](spec/matplotlib/compat.md); not all charts and
+See the [compatibility guide](https://github.com/reflex-dev/xy/blob/main/spec/matplotlib/compat.md); not all charts and
 functionality are supported yet.
 
 ## Customize every layer
@@ -152,7 +152,7 @@ stable (10 byte-identical frames), so progressive renderers are charged until
 their last chunk lands.
 
 <p align="center">
-  <img src="spec/assets/ux-render-time.png" alt="Time until every point is on screen, 10k to 100M points, for XY, Matplotlib, and Plotly. Lower is better." width="1200">
+  <img src="https://raw.githubusercontent.com/reflex-dev/xy/main/spec/assets/ux-render-time.png" alt="Time until every point is on screen, 10k to 100M points, for XY, Matplotlib, and Plotly. Lower is better." width="1200">
 </p>
 
 XY holds **0.071 s at 10k and 0.081 s at 100M**, flat across four orders of
@@ -193,8 +193,8 @@ One machine (Apple M5 Pro), one run per cell; at the small end the timings
 carry roughly ±10 ms of run-to-run spread.
 
 For the environment, methodology, per-size videos, and raw results, see the
-[benchmark runbook](benchmarks/README.md) and
-[competitive benchmark specification](spec/benchmarks/results.md).
+[benchmark runbook](https://github.com/reflex-dev/xy/blob/main/benchmarks/README.md) and
+[competitive benchmark specification](https://github.com/reflex-dev/xy/blob/main/spec/benchmarks/results.md).
 
 ## Embed XY in a Reflex app
 
@@ -250,20 +250,20 @@ app.add_page(index)
 Hover, pan, and zoom keep working. For charts driven by Reflex state, events, or
 live streams, see the
 [Reflex integration guide](https://reflex.dev/docs/xy/integrations/reflex/) and
-the [runnable example app](examples/reflex/).
+the [runnable example app](https://github.com/reflex-dev/xy/tree/main/examples/reflex/).
 
 ## Examples
 
 Each notebook fetches its rows from the linked public source; no raw datasets
 are stored in this repository. Counts describe the featured chart, and the
 notebooks scale further. See the
-[example guide](examples/real_world/README.md) for sources, workload controls,
+[example guide](https://github.com/reflex-dev/xy/blob/main/examples/real_world/README.md) for sources, workload controls,
 and setup.
 
 |  |  |  |
 | :---: | :---: | :---: |
-| **Gaia DR3 · HR diagram**<br><sub>250,000 plotted stars</sub><br><br>![Gaia DR3 stellar color versus absolute magnitude.](examples/real_world/assets/01-gaia-hr-diagram.png)<br><br>[Open notebook](examples/real_world/01_gaia_hr_diagram.ipynb) | **gnomAD v4.1 · allele frequency**<br><sub>164,000 plotted variants</sub><br><br>![gnomAD allele frequency across all autosomes.](examples/real_world/assets/02-gnomad-allele-frequency.png)<br><br>[Open notebook](examples/real_world/02_gnomad_allele_frequency.ipynb) | **Pan-UKBB · Manhattan plot**<br><sub>814,294 plotted variants</sub><br><br>![Pan-UKBB standing-height associations across all autosomes.](examples/real_world/assets/03-pan-ukbb-manhattan.png)<br><br>[Open notebook](examples/real_world/03_pan_ukbb_manhattan.ipynb) |
-| **Dukascopy · EUR/USD ticks**<br><sub>101,427 plotted ticks</sub><br><br>![Dukascopy EUR/USD midpoint quotes.](examples/real_world/assets/04-dukascopy-fx-ticks.png)<br><br>[Open notebook](examples/real_world/04_dukascopy_fx_ticks.ipynb) | **LIGO · GW150914 strain**<br><sub>16,777,216 raw · 3,441 shown</sub><br><br>![GWOSC reconstructed Hanford waveform for GW150914.](examples/real_world/assets/05-ligo-gw150914-strain.png)<br><br>[Open notebook](examples/real_world/05_ligo_gw150914_strain.ipynb) | **NYC TLC · taxi pickup density**<br><sub>300,000 pickup records</sub><br><br>![Locally projected NYC yellow-taxi pickup hexbin density.](examples/real_world/assets/06-nyc-taxi-density.png)<br><br>[Open notebook](examples/real_world/06_nyc_taxi_density.ipynb) |
+| **Gaia DR3 · HR diagram**<br><sub>250,000 plotted stars</sub><br><br>![Gaia DR3 stellar color versus absolute magnitude.](https://raw.githubusercontent.com/reflex-dev/xy/main/examples/real_world/assets/01-gaia-hr-diagram.png)<br><br>[Open notebook](https://github.com/reflex-dev/xy/blob/main/examples/real_world/01_gaia_hr_diagram.ipynb) | **gnomAD v4.1 · allele frequency**<br><sub>164,000 plotted variants</sub><br><br>![gnomAD allele frequency across all autosomes.](https://raw.githubusercontent.com/reflex-dev/xy/main/examples/real_world/assets/02-gnomad-allele-frequency.png)<br><br>[Open notebook](https://github.com/reflex-dev/xy/blob/main/examples/real_world/02_gnomad_allele_frequency.ipynb) | **Pan-UKBB · Manhattan plot**<br><sub>814,294 plotted variants</sub><br><br>![Pan-UKBB standing-height associations across all autosomes.](https://raw.githubusercontent.com/reflex-dev/xy/main/examples/real_world/assets/03-pan-ukbb-manhattan.png)<br><br>[Open notebook](https://github.com/reflex-dev/xy/blob/main/examples/real_world/03_pan_ukbb_manhattan.ipynb) |
+| **Dukascopy · EUR/USD ticks**<br><sub>101,427 plotted ticks</sub><br><br>![Dukascopy EUR/USD midpoint quotes.](https://raw.githubusercontent.com/reflex-dev/xy/main/examples/real_world/assets/04-dukascopy-fx-ticks.png)<br><br>[Open notebook](https://github.com/reflex-dev/xy/blob/main/examples/real_world/04_dukascopy_fx_ticks.ipynb) | **LIGO · GW150914 strain**<br><sub>16,777,216 raw · 3,441 shown</sub><br><br>![GWOSC reconstructed Hanford waveform for GW150914.](https://raw.githubusercontent.com/reflex-dev/xy/main/examples/real_world/assets/05-ligo-gw150914-strain.png)<br><br>[Open notebook](https://github.com/reflex-dev/xy/blob/main/examples/real_world/05_ligo_gw150914_strain.ipynb) | **NYC TLC · taxi pickup density**<br><sub>300,000 pickup records</sub><br><br>![Locally projected NYC yellow-taxi pickup hexbin density.](https://raw.githubusercontent.com/reflex-dev/xy/main/examples/real_world/assets/06-nyc-taxi-density.png)<br><br>[Open notebook](https://github.com/reflex-dev/xy/blob/main/examples/real_world/06_nyc_taxi_density.ipynb) |
 
 ## How it works
 
@@ -287,7 +287,7 @@ So a dense overview can aggregate while a narrow view returns exact points. With
 a live host, pan and zoom request a refined payload. Canonical f64 data stays in
 Python, so hover and selection still return original rows.
 
-For the full design, see the [design dossier](spec/design-dossier.md).
+For the full design, see the [design dossier](https://github.com/reflex-dev/xy/blob/main/spec/design-dossier.md).
 
 ## Roadmap
 
@@ -307,6 +307,6 @@ next, no dates implied:
 - **Slope, bump, and dumbbell**
 - **3D and volume:** scatter, surfaces, meshes, isosurfaces, and volumetric views
 
-The full ranked backlog is in the [chart roadmap](spec/api/chart-roadmap.md).
+The full ranked backlog is in the [chart roadmap](https://github.com/reflex-dev/xy/blob/main/spec/api/chart-roadmap.md).
 Want a chart or feature that isn't listed?
 [Open an issue](https://github.com/reflex-dev/xy/issues/new).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,13 +96,6 @@ path = "hatch_build.py"
 
 [tool.hatch.build.targets.sdist]
 include = [
-    ".github/workflows/ci.yml",
-    ".github/workflows/codspeed.yml",
-    ".github/workflows/release.yml",
-    # The adapter's release workflow rides along (repo infra, like release.yml)
-    # even though the adapter *package* stays out of this sdist: the shipped
-    # test suite validates all four workflows via scripts/verify_ci_workflow.py.
-    ".github/workflows/release-reflex-xy.yml",
     # The xy package only — python/reflex-xy is its own distributable
     # (own pyproject, depends on reflex) and must not ride in this sdist;
     # scripts/verify_sdist.py enforces both the no-reflex-dependency rule
@@ -115,22 +108,9 @@ include = [
     "js",
     "package.json",
     "package-lock.json",
-    "benchmarks",
-    "docs",
-    "spec",
-    "examples/fastapi/*.py",
-    "examples/fastapi/pyproject.toml",
-    "examples/fastapi/README.md",
-    "examples/reflex/pyproject.toml",
-    "examples/reflex/README.md",
-    "examples/reflex/rxconfig.py",
-    "examples/reflex/xy_reflex_demo/*.py",
-    "scripts",
-    "tests",
     "Cargo.toml",
     "Cargo.lock",
     "hatch_build.py",
-    "Makefile",
     "README.md",
     "LICENSE",
     "CHANGELOG.md",
@@ -138,7 +118,15 @@ include = [
     "CONTRIBUTING.md",
 ]
 exclude = [
-    "/docs/app/**",
+    # Repository-only development, CI, documentation, and evidence material.
+    "/.github/**",
+    "/benchmarks/**",
+    "/docs/**",
+    "/examples/**",
+    "/Makefile",
+    "/scripts/**",
+    "/spec/**",
+    "/tests/**",
     "/.*-venv/**",
     "/.venv/**",
     "/venv/**",
@@ -149,9 +137,6 @@ exclude = [
     "/node_modules/**",
     "/target/**",
     "/dist/**",
-    # Adapter tests ship with the reflex-xy package's repo checkout, not
-    # with the xy sdist (whose package they can't exercise anyway).
-    "/tests/reflex_adapter/**",
     # Belt and braces for the include narrowing above: hatchling auto-admits
     # readme-named files, which would smuggle adapter docs back in.
     "/python/reflex-xy/**",

--- a/scripts/verify_sdist.py
+++ b/scripts/verify_sdist.py
@@ -131,13 +131,14 @@ def _member_path(name: str) -> PurePosixPath:
 def _normalized_files(path: str) -> tuple[str, set[str]]:
     roots: set[str] = set()
     files: set[str] = set()
+    directories: set[str] = set()
     with tarfile.open(path, "r:gz") as tf:
         for member in tf.getmembers():
             member_path = _member_path(member.name)
             root = member_path.parts[0]
             roots.add(root)
+            relative_parts = member_path.parts[1:]
             if member.isfile():
-                relative_parts = member_path.parts[1:]
                 if not relative_parts:
                     raise AssertionError(
                         f"sdist top-level entry must be a directory: {member.name!r}"
@@ -147,7 +148,8 @@ def _normalized_files(path: str) -> tuple[str, set[str]]:
                     raise AssertionError(f"sdist contains duplicate file member: {rel}")
                 files.add(rel)
             elif member.isdir():
-                continue
+                if relative_parts:
+                    directories.add("/".join(relative_parts))
             else:
                 raise AssertionError(f"sdist contains non-regular member: {member.name}")
     if len(roots) != 1:
@@ -157,6 +159,16 @@ def _normalized_files(path: str) -> tuple[str, set[str]]:
     root = next(iter(roots))
     if not ROOT_RE.match(root):
         raise AssertionError(f"sdist top-level directory has unexpected name: {root!r}")
+
+    collisions = sorted(files & directories)
+    for name in files | directories:
+        parts = PurePosixPath(name).parts
+        if any("/".join(parts[:index]) in files for index in range(1, len(parts))):
+            collisions.append(name)
+    if collisions:
+        raise AssertionError(
+            f"sdist contains file/directory path collisions: {sorted(set(collisions))}"
+        )
     return root, files
 
 
@@ -250,6 +262,10 @@ def verify_sdist(path: str) -> None:
         name
         for name in files
         if PurePosixPath(name).parts[0] not in ALLOWED_TOP_LEVEL
+        or (
+            PurePosixPath(name).parts[0] == "python"
+            and PurePosixPath(name).parts[:2] != ("python", "xy")
+        )
         or any(part in FORBIDDEN_PARTS for part in PurePosixPath(name).parts)
         or any(name.endswith(suffix) for suffix in FORBIDDEN_SUFFIXES)
     )

--- a/scripts/verify_sdist.py
+++ b/scripts/verify_sdist.py
@@ -12,7 +12,6 @@ before installing anything.
 from __future__ import annotations
 
 import argparse
-import json
 import re
 import sys
 import tarfile
@@ -21,45 +20,13 @@ from pathlib import PurePosixPath
 from typing import Optional
 
 REQUIRED_FILES = {
-    ".github/workflows/ci.yml",
-    ".github/workflows/codspeed.yml",
-    ".github/workflows/release.yml",
-    ".github/workflows/release-reflex-xy.yml",
     "CHANGELOG.md",
     "CONTRIBUTING.md",
     "Cargo.lock",
     "Cargo.toml",
     "LICENSE",
-    "Makefile",
     "PKG-INFO",
     "SECURITY.md",
-    "benchmarks/__init__.py",
-    "benchmarks/_browser.py",
-    "benchmarks/_xy_browser.py",
-    "benchmarks/baseline.json",
-    "benchmarks/bench.py",
-    "benchmarks/bench_2d_charts.py",
-    "benchmarks/bench_pyplot_vs_matplotlib.py",
-    "benchmarks/bench_dashboard.py",
-    "benchmarks/bench_install.py",
-    "benchmarks/bench_interaction.py",
-    "benchmarks/bench_line.py",
-    "benchmarks/bench_native.py",
-    "benchmarks/bench_scatter_native.py",
-    "benchmarks/bench_vs.py",
-    "benchmarks/bench_workflows.py",
-    "benchmarks/categories.py",
-    "benchmarks/environment.py",
-    "spec/design-dossier.md",
-    "spec/api/api-examples.md",
-    "spec/api/chart-roadmap.md",
-    "spec/benchmarks/results.md",
-    "spec/design/renderer-architecture.md",
-    "spec/matplotlib/compat.md",
-    "spec/process/contributing.md",
-    "spec/process/production-readiness.md",
-    "spec/assets/benchmark-snapshot.svg",
-    "spec/assets/launch-benchmark-comparison.svg",
     "hatch_build.py",
     "pyproject.toml",
     "js/build.mjs",
@@ -70,8 +37,15 @@ REQUIRED_FILES = {
     "js/src/30_ticks.ts",
     "js/src/40_gl.ts",
     "js/src/45_lod.ts",
+    "js/src/46_worker.ts",
     "js/src/50_chartview.ts",
+    "js/src/51_annotations.ts",
+    "js/src/52_tooltip.ts",
+    "js/src/53_interaction.ts",
+    "js/src/54_kernel.ts",
     "js/src/55_marks.ts",
+    "js/src/56_animation.ts",
+    "js/src/57_viewstate.ts",
     "js/src/60_entries.ts",
     "package.json",
     "package-lock.json",
@@ -95,41 +69,15 @@ REQUIRED_FILES = {
     "python/xy/static/index.js",
     "python/xy/static/standalone.js",
     "python/xy/widget.py",
-    "examples/fastapi/pyproject.toml",
-    "examples/fastapi/app.py",
-    "examples/fastapi/charts.py",
-    "examples/fastapi/live_drilldown.py",
-    "examples/reflex/pyproject.toml",
-    "examples/reflex/rxconfig.py",
-    "examples/reflex/xy_reflex_demo/__init__.py",
-    "examples/reflex/xy_reflex_demo/xy_reflex_demo.py",
-    "scripts/check_public_api.py",
-    "scripts/gen_capability_matrix.py",
-    "scripts/check_python_floor.py",
-    "scripts/check_regressions.py",
-    "scripts/bench_dashboard.py",
-    "scripts/bench_interaction.py",
-    "scripts/bench_pyplot_vs_matplotlib.py",
-    "scripts/verify_ci_workflow.py",
-    "scripts/verify_benchmark_report.py",
-    "scripts/verify_local.py",
-    "scripts/verify_reflex_xy_dist.py",
-    "scripts/verify_sdist.py",
-    "scripts/verify_wheel.py",
+    "src/css.rs",
+    "src/font.rs",
     "src/kernels.rs",
     "src/lib.rs",
-    "tests/test_public_api.py",
-    "tests/test_benchmark_environment.py",
-    "tests/test_bench_pyplot_vs_matplotlib.py",
-    "tests/test_check_regressions.py",
-    "tests/test_example_apps.py",
-    "tests/test_type_surface.py",
-    "tests/test_verify_benchmark_report.py",
-    "tests/test_verify_ci_workflow.py",
-    "tests/test_verify_local.py",
-    "tests/test_verify_reflex_xy_dist.py",
-    "tests/test_verify_sdist.py",
-    "tests/test_verify_wheel.py",
+    "src/raster.rs",
+    "src/simd.rs",
+    "src/svg.rs",
+    "src/tiles.rs",
+    "src/transition.rs",
 }
 
 FORBIDDEN_PARTS = {
@@ -149,6 +97,16 @@ FORBIDDEN_PARTS = {
     "wheelhouse",
 }
 FORBIDDEN_SUFFIXES = {".dll", ".dylib", ".pyd", ".pyc", ".pyo", ".so", ".whl"}
+FORBIDDEN_TOP_LEVEL = {
+    ".github",
+    "Makefile",
+    "benchmarks",
+    "docs",
+    "examples",
+    "scripts",
+    "spec",
+    "tests",
+}
 ROOT_RE = re.compile(r"^xy-\d+\.\d+\.\d+(?:[A-Za-z0-9_.+-]*)?$")
 
 
@@ -266,59 +224,25 @@ def _require_exact_file(path: str, root: str, member: str, expected: bytes) -> N
         raise AssertionError(f"{member} must be an empty full-package PEP 561 marker")
 
 
-def _require_baseline_json(path: str, root: str) -> None:
-    with tarfile.open(path, "r:gz") as tf:
-        data = tf.extractfile(f"{root}/benchmarks/baseline.json")
-        if data is None:
-            raise AssertionError("benchmarks/baseline.json is missing")
-        text = data.read().decode("utf-8")
-    try:
-        baseline = json.loads(text)
-    except json.JSONDecodeError as exc:
-        raise AssertionError(f"benchmarks/baseline.json is not valid JSON: {exc}") from exc
-    metrics = baseline.get("metrics") if isinstance(baseline, dict) else None
-    if not isinstance(metrics, dict) or not metrics:
-        raise AssertionError("benchmarks/baseline.json must contain a non-empty metrics object")
-
-
-# Every grouped subdirectory of spec/ must survive packaging. Pinning
-# individual files alone would let a whole group be dropped as long as the
-# pinned member stayed, so require each group to be non-empty in its own right.
-SPEC_SUBDIRS = ("api", "benchmarks", "design", "matplotlib", "process")
-
-
-def _require_spec_layout(files: set[str]) -> None:
-    empty = [
-        name
-        for name in SPEC_SUBDIRS
-        if not any(f.startswith(f"spec/{name}/") and f.endswith(".md") for f in files)
-    ]
-    if empty:
-        raise AssertionError(f"sdist has no markdown under spec/ subdirectories: {empty}")
-
-    svgs = sorted(f for f in files if f.startswith("spec/assets/") and f.endswith(".svg"))
-    if len(svgs) < 2:
-        raise AssertionError(f"sdist is missing spec/assets SVG evidence snapshots: {svgs}")
-
-
 def verify_sdist(path: str) -> None:
     root, files = _normalized_files(path)
     missing = sorted(REQUIRED_FILES - files)
     if missing:
         raise AssertionError(f"sdist missing required files: {missing}")
-    _require_spec_layout(files)
 
     forbidden = sorted(
         name
         for name in files
-        if any(part in FORBIDDEN_PARTS for part in PurePosixPath(name).parts)
+        if PurePosixPath(name).parts[0] in FORBIDDEN_TOP_LEVEL
+        or any(part in FORBIDDEN_PARTS for part in PurePosixPath(name).parts)
         or any(name.endswith(suffix) for suffix in FORBIDDEN_SUFFIXES)
     )
     if forbidden:
-        raise AssertionError(f"sdist contains generated/native artifacts: {forbidden}")
+        raise AssertionError(
+            f"sdist contains repository-only/generated/native artifacts: {forbidden}"
+        )
     _require_pkg_info(path, root)
     _require_exact_file(path, root, "python/xy/py.typed", b"")
-    _require_baseline_json(path, root)
     _require_file_contains(
         path,
         root,
@@ -343,95 +267,6 @@ def verify_sdist(path: str) -> None:
             "export function render(",
             "export function renderStandalone(",
             "export default { render, decodeFrame };",
-        },
-    )
-    _require_file_contains(
-        path,
-        root,
-        "spec/api/api-examples.md",
-        {
-            "Chart Family Quick Reference",
-            "Small Business Chart",
-            "Revenue vs pipeline",
-            "xy.heatmap(",
-            "xy.heatmap_chart",
-        },
-    )
-    _require_file_contains(
-        path,
-        root,
-        "spec/benchmarks/results.md",
-        {
-            "benchmark-report",
-            "regression-benchmark-report",
-            "spec/benchmarks/metrics.md",
-            "scatter.json",
-            "kernel.json",
-        },
-    )
-    _require_file_contains(
-        path,
-        root,
-        "spec/process/production-readiness.md",
-        {
-            "Release-Blocking Gates",
-            "make check-artifacts",
-            "make check-examples",
-            "example apps' source",
-            "package-only",
-            "sdist-only",
-            "scripts/verify_benchmark_report.py",
-            "scripts/verify_wheel.py",
-            "import xy",
-        },
-    )
-    _require_file_contains(
-        path,
-        root,
-        "spec/process/contributing.md",
-        {
-            "Pull Request Checklist",
-            "make check-full",
-            "make check-sdist",
-            "make check-examples",
-            "make check-benchmark-report",
-            "Competitive Evidence",
-            "outperform every competing charting library",
-        },
-    )
-    _require_file_contains(
-        path,
-        root,
-        ".github/workflows/ci.yml",
-        {"scripts/verify_ci_workflow.py", "actions/upload-artifact@", "continue-on-error: true"},
-    )
-    _require_file_contains(
-        path,
-        root,
-        ".github/workflows/codspeed.yml",
-        {"CodSpeedHQ/action@", "pytest-codspeed", 'k.BACKEND == "native"'},
-    )
-    _require_file_contains(
-        path,
-        root,
-        ".github/workflows/release.yml",
-        {
-            "pypa/gh-action-pypi-publish@",
-            "scripts/verify_wheel.py",
-            "scripts/verify_sdist.py",
-            "id-token: write",
-        },
-    )
-    _require_file_contains(
-        path,
-        root,
-        ".github/workflows/release-reflex-xy.yml",
-        {
-            'tags: ["reflex-xy-v*"]',
-            "pypa/gh-action-pypi-publish@",
-            "scripts/verify_reflex_xy_dist.py",
-            "scripts/check_release_version.py --package reflex-xy",
-            "id-token: write",
         },
     )
 

--- a/scripts/verify_sdist.py
+++ b/scripts/verify_sdist.py
@@ -26,6 +26,7 @@ REQUIRED_FILES = {
     "Cargo.toml",
     "LICENSE",
     "PKG-INFO",
+    "README.md",
     "SECURITY.md",
     "hatch_build.py",
     "pyproject.toml",
@@ -97,15 +98,25 @@ FORBIDDEN_PARTS = {
     "wheelhouse",
 }
 FORBIDDEN_SUFFIXES = {".dll", ".dylib", ".pyd", ".pyc", ".pyo", ".so", ".whl"}
-FORBIDDEN_TOP_LEVEL = {
-    ".github",
-    "Makefile",
-    "benchmarks",
-    "docs",
-    "examples",
-    "scripts",
-    "spec",
-    "tests",
+ALLOWED_TOP_LEVEL = {
+    # Hatchling force-includes the active VCS exclusion file so builds from the
+    # unpacked sdist preserve the source-selection rules.
+    ".gitignore",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "Cargo.lock",
+    "Cargo.toml",
+    "LICENSE",
+    "PKG-INFO",
+    "README.md",
+    "SECURITY.md",
+    "hatch_build.py",
+    "js",
+    "package-lock.json",
+    "package.json",
+    "pyproject.toml",
+    "python",
+    "src",
 }
 ROOT_RE = re.compile(r"^xy-\d+\.\d+\.\d+(?:[A-Za-z0-9_.+-]*)?$")
 
@@ -126,7 +137,12 @@ def _normalized_files(path: str) -> tuple[str, set[str]]:
             root = member_path.parts[0]
             roots.add(root)
             if member.isfile():
-                rel = "/".join(member_path.parts[1:])
+                relative_parts = member_path.parts[1:]
+                if not relative_parts:
+                    raise AssertionError(
+                        f"sdist top-level entry must be a directory: {member.name!r}"
+                    )
+                rel = "/".join(relative_parts)
                 if rel in files:
                     raise AssertionError(f"sdist contains duplicate file member: {rel}")
                 files.add(rel)
@@ -233,7 +249,7 @@ def verify_sdist(path: str) -> None:
     forbidden = sorted(
         name
         for name in files
-        if PurePosixPath(name).parts[0] in FORBIDDEN_TOP_LEVEL
+        if PurePosixPath(name).parts[0] not in ALLOWED_TOP_LEVEL
         or any(part in FORBIDDEN_PARTS for part in PurePosixPath(name).parts)
         or any(name.endswith(suffix) for suffix in FORBIDDEN_SUFFIXES)
     )

--- a/tests/test_verify_sdist.py
+++ b/tests/test_verify_sdist.py
@@ -198,6 +198,8 @@ def test_verify_sdist_rejects_missing_static_bundle(tmp_path: Path) -> None:
         "docs/index.md",
         "examples/demo.ipynb",
         "pr-assets/review.png",
+        "python/other-package/__init__.py",
+        "python/reflex-xy/reflex_xy/__init__.py",
         "scripts/verify_local.py",
         "spec/design-dossier.md",
         "tests/test_import.py",
@@ -266,6 +268,14 @@ def test_verify_sdist_rejects_regular_file_at_distribution_root(tmp_path: Path) 
     _write_sdist(sdist, root_file=True)
 
     with pytest.raises(AssertionError, match="top-level entry must be a directory"):
+        verify_sdist.verify_sdist(str(sdist))
+
+
+def test_verify_sdist_rejects_file_directory_path_collisions(tmp_path: Path) -> None:
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
+    _write_sdist(sdist, extra={"README.md/repository-only.txt": b"not extractable"})
+
+    with pytest.raises(AssertionError, match="file/directory path collisions"):
         verify_sdist.verify_sdist(str(sdist))
 
 

--- a/tests/test_verify_sdist.py
+++ b/tests/test_verify_sdist.py
@@ -27,93 +27,6 @@ ENTRIES_JS = (
     "const padding = '" + ("x" * 1000) + "';\n"
     "export default { render, decodeFrame };\n"
 )
-API_EXAMPLES_MD = (
-    "# API Examples\n\n"
-    "## Chart Family Quick Reference\n\n"
-    "| Chart family | Fluent API | Composition API |\n"
-    "|---|---|---|\n"
-    "| Heatmap | `Figure().heatmap(z, x=x, y=y)` | `xy.heatmap_chart(xy.heatmap(...))` |\n"
-    "\n## Small Business Chart\n\n"
-    "Revenue vs pipeline\n" + ("api examples padding\n" * 100)
-)
-BENCHMARK_MD = (
-    "# Benchmark\n\n"
-    "The docs/benchmark_ci.md numbers land in the benchmark-report artifact.\n"
-    "The spec/benchmarks/metrics.md regression table, scatter.json, and kernel.json "
-    "land in the regression-benchmark-report artifact.\n" + ("benchmark padding\n" * 100)
-)
-PRODUCTION_READINESS_MD = (
-    "# Production Readiness\n\n"
-    "## Release-Blocking Gates\n\n"
-    "`import xy` stays lightweight.\n"
-    "Use `make check-artifacts` for exact artifact verification.\n"
-    "Use `make check-examples` for docs and example-app checks.\n"
-    "The sdist includes the example apps' source, while wheels stay package-only. "
-    "Docs, tests, benchmarks, scripts, and the examples/ apps are sdist-only.\n"
-    "Run scripts/verify_benchmark_report.py, scripts/verify_wheel.py, and "
-    "scripts/verify_sdist.py before releases.\n" + ("production readiness padding\n" * 100)
-)
-CONTRIBUTING_MD = (
-    "# Contributing\n\n"
-    "## Pull Request Checklist\n\n"
-    "Run make check-full, make check-sdist, make check-wheel, and "
-    "make check-benchmark-report.\n"
-    "Run make check-examples for spec/api/api-examples.md and "
-    "the example apps.\n\n"
-    "## Competitive Evidence\n\n"
-    "XY aims to outperform every competing charting library.\n" + ("contributing padding\n" * 100)
-)
-CI_YML = (
-    "name: CI\n"
-    "jobs:\n"
-    "  benchmark:\n"
-    "    continue-on-error: true\n"
-    "    steps:\n"
-    "      - run: python scripts/verify_ci_workflow.py\n"
-    "      - uses: actions/upload-artifact@v4\n" + ("ci workflow padding\n" * 100)
-)
-CODSPEED_YML = (
-    "name: CodSpeed\n"
-    "jobs:\n"
-    "  benchmarks:\n"
-    "    steps:\n"
-    "      - uses: CodSpeedHQ/action@v4\n"
-    "      - run: uv pip install pytest-codspeed\n"
-    "      - run: python -c 'import xy.kernels as k; assert k.BACKEND == \"native\"'\n"
-    + ("codspeed workflow padding\n" * 100)
-)
-RELEASE_YML = (
-    "name: Release\n"
-    "jobs:\n"
-    "  wheels:\n"
-    "    steps:\n"
-    "      - run: python scripts/verify_wheel.py dist/example.whl --expect-native\n"
-    "  sdist:\n"
-    "    steps:\n"
-    "      - run: python scripts/verify_sdist.py dist/example.tar.gz\n"
-    "  publish:\n"
-    "    permissions:\n"
-    "      id-token: write\n"
-    "    steps:\n"
-    "      - uses: pypa/gh-action-pypi-publish@release/v1\n" + ("release workflow padding\n" * 100)
-)
-RELEASE_REFLEX_XY_YML = (
-    "name: Release reflex-xy\n"
-    "on:\n"
-    "  push:\n"
-    '    tags: ["reflex-xy-v*"]\n'
-    "jobs:\n"
-    "  build:\n"
-    "    steps:\n"
-    "      - run: python3 scripts/verify_reflex_xy_dist.py python/reflex-xy/dist/*\n"
-    "  publish:\n"
-    "    permissions:\n"
-    "      id-token: write\n"
-    "    steps:\n"
-    "      - run: python3 scripts/check_release_version.py --package reflex-xy\n"
-    "      - uses: pypa/gh-action-pypi-publish@release/v1\n"
-    + ("adapter release workflow padding\n" * 40)
-)
 DEFAULT_PKG_INFO = (
     "Metadata-Version: 2.4\n"
     "Name: xy\n"
@@ -122,7 +35,6 @@ DEFAULT_PKG_INFO = (
     "Requires-Dist: anywidget>=0.9\n"
     "Requires-Dist: numpy>=1.24\n"
 )
-BASELINE_JSON = '{"metrics": {"scatter.tier.100000": "direct"}}\n'
 
 
 def _load_sdist_module():
@@ -166,30 +78,12 @@ def _write_sdist(
             elif name in replacements:
                 raw = replacements[name]
                 data = raw.encode("utf-8") if isinstance(raw, str) else raw
-            elif name == "benchmarks/baseline.json":
-                data = BASELINE_JSON.encode("utf-8")
             elif name == "python/xy/static/index.js":
                 data = INDEX_JS.encode("utf-8")
             elif name == "python/xy/static/standalone.js":
                 data = STANDALONE_JS.encode("utf-8")
             elif name == "js/src/60_entries.ts":
                 data = ENTRIES_JS.encode("utf-8")
-            elif name == "spec/api/api-examples.md":
-                data = API_EXAMPLES_MD.encode("utf-8")
-            elif name == "spec/benchmarks/results.md":
-                data = BENCHMARK_MD.encode("utf-8")
-            elif name == "spec/process/production-readiness.md":
-                data = PRODUCTION_READINESS_MD.encode("utf-8")
-            elif name == "spec/process/contributing.md":
-                data = CONTRIBUTING_MD.encode("utf-8")
-            elif name == ".github/workflows/ci.yml":
-                data = CI_YML.encode("utf-8")
-            elif name == ".github/workflows/codspeed.yml":
-                data = CODSPEED_YML.encode("utf-8")
-            elif name == ".github/workflows/release.yml":
-                data = RELEASE_YML.encode("utf-8")
-            elif name == ".github/workflows/release-reflex-xy.yml":
-                data = RELEASE_REFLEX_XY_YML.encode("utf-8")
             _add_file(tf, f"{root}/{name}", data)
         for name, data in extra.items():
             _add_file(tf, f"{root}/{name}", data)
@@ -274,204 +168,32 @@ def test_verify_sdist_rejects_missing_static_bundle(tmp_path: Path) -> None:
         verify_sdist.verify_sdist(str(sdist))
 
 
+@pytest.mark.parametrize(
+    "name",
+    [
+        ".github/workflows/ci.yml",
+        "Makefile",
+        "benchmarks/bench.py",
+        "docs/index.md",
+        "examples/demo.ipynb",
+        "scripts/verify_local.py",
+        "spec/design-dossier.md",
+        "tests/test_import.py",
+    ],
+)
+def test_verify_sdist_rejects_repository_only_content(tmp_path: Path, name: str) -> None:
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
+    _write_sdist(sdist, extra={name: b"repository-only content"})
+
+    with pytest.raises(AssertionError, match="generated/native artifacts"):
+        verify_sdist.verify_sdist(str(sdist))
+
+
 def test_verify_sdist_rejects_partial_type_marker(tmp_path: Path) -> None:
     sdist = tmp_path / "xy-0.0.1.tar.gz"
     _write_sdist(sdist, replacements={"python/xy/py.typed": "partial\n"})
 
     with pytest.raises(AssertionError, match="full-package PEP 561 marker"):
-        verify_sdist.verify_sdist(str(sdist))
-
-
-def test_verify_sdist_rejects_missing_production_docs_or_tooling(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.0.1.tar.gz"
-    _write_sdist(sdist, omit={"spec/process/production-readiness.md", "scripts/verify_local.py"})
-
-    with pytest.raises(AssertionError, match="production-readiness"):
-        verify_sdist.verify_sdist(str(sdist))
-
-
-def test_verify_sdist_requires_every_spec_subdirectory(tmp_path: Path) -> None:
-    """A pinned member per group is not enough — the group itself must survive."""
-    sdist = tmp_path / "xy-0.0.1.tar.gz"
-    _write_sdist(sdist, omit={"spec/matplotlib/compat.md"})
-
-    with pytest.raises(AssertionError, match="spec/matplotlib/compat"):
-        verify_sdist.verify_sdist(str(sdist))
-
-
-@pytest.mark.parametrize("subdir", verify_sdist.SPEC_SUBDIRS)
-def test_require_spec_layout_rejects_empty_subdirectory(subdir: str) -> None:
-    files = {f"spec/{name}/doc.md" for name in verify_sdist.SPEC_SUBDIRS}
-    files |= {
-        "spec/assets/benchmark-snapshot.svg",
-        "spec/assets/launch-benchmark-comparison.svg",
-    }
-    verify_sdist._require_spec_layout(files)
-
-    files.discard(f"spec/{subdir}/doc.md")
-    with pytest.raises(AssertionError, match=subdir):
-        verify_sdist._require_spec_layout(files)
-
-
-def test_require_spec_layout_rejects_missing_asset_snapshots() -> None:
-    files = {f"spec/{name}/doc.md" for name in verify_sdist.SPEC_SUBDIRS}
-    files.add("spec/assets/benchmark-snapshot.svg")
-
-    with pytest.raises(AssertionError, match="spec/assets"):
-        verify_sdist._require_spec_layout(files)
-
-
-def test_require_spec_layout_ignores_non_markdown_group_members() -> None:
-    """A group left holding only stray non-markdown files is still empty."""
-    files = {f"spec/{name}/doc.md" for name in verify_sdist.SPEC_SUBDIRS}
-    files |= {
-        "spec/assets/benchmark-snapshot.svg",
-        "spec/assets/launch-benchmark-comparison.svg",
-    }
-    files.discard("spec/design/doc.md")
-    files.add("spec/design/notes.txt")
-
-    with pytest.raises(AssertionError, match="design"):
-        verify_sdist._require_spec_layout(files)
-
-
-def test_verify_sdist_rejects_missing_benchmark_harness(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.0.1.tar.gz"
-    _write_sdist(sdist, omit={"benchmarks/bench_vs.py", "benchmarks/environment.py"})
-
-    with pytest.raises(AssertionError, match="benchmarks/bench_vs"):
-        verify_sdist.verify_sdist(str(sdist))
-
-
-def test_verify_sdist_rejects_missing_workflow_benchmark(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.0.1.tar.gz"
-    _write_sdist(sdist, omit={"benchmarks/bench_workflows.py"})
-
-    with pytest.raises(AssertionError, match="benchmarks/bench_workflows"):
-        verify_sdist.verify_sdist(str(sdist))
-
-
-def test_verify_sdist_rejects_missing_regression_gate_files(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.0.1.tar.gz"
-    _write_sdist(
-        sdist,
-        omit={
-            "benchmarks/baseline.json",
-            "benchmarks/bench_line.py",
-            "benchmarks/bench_install.py",
-            "scripts/check_regressions.py",
-            "tests/test_check_regressions.py",
-        },
-    )
-
-    with pytest.raises(AssertionError, match=r"benchmarks/baseline\.json"):
-        verify_sdist.verify_sdist(str(sdist))
-
-
-def test_verify_sdist_rejects_corrupt_benchmark_baseline(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.0.1.tar.gz"
-    _write_sdist(sdist, replacements={"benchmarks/baseline.json": '{"metrics": {}}'})
-
-    with pytest.raises(AssertionError, match="non-empty metrics object"):
-        verify_sdist.verify_sdist(str(sdist))
-
-
-def test_verify_sdist_rejects_missing_example_app_files(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.0.1.tar.gz"
-    _write_sdist(
-        sdist,
-        omit={
-            "examples/fastapi/app.py",
-            "examples/reflex/xy_reflex_demo/xy_reflex_demo.py",
-            "tests/test_example_apps.py",
-        },
-    )
-
-    with pytest.raises(AssertionError, match="examples/"):
-        verify_sdist.verify_sdist(str(sdist))
-
-
-def test_verify_sdist_rejects_stale_api_examples_doc(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.0.1.tar.gz"
-    _write_sdist(
-        sdist,
-        replacements={"spec/api/api-examples.md": "# API Examples\n" + ("padding\n" * 200)},
-    )
-
-    with pytest.raises(AssertionError, match="api-examples"):
-        verify_sdist.verify_sdist(str(sdist))
-
-
-def test_verify_sdist_rejects_stale_benchmark_doc(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.0.1.tar.gz"
-    _write_sdist(
-        sdist,
-        replacements={"spec/benchmarks/results.md": "# Benchmark\n" + ("padding\n" * 200)},
-    )
-
-    with pytest.raises(AssertionError, match="benchmark"):
-        verify_sdist.verify_sdist(str(sdist))
-
-
-def test_verify_sdist_rejects_stale_production_readiness_doc(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.0.1.tar.gz"
-    _write_sdist(
-        sdist,
-        replacements={
-            "spec/process/production-readiness.md": "# Production Readiness\n" + ("padding\n" * 200)
-        },
-    )
-
-    with pytest.raises(AssertionError, match="production-readiness"):
-        verify_sdist.verify_sdist(str(sdist))
-
-
-def test_verify_sdist_rejects_stale_contributing_doc(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.0.1.tar.gz"
-    _write_sdist(
-        sdist,
-        replacements={"spec/process/contributing.md": "# Contributing\n" + ("padding\n" * 200)},
-    )
-
-    with pytest.raises(AssertionError, match="contributing"):
-        verify_sdist.verify_sdist(str(sdist))
-
-
-def test_verify_sdist_rejects_missing_release_workflow(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.0.1.tar.gz"
-    _write_sdist(sdist, omit={".github/workflows/release.yml"})
-
-    with pytest.raises(AssertionError, match=r"release\.yml"):
-        verify_sdist.verify_sdist(str(sdist))
-
-
-def test_verify_sdist_rejects_missing_codspeed_workflow(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.0.1.tar.gz"
-    _write_sdist(sdist, omit={".github/workflows/codspeed.yml"})
-
-    with pytest.raises(AssertionError, match=r"codspeed\.yml"):
-        verify_sdist.verify_sdist(str(sdist))
-
-
-def test_verify_sdist_rejects_corrupt_codspeed_workflow(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.0.1.tar.gz"
-    _write_sdist(
-        sdist,
-        replacements={".github/workflows/codspeed.yml": "name: CodSpeed\n" + ("padding\n" * 200)},
-    )
-
-    with pytest.raises(AssertionError, match=r"codspeed\.yml"):
-        verify_sdist.verify_sdist(str(sdist))
-
-
-def test_verify_sdist_rejects_corrupt_release_workflow(tmp_path: Path) -> None:
-    sdist = tmp_path / "xy-0.0.1.tar.gz"
-    _write_sdist(
-        sdist,
-        replacements={".github/workflows/release.yml": "name: Release\n" + ("padding\n" * 200)},
-    )
-
-    with pytest.raises(AssertionError, match=r"release\.yml"):
         verify_sdist.verify_sdist(str(sdist))
 
 

--- a/tests/test_verify_sdist.py
+++ b/tests/test_verify_sdist.py
@@ -63,12 +63,15 @@ def _write_sdist(
     omit: Optional[set[str]] = None,
     extra: Optional[dict[str, bytes]] = None,
     replacements: Optional[dict[str, Union[bytes, str]]] = None,
+    root_file: bool = False,
 ) -> None:
     root = "xy-0.0.1"
     omit = omit or set()
     extra = extra or {}
     replacements = replacements or {}
     with tarfile.open(path, "w:gz") as tf:
+        if root_file:
+            _add_file(tf, root, b"not a directory")
         for name in sorted(verify_sdist.REQUIRED_FILES - omit):
             data = b""
             if name == "PKG-INFO" and pkg_info is not None:
@@ -94,6 +97,21 @@ def test_verify_sdist_accepts_required_source_shape(tmp_path: Path) -> None:
     _write_sdist(sdist)
 
     verify_sdist.verify_sdist(str(sdist))
+
+
+@pytest.mark.parametrize(
+    "root", [".github", "benchmarks", "docs", "examples", "scripts", "spec", "tests"]
+)
+def test_readme_does_not_reference_excluded_sdist_content(root: str) -> None:
+    readme = (Path(__file__).resolve().parents[1] / "README.md").read_text()
+    relative_references = (
+        f"]({root}/",
+        f'href="{root}/',
+        f'src="{root}/',
+        f'srcset="{root}/',
+    )
+
+    assert not any(reference in readme for reference in relative_references)
 
 
 def test_verify_sdist_accepts_normalized_metadata_spacing(tmp_path: Path) -> None:
@@ -171,14 +189,19 @@ def test_verify_sdist_rejects_missing_static_bundle(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "name",
     [
+        ".agents/config.json",
+        ".binder/environment.yml",
         ".github/workflows/ci.yml",
+        "AGENTS.md",
         "Makefile",
         "benchmarks/bench.py",
         "docs/index.md",
         "examples/demo.ipynb",
+        "pr-assets/review.png",
         "scripts/verify_local.py",
         "spec/design-dossier.md",
         "tests/test_import.py",
+        "uv.lock",
     ],
 )
 def test_verify_sdist_rejects_repository_only_content(tmp_path: Path, name: str) -> None:
@@ -235,6 +258,14 @@ def test_verify_sdist_rejects_duplicate_file_member(tmp_path: Path) -> None:
     _write_sdist(sdist, extra={"LICENSE": b"duplicate"})
 
     with pytest.raises(AssertionError, match="duplicate file member"):
+        verify_sdist.verify_sdist(str(sdist))
+
+
+def test_verify_sdist_rejects_regular_file_at_distribution_root(tmp_path: Path) -> None:
+    sdist = tmp_path / "xy-0.0.1.tar.gz"
+    _write_sdist(sdist, root_file=True)
+
+    with pytest.raises(AssertionError, match="top-level entry must be a directory"):
         verify_sdist.verify_sdist(str(sdist))
 
 


### PR DESCRIPTION
## Summary

- limit the `xy` source distribution to package and reproducible build inputs
- exclude repository-only CI workflows, benchmarks, docs, examples, scripts, specifications, tests, and the Makefile
- tighten the sdist verifier so those roots cannot be reintroduced
- require the complete Rust and TypeScript source sets used to rebuild the native core and render client

## Why

The previous broad sdist allowlist treated the release archive as a repository snapshot. In particular, documentation evidence and README animations made the published source archive much larger without helping users build or install `xy`.

On current `main`, this reduces the generated sdist from 12.27 MB to 1.46 MB (about 88%) while leaving wheels unchanged.

## Validation

- `uv run --no-project --with pytest --with numpy python -m pytest tests/test_verify_sdist.py -q` — 29 passed
- built the sdist with `uv build --sdist`
- verified the exact artifact with `scripts/verify_sdist.py`
- confirmed no repository-only roots are present in the tarball
- installed the exact sdist into a temporary target with native Rust and both JavaScript bundles present
- imported `xy` from the resulting installation

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README links to use stable GitHub URLs for assets, documentation, benchmarks, design materials, roadmap items, and examples.

* **Packaging**
  * Refined source distribution contents to include required project sources while excluding repository-only files and directories.

* **Bug Fixes**
  * Improved distribution validation to detect unexpected top-level files and references to excluded content.

* **Tests**
  * Updated packaging checks to reflect the current source distribution structure and strengthened archive validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->