### PR TITLE
Fix integer overflow in center_range for extreme coordinates

### DIFF
--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -287,8 +287,8 @@ fn reduce_color_level(prev_counts: &[u32], prev_color: &[[u16; 4]], dim: usize) 
 fn center_range(lo: f64, hi: f64, full_lo: f64, full_hi: f64, dim: usize) -> (usize, usize) {
     let cell = (full_hi - full_lo) / dim as f64;
     // center of cell i is full_lo + (i + 0.5) * cell; inside ⇔ lo <= c < hi
-    let first = ((lo - full_lo) / cell - 0.5).ceil().max(0.0) as usize;
-    let last = (((hi - full_lo) / cell - 0.5).floor() as isize + 1).max(0) as usize;
+    let first = ((lo - full_lo) / cell - 0.5).ceil().max(0.0).min(usize::MAX as f64) as usize;
+    let last = (((hi - full_lo) / cell - 0.5).floor().min(isize::MAX as f64 - 1.0) as isize + 1).max(0) as usize;
     (first.min(dim), last.min(dim))
 }
 
@@ -1119,11 +1119,8 @@ mod tests {
         assert_eq!(count(&p, 50.0, 50.0, 0.0, 100.0), 0.0);
     }
 
-    // Release-only: in debug builds center_range's `as isize + 1` panics on
-    // these magnitudes (pre-existing, caught by ffi_guard at the ABI); the
-    // wrap to cx1 < cx0 that reaches compose's row slicing only occurs in
-    // release, where the old indexed loop silently iterated it as empty.
-    #[cfg(not(debug_assertions))]
+    // The center_range function now saturates properly for astronomically large
+    // coordinates, so this test runs in both debug and release builds.
     #[test]
     fn compose_window_astronomically_past_domain_is_empty_not_panic() {
         let (x, y) = cross(4000);

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -287,9 +287,10 @@ fn reduce_color_level(prev_counts: &[u32], prev_color: &[[u16; 4]], dim: usize) 
 fn center_range(lo: f64, hi: f64, full_lo: f64, full_hi: f64, dim: usize) -> (usize, usize) {
     let cell = (full_hi - full_lo) / dim as f64;
     // center of cell i is full_lo + (i + 0.5) * cell; inside ⇔ lo <= c < hi
-    let first = ((lo - full_lo) / cell - 0.5).ceil().max(0.0).min(usize::MAX as f64) as usize;
-    let last = (((hi - full_lo) / cell - 0.5).floor().min(isize::MAX as f64 - 1.0) as isize + 1).max(0) as usize;
-    (first.min(dim), last.min(dim))
+    let first = ((lo - full_lo) / cell - 0.5).ceil().max(0.0).min(dim as f64) as usize;
+    let last = (((hi - full_lo) / cell - 0.5).floor()).max(0.0) as usize;
+    let last = last.saturating_add(1).min(dim);
+    (first, last)
 }
 
 /// Approximate in-window count from the finest level (whole cells whose


### PR DESCRIPTION
### Summary
Fixed a bug in `center_range` ([src/tiles.rs](https://github.com/reflex-dev/xy/blob/main/src/tiles.rs)) where casting f64 to `isize`/`usize` would panic in debug builds for extremely large coordinates (> `isize::MAX` ≈ 9.22e18), while silently wrapping in release builds.

### The Bug
The `center_range` function computes cell index ranges for a coordinate window. With astronomically large coordinates (e.g., 1e18, 1e21 common from timestamp data or bad input), the intermediate f64 computation exceeded `isize::MAX`:

```rust
let first = ((lo - full_lo) / cell - 0.5).ceil().max(0.0) as usize;
let last = (((hi - full_lo) / cell - 0.5).floor() as isize + 1).max(0) as usize;
```

- Debug builds: **panic** on `as isize` overflow
- Release builds: **silent wraparound** → `cx1 < cx0` → downstream bugs

The existing test `compose_window_astronomically_past_domain_is_empty_not_panic` was gated with `#[cfg(not(debug_assertions))]` to avoid the debug panic, confirming this was a known but unfixed issue.

### The Fix
Added saturation clamping before integer casts:

```rust
let first = ((lo - full_lo) / cell - 0.5).ceil().max(0.0).min(usize::MAX as f64) as usize;
let last = (((hi - full_lo) / cell - 0.5).floor().min(isize::MAX as f64 - 1.0) as isize + 1).max(0) as usize;
```

- `first`: Clamped to `[0, usize::MAX]` before `as usize`
- `last`: Clamped floor to `[0, isize::MAX - 1]` so `+1` stays in range
- Final `.min(dim)` ensures valid cell index range

### Testing
- The previously release-only test now runs in **both debug and release** builds
- Verifies coordinates like 1e21 and 1e18 produce empty (zero) results without panicking
- All existing tests pass

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when handling extremely large coordinates.
  * Prevented potential overflow or crashes during tile composition.

* **Tests**
  * Expanded robustness testing to run across all build configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->