### PR TITLE
Prepare v0.0.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ in the README).
 
 ## [Unreleased]
 
+## [0.0.5] - 2026-07-31
+
 ### Added
 - Reflex integration is now bundled in the `xy` distribution and installed as
   `xy[reflex]`. The `reflex_xy` import namespace and JSX wrapper ship in every


### PR DESCRIPTION
## Summary

- date the accumulated changelog as `0.0.5`
- keep a fresh `Unreleased` section for follow-up work

## Validation

- `python scripts/check_release_version.py --tag v0.0.5`
- `make check-ci`
- release/version and artifact workflow tests: `218 passed`
- `git diff --check`

After this PR merges and CI is green, pushing tag `v0.0.5` will publish the unified `xy` distribution, including the bundled `reflex_xy` integration and `xy[reflex]` extra.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added changelog entry for the 0.0.5 release dated July 31, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->