### PR TITLE
Complete the PEP 561 typing surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -763,7 +763,7 @@ jobs:
       - name: Typecheck installed-wheel public surface
         shell: bash
         run: |
-          uv pip install -p smoke ty
+          uv pip install -p smoke ty==0.0.57
           if [ -x smoke/bin/python ]; then
             python_exe=smoke/bin/python
             ty_exe=smoke/bin/ty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,12 +177,10 @@ jobs:
           .venv/bin/ruff check .
           .venv/bin/ruff format --check .
 
-      # ty is pre-1.0 (0.0.x) and advisory here: it type-checks the shippable
-      # library and reports findings, but doesn't gate the build — pytest, ruff,
-      # and cargo are the hard gates. Test/benchmark code intentionally
-      # subscripts known-non-None Optionals, which ty can't narrow.
-      - name: Typecheck (ty, advisory)
-        run: .venv/bin/ty check python || echo "::warning::ty reported type findings (advisory)"
+      # Include a package-external consumer so lazy root exports cannot silently
+      # degrade to Any even when the implementation modules remain well typed.
+      - name: Typecheck (ty)
+        run: .venv/bin/python scripts/check_typing.py
 
       - name: Python tests (native core)
         # Point PNG-export tests at the Playwright Chromium (not on PATH) so the
@@ -761,6 +759,20 @@ jobs:
           uv pip install -p smoke dist/*.whl numpy anywidget
           ./smoke/bin/python -c "import xy, xy.kernels as k; assert k.BACKEND == 'native', k.BACKEND; print('native core loaded')" \
             || ./smoke/Scripts/python.exe -c "import xy, xy.kernels as k; assert k.BACKEND == 'native', k.BACKEND; print('native core loaded')"
+
+      - name: Typecheck installed-wheel public surface
+        shell: bash
+        run: |
+          uv pip install -p smoke ty
+          if [ -x smoke/bin/python ]; then
+            python_exe=smoke/bin/python
+            ty_exe=smoke/bin/ty
+          else
+            python_exe=smoke/Scripts/python.exe
+            ty_exe=smoke/Scripts/ty.exe
+          fi
+          python scripts/check_typing.py --consumer-only \
+            --python-executable "$python_exe" --ty-executable "$ty_exe"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,9 @@ known-first-party = ["reflex_xy", "xy"]
 
 [tool.ty.environment]
 python = ".venv"
+# Maintenance entry points are executable by path and import sibling helpers by
+# their local module names. Keep those imports visible when checking scripts.
+extra-paths = ["scripts"]
 
 [tool.ty.src]
 # Type-check the shippable library; tests/scripts/benchmarks use dynamic

--- a/python/reflex_xy/namespace.py
+++ b/python/reflex_xy/namespace.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 
 import asyncio
 import urllib.parse
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from typing import TYPE_CHECKING, Any, Optional
 
 from socketio import AsyncNamespace
@@ -123,7 +123,9 @@ def _plain(value: Any) -> Any:
     return value
 
 
-def _buffer_bytes(buffers: Any) -> list[bytes]:
+def _buffer_bytes(
+    buffers: Optional[Sequence[bytes | bytearray | memoryview]],
+) -> list[bytes | bytearray]:
     """socket.io attaches `bytes`/`bytearray` only; memoryviews must convert.
 
     This is the single wire copy of each column (the join copy the split
@@ -334,7 +336,7 @@ class XYNamespace(AsyncNamespace):
         self,
         token: str,
         message: dict[str, Any],
-        buffers: Optional[list[bytes]] = None,
+        buffers: Optional[Sequence[bytes | bytearray | memoryview]] = None,
         version: Optional[int] = None,
     ) -> None:
         """Push one channel message to every subscriber of a figure."""

--- a/python/reflex_xy/registry.py
+++ b/python/reflex_xy/registry.py
@@ -21,7 +21,7 @@ import threading
 import time
 import uuid
 from collections import deque
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -38,7 +38,8 @@ DEFAULT_TTL_SECONDS = 30 * 60.0
 _SWEEP_INTERVAL_SECONDS = 60.0
 
 
-PushHook = Callable[[str, dict, list[bytes], Optional[int]], Awaitable[None]]
+PushBuffer = bytes | bytearray | memoryview
+PushHook = Callable[[str, dict, Sequence[PushBuffer], Optional[int]], Awaitable[None]]
 
 
 @dataclass
@@ -48,7 +49,7 @@ class _QueuedPush:
     callback: PushHook
     token: str
     message: dict
-    buffers: list[bytes]
+    buffers: list[PushBuffer]
     version: Optional[int]
     completion: Optional[asyncio.Future[None]] = None
 
@@ -153,7 +154,7 @@ class FigureRegistry:
         entry: FigureEntry,
         token: str,
         message: dict,
-        buffers: list[bytes],
+        buffers: Sequence[PushBuffer],
         version: Optional[int],
         *,
         completion: Optional[asyncio.Future[None]] = None,
@@ -169,7 +170,7 @@ class FigureRegistry:
         loop = self._loop
         if callback is None or loop is None:
             return False, None
-        queued = _QueuedPush(callback, token, message, buffers, version, completion)
+        queued = _QueuedPush(callback, token, message, list(buffers), version, completion)
         with self._mutex:
             entry._push_queue.append(queued)
             if entry._push_drain_scheduled:

--- a/python/xy/__init__.py
+++ b/python/xy/__init__.py
@@ -25,6 +25,11 @@ from __future__ import annotations
 from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
+# ``__getattr__`` materializes this lazily at runtime.  The declaration keeps
+# the PEP 561 surface concrete for static consumers without paying the
+# ``importlib.metadata`` lookup during ``import xy``.
+__version__: str
+
 _EXPORTS = {
     "Annotation": ".components",
     "Animation": ".components",
@@ -283,18 +288,22 @@ if TYPE_CHECKING:
     from ._figure import Selection
     from .columns import Column, ColumnStore, ZoneMaps
     from .components import (
+        Animation,
         Annotation,
         Axis,
         Chart,
         Colorbar,
         Component,
+        ExportConfig,
         FacetChart,
         Interaction,
         Legend,
         Mark,
         Modebar,
+        Spring,
         Theme,
         Tooltip,
+        animation,
         area,
         area_chart,
         arrow,
@@ -330,6 +339,7 @@ if TYPE_CHECKING:
         legend,
         line,
         line_chart,
+        mark,
         marker,
         modebar,
         pie_chart,
@@ -342,6 +352,9 @@ if TYPE_CHECKING:
         sankey_chart,
         scatter,
         scatter_chart,
+        segments,
+        segments_chart,
+        spring,
         stairs,
         stairs_chart,
         stem,
@@ -354,6 +367,8 @@ if TYPE_CHECKING:
         threshold,
         threshold_zone,
         tooltip,
+        triangle_mesh,
+        triangle_mesh_chart,
         violin,
         violin_chart,
         vline,
@@ -365,3 +380,10 @@ if TYPE_CHECKING:
     )
     from .dom import CHART_DOM_SLOTS
     from .export import Engine, write_images
+    from .plugins import (
+        MarkContext,
+        MarkPlugin,
+        register_mark,
+        registered_marks,
+        unregister_mark,
+    )

--- a/python/xy/_figure.py
+++ b/python/xy/_figure.py
@@ -12,7 +12,7 @@ import math
 import warnings
 from collections.abc import Mapping, Sequence
 from os import PathLike
-from typing import Any, Optional, TypeAlias, Union
+from typing import Any, Optional, TypeAlias, Union, cast
 
 import numpy as np
 
@@ -1738,7 +1738,8 @@ class Figure(AnnotationsMixin, PayloadMixin):
         if t.kind == "ribbon":
             # x is just the two faces; y needs all four span edges, two of
             # which ride in the `x`/`y` slots (ribbon geometry contract).
-            return [t.x0, t.x1] if axis == "x" else [t.y0, t.y1, t.x, t.y]
+            columns = [t.x0, t.x1] if axis == "x" else [t.y0, t.y1, t.x, t.y]
+            return cast(list[Column], columns)
         if t.x0 is not None and t.x1 is not None and t.y0 is not None and t.y1 is not None:
             return [t.x0, t.x1] if axis == "x" else [t.y0, t.y1]
         return [t.x if axis == "x" else t.y]
@@ -1958,7 +1959,7 @@ class Figure(AnnotationsMixin, PayloadMixin):
         alpha: Any = None,
         stroke_width: Any = None,
         symbol: Any = None,
-    ) -> tuple[dict[str, Any], list[bytes]]:
+    ) -> tuple[dict[str, Any], list[memoryview]]:
         """Streaming append: extend a scatter/line trace's canonical columns
         and get the client refresh message back. The widget's `append` sends
         it; headless callers can inspect or discard it. Payloads stay

--- a/python/xy/_figure.py
+++ b/python/xy/_figure.py
@@ -12,7 +12,7 @@ import math
 import warnings
 from collections.abc import Mapping, Sequence
 from os import PathLike
-from typing import Any, Optional, TypeAlias, Union, cast
+from typing import Any, Optional, TypeAlias, Union
 
 import numpy as np
 
@@ -1738,8 +1738,9 @@ class Figure(AnnotationsMixin, PayloadMixin):
         if t.kind == "ribbon":
             # x is just the two faces; y needs all four span edges, two of
             # which ride in the `x`/`y` slots (ribbon geometry contract).
-            columns = [t.x0, t.x1] if axis == "x" else [t.y0, t.y1, t.x, t.y]
-            return cast(list[Column], columns)
+            if t.x0 is None or t.x1 is None or t.y0 is None or t.y1 is None:
+                raise ValueError("ribbon trace missing geometry columns")
+            return [t.x0, t.x1] if axis == "x" else [t.y0, t.y1, t.x, t.y]
         if t.x0 is not None and t.x1 is not None and t.y0 is not None and t.y1 is not None:
             return [t.x0, t.x1] if axis == "x" else [t.y0, t.y1]
         return [t.x if axis == "x" else t.y]

--- a/python/xy/_hosts.py
+++ b/python/xy/_hosts.py
@@ -26,6 +26,7 @@ class FigureHost(Protocol):
     axis_options: dict[str, dict[str, Any]]
     _axis_categories: dict[str, list[str]]
     title: Optional[str]
+    title_options: list[dict[str, Any]]
     width: Any
     height: Any
     padding: Any

--- a/python/xy/_raster.py
+++ b/python/xy/_raster.py
@@ -16,7 +16,7 @@ import struct
 from collections.abc import Callable, Sequence
 from itertools import pairwise
 from os import PathLike
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import numpy as np
 
@@ -3372,7 +3372,7 @@ def _emit_colorbar(
     ticks = options.get("ticks")
     supplied_labels = options.get("tick_labels")
     tick_label_map = (
-        {float(value): str(supplied_labels[index]) for index, value in enumerate(ticks)}
+        {float(cast(Any, value)): str(supplied_labels[index]) for index, value in enumerate(ticks)}
         if isinstance(ticks, list)
         and isinstance(supplied_labels, list)
         and len(ticks) == len(supplied_labels)

--- a/python/xy/_svg.py
+++ b/python/xy/_svg.py
@@ -25,7 +25,7 @@ from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from itertools import pairwise
 from os import PathLike
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple, Optional, cast
 
 import numpy as np
 
@@ -86,7 +86,7 @@ def _flag_stops() -> list[tuple[int, int, int]]:
     # Match Matplotlib's ``bytes=True`` conversion, which truncates rather than
     # rounds each clipped channel after scaling it to the uint8 range.
     rgb = (np.clip(channels, 0.0, 1.0) * 255.0).astype(np.uint8)
-    return [tuple(int(channel) for channel in row) for row in rgb]
+    return [(int(row[0]), int(row[1]), int(row[2])) for row in rgb]
 
 
 # Mirrors js/src/10_colormaps.ts COLORMAP_STOPS (§36) — test-guarded.
@@ -4700,7 +4700,7 @@ def _annotation_connector_unclipped(
     else:
         return False
     try:
-        x, y = float(target[0]), float(target[1])
+        x, y = float(cast(Any, target[0])), float(cast(Any, target[1]))
         if polar is not None:
             if not bool(polar.position_mask(x, y)):
                 return False

--- a/python/xy/pyplot/_artists.py
+++ b/python/xy/pyplot/_artists.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Iterator, Sequence
 from operator import index as operator_index
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import numpy as np
 
@@ -568,7 +568,7 @@ class PathCollection(Artist):
         else:
             from ._ticker import MaxNLocator
 
-            count = 9 if num == "auto" else max(1, int(num))
+            count = 9 if num == "auto" else max(1, int(cast(Any, num)))
             ticks = MaxNLocator(count).tick_values(
                 float(transformed.min()), float(transformed.max())
             )
@@ -1621,7 +1621,7 @@ def _legend_item_from_entry(
         style["stroke"] = stroke
     stroke_width = kw.get("stroke_width")
     if stroke_width is not None and np.isscalar(stroke_width):
-        style["stroke_width"] = float(stroke_width)
+        style["stroke_width"] = float(cast(Any, stroke_width))
     hatch = kw.get("hatch", entry.get("pie_hatch"))
     if hatch:
         style["hatch"] = str(hatch)
@@ -1681,7 +1681,7 @@ def _legend_marker_style(entry: dict[str, Any]) -> dict[str, Any]:
     for key in ("size", "stroke_width"):
         value = kw.get(key)
         if value is not None and np.isscalar(value):
-            marker[key] = float(value)
+            marker[key] = float(cast(Any, value))
     return marker
 
 

--- a/python/xy/pyplot/_axes.py
+++ b/python/xy/pyplot/_axes.py
@@ -10,6 +10,7 @@ test in tests/pyplot/.
 
 from __future__ import annotations
 
+import builtins
 import copy
 import math
 import warnings
@@ -20,7 +21,7 @@ from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import suppress
 from datetime import datetime, timedelta
 from itertools import pairwise
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Optional, cast
 
 import numpy as np
 
@@ -1380,6 +1381,7 @@ class Axes(PlotTypeMixin):
         # whose chart is the panel and not the whole figure; otherwise the
         # chart *is* the figure and the rectangle comes from get_position().
         self._plot_box_px: Optional[tuple[float, float, float, float]] = None
+        self._shared_render_domains: dict[str, tuple[float, float]] = {}
         self._padding: Optional[list[float]] = None
         # "cartesian" or "polar" — matplotlib's `projection=` argument. Polar
         # reinterprets the same two axes (x carries theta, y carries r), which
@@ -1887,15 +1889,15 @@ class Axes(PlotTypeMixin):
         if transform is not None:
             x, y = self._transform_points(x, y, transform)
         if np.ma.isMaskedArray(x):
-            masked_x = np.ma.asarray(x)
+            masked_x = cast(np.ma.MaskedArray, np.ma.asarray(x))
             if masked_x.dtype.kind in "iub":
                 masked_x = masked_x.astype(np.float64)
-            x = masked_x.filled(np.nan)
+            x = np.ma.filled(masked_x, np.nan)
         if np.ma.isMaskedArray(y):
-            masked_y = np.ma.asarray(y)
+            masked_y = cast(np.ma.MaskedArray, np.ma.asarray(y))
             if masked_y.dtype.kind in "iub":
                 masked_y = masked_y.astype(np.float64)
-            y = masked_y.filled(np.nan)
+            y = np.ma.filled(masked_y, np.nan)
         per = dict(base)
         this_marker = marker
         if fmt:
@@ -4226,7 +4228,7 @@ class Axes(PlotTypeMixin):
         spec = host._scale_specs[key]
         values = np.asarray(bounds, dtype=np.float64)
         if spec["name"] != "log":
-            return tuple(map(float, values))
+            return float(values[0]), float(values[1])
         base = float(spec.get("base", 10.0))
         if inverse:
             transformed = np.power(base, values)
@@ -4242,7 +4244,7 @@ class Axes(PlotTypeMixin):
                 transformed = np.log(fallback) / np.log(base)
             if not np.isfinite(transformed).all():
                 raise ValueError("log aspect limits must be positive and finite")
-        return tuple(map(float, transformed))
+        return float(transformed[0]), float(transformed[1])
 
     def get_position(self, original: bool = False) -> Bbox:
         """The axes rectangle in figure fractions, as a `Bbox`.
@@ -7721,8 +7723,8 @@ class Axes(PlotTypeMixin):
     def _apply_legend_handle_styles(
         self,
         core_figure: Any,
-        claimed_trace_ids: Optional[set[int]] = None,
-    ) -> set[int]:
+        claimed_trace_ids: Optional[builtins.set[int]] = None,
+    ) -> builtins.set[int]:
         """Attach Matplotlib-only handle paint to automatic legend traces.
 
         Plot markers and dash gap colors are separate XY marks so the data
@@ -8052,7 +8054,7 @@ class Axes(PlotTypeMixin):
 
             x_values, y_values = entry.get("x"), entry.get("y")
             if kind == "@arrow":
-                args = entry.get("args") or ()
+                args: tuple[Any, ...] = tuple(entry.get("args") or ())
                 if len(args) >= 4:
                     x_values, y_values = (args[0], args[2]), (args[1], args[3])
             elif kind == "@mark" and entry.get("factory") == "stairs":
@@ -8061,7 +8063,7 @@ class Axes(PlotTypeMixin):
                 # Legend._auto_legend_data(). Feeding the compact arguments to
                 # the generic (x, y) path reverses the axes and makes the
                 # histogram effectively invisible to ``loc="best"``.
-                args = entry.get("args") or ()
+                args = tuple(entry.get("args") or ())
                 if len(args) >= 2:
                     try:
                         values = axis_values(args[0], "y")
@@ -8166,7 +8168,7 @@ class Axes(PlotTypeMixin):
                 unresolved_hits = _path_intersects_boxes(
                     path_xn,
                     path_yn,
-                    (
+                    [
                         (
                             candidates[index][1],
                             candidates[index][2],
@@ -8174,7 +8176,7 @@ class Axes(PlotTypeMixin):
                             candidates[index][4],
                         )
                         for index in unresolved
-                    ),
+                    ],
                 )
                 for index, hit in zip(unresolved, unresolved_hits, strict=True):
                     path_hits[index] = hit

--- a/python/xy/pyplot/_colors.py
+++ b/python/xy/pyplot/_colors.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import numbers
 import re
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from typing import Any, NamedTuple, Optional, TypeGuard, cast
 
 import numpy as np
@@ -506,8 +506,11 @@ def prepare_boundary_norm(
 
     source = np.ma.asarray(values, dtype=np.float64)
     raw = np.asarray(source.filled(np.nan), dtype=np.float64)
-    mapped = np.ma.asarray(norm(source))
-    cmap_callable = cmap if callable(cmap) else Cmap(resolve_cmap(cmap))
+    norm_callable = cast(Callable[[Any], Any], norm)
+    mapped = np.ma.asarray(norm_callable(source))
+    cmap_callable: Callable[[Any], Any] = (
+        cast(Callable[[Any], Any], cmap) if callable(cmap) else Cmap(resolve_cmap(cmap))
+    )
     rgba = np.asarray(cmap_callable(mapped.filled(0)), dtype=np.float64)
     expected = raw.shape + (3,)
     if rgba.shape not in {expected, raw.shape + (4,)}:
@@ -524,7 +527,7 @@ def prepare_boundary_norm(
 
     midpoints = (boundaries[:-1] + boundaries[1:]) * 0.5
     band_rgba = np.asarray(
-        cmap_callable(np.ma.asarray(norm(midpoints)).filled(0)), dtype=np.float64
+        cmap_callable(np.ma.asarray(norm_callable(midpoints)).filled(0)), dtype=np.float64
     )
     if (
         band_rgba.ndim != 2
@@ -588,8 +591,16 @@ def normalize_scalar_grid(
     if norm_name == "linear":
         if lo_arg is None and hi_arg is None:
             return raw, None, "linear"
-        lo = float(lo_arg) if lo_arg is not None else (float(finite.min()) if finite.size else 0.0)
-        hi = float(hi_arg) if hi_arg is not None else (float(finite.max()) if finite.size else 1.0)
+        lo = (
+            scalar_float(lo_arg)
+            if lo_arg is not None
+            else (float(finite.min()) if finite.size else 0.0)
+        )
+        hi = (
+            scalar_float(hi_arg)
+            if hi_arg is not None
+            else (float(finite.max()) if finite.size else 1.0)
+        )
         if not np.isfinite([lo, hi]).all():
             raise ValueError("vmin and vmax must be finite")
         if hi < lo:
@@ -599,8 +610,8 @@ def normalize_scalar_grid(
     positive = finite[finite > 0.0]
     if not positive.size and (lo_arg is None or hi_arg is None):
         raise ValueError("log normalization requires at least one positive finite value")
-    lo = float(lo_arg) if lo_arg is not None else float(positive.min())
-    hi = float(hi_arg) if hi_arg is not None else float(positive.max())
+    lo = scalar_float(lo_arg) if lo_arg is not None else float(positive.min())
+    hi = scalar_float(hi_arg) if hi_arg is not None else float(positive.max())
     if not np.isfinite([lo, hi]).all() or lo <= 0.0 or hi <= 0.0:
         raise ValueError("Invalid vmin or vmax")
     if hi < lo:

--- a/python/xy/pyplot/_grid.py
+++ b/python/xy/pyplot/_grid.py
@@ -455,13 +455,15 @@ def compose_svg(
         block,
         size,
     )
-    title = (
-        f'<text x="{width * float(style.get("x", 0.5)):g}" y="{baseline:g}" text-anchor="{anchor}" '
-        f'font-family="{_html.escape(str(style.get("family", "system-ui,sans-serif")))}" font-size="{size:g}" font-weight="{_html.escape(str(style.get("weight", "normal")))}" fill="{_html.escape(str(style.get("color", "#262626")))}">'
-        f"{_svg_text_lines(suptitle, width * float(style.get('x', 0.5)), block.line_step)}</text>"
-        if suptitle
-        else ""
-    )
+    if suptitle:
+        assert block is not None
+        title = (
+            f'<text x="{width * float(style.get("x", 0.5)):g}" y="{baseline:g}" text-anchor="{anchor}" '
+            f'font-family="{_html.escape(str(style.get("family", "system-ui,sans-serif")))}" font-size="{size:g}" font-weight="{_html.escape(str(style.get("weight", "normal")))}" fill="{_html.escape(str(style.get("color", "#262626")))}">'
+            f"{_svg_text_lines(suptitle, width * float(style.get('x', 0.5)), block.line_step)}</text>"
+        )
+    else:
+        title = ""
     labels = _svg_figure_labels(figure_labels or [], width, height)
     legend = ""
     if figure_legend and figure_legend.get("items"):

--- a/python/xy/pyplot/_mplfig.py
+++ b/python/xy/pyplot/_mplfig.py
@@ -11,7 +11,7 @@ import inspect
 import uuid
 from os import PathLike
 from pathlib import Path
-from typing import Any, Literal, Optional, overload
+from typing import Any, Literal, Optional, cast, overload
 
 import numpy as np
 
@@ -176,13 +176,13 @@ def _probe_axis_spec(ax: Axes, width: int, height: int) -> dict[str, Any]:
             if hasattr(ax, "_materialize_plot_px"):
                 del ax._materialize_plot_px
         else:
-            ax._materialize_plot_px = previous_plot_px
+            ax._materialize_plot_px = cast(tuple[float, float], previous_plot_px)
         if twin is not None:
             if previous_twin_plot_px is missing:
                 if hasattr(twin, "_materialize_plot_px"):
                     del twin._materialize_plot_px
             else:
-                twin._materialize_plot_px = previous_twin_plot_px
+                twin._materialize_plot_px = cast(tuple[float, float], previous_twin_plot_px)
 
 
 def _measured_axis_chrome(ax: Axes, width: int, height: int) -> tuple[float, float, float, float]:
@@ -1298,7 +1298,9 @@ class Figure:
                     "colorbar(format=...) without fixed ticks",
                     "format= together with ticks= or a discrete mappable",
                 )
-            options["tick_labels"] = _colorbar_tick_labels(formatter, options["ticks"])
+            options["tick_labels"] = _colorbar_tick_labels(
+                formatter, cast(list[float], options["ticks"])
+            )
         extend = kwargs.pop("extend", None)
         if extend is None:
             # A contour set owns its extend state. Matplotlib colorbars inherit
@@ -1643,6 +1645,7 @@ class Figure:
         if sharex or sharey:
             for ax in axes.values():
                 spec = ax._subplot_spec
+                assert spec is not None
                 if sharex and spec.rows[1] < nrows:
                     ax._apply_tick_label_side_visibility("x", {"labelbottom": False})
                 if sharey and spec.cols[0] > 0:
@@ -1898,7 +1901,8 @@ class Figure:
                     members = [figures[i] for i in group]
                     source_ax = self._axes[group[0]]
                     if dim in source_ax._explicit_domains:
-                        domain = tuple(map(float, source_ax._axis[dim]["domain"]))
+                        raw_domain = source_ax._axis[dim]["domain"]
+                        domain = float(raw_domain[0]), float(raw_domain[1])
                     else:
                         # Matplotlib shared limits autoscale over the group's
                         # data; dataless panels follow the group instead of
@@ -1922,14 +1926,13 @@ class Figure:
             for index, (ax, domains) in enumerate(zip(self._axes, shared_domains, strict=True)):
                 if not any(entry["kind"] == "@axline" for entry in ax._entries):
                     continue
-                data_domains = {}
+                data_domains: dict[str, tuple[float, float]] = {}
                 for dim, domain in domains.items():
                     spec = ax._scale_specs[dim]
-                    data_domains[dim] = tuple(
-                        map(
-                            float,
-                            _scale_values(np.asarray(domain), spec, inverse=True),
-                        )
+                    transformed = _scale_values(np.asarray(domain), spec, inverse=True)
+                    data_domains[dim] = (
+                        float(transformed[0]),
+                        float(transformed[1]),
                     )
                 if getattr(ax, "_shared_render_domains", {}) != data_domains:
                     ax._shared_render_domains = data_domains

--- a/python/xy/pyplot/_plot_types.py
+++ b/python/xy/pyplot/_plot_types.py
@@ -706,8 +706,12 @@ def _pie_hatch_geometry(
             y0.append(clipped_start[1])
             x1.append(clipped_end[0])
             y1.append(clipped_end[1])
-    arrays = tuple(np.asarray(values, dtype=np.float64) for values in (x0, y0, x1, y1))
-    return arrays  # type: ignore[return-value]
+    return (
+        np.asarray(x0, dtype=np.float64),
+        np.asarray(y0, dtype=np.float64),
+        np.asarray(x1, dtype=np.float64),
+        np.asarray(y1, dtype=np.float64),
+    )
 
 
 def _limit_error(error: Any, lower_limits: Any, upper_limits: Any, size: int) -> Any:
@@ -1234,6 +1238,11 @@ class PlotTypeMixin:
     """Additional Matplotlib chart methods kept out of the core ``Axes`` type."""
 
     if TYPE_CHECKING:
+        figure: Any
+        transAxes: Any
+        _entries: list[dict[str, Any]]
+        _scale_specs: dict[str, dict[str, Any]]
+        _y2_of: Any
 
         def _add(self, kind: str, entry: dict[str, Any]) -> dict[str, Any]: ...
 
@@ -1278,6 +1287,20 @@ class PlotTypeMixin:
         def _axis_props(self, axis: str) -> dict[str, Any]: ...
 
         def _invalidate(self) -> None: ...
+
+        def _reserve_annotation_margin(self, axis: str, margin: float) -> None: ...
+
+        def scatter(self, *args: Any, **kwargs: Any) -> PathCollection: ...
+
+        def get_position(self, original: bool = False) -> Any: ...
+
+        def get_xlim(self) -> tuple[float, float]: ...
+
+        def get_ylim(self) -> tuple[float, float]: ...
+
+        def set_aspect(self, aspect: Any, **kwargs: Any) -> None: ...
+
+        def set_axis_off(self) -> None: ...
 
     def semilogx(self, *args: Any, **kwargs: Any) -> list[Line2D]:
         """Like ``plot``, but sets the x-axis to log scale first.
@@ -2125,15 +2148,16 @@ class PlotTypeMixin:
                 dx = pixel_padding * display_direction * (1.0 if positive else -1.0)
                 dy = 0.0
                 vertical_align = "center"
+            text_style: dict[str, Any] = {"vertical_align": vertical_align}
             text_kwargs: dict[str, Any] = {
                 "color": resolve_color(color) if color is not None else None,
                 "anchor": anchor,
                 "dx": dx,
                 "dy": dy,
-                "style": {"vertical_align": vertical_align},
+                "style": text_style,
             }
             if fontsize is not None:
-                text_kwargs["style"]["font_size"] = float(fontsize)
+                text_style["font_size"] = float(fontsize)
             entry = self._add("@text", {"args": (x, y, label), "kwargs": text_kwargs})
             result.append(Text(self, entry))
         return result
@@ -5461,12 +5485,10 @@ class PlotTypeMixin:
                     else resolve_color(darkened)
                 )
                 opacity = face_rgba[3] if shadow_alpha is None else float(shadow_alpha)
-                shifted = tuple(
-                    (
-                        vertex[0] + shift_x,
-                        vertex[1] + shift_y,
-                    )
-                    for vertex in vertices
+                shifted = (
+                    (vertices[0][0] + shift_x, vertices[0][1] + shift_y),
+                    (vertices[1][0] + shift_x, vertices[1][1] + shift_y),
+                    (vertices[2][0] + shift_x, vertices[2][1] + shift_y),
                 )
                 shadow_entry = self._add(
                     "@mark",
@@ -6498,7 +6520,7 @@ class PlotTypeMixin:
                 anchor_rx = self._quiver_render_values([raw_x], metrics["x_spec"])[0]
                 anchor_ry = self._quiver_render_values([raw_y], metrics["y_spec"])[0]
                 x_fraction = y_fraction = None
-            if x_fraction is not None:
+            if x_fraction is not None and y_fraction is not None:
                 anchor_rx = float(metrics["render_xlim"][0]) + float(x_fraction) * (
                     float(metrics["render_xlim"][1]) - float(metrics["render_xlim"][0])
                 )

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,12 @@
+"""Repository-only maintenance scripts."""
+
+from __future__ import annotations
+
+import sys
+
+from . import _ty_tools
+
+# Direct path execution imports helpers from the scripts directory by their
+# local name. Package execution loads this module first, so expose that same
+# name once here instead of duplicating fallbacks in every entry point.
+sys.modules.setdefault("_ty_tools", _ty_tools)

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import sys
 
-from . import _ty_tools
+from scripts import _ty_tools
 
 # Direct path execution imports helpers from the scripts directory by their
-# local name. Package execution loads this module first, so expose that same
-# name once here instead of duplicating fallbacks in every entry point.
-sys.modules.setdefault("_ty_tools", _ty_tools)
+# local name. Package execution loads this module first, so make that name
+# resolve to the same helper without duplicating fallbacks in every entry point.
+sys.modules["_ty_tools"] = _ty_tools

--- a/scripts/_ty_tools.py
+++ b/scripts/_ty_tools.py
@@ -25,11 +25,12 @@ def resolve_ty_executable(
     python: str | os.PathLike[str],
     *,
     required: bool = True,
+    os_name: str | None = None,
 ) -> Path:
     """Resolve the ty executable beside Python first, then through PATH."""
-    executable = ty_executable_name()
+    executable = ty_executable_name(os_name)
     sibling = Path(python).expanduser().with_name(executable)
-    if sibling.is_file():
+    if sibling.is_file() and os.access(sibling, os.X_OK):
         return sibling.absolute()
     found = shutil.which(executable)
     if found is not None:

--- a/scripts/_ty_tools.py
+++ b/scripts/_ty_tools.py
@@ -1,0 +1,39 @@
+"""Shared resolution helpers for the ``ty`` command-line executable."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+
+def ty_executable_name(os_name: str | None = None) -> str:
+    """Return ty's platform-specific executable name."""
+    return "ty.exe" if (os.name if os_name is None else os_name) == "nt" else "ty"
+
+
+def absolute_executable(value: str | os.PathLike[str]) -> Path:
+    """Return an absolute executable path, resolving bare commands through PATH."""
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        resolved = shutil.which(str(path))
+        path = Path(resolved) if resolved is not None else Path.cwd() / path
+    return path.absolute()
+
+
+def resolve_ty_executable(
+    python: str | os.PathLike[str],
+    *,
+    required: bool = True,
+) -> Path:
+    """Resolve the ty executable beside Python first, then through PATH."""
+    executable = ty_executable_name()
+    sibling = Path(python).expanduser().with_name(executable)
+    if sibling.is_file():
+        return sibling.absolute()
+    found = shutil.which(executable)
+    if found is not None:
+        return Path(found).absolute()
+    if required:
+        raise FileNotFoundError("cannot find ty beside Python or on PATH")
+    return Path(executable)

--- a/scripts/check_public_api.py
+++ b/scripts/check_public_api.py
@@ -365,9 +365,15 @@ def validate_static_typing_surface(
             and statement.test.id == "TYPE_CHECKING"
         ):
             continue
-        for child in ast.walk(statement):
-            if isinstance(child, ast.ImportFrom | ast.Import):
-                declared.update(alias.asname or alias.name for alias in child.names)
+        for child in statement.body:
+            if isinstance(child, ast.ImportFrom):
+                declared.update(
+                    alias.asname or alias.name for alias in child.names if alias.name != "*"
+                )
+            elif isinstance(child, ast.Import):
+                declared.update(
+                    alias.asname or alias.name.split(".", 1)[0] for alias in child.names
+                )
 
     missing = sorted(public_names - declared)
     if missing:

--- a/scripts/check_public_api.py
+++ b/scripts/check_public_api.py
@@ -14,6 +14,7 @@ release or CI green build.
 from __future__ import annotations
 
 import argparse
+import ast
 import importlib
 import json
 import os
@@ -334,6 +335,48 @@ def validate_pep561_marker(
     return []
 
 
+def validate_static_typing_surface(
+    pkg: ModuleType,
+    init_path: Path = ROOT / "python" / "xy" / "__init__.py",
+) -> list[str]:
+    """Ensure every lazy root export also has a static declaration.
+
+    Runtime consumers resolve root names through ``__getattr__``.  A type
+    checker cannot infer the per-name types hidden behind that dynamic hook, so
+    each public name must also be imported under ``TYPE_CHECKING`` (or, for a
+    lazily materialized scalar such as ``__version__``, explicitly annotated).
+    """
+    errors: list[str] = []
+    public_names = set(_string_list(getattr(pkg, "__all__", None), "__all__", errors))
+
+    try:
+        tree = ast.parse(init_path.read_text(encoding="utf-8"), filename=str(init_path))
+    except (OSError, SyntaxError) as exc:
+        return [*errors, f"cannot inspect static typing surface in {init_path}: {exc}"]
+
+    declared: set[str] = set()
+    for statement in tree.body:
+        if isinstance(statement, ast.AnnAssign) and isinstance(statement.target, ast.Name):
+            declared.add(statement.target.id)
+            continue
+        if not (
+            isinstance(statement, ast.If)
+            and isinstance(statement.test, ast.Name)
+            and statement.test.id == "TYPE_CHECKING"
+        ):
+            continue
+        for child in ast.walk(statement):
+            if isinstance(child, ast.ImportFrom | ast.Import):
+                declared.update(alias.asname or alias.name for alias in child.names)
+
+    missing = sorted(public_names - declared)
+    if missing:
+        errors.append(
+            f"xy public names have no static TYPE_CHECKING import or annotation: {missing}"
+        )
+    return errors
+
+
 def _loaded_import_budget_modules() -> list[str]:
     return sorted(
         name for name in sys.modules if name in HEAVY_THIRD_PARTY_IMPORTS or name.startswith("xy.")
@@ -483,6 +526,7 @@ def check_public_api(*, check_lazy_import: bool = True) -> list[str]:
     errors = check_all_fresh_import_budgets() if check_lazy_import else []
     errors.extend(validate_version_consistency(pkg))
     errors.extend(validate_pep561_marker())
+    errors.extend(validate_static_typing_surface(pkg))
     errors.extend(validate_public_api(pkg))
     errors.extend(validate_component_public_api(pkg))
     errors.extend(validate_declarative_api_contract(pkg))

--- a/scripts/check_typing.py
+++ b/scripts/check_typing.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import os
 import re
@@ -16,6 +17,7 @@ from pathlib import Path
 from typing import Optional
 
 ROOT = Path(__file__).resolve().parents[1]
+SOURCE_INIT = ROOT / "python" / "xy" / "__init__.py"
 SOURCE_PATHS = ("python", "tests/typing_pep561_consumer.py")
 REVEAL_RE = re.compile(
     r"consumer\.py:(?P<line>\d+):\d+: info\[revealed-type\] "
@@ -53,14 +55,49 @@ def _run_package_check(ty: Path) -> bool:
     return proc.returncode == 0
 
 
-def _installed_public_names(python: Path, *, cwd: Path) -> list[str]:
-    code = "import json, xy; print(json.dumps(xy.__all__))"
+def _environment_without_pythonpath() -> dict[str, str]:
     env = os.environ.copy()
     env.pop("PYTHONPATH", None)
+    return env
+
+
+def _canonical_public_names(init_path: Path = SOURCE_INIT) -> list[str]:
+    try:
+        tree = ast.parse(init_path.read_text(encoding="utf-8"), filename=str(init_path))
+    except (OSError, SyntaxError) as exc:
+        raise RuntimeError(f"cannot inspect canonical xy exports in {init_path}: {exc}") from exc
+
+    for statement in tree.body:
+        if not (
+            isinstance(statement, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == "_EXPORTS"
+                for target in statement.targets
+            )
+        ):
+            continue
+        try:
+            exports = ast.literal_eval(statement.value)
+        except (ValueError, SyntaxError) as exc:
+            raise RuntimeError(f"{init_path} _EXPORTS must be a literal dict") from exc
+        if not isinstance(exports, dict) or any(
+            not isinstance(name, str) or not name.isidentifier() or not isinstance(module, str)
+            for name, module in exports.items()
+        ):
+            raise RuntimeError(
+                f"{init_path} _EXPORTS must be a literal dict[str, str] with identifier keys"
+            )
+        return sorted({*exports, "__version__"})
+
+    raise RuntimeError(f"{init_path} does not define canonical _EXPORTS")
+
+
+def _installed_public_names(python: Path, *, cwd: Path) -> list[str]:
+    code = "import json, xy; print(json.dumps(xy.__all__))"
     proc = subprocess.run(
         [str(python), "-c", code],
         cwd=cwd,
-        env=env,
+        env=_environment_without_pythonpath(),
         check=False,
         capture_output=True,
         text=True,
@@ -79,6 +116,10 @@ def _installed_public_names(python: Path, *, cwd: Path) -> list[str]:
     if len(value) != len(set(value)):
         raise RuntimeError("installed xy.__all__ contains duplicate names")
     return sorted(value)
+
+
+def _public_name_drift(expected: list[str], installed: list[str]) -> tuple[list[str], list[str]]:
+    return sorted(set(expected) - set(installed)), sorted(set(installed) - set(expected))
 
 
 def _parse_revealed_types(output: str, line_names: dict[int, str]) -> dict[str, str]:
@@ -102,7 +143,22 @@ def _dynamic_root_names(revealed: dict[str, str]) -> list[str]:
 def _run_installed_consumer_check(python: Path, ty: Path) -> bool:
     with tempfile.TemporaryDirectory(prefix="xy-typing-consumer-") as raw_tmp:
         tmp = Path(raw_tmp)
-        names = _installed_public_names(python, cwd=tmp)
+        names = _canonical_public_names()
+        installed_names = _installed_public_names(python, cwd=tmp)
+        missing_exports, extra_exports = _public_name_drift(names, installed_names)
+        if missing_exports:
+            print(
+                f"installed xy.__all__ is missing canonical exports: {missing_exports}",
+                file=sys.stderr,
+            )
+        if extra_exports:
+            print(
+                f"installed xy.__all__ contains unexpected exports: {extra_exports}",
+                file=sys.stderr,
+            )
+        if missing_exports or extra_exports:
+            return False
+
         lines = ["from typing import reveal_type", "", "import xy", ""]
         line_names: dict[int, str] = {}
         for name in names:
@@ -138,6 +194,7 @@ requires-python = ">=3.11"
         proc = subprocess.run(
             command,
             cwd=tmp,
+            env=_environment_without_pythonpath(),
             check=False,
             capture_output=True,
             text=True,
@@ -158,7 +215,7 @@ requires-python = ">=3.11"
             print(output, file=sys.stderr)
             return False
 
-        print(f"installed typing consumer OK: {len(names)} xy.__all__ exports have concrete types")
+        print(f"installed typing consumer OK: {len(names)} canonical exports have concrete types")
         return True
 
 

--- a/scripts/check_typing.py
+++ b/scripts/check_typing.py
@@ -9,12 +9,18 @@ import json
 import os
 import re
 import shlex
-import shutil
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
 from typing import Optional
+
+try:
+    from _ty_tools import absolute_executable, resolve_ty_executable
+except ModuleNotFoundError as exc:  # imported by tests from the repository root
+    if exc.name != "_ty_tools":
+        raise
+    from scripts._ty_tools import absolute_executable, resolve_ty_executable
 
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE_INIT = ROOT / "python" / "xy" / "__init__.py"
@@ -23,25 +29,6 @@ REVEAL_RE = re.compile(
     r"consumer\.py:(?P<line>\d+):\d+: info\[revealed-type\] "
     r"Revealed type(?: is)?(?::)? `(?P<type>.*)`$"
 )
-
-
-def _absolute_executable(value: str | os.PathLike[str]) -> Path:
-    path = Path(value).expanduser()
-    if not path.is_absolute():
-        resolved = shutil.which(str(path))
-        path = Path(resolved) if resolved is not None else Path.cwd() / path
-    return path.absolute()
-
-
-def _default_ty(python: Path) -> Path:
-    executable = "ty.exe" if os.name == "nt" else "ty"
-    sibling = python.with_name(executable)
-    if sibling.is_file():
-        return sibling
-    found = shutil.which("ty")
-    if found is None:
-        raise FileNotFoundError("cannot find ty beside Python or on PATH")
-    return Path(found).absolute()
 
 
 def _print_command(command: list[str], *, cwd: Path) -> None:
@@ -233,8 +220,12 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument("--ty-executable", help="ty executable used for both checks")
     args = parser.parse_args(argv)
 
-    python = _absolute_executable(args.python_executable or sys.executable)
-    ty = _absolute_executable(args.ty_executable) if args.ty_executable else _default_ty(python)
+    python = absolute_executable(args.python_executable or sys.executable)
+    ty = (
+        absolute_executable(args.ty_executable)
+        if args.ty_executable
+        else resolve_ty_executable(python)
+    )
 
     package_ok = args.consumer_only or _run_package_check(ty)
     consumer_ok = _run_installed_consumer_check(python, ty)

--- a/scripts/check_typing.py
+++ b/scripts/check_typing.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Type-check the shipped package and its installed lazy root surface."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_PATHS = ("python", "tests/typing_pep561_consumer.py")
+REVEAL_RE = re.compile(
+    r"consumer\.py:(?P<line>\d+):\d+: info\[revealed-type\] "
+    r"Revealed type(?: is)?(?::)? `(?P<type>.*)`$"
+)
+
+
+def _absolute_executable(value: str | os.PathLike[str]) -> Path:
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        resolved = shutil.which(str(path))
+        path = Path(resolved) if resolved is not None else Path.cwd() / path
+    return path.absolute()
+
+
+def _default_ty(python: Path) -> Path:
+    executable = "ty.exe" if os.name == "nt" else "ty"
+    sibling = python.with_name(executable)
+    if sibling.is_file():
+        return sibling
+    found = shutil.which("ty")
+    if found is None:
+        raise FileNotFoundError("cannot find ty beside Python or on PATH")
+    return Path(found).absolute()
+
+
+def _print_command(command: list[str], *, cwd: Path) -> None:
+    print(f"$ (cd {shlex.quote(str(cwd))} && {shlex.join(command)})")
+
+
+def _run_package_check(ty: Path) -> bool:
+    command = [str(ty), "check", *SOURCE_PATHS, "--output-format", "concise"]
+    _print_command(command, cwd=ROOT)
+    proc = subprocess.run(command, cwd=ROOT, check=False, text=True)
+    return proc.returncode == 0
+
+
+def _installed_public_names(python: Path, *, cwd: Path) -> list[str]:
+    code = "import json, xy; print(json.dumps(xy.__all__))"
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    proc = subprocess.run(
+        [str(python), "-c", code],
+        cwd=cwd,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout).strip()
+        raise RuntimeError(f"cannot import installed xy with {python}: {detail}")
+    try:
+        value = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"installed xy.__all__ probe returned invalid JSON: {exc}") from exc
+    if not isinstance(value, list) or any(
+        not isinstance(name, str) or not name.isidentifier() for name in value
+    ):
+        raise RuntimeError(f"installed xy.__all__ must be a list of identifiers, got {value!r}")
+    if len(value) != len(set(value)):
+        raise RuntimeError("installed xy.__all__ contains duplicate names")
+    return sorted(value)
+
+
+def _parse_revealed_types(output: str, line_names: dict[int, str]) -> dict[str, str]:
+    revealed: dict[str, str] = {}
+    for raw_line in output.splitlines():
+        match = REVEAL_RE.search(raw_line)
+        if match is None:
+            continue
+        line = int(match.group("line"))
+        name = line_names.get(line)
+        if name is not None:
+            revealed[name] = match.group("type")
+    return revealed
+
+
+def _dynamic_root_names(revealed: dict[str, str]) -> list[str]:
+    """Return exports whose value itself is dynamic, not merely parametrized by Any."""
+    return sorted(name for name, type_name in revealed.items() if type_name in {"Any", "Unknown"})
+
+
+def _run_installed_consumer_check(python: Path, ty: Path) -> bool:
+    with tempfile.TemporaryDirectory(prefix="xy-typing-consumer-") as raw_tmp:
+        tmp = Path(raw_tmp)
+        names = _installed_public_names(python, cwd=tmp)
+        lines = ["from typing import reveal_type", "", "import xy", ""]
+        line_names: dict[int, str] = {}
+        for name in names:
+            lines.append(f"reveal_type(xy.{name})")
+            line_names[len(lines)] = name
+        consumer = tmp / "consumer.py"
+        consumer.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        (tmp / "pyproject.toml").write_text(
+            """\
+[project]
+name = "xy-typing-consumer"
+version = "0"
+requires-python = ">=3.11"
+""",
+            encoding="utf-8",
+        )
+
+        command = [
+            str(ty),
+            "check",
+            "--project",
+            str(tmp),
+            "--python",
+            str(python),
+            str(consumer),
+            "--output-format",
+            "concise",
+            "--no-progress",
+            "--color",
+            "never",
+        ]
+        _print_command(command, cwd=tmp)
+        proc = subprocess.run(
+            command,
+            cwd=tmp,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        output = "\n".join(part for part in (proc.stdout, proc.stderr) if part)
+        if proc.returncode != 0:
+            print(output, file=sys.stderr)
+            return False
+
+        revealed = _parse_revealed_types(output, line_names)
+        missing = sorted(set(names) - set(revealed))
+        dynamic = _dynamic_root_names(revealed)
+        if missing:
+            print(f"installed consumer did not reveal types for: {missing}", file=sys.stderr)
+        if dynamic:
+            print(f"installed xy root exports resolve dynamically: {dynamic}", file=sys.stderr)
+        if missing or dynamic:
+            print(output, file=sys.stderr)
+            return False
+
+        print(f"installed typing consumer OK: {len(names)} xy.__all__ exports have concrete types")
+        return True
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--consumer-only",
+        action="store_true",
+        help="skip the source-tree package check (for an isolated wheel smoke)",
+    )
+    parser.add_argument(
+        "--python-executable",
+        help="Python environment containing the xy installation to inspect",
+    )
+    parser.add_argument("--ty-executable", help="ty executable used for both checks")
+    args = parser.parse_args(argv)
+
+    python = _absolute_executable(args.python_executable or sys.executable)
+    ty = _absolute_executable(args.ty_executable) if args.ty_executable else _default_ty(python)
+
+    package_ok = args.consumer_only or _run_package_check(ty)
+    consumer_ok = _run_installed_consumer_check(python, ty)
+    return 0 if package_ok and consumer_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_typing.py
+++ b/scripts/check_typing.py
@@ -13,9 +13,12 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from _ty_tools import absolute_executable, resolve_ty_executable
+if TYPE_CHECKING:
+    from scripts import _ty_tools
+else:
+    import _ty_tools
 
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE_INIT = ROOT / "python" / "xy" / "__init__.py"
@@ -215,11 +218,11 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument("--ty-executable", help="ty executable used for both checks")
     args = parser.parse_args(argv)
 
-    python = absolute_executable(args.python_executable or sys.executable)
+    python = _ty_tools.absolute_executable(args.python_executable or sys.executable)
     ty = (
-        absolute_executable(args.ty_executable)
+        _ty_tools.absolute_executable(args.ty_executable)
         if args.ty_executable
-        else resolve_ty_executable(python)
+        else _ty_tools.resolve_ty_executable(python)
     )
 
     package_ok = args.consumer_only or _run_package_check(ty)

--- a/scripts/check_typing.py
+++ b/scripts/check_typing.py
@@ -15,12 +15,7 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
-try:
-    from _ty_tools import absolute_executable, resolve_ty_executable
-except ModuleNotFoundError as exc:  # imported by tests from the repository root
-    if exc.name != "_ty_tools":
-        raise
-    from scripts._ty_tools import absolute_executable, resolve_ty_executable
+from _ty_tools import absolute_executable, resolve_ty_executable
 
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE_INIT = ROOT / "python" / "xy" / "__init__.py"

--- a/scripts/check_typing.py
+++ b/scripts/check_typing.py
@@ -13,12 +13,9 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
-if TYPE_CHECKING:
-    from scripts import _ty_tools
-else:
-    import _ty_tools
+import _ty_tools
 
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE_INIT = ROOT / "python" / "xy" / "__init__.py"

--- a/scripts/verify_local.py
+++ b/scripts/verify_local.py
@@ -19,12 +19,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
-try:
-    from _ty_tools import resolve_ty_executable
-except ModuleNotFoundError as exc:  # imported by tests from the repository root
-    if exc.name != "_ty_tools":
-        raise
-    from scripts._ty_tools import resolve_ty_executable
+from _ty_tools import resolve_ty_executable
 
 ROOT = Path(__file__).resolve().parents[1]
 

--- a/scripts/verify_local.py
+++ b/scripts/verify_local.py
@@ -17,9 +17,12 @@ import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from _ty_tools import resolve_ty_executable
+if TYPE_CHECKING:
+    from scripts import _ty_tools
+else:
+    import _ty_tools
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -56,7 +59,7 @@ def _base_checks(
     wheel_expect: Optional[str] = None,
 ) -> dict[str, Check]:
     py = _python()
-    ty = str(resolve_ty_executable(py, required=False))
+    ty = str(_ty_tools.resolve_ty_executable(py, required=False))
     chromium_arg = str(chromium) if chromium is not None else "<CHROMIUM>"
     chromium_paths = (chromium,) if chromium is not None else ()
     sdist_arg = str(sdist) if sdist is not None else "<SDIST>"

--- a/scripts/verify_local.py
+++ b/scripts/verify_local.py
@@ -46,6 +46,14 @@ def _python() -> str:
     return sys.executable
 
 
+def _ty_executable(python: str) -> str:
+    executable = "ty.exe" if os.name == "nt" else "ty"
+    sibling = Path(python).with_name(executable)
+    if sibling.is_file():
+        return str(sibling)
+    return shutil.which(executable) or executable
+
+
 def _base_checks(
     chromium: Optional[Path] = None,
     *,
@@ -54,6 +62,7 @@ def _base_checks(
     wheel_expect: Optional[str] = None,
 ) -> dict[str, Check]:
     py = _python()
+    ty = _ty_executable(py)
     chromium_arg = str(chromium) if chromium is not None else "<CHROMIUM>"
     chromium_paths = (chromium,) if chromium is not None else ()
     sdist_arg = str(sdist) if sdist is not None else "<SDIST>"
@@ -173,8 +182,8 @@ def _base_checks(
         Check(
             "ty",
             "type check shippable Python package and external-consumer surface",
-            (py, "scripts/check_typing.py"),
-            requires_modules=("ty",),
+            (py, "scripts/check_typing.py", "--ty-executable", ty),
+            requires_executables=(ty,),
         ),
         Check("pytest", "Python tests", (py, "-m", "pytest", "-q"), requires_modules=("pytest",)),
         Check(
@@ -431,7 +440,11 @@ def missing_reasons(check: Check) -> list[str]:
             hint = {
                 "cargo": "Install Rust with rustup, or use `make check` for the quick non-Rust gate.",
                 "node": "Install Node 18+, or use `make check` for the quick non-JS gate.",
-            }.get(exe, f"Install {exe} or skip this check.")
+            }.get(exe)
+            if hint is None and Path(exe).name in {"ty", "ty.exe"}:
+                hint = "Run `make setup` or `uv pip install -e . --group dev` before type checks."
+            if hint is None:
+                hint = f"Install {exe} or skip this check."
             reasons.append(f"missing executable {exe!r}. {hint}")
     if check.requires_node_major is not None and shutil.which("node") is not None:
         try:

--- a/scripts/verify_local.py
+++ b/scripts/verify_local.py
@@ -19,6 +19,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
+try:
+    from _ty_tools import resolve_ty_executable
+except ModuleNotFoundError as exc:  # imported by tests from the repository root
+    if exc.name != "_ty_tools":
+        raise
+    from scripts._ty_tools import resolve_ty_executable
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -46,14 +53,6 @@ def _python() -> str:
     return sys.executable
 
 
-def _ty_executable(python: str) -> str:
-    executable = "ty.exe" if os.name == "nt" else "ty"
-    sibling = Path(python).with_name(executable)
-    if sibling.is_file():
-        return str(sibling)
-    return shutil.which(executable) or executable
-
-
 def _base_checks(
     chromium: Optional[Path] = None,
     *,
@@ -62,7 +61,7 @@ def _base_checks(
     wheel_expect: Optional[str] = None,
 ) -> dict[str, Check]:
     py = _python()
-    ty = _ty_executable(py)
+    ty = str(resolve_ty_executable(py, required=False))
     chromium_arg = str(chromium) if chromium is not None else "<CHROMIUM>"
     chromium_paths = (chromium,) if chromium is not None else ()
     sdist_arg = str(sdist) if sdist is not None else "<SDIST>"

--- a/scripts/verify_local.py
+++ b/scripts/verify_local.py
@@ -17,12 +17,9 @@ import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
-if TYPE_CHECKING:
-    from scripts import _ty_tools
-else:
-    import _ty_tools
+import _ty_tools
 
 ROOT = Path(__file__).resolve().parents[1]
 

--- a/scripts/verify_local.py
+++ b/scripts/verify_local.py
@@ -37,9 +37,8 @@ class Check:
     requires_rust_toolchain: bool = False
     requires_rust_clippy: bool = False
     requires_argument: Optional[str] = None
-    # Advisory checks report findings but do not fail the gate — mirrors how CI
-    # runs them (e.g. ty is pre-1.0 and can't narrow known-non-None Optionals or
-    # NumPy dtypes across stub versions). Keep this in sync with ci.yml.
+    # Advisory checks report findings but do not fail the gate. Keep this in
+    # sync with ci.yml whenever a workflow check intentionally runs that way.
     advisory: bool = False
 
 
@@ -104,6 +103,7 @@ def _base_checks(
                 "pytest",
                 "-q",
                 "tests/test_public_api.py",
+                "tests/test_check_typing.py",
                 "tests/test_type_surface.py",
                 "tests/test_components.py::test_declarative_core_contract_for_layered_axis_chrome_and_interaction",
                 "tests/test_components.py::test_declarative_chart_keeps_notebook_export_and_framework_chrome_contract",
@@ -172,10 +172,9 @@ def _base_checks(
         ),
         Check(
             "ty",
-            "type check shippable Python package (advisory)",
-            (py, "-m", "ty", "check", "python"),
+            "type check shippable Python package and external-consumer surface",
+            (py, "scripts/check_typing.py"),
             requires_modules=("ty",),
-            advisory=True,
         ),
         Check("pytest", "Python tests", (py, "-m", "pytest", "-q"), requires_modules=("pytest",)),
         Check(

--- a/tests/test_check_typing.py
+++ b/tests/test_check_typing.py
@@ -22,10 +22,13 @@ def _load_check_typing_module():
     except KeyError:
         previous = module
         had_previous = False
+    previous_sys_path = sys.path.copy()
+    sys.path.insert(0, str(path.parent))
     sys.modules[spec.name] = module
     try:
         spec.loader.exec_module(module)
     finally:
+        sys.path[:] = previous_sys_path
         if had_previous:
             sys.modules[spec.name] = previous
         else:

--- a/tests/test_check_typing.py
+++ b/tests/test_check_typing.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import importlib.util
+import os
+import subprocess
 import sys
 from pathlib import Path
+
+import xy
 
 
 def _load_check_typing_module():
@@ -16,6 +20,83 @@ def _load_check_typing_module():
 
 
 check_typing = _load_check_typing_module()
+
+
+def test_canonical_public_names_come_from_source_exports(tmp_path: Path) -> None:
+    init_path = tmp_path / "__init__.py"
+    init_path.write_text(
+        '_EXPORTS = {"Second": ".second", "First": ".first"}\n',
+        encoding="utf-8",
+    )
+
+    assert check_typing._canonical_public_names(init_path) == [
+        "First",
+        "Second",
+        "__version__",
+    ]
+
+
+def test_canonical_public_names_match_the_current_root_contract() -> None:
+    names = check_typing._canonical_public_names()
+
+    assert len(names) == 102
+    assert names == sorted(xy.__all__)
+
+
+def test_public_name_drift_reports_missing_and_extra_exports() -> None:
+    missing, extra = check_typing._public_name_drift(
+        ["First", "Second", "__version__"],
+        ["Second", "Unexpected", "__version__"],
+    )
+
+    assert missing == ["First"]
+    assert extra == ["Unexpected"]
+
+
+def test_installed_consumer_rejects_missing_and_extra_wheel_exports(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(check_typing, "_canonical_public_names", lambda: ["First", "Second"])
+    monkeypatch.setattr(check_typing, "_installed_public_names", lambda *_args, **_kwargs: [])
+
+    assert check_typing._run_installed_consumer_check(Path("python"), Path("ty")) is False
+    assert "missing canonical exports: ['First', 'Second']" in capsys.readouterr().err
+
+    monkeypatch.setattr(
+        check_typing,
+        "_installed_public_names",
+        lambda *_args, **_kwargs: ["First", "Unexpected"],
+    )
+
+    assert check_typing._run_installed_consumer_check(Path("python"), Path("ty")) is False
+    error = capsys.readouterr().err
+    assert "missing canonical exports: ['Second']" in error
+    assert "unexpected exports: ['Unexpected']" in error
+
+
+def test_installed_consumer_typecheck_removes_pythonpath(monkeypatch) -> None:
+    monkeypatch.setenv("PYTHONPATH", "/tmp/checkout-shadow")
+    monkeypatch.setattr(check_typing, "_canonical_public_names", lambda: ["Only"])
+    monkeypatch.setattr(
+        check_typing,
+        "_installed_public_names",
+        lambda *_args, **_kwargs: ["Only"],
+    )
+    captured_env: dict[str, str] = {}
+
+    def fake_run(command, **kwargs):
+        captured_env.update(kwargs["env"])
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout="/tmp/consumer.py:5:13: info[revealed-type] Revealed type: `int`\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(check_typing.subprocess, "run", fake_run)
+
+    assert check_typing._run_installed_consumer_check(Path("python"), Path("ty")) is True
+
+    assert "PYTHONPATH" not in captured_env
+    assert os.environ["PYTHONPATH"] == "/tmp/checkout-shadow"
 
 
 def test_revealed_type_parser_accepts_current_and_legacy_ty_wording() -> None:

--- a/tests/test_check_typing.py
+++ b/tests/test_check_typing.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import runpy
 import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import xy
 
@@ -14,12 +16,60 @@ def _load_check_typing_module():
     spec = importlib.util.spec_from_file_location("check_typing", path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
+    try:
+        previous = sys.modules[spec.name]
+        had_previous = True
+    except KeyError:
+        previous = module
+        had_previous = False
     sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if had_previous:
+            sys.modules[spec.name] = previous
+        else:
+            sys.modules.pop(spec.name, None)
     return module
 
 
 check_typing = _load_check_typing_module()
+
+
+def test_check_typing_loader_does_not_leak_module(monkeypatch) -> None:
+    monkeypatch.delitem(sys.modules, "check_typing", raising=False)
+
+    loaded = _load_check_typing_module()
+
+    assert loaded is not None
+    assert "check_typing" not in sys.modules
+
+
+def test_check_typing_loader_restores_existing_module(monkeypatch) -> None:
+    previous = ModuleType("check_typing")
+    monkeypatch.setitem(sys.modules, "check_typing", previous)
+
+    loaded = _load_check_typing_module()
+
+    assert loaded is not previous
+    assert sys.modules["check_typing"] is previous
+
+
+def test_external_consumer_fixture_is_runtime_side_effect_free(monkeypatch) -> None:
+    path = Path(__file__).with_name("typing_pep561_consumer.py")
+    namespace = runpy.run_path(str(path))
+    check = namespace["check_root_typing_surface"]
+    before = xy.registered_marks()
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("runtime consumer fixture called register_mark")
+
+    monkeypatch.setattr(xy, "register_mark", fail_if_called)
+
+    check()
+    check()
+
+    assert xy.registered_marks() == before
 
 
 def test_canonical_public_names_come_from_source_exports(tmp_path: Path) -> None:

--- a/tests/test_check_typing.py
+++ b/tests/test_check_typing.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_check_typing_module():
+    path = Path(__file__).resolve().parents[1] / "scripts" / "check_typing.py"
+    spec = importlib.util.spec_from_file_location("check_typing", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check_typing = _load_check_typing_module()
+
+
+def test_revealed_type_parser_accepts_current_and_legacy_ty_wording() -> None:
+    output = "\n".join(
+        (
+            "/tmp/consumer.py:5:13: info[revealed-type] Revealed type: `str`",
+            "/tmp/consumer.py:6:13: info[revealed-type] Revealed type is `Any`",
+        )
+    )
+
+    revealed = check_typing._parse_revealed_types(output, {5: "version", 6: "missing"})
+
+    assert revealed == {"version": "str", "missing": "Any"}
+
+
+def test_dynamic_root_check_does_not_reject_typed_signatures_containing_any() -> None:
+    revealed = {
+        "dynamic": "Any",
+        "unknown": "Unknown",
+        "factory": "def chart(**props: Any) -> Chart",
+        "klass": "<class 'Chart'>",
+    }
+
+    assert check_typing._dynamic_root_names(revealed) == ["dynamic", "unknown"]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -405,3 +405,24 @@ def test_public_api_checker_rejects_partial_pep561_marker(tmp_path: Path) -> Non
     errors = check_public_api.validate_pep561_marker(marker)
 
     assert any("full-package PEP 561 marker" in error for error in errors)
+
+
+def test_static_typing_surface_rejects_lazy_only_export(tmp_path: Path) -> None:
+    init_path = tmp_path / "__init__.py"
+    init_path.write_text(
+        """\
+from typing import TYPE_CHECKING
+
+__version__: str
+
+if TYPE_CHECKING:
+    from .components import Typed
+""",
+        encoding="utf-8",
+    )
+    fake = ModuleType("xy")
+    fake.__all__ = ["__version__", "Typed", "LazyOnly"]
+
+    errors = check_public_api.validate_static_typing_surface(fake, init_path)
+
+    assert any("LazyOnly" in error and "TYPE_CHECKING" in error for error in errors)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -425,4 +425,36 @@ if TYPE_CHECKING:
 
     errors = check_public_api.validate_static_typing_surface(fake, init_path)
 
-    assert any("LazyOnly" in error and "TYPE_CHECKING" in error for error in errors)
+    assert errors == [
+        "xy public names have no static TYPE_CHECKING import or annotation: ['LazyOnly']"
+    ]
+
+
+def test_static_typing_surface_ignores_nested_and_else_imports(tmp_path: Path) -> None:
+    init_path = tmp_path / "__init__.py"
+    init_path.write_text(
+        """\
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .components import Typed
+
+    def helper():
+        from .components import FunctionOnly
+
+    class Namespace:
+        from .components import ClassOnly
+else:
+    from .components import ElseOnly
+""",
+        encoding="utf-8",
+    )
+    fake = ModuleType("xy")
+    fake.__all__ = ["Typed", "FunctionOnly", "ClassOnly", "ElseOnly"]
+
+    errors = check_public_api.validate_static_typing_surface(fake, init_path)
+
+    assert errors == [
+        "xy public names have no static TYPE_CHECKING import or annotation: "
+        "['ClassOnly', 'ElseOnly', 'FunctionOnly']"
+    ]

--- a/tests/test_sankey.py
+++ b/tests/test_sankey.py
@@ -200,6 +200,14 @@ def test_ribbon_autorange_covers_both_spans() -> None:
     assert lo <= 0.0 and hi >= 0.95
 
 
+def test_ribbon_autorange_rejects_incomplete_geometry() -> None:
+    figure = _ribbon_figure()
+    figure.traces[0].x0 = None
+
+    with pytest.raises(ValueError, match="ribbon trace missing geometry columns"):
+        figure.x_range()
+
+
 def test_sankey_chart_builds_ribbon_traces_only() -> None:
     chart = xy.sankey_chart(LINKS, width=680, height=420)
     figure = chart.figure()

--- a/tests/test_verify_local.py
+++ b/tests/test_verify_local.py
@@ -4,9 +4,9 @@ import importlib.util
 import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
-from scripts._ty_tools import ty_executable_name
 
 
 def _load_verify_local_module():
@@ -14,8 +14,23 @@ def _load_verify_local_module():
     spec = importlib.util.spec_from_file_location("verify_local", path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
+    try:
+        previous = sys.modules[spec.name]
+        had_previous = True
+    except KeyError:
+        previous = ModuleType(spec.name)
+        had_previous = False
+    previous_sys_path = sys.path.copy()
+    sys.path.insert(0, str(path.parent))
     sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path[:] = previous_sys_path
+        if had_previous:
+            sys.modules[spec.name] = previous
+        else:
+            sys.modules.pop(spec.name, None)
     return module
 
 
@@ -143,7 +158,24 @@ def test_ty_executable_falls_back_to_path(tmp_path: Path, monkeypatch) -> None:
     assert verify_local.resolve_ty_executable(str(python)) == Path("/path/ty")
 
 
-def test_ty_executable_uses_one_platform_name_for_path_lookup(tmp_path: Path, monkeypatch) -> None:
+def test_ty_executable_skips_non_executable_sibling(tmp_path: Path, monkeypatch) -> None:
+    python = tmp_path / "python"
+    sibling = tmp_path / ("ty.exe" if verify_local.os.name == "nt" else "ty")
+    python.touch()
+    sibling.touch()
+    monkeypatch.setattr(verify_local.os, "access", lambda _path, _mode: False)
+    monkeypatch.setattr(verify_local.shutil, "which", lambda _executable: "/path/ty")
+
+    assert verify_local.resolve_ty_executable(str(python)) == Path("/path/ty")
+
+
+@pytest.mark.parametrize(("os_name", "expected"), [("posix", "ty"), ("nt", "ty.exe")])
+def test_ty_executable_uses_platform_name_for_path_lookup(
+    tmp_path: Path,
+    monkeypatch,
+    os_name: str,
+    expected: str,
+) -> None:
     python = tmp_path / "python"
     python.touch()
     looked_up: list[str] = []
@@ -153,16 +185,14 @@ def test_ty_executable_uses_one_platform_name_for_path_lookup(tmp_path: Path, mo
 
     monkeypatch.setattr(verify_local.shutil, "which", fake_which)
 
-    candidate = verify_local.resolve_ty_executable(str(python), required=False)
+    candidate = verify_local.resolve_ty_executable(
+        str(python),
+        required=False,
+        os_name=os_name,
+    )
 
-    expected = ty_executable_name()
     assert looked_up == [expected]
     assert candidate == Path(expected)
-
-
-@pytest.mark.parametrize(("os_name", "expected"), [("posix", "ty"), ("nt", "ty.exe")])
-def test_ty_executable_name_is_platform_specific(os_name: str, expected: str) -> None:
-    assert ty_executable_name(os_name) == expected
 
 
 def test_missing_ty_cli_has_actionable_preflight_error(monkeypatch) -> None:
@@ -178,17 +208,15 @@ def test_missing_ty_cli_has_actionable_preflight_error(monkeypatch) -> None:
 
 
 def test_ty_findings_fail_the_gate() -> None:
-    import scripts.verify_local as vl
-
     def fake_run(check: verify_local.Check) -> int:
         return 1 if check.name == "ty" else 0
 
-    original = vl.run_check
-    vl.run_check = fake_run  # type: ignore[assignment]
+    original = verify_local.run_check
+    verify_local.run_check = fake_run
     try:
-        rc = vl.main(["--only", "ty"])
+        rc = verify_local.main(["--only", "ty"])
     finally:
-        vl.run_check = original  # type: ignore[assignment]
+        verify_local.run_check = original
     assert rc == 1
 
 

--- a/tests/test_verify_local.py
+++ b/tests/test_verify_local.py
@@ -61,6 +61,27 @@ def test_ty_script_entrypoints_support_path_and_module_execution(
     assert proc.returncode == 0, proc.stderr
 
 
+def test_scripts_package_replaces_conflicting_ty_tools_alias() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys, types; "
+                "sys.modules['_ty_tools'] = types.ModuleType('_ty_tools'); "
+                "import scripts, _ty_tools; "
+                "assert _ty_tools is scripts._ty_tools"
+            ),
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+
+
 def test_default_selection_is_quick_checks_only() -> None:
     checks = verify_local._base_checks()
     selected = verify_local.select_checks(checks)

--- a/tests/test_verify_local.py
+++ b/tests/test_verify_local.py
@@ -112,11 +112,46 @@ def test_security_export_check_is_known_as_targeted_gate() -> None:
 
 def test_ty_check_is_gating_and_includes_external_consumer() -> None:
     checks = verify_local._base_checks()
-    assert checks["ty"].advisory is False
-    assert checks["ty"].command[-1] == "scripts/check_typing.py"
+    check = checks["ty"]
+    assert check.advisory is False
+    assert check.command[1] == "scripts/check_typing.py"
+    assert check.command[-2] == "--ty-executable"
+    assert check.command[-1:] == check.requires_executables
+    assert check.requires_modules == ()
 
     gating = [c.name for c in checks.values() if not c.advisory]
     assert "ty" in gating and "pytest" in gating and "ruff_check" in gating
+
+
+def test_ty_executable_prefers_python_sibling(tmp_path: Path, monkeypatch) -> None:
+    python = tmp_path / "python"
+    sibling = tmp_path / ("ty.exe" if verify_local.os.name == "nt" else "ty")
+    python.touch()
+    sibling.touch()
+    sibling.chmod(0o755)
+    monkeypatch.setattr(verify_local.shutil, "which", lambda _executable: "/path/ty")
+
+    assert verify_local._ty_executable(str(python)) == str(sibling)
+
+
+def test_ty_executable_falls_back_to_path(tmp_path: Path, monkeypatch) -> None:
+    python = tmp_path / "python"
+    python.touch()
+    monkeypatch.setattr(verify_local.shutil, "which", lambda _executable: "/path/ty")
+
+    assert verify_local._ty_executable(str(python)) == "/path/ty"
+
+
+def test_missing_ty_cli_has_actionable_preflight_error(monkeypatch) -> None:
+    executable = "ty.exe" if verify_local.os.name == "nt" else "ty"
+    monkeypatch.setattr(verify_local, "_python", lambda: "/missing/python")
+    monkeypatch.setattr(verify_local.shutil, "which", lambda _executable: None)
+
+    check = verify_local._base_checks()["ty"]
+    reasons = verify_local.missing_reasons(check)
+
+    assert check.requires_executables == (executable,)
+    assert any("missing executable" in reason and "make setup" in reason for reason in reasons)
 
 
 def test_ty_findings_fail_the_gate() -> None:

--- a/tests/test_verify_local.py
+++ b/tests/test_verify_local.py
@@ -38,6 +38,29 @@ verify_local = _load_verify_local_module()
 ROOT = Path(__file__).resolve().parents[1]
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        ("scripts/check_typing.py", "--help"),
+        ("-m", "scripts.check_typing", "--help"),
+        ("scripts/verify_local.py", "--help"),
+        ("-m", "scripts.verify_local", "--help"),
+    ],
+)
+def test_ty_script_entrypoints_support_path_and_module_execution(
+    command: tuple[str, ...],
+) -> None:
+    proc = subprocess.run(
+        [sys.executable, *command],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+
+
 def test_default_selection_is_quick_checks_only() -> None:
     checks = verify_local._base_checks()
     selected = verify_local.select_checks(checks)
@@ -147,7 +170,7 @@ def test_ty_executable_prefers_python_sibling(tmp_path: Path, monkeypatch) -> No
     sibling.chmod(0o755)
     monkeypatch.setattr(verify_local.shutil, "which", lambda _executable: "/path/ty")
 
-    assert verify_local.resolve_ty_executable(str(python)) == sibling
+    assert verify_local._ty_tools.resolve_ty_executable(str(python)) == sibling
 
 
 def test_ty_executable_falls_back_to_path(tmp_path: Path, monkeypatch) -> None:
@@ -155,7 +178,7 @@ def test_ty_executable_falls_back_to_path(tmp_path: Path, monkeypatch) -> None:
     python.touch()
     monkeypatch.setattr(verify_local.shutil, "which", lambda _executable: "/path/ty")
 
-    assert verify_local.resolve_ty_executable(str(python)) == Path("/path/ty")
+    assert verify_local._ty_tools.resolve_ty_executable(str(python)) == Path("/path/ty")
 
 
 def test_ty_executable_skips_non_executable_sibling(tmp_path: Path, monkeypatch) -> None:
@@ -166,7 +189,7 @@ def test_ty_executable_skips_non_executable_sibling(tmp_path: Path, monkeypatch)
     monkeypatch.setattr(verify_local.os, "access", lambda _path, _mode: False)
     monkeypatch.setattr(verify_local.shutil, "which", lambda _executable: "/path/ty")
 
-    assert verify_local.resolve_ty_executable(str(python)) == Path("/path/ty")
+    assert verify_local._ty_tools.resolve_ty_executable(str(python)) == Path("/path/ty")
 
 
 @pytest.mark.parametrize(("os_name", "expected"), [("posix", "ty"), ("nt", "ty.exe")])
@@ -185,7 +208,7 @@ def test_ty_executable_uses_platform_name_for_path_lookup(
 
     monkeypatch.setattr(verify_local.shutil, "which", fake_which)
 
-    candidate = verify_local.resolve_ty_executable(
+    candidate = verify_local._ty_tools.resolve_ty_executable(
         str(python),
         required=False,
         os_name=os_name,

--- a/tests/test_verify_local.py
+++ b/tests/test_verify_local.py
@@ -110,21 +110,16 @@ def test_security_export_check_is_known_as_targeted_gate() -> None:
     assert selected[0].requires_modules == ("pytest",)
 
 
-def test_ty_check_is_advisory_matching_ci() -> None:
-    # ci.yml runs `ty check python || echo "::warning::..."` — advisory, not
-    # gating (pre-1.0, can't narrow Optionals / NumPy dtypes across stub
-    # versions). The local full gate must match, or `make check-full` fails on
-    # findings CI ignores. If ty ever goes gating, flip both together.
+def test_ty_check_is_gating_and_includes_external_consumer() -> None:
     checks = verify_local._base_checks()
-    assert checks["ty"].advisory is True
-    # every other check stays gating
+    assert checks["ty"].advisory is False
+    assert checks["ty"].command[-1] == "scripts/check_typing.py"
+
     gating = [c.name for c in checks.values() if not c.advisory]
-    assert "ty" not in gating and "pytest" in gating and "ruff_check" in gating
+    assert "ty" in gating and "pytest" in gating and "ruff_check" in gating
 
 
-def test_advisory_check_findings_do_not_fail_the_gate() -> None:
-    # A failing advisory check warns but returns success; a failing gating
-    # check still fails. Drive main() with a stubbed runner.
+def test_ty_findings_fail_the_gate() -> None:
     import scripts.verify_local as vl
 
     def fake_run(check: verify_local.Check) -> int:
@@ -136,7 +131,7 @@ def test_advisory_check_findings_do_not_fail_the_gate() -> None:
         rc = vl.main(["--only", "ty"])
     finally:
         vl.run_check = original  # type: ignore[assignment]
-    assert rc == 0  # advisory finding does not gate
+    assert rc == 1
 
 
 def test_error_safety_check_is_known_as_targeted_gate() -> None:
@@ -171,6 +166,7 @@ def test_api_surface_check_is_known_as_targeted_gate() -> None:
     assert [check.name for check in selected] == ["api_surface"]
     command = selected[0].command
     assert "tests/test_public_api.py" in command
+    assert "tests/test_check_typing.py" in command
     assert "tests/test_type_surface.py" in command
     assert (
         "tests/test_components.py::test_declarative_core_contract_for_layered_axis_chrome_and_interaction"
@@ -406,6 +402,7 @@ def test_dry_run_includes_api_surface_gate(capsys) -> None:
     assert "scripts/check_public_api.py" in out
     assert "api_surface" in out
     assert "tests/test_public_api.py" in out
+    assert "tests/test_check_typing.py" in out
     assert "tests/test_type_surface.py" in out
 
 

--- a/tests/test_verify_local.py
+++ b/tests/test_verify_local.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from scripts._ty_tools import ty_executable_name
 
 
 def _load_verify_local_module():
@@ -131,7 +132,7 @@ def test_ty_executable_prefers_python_sibling(tmp_path: Path, monkeypatch) -> No
     sibling.chmod(0o755)
     monkeypatch.setattr(verify_local.shutil, "which", lambda _executable: "/path/ty")
 
-    assert verify_local._ty_executable(str(python)) == str(sibling)
+    assert verify_local.resolve_ty_executable(str(python)) == sibling
 
 
 def test_ty_executable_falls_back_to_path(tmp_path: Path, monkeypatch) -> None:
@@ -139,7 +140,29 @@ def test_ty_executable_falls_back_to_path(tmp_path: Path, monkeypatch) -> None:
     python.touch()
     monkeypatch.setattr(verify_local.shutil, "which", lambda _executable: "/path/ty")
 
-    assert verify_local._ty_executable(str(python)) == "/path/ty"
+    assert verify_local.resolve_ty_executable(str(python)) == Path("/path/ty")
+
+
+def test_ty_executable_uses_one_platform_name_for_path_lookup(tmp_path: Path, monkeypatch) -> None:
+    python = tmp_path / "python"
+    python.touch()
+    looked_up: list[str] = []
+
+    def fake_which(executable: str) -> None:
+        looked_up.append(executable)
+
+    monkeypatch.setattr(verify_local.shutil, "which", fake_which)
+
+    candidate = verify_local.resolve_ty_executable(str(python), required=False)
+
+    expected = ty_executable_name()
+    assert looked_up == [expected]
+    assert candidate == Path(expected)
+
+
+@pytest.mark.parametrize(("os_name", "expected"), [("posix", "ty"), ("nt", "ty.exe")])
+def test_ty_executable_name_is_platform_specific(os_name: str, expected: str) -> None:
+    assert ty_executable_name(os_name) == expected
 
 
 def test_missing_ty_cli_has_actionable_preflight_error(monkeypatch) -> None:

--- a/tests/typing_pep561_consumer.py
+++ b/tests/typing_pep561_consumer.py
@@ -8,7 +8,7 @@ where a lazy root export silently falls back to ``Any``.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import assert_type
+from typing import TYPE_CHECKING, assert_type
 
 import xy
 
@@ -20,24 +20,25 @@ def _build_plugin(context: xy.MarkContext) -> Sequence[xy.Mark]:
 
 def check_root_typing_surface() -> None:
     """Type-check the public root without executing or mutating the registry."""
-    assert_type(xy.__version__, str)
+    if TYPE_CHECKING:
+        assert_type(xy.__version__, str)
 
-    assert_type(xy.Animation(), xy.Animation)
-    assert_type(xy.ExportConfig(), xy.ExportConfig)
-    assert_type(xy.Spring(), xy.Spring)
-    assert_type(xy.MarkContext(columns={}, options={}), xy.MarkContext)
-    assert_type(xy.MarkPlugin(name="consumer_fixture", build=_build_plugin), xy.MarkPlugin)
+        assert_type(xy.Animation(), xy.Animation)
+        assert_type(xy.ExportConfig(), xy.ExportConfig)
+        assert_type(xy.Spring(), xy.Spring)
+        assert_type(xy.MarkContext(columns={}, options={}), xy.MarkContext)
+        assert_type(xy.MarkPlugin(name="consumer_fixture", build=_build_plugin), xy.MarkPlugin)
 
-    assert_type(xy.animation(), xy.Animation)
-    assert_type(xy.export_config(), xy.ExportConfig)
-    assert_type(xy.mark("plugin"), xy.Mark)
-    assert_type(xy.segments(), xy.Mark)
-    assert_type(xy.segments_chart(), xy.Chart)
-    assert_type(xy.spring(), xy.Spring)
-    assert_type(xy.triangle_mesh(), xy.Mark)
-    assert_type(xy.triangle_mesh_chart(), xy.Chart)
+        assert_type(xy.animation(), xy.Animation)
+        assert_type(xy.export_config(), xy.ExportConfig)
+        assert_type(xy.mark("plugin"), xy.Mark)
+        assert_type(xy.segments(), xy.Mark)
+        assert_type(xy.segments_chart(), xy.Chart)
+        assert_type(xy.spring(), xy.Spring)
+        assert_type(xy.triangle_mesh(), xy.Mark)
+        assert_type(xy.triangle_mesh_chart(), xy.Chart)
 
-    plugin = xy.MarkPlugin(name="consumer_fixture", build=_build_plugin)
-    assert_type(xy.register_mark(plugin), xy.MarkPlugin)
-    assert_type(xy.registered_marks(), tuple[str, ...])
-    assert_type(xy.unregister_mark("consumer_fixture"), None)
+        plugin = xy.MarkPlugin(name="consumer_fixture", build=_build_plugin)
+        assert_type(xy.register_mark(plugin), xy.MarkPlugin)
+        assert_type(xy.registered_marks(), tuple[str, ...])
+        assert_type(xy.unregister_mark("consumer_fixture"), None)

--- a/tests/typing_pep561_consumer.py
+++ b/tests/typing_pep561_consumer.py
@@ -5,6 +5,8 @@ at ``xy``: importing the implementation modules directly would miss regressions
 where a lazy root export silently falls back to ``Any``.
 """
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 from typing import assert_type
 

--- a/tests/typing_pep561_consumer.py
+++ b/tests/typing_pep561_consumer.py
@@ -1,0 +1,41 @@
+"""External-consumer assertions for the lazy ``xy`` root API.
+
+This module is checked by ty but is not a pytest test.  Keep the imports rooted
+at ``xy``: importing the implementation modules directly would miss regressions
+where a lazy root export silently falls back to ``Any``.
+"""
+
+from collections.abc import Sequence
+from typing import assert_type
+
+import xy
+
+
+def _build_plugin(context: xy.MarkContext) -> Sequence[xy.Mark]:
+    del context
+    return ()
+
+
+def check_root_typing_surface() -> None:
+    """Type-check the public root without executing or mutating the registry."""
+    assert_type(xy.__version__, str)
+
+    assert_type(xy.Animation(), xy.Animation)
+    assert_type(xy.ExportConfig(), xy.ExportConfig)
+    assert_type(xy.Spring(), xy.Spring)
+    assert_type(xy.MarkContext(columns={}, options={}), xy.MarkContext)
+    assert_type(xy.MarkPlugin(name="consumer_fixture", build=_build_plugin), xy.MarkPlugin)
+
+    assert_type(xy.animation(), xy.Animation)
+    assert_type(xy.export_config(), xy.ExportConfig)
+    assert_type(xy.mark("plugin"), xy.Mark)
+    assert_type(xy.segments(), xy.Mark)
+    assert_type(xy.segments_chart(), xy.Chart)
+    assert_type(xy.spring(), xy.Spring)
+    assert_type(xy.triangle_mesh(), xy.Mark)
+    assert_type(xy.triangle_mesh_chart(), xy.Chart)
+
+    plugin = xy.MarkPlugin(name="consumer_fixture", build=_build_plugin)
+    assert_type(xy.register_mark(plugin), xy.MarkPlugin)
+    assert_type(xy.registered_marks(), tuple[str, ...])
+    assert_type(xy.unregister_mark("consumer_fixture"), None)


### PR DESCRIPTION
## What changed

- complete the lazy `xy` root typing mirror and declare `xy.__version__: str`
- fix the 77 diagnostics in the shipped Python tree without blanket ignores
- validate parity between `xy.__all__` and static declarations
- add a package-external consumer fixture for the previously dynamic exports
- add an isolated installed-package probe that checks all 102 root exports from the selected interpreter and rejects exact `Any`/`Unknown`
- run that probe against built wheels in the wheel smoke matrix
- make the package and consumer typechecks hard CI and local gates
- preserve append memoryviews through registry queuing and convert them only at the existing Socket.IO transport boundary

## Why

The root module resolves exports lazily through `__getattr__ -> Any` to keep `import xy` lightweight. Its separately maintained `TYPE_CHECKING` mirror had drifted, so 15 public exports plus `__version__` lost their types for PEP 561 consumers. Because `ty` was advisory, 77 additional shipped-package diagnostics had accumulated without failing CI.

This change keeps the lazy runtime design while making the static contract complete and enforceable for both source checkouts and actual wheel installations.

## User impact

Editors and type checkers now retain concrete root types for the complete public API. Future root-export drift, package diagnostics, and wheel-only typing regressions fail CI.

## Validation

- `.venv/bin/python scripts/check_typing.py` — zero package diagnostics; 102/102 root exports concrete
- isolated locally built wheel consumer — 102/102 root exports concrete
- `.venv/bin/pytest -q` — 3,952 passed, 108 skipped
- final targeted suite — 105 passed
- append Socket.IO regression — passed
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/python scripts/check_public_api.py`
- `.venv/bin/python scripts/verify_ci_workflow.py`

Fixes #429

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded plotting and messaging APIs to accept common bytes-like buffers.
  * Added a public package version declaration and improved static typing for exported APIs.
  * Added support for figure title options in host integrations.

* **Bug Fixes**
  * Improved handling of masked integer and boolean plot data.
  * Corrected SVG title generation and ribbon autoranging for incomplete geometry.

* **Tests**
  * Added comprehensive public API and external consumer type-checking validation.
  * Type checking is now a required release-quality verification gate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->