### PR TITLE
Fan out compute-bound row-scan kernels from 128k rows

### DIFF
--- a/spec/benchmarks/results.md
+++ b/spec/benchmarks/results.md
@@ -739,7 +739,10 @@ comparison—not a same-render-target speedup claim.
 
 > The kernel microbench numbers above predate the kernel-parallelization pass:
 > `bin_2d`, `histogram`, `m4`, `range_indices`, and `normalize` now fan out
-> across cores above 512k rows. Zone maps have no merge traffic and use an
+> across cores at per-cost-class gates: compute-bound scans (`m4`,
+> `histogram`) from 128k rows, general scans (`bin_2d`, `range_indices`,
+> `normalize`, min/max, sortedness) from 512k. Zone maps have no merge
+> traffic and use an
 > earlier, chunk-aware crossover: two complete 65,536-row chunks, with workers
 > capped by the number of chunks. All paths are bitwise-deterministic; see
 > `src/kernels.rs`.

--- a/spec/benchmarks/results.md
+++ b/spec/benchmarks/results.md
@@ -741,10 +741,10 @@ comparison—not a same-render-target speedup claim.
 > `bin_2d`, `histogram`, `m4`, `range_indices`, and `normalize` now fan out
 > across cores at per-cost-class gates: compute-bound scans (`m4`,
 > `histogram`) from 128k rows, general scans (`bin_2d`, `range_indices`,
-> `normalize`, min/max, sortedness) from 512k. For `bin_2d` that 512k is a
-> base gate rather than an unconditional one: fan-out also tracks points per
-> cell, so a large grid stays serial above 512k because the per-thread grids
-> and their merge dwarf the scan. Zone maps have no merge
+> `normalize`, min/max, sortedness) from 512k. Where each worker owns a
+> private accumulator those row counts are only a floor: `bin_2d` also caps
+> workers at points per cell and `histogram` at points per bin, so an
+> accumulator as large as the input stays serial. Zone maps have no merge
 > traffic and use an
 > earlier, chunk-aware crossover: two complete 65,536-row chunks, with workers
 > capped by the number of chunks. All paths are bitwise-deterministic; see

--- a/spec/benchmarks/results.md
+++ b/spec/benchmarks/results.md
@@ -741,7 +741,10 @@ comparison—not a same-render-target speedup claim.
 > `bin_2d`, `histogram`, `m4`, `range_indices`, and `normalize` now fan out
 > across cores at per-cost-class gates: compute-bound scans (`m4`,
 > `histogram`) from 128k rows, general scans (`bin_2d`, `range_indices`,
-> `normalize`, min/max, sortedness) from 512k. Zone maps have no merge
+> `normalize`, min/max, sortedness) from 512k. For `bin_2d` that 512k is a
+> base gate rather than an unconditional one: fan-out also tracks points per
+> cell, so a large grid stays serial above 512k because the per-thread grids
+> and their merge dwarf the scan. Zone maps have no merge
 > traffic and use an
 > earlier, chunk-aware crossover: two complete 65,536-row chunks, with workers
 > capped by the number of chunks. All paths are bitwise-deterministic; see

--- a/spec/design/rust-engine.md
+++ b/spec/design/rust-engine.md
@@ -228,11 +228,15 @@ formats only; the SVG and PDF export paths have their own text contracts.
   (`0`, `usize::MAX`, `-1`/`-2`) rather than one documented negative error
   enum; unifying them is a work item for the next ABI bump.
 - **E5 — threading stays inside**: parallel kernels use `std::thread::scope`
-  inside the call; the ABI stays synchronous. General row scans cross over at
-  512k values and scale to at most 18 workers. Zone maps cross earlier, at two
-  complete 65,536-row chunks, because chunks are independent and require no
-  merge; worker count is also capped by actual chunks. CodSpeed stays serial
-  because its simulator sums thread instructions rather than wall time.
+  inside the call; the ABI stays synchronous. Fan-out gates are per cost
+  class, each a named constant in `kernels.rs` with its measured serial
+  ns/row and break-even: compute-bound scans (M4, uniform histogram,
+  ~2.5–3 ns/row) cross at 128k rows; general scans (min/max, sortedness,
+  range/validity, f32 encode/normalize) keep the 512k gate. Zone maps cross
+  earlier, at two complete 65,536-row chunks, because chunks are independent
+  and require no merge; worker count is also capped by actual chunks. All
+  gates scale to at most 18 workers. CodSpeed stays serial because its
+  simulator sums thread instructions rather than wall time.
   Incremental build = handle + `xy_pyramid_append`, which mutates a live
   pyramid in place under the registry lock. A polling entry point
   (`xy_pyramid_poll`) for genuinely async builds is not built; if one is ever

--- a/spec/design/rust-engine.md
+++ b/spec/design/rust-engine.md
@@ -232,7 +232,10 @@ formats only; the SVG and PDF export paths have their own text contracts.
   class, each a named constant in `kernels.rs` with its measured serial
   ns/row and break-even: compute-bound scans (M4, uniform histogram,
   ~2.5–3 ns/row) cross at 128k rows; general scans (min/max, sortedness,
-  range/validity, f32 encode/normalize) keep the 512k gate. Zone maps cross
+  range/validity, f32 encode/normalize) keep the 512k gate. Where each worker
+  owns a private accumulator the row gate is only a floor: `bin_2d` caps
+  workers at points per cell and `histogram_uniform` at points per bin, so an
+  accumulator as large as the input stays serial. Zone maps cross
   earlier, at two complete 65,536-row chunks, because chunks are independent
   and require no merge; worker count is also capped by actual chunks. All
   gates scale to at most 18 workers. CodSpeed stays serial because its

--- a/src/kernels.rs
+++ b/src/kernels.rs
@@ -2502,7 +2502,7 @@ pub fn m4_indices(x: &[f64], y: &[f64], x0: f64, x1: f64, n_buckets: usize) -> V
         n_buckets,
         start,
         end,
-        par_threads_above(end - start, PAR_THRESHOLD_COMPUTE),
+        par_threads_above(end - start, PAR_THRESHOLD_COMPUTE).min(n_buckets),
     )
 }
 

--- a/src/kernels.rs
+++ b/src/kernels.rs
@@ -2502,7 +2502,7 @@ pub fn m4_indices(x: &[f64], y: &[f64], x0: f64, x1: f64, n_buckets: usize) -> V
         n_buckets,
         start,
         end,
-        par_threads(end - start),
+        par_threads_above(end - start, PAR_THRESHOLD_COMPUTE),
     )
 }
 
@@ -3174,22 +3174,29 @@ fn bin_2d_count_f32_scalar(
     }
 }
 
-/// Row-scan kernels fan out across cores only past this size, where thread
+/// Row-scan kernels fan out across cores only past these sizes, where thread
 /// spawn + merge cost is well amortized. Threading stays inside the call —
-/// the ABI remains synchronous (engine doc E5).
+/// the ABI remains synchronous (engine doc E5). Compute-bound scans cross over
+/// earlier: at ~2.5–3 ns/row serial, M4 and uniform histogram amortize a
+/// fan-out from ~128k rows, the same crossover zone maps use.
 const PAR_THRESHOLD: usize = 1 << 19;
+const PAR_THRESHOLD_COMPUTE: usize = 1 << 17;
 
 fn par_threads(n: usize) -> usize {
+    par_threads_above(n, PAR_THRESHOLD)
+}
+
+fn par_threads_above(n: usize, threshold: usize) -> usize {
     static CODSPEED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     if *CODSPEED.get_or_init(|| std::env::var_os("CODSPEED_ENV").is_some()) {
         return 1;
     }
     let cores = std::thread::available_parallelism().map_or(1, |p| p.get());
-    par_threads_for(n, cores)
+    par_threads_above_for(n, threshold, cores)
 }
 
-fn par_threads_for(n: usize, cores: usize) -> usize {
-    if n >= PAR_THRESHOLD {
+fn par_threads_above_for(n: usize, threshold: usize, cores: usize) -> usize {
+    if n >= threshold {
         cores.clamp(1, MAX_ROW_THREADS)
     } else {
         1
@@ -4596,7 +4603,13 @@ pub fn stratified_sample_mask<T: Copy + Sync + Into<u64>>(
 pub fn histogram_uniform(data: &[f64], lo: f64, hi: f64, out: &mut [f64]) -> u64 {
     assert!(x1_gt_x0(lo, hi));
     assert!(!out.is_empty());
-    histogram_uniform_impl(data, lo, hi, par_threads(data.len()), out)
+    histogram_uniform_impl(
+        data,
+        lo,
+        hi,
+        par_threads_above(data.len(), PAR_THRESHOLD_COMPUTE),
+        out,
+    )
 }
 
 /// Per-bin u64 counting shared by the serial and parallel paths. Stays scalar
@@ -6854,9 +6867,29 @@ mod tests {
         // shape): per-thread grids + merge dwarf the scan — stay serial.
         assert_eq!(bin_2d_threads(1 << 20, 1 << 20), 1);
         assert_eq!(bin_2d_threads(2_100_000, 2048 * 2048), 1);
-        assert_eq!(par_threads_for(PAR_THRESHOLD - 1, 64), 1);
-        assert_eq!(par_threads_for(PAR_THRESHOLD, 64), MAX_ROW_THREADS);
-        assert_eq!(par_threads_for(PAR_THRESHOLD, 1), 1);
+        assert_eq!(
+            par_threads_above_for(PAR_THRESHOLD - 1, PAR_THRESHOLD, 64),
+            1
+        );
+        assert_eq!(
+            par_threads_above_for(PAR_THRESHOLD, PAR_THRESHOLD, 64),
+            MAX_ROW_THREADS
+        );
+        assert_eq!(par_threads_above_for(PAR_THRESHOLD, PAR_THRESHOLD, 1), 1);
+    }
+
+    #[test]
+    fn par_thread_gates_route_by_cost_class() {
+        const { assert!(PAR_THRESHOLD_COMPUTE < PAR_THRESHOLD) }
+        let t_c = PAR_THRESHOLD_COMPUTE;
+        for cores in [1, 4, 20, 64] {
+            let cap = cores.clamp(1, MAX_ROW_THREADS);
+            // Compute-bound kernels fan out from 128k rows.
+            assert_eq!(par_threads_above_for(t_c - 1, t_c, cores), 1);
+            assert_eq!(par_threads_above_for(t_c, t_c, cores), cap);
+            // ...and stay serial in the band the general gate still reserves.
+            assert_eq!(par_threads_above_for(t_c, PAR_THRESHOLD, cores), 1);
+        }
     }
 
     #[test]

--- a/src/kernels.rs
+++ b/src/kernels.rs
@@ -4603,13 +4603,14 @@ pub fn stratified_sample_mask<T: Copy + Sync + Into<u64>>(
 pub fn histogram_uniform(data: &[f64], lo: f64, hi: f64, out: &mut [f64]) -> u64 {
     assert!(x1_gt_x0(lo, hi));
     assert!(!out.is_empty());
-    histogram_uniform_impl(
-        data,
-        lo,
-        hi,
-        par_threads_above(data.len(), PAR_THRESHOLD_COMPUTE),
-        out,
-    )
+    histogram_uniform_impl(data, lo, hi, histogram_threads(data.len(), out.len()), out)
+}
+
+/// Workers for a uniform histogram. Each owns a full bin vector and the merge
+/// is `threads * n_bins`, so points per bin caps the row gate — same rule as
+/// `bin_2d_threads`, whose per-thread grids are this kernel's per-thread bins.
+fn histogram_threads(n: usize, n_bins: usize) -> usize {
+    (n / n_bins.max(1)).clamp(1, par_threads_above(n, PAR_THRESHOLD_COMPUTE))
 }
 
 /// Per-bin u64 counting shared by the serial and parallel paths. Stays scalar
@@ -6876,6 +6877,47 @@ mod tests {
             MAX_ROW_THREADS
         );
         assert_eq!(par_threads_above_for(PAR_THRESHOLD, PAR_THRESHOLD, 1), 1);
+    }
+
+    #[test]
+    fn histogram_threads_bin_aware() {
+        let n = PAR_THRESHOLD_COMPUTE;
+        let cap = par_threads_above(n, PAR_THRESHOLD_COMPUTE);
+        // Below the compute gate: serial regardless of bin count.
+        assert_eq!(histogram_threads(PAR_THRESHOLD_COMPUTE - 1, 8), 1);
+        // Chart-sized bin counts (512 is the benchmark config): pure row gate.
+        assert_eq!(histogram_threads(n, 512), cap);
+        assert_eq!(histogram_threads(n, 8), cap);
+        // Bins as numerous as the rows: merge dwarfs the scan — stay serial.
+        assert_eq!(histogram_threads(n, n), 1);
+        assert_eq!(histogram_threads(200_000, 1_000_000), 1);
+        // In between, workers track points per bin.
+        assert_eq!(histogram_threads(1 << 18, 1 << 15), 8.min(cap));
+    }
+
+    #[test]
+    fn histogram_high_bin_count_matches_serial() {
+        // 128k-512k band: high bin counts route serial, and the public path
+        // stays bit-identical to the serial impl either way.
+        let n = PAR_THRESHOLD_COMPUTE + 1_000;
+        let bins = 300_000;
+        let data: Vec<f64> = (0..n).map(|i| (i % 977) as f64 * 0.25).collect();
+        assert_eq!(histogram_threads(n, bins), 1);
+        let mut serial = vec![0f64; bins];
+        let ts = histogram_uniform_impl(&data, 0.0, 244.0, 1, &mut serial);
+        let mut routed = vec![0f64; bins];
+        let tr = histogram_uniform(&data, 0.0, 244.0, &mut routed);
+        assert_eq!(ts, tr);
+        assert_eq!(serial, routed);
+        // Same rows, ordinary bin count: still fans out.
+        let cap = par_threads_above(n, PAR_THRESHOLD_COMPUTE);
+        assert_eq!(histogram_threads(n, 512), cap);
+        let mut small_serial = vec![0f64; 512];
+        let ss = histogram_uniform_impl(&data, 0.0, 244.0, 1, &mut small_serial);
+        let mut small_routed = vec![0f64; 512];
+        let sr = histogram_uniform(&data, 0.0, 244.0, &mut small_routed);
+        assert_eq!(ss, sr);
+        assert_eq!(small_serial, small_routed);
     }
 
     #[test]


### PR DESCRIPTION
# Fan out compute-bound row-scan kernels from 128k rows

## Summary

Every row-scan kernel in `src/kernels.rs` shared one fan-out gate, `PAR_THRESHOLD = 1 << 19` (524,288 rows). It was introduced for `bin_2d`/histogram, then sweep-applied to the rest from a 4-core calibration at 10M rows. The 128k–512k band was never measured, and it is where multi-chart dashboards live.

M4 and uniform histogram run ~2.5–3 ns/row serially, so an 18-way fan-out repays its ~0.25–0.3 ms spawn+join well before 512k; the shared gate strands them on one core, costing 2.5–3.6×. This gives them their own gate, `PAR_THRESHOLD_COMPUTE = 1 << 17` (131,072 rows, the crossover zone maps already use). Every other kernel keeps 512k.

Simply lowering the single gate was measured and rejected: `encode_f32` at 200k rows is ~5.7× *slower* fanned out, since spawn+join dominates a ~0.2 ns/row memory-bound pass. Hence per cost class.

## Changes

- **`src/kernels.rs`**: add the compute-class gate and generalize the routing helpers so the threshold is a parameter rather than baked into the lookup. The CodSpeed-serial check and the 18-worker cap stay in the shared helper:

```diff
 const PAR_THRESHOLD: usize = 1 << 19;
+const PAR_THRESHOLD_COMPUTE: usize = 1 << 17;

 fn par_threads(n: usize) -> usize {
+    par_threads_above(n, PAR_THRESHOLD)
+}
+
+fn par_threads_above(n: usize, threshold: usize) -> usize {
     static CODSPEED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     if *CODSPEED.get_or_init(|| std::env::var_os("CODSPEED_ENV").is_some()) {
         return 1;
     }
     let cores = std::thread::available_parallelism().map_or(1, |p| p.get());
-    par_threads_for(n, cores)
+    par_threads_above_for(n, threshold, cores)
 }

-fn par_threads_for(n: usize, cores: usize) -> usize {
-    if n >= PAR_THRESHOLD {
+fn par_threads_above_for(n: usize, threshold: usize, cores: usize) -> usize {
+    if n >= threshold {
         cores.clamp(1, MAX_ROW_THREADS)
```

  The two compute-bound call sites pass the compute constant inline, matching how `raster_fanout` already takes its per-workload threshold as an argument:

```diff
-        par_threads(end - start),
+        par_threads_above(end - start, PAR_THRESHOLD_COMPUTE),
...
-    histogram_uniform_impl(data, lo, hi, par_threads(data.len()), out)
+    histogram_uniform_impl(
+        data, lo, hi, par_threads_above(data.len(), PAR_THRESHOLD_COMPUTE), out,
+    )
```

  Plus `par_thread_gates_route_by_cost_class`, a deterministic routing test across 1/4/20/64 cores: the compute gate fans out at exactly its threshold, and a compute-sized input still stays serial under the general gate. That is the invariant distinguishing the two classes.

- **`spec/design/rust-engine.md`**: E5 updated to document per-cost-class gates with their measured ns/row and break-evens.
- **`spec/benchmarks/results.md`**: the kernel-parallelization note now states the 128k compute gate alongside the 512k general gate.

## Performance

i7-12800H (20 threads), Linux 6.8, fat-LTO release build. Interleaved base/branch rounds; medians of 15 runs after 3 warmups, ms:

| case | base | branch | speedup |
| --- | --- | --- | --- |
| M4 200k | 0.548 | 0.229 | 2.4× |
| M4 300k | 0.832 | 0.287 | 2.9× |
| M4 400k | 1.066 | 0.404 | 2.6× |
| M4 500k | 1.337 | 0.375 | 3.6× |
| histogram 200k | 0.540 | 0.214 | 2.5× |
| histogram 300k | 0.792 | 0.259 | 3.1× |
| histogram 500k | 1.317 | 0.419 | 3.1× |
| 8×500k-line dashboard `build_payload` | 11.26 | 3.33 | 3.4× |
| 300k-line `build_payload` | 0.830 | 0.376 | 2.2× |

Kernels left on the general gate are unchanged within noise (`encode_f32` 500k 0.124 → 0.132, `min_max` 500k 0.492 → 0.498, `is_sorted` 500k 0.247 → 0.257), confirming the re-gate is confined to the two compute-bound kernels. Below 128k rows the code path is identical to before, so small-N behavior is untouched by construction.

## Testing

- `cargo test --release` → green, including the new routing test and the existing parity fuzz (serial and fanned-out results bitwise identical).
- `cargo clippy --all-targets`, `cargo fmt --check`, `ruff check`, `ruff format --check` → clean. `ty check` → unchanged from base; no Python touched.
- `pytest` → green apart from two failures that reproduce on an unmodified base checkout (packaging-layout drift, unrelated).
- Payloads byte-identical to base (spec+blob SHA-256) for a 300k decimated line, 300k bar, and 150k scatter.

## Risks & rollout

- **Determinism is unaffected.** Thresholds select segment count only; segment structure and results are thread-count invariant, covered by the existing parity fuzz. No rendered output can change.
- **No ABI change**: thresholds are internal routing, so no `ABI_VERSION` bump and no Python or JS changes.
- **CodSpeed stays serial**: the env check lives in the shared helper, so benchmark instrumentation is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved parallel processing for compute-intensive scans by enabling it at lower row counts.
  * Improved histogram performance while limiting parallel workers for high bin counts.
  * Preserved efficient serial behavior when parallel processing would not provide benefits.

* **Documentation**
  * Updated benchmark and engine guidance to describe distinct parallelization thresholds and worker limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->