### PR TITLE
update aiohttp>=3.14.3 (CVE-2026-69244)

### DIFF
--- a/docs/app/uv.lock
+++ b/docs/app/uv.lock
@@ -1802,7 +1802,7 @@ provides-extras = ["reflex"]
 [package.metadata.requires-dev]
 codspeed = [{ name = "pytest-codspeed", specifier = ">=5,<6" }]
 dev = [
-    { name = "aiohttp", specifier = ">=3.9" },
+    { name = "aiohttp", specifier = ">=3.14.3" },
     { name = "hypothesis", specifier = ">=6" },
     { name = "pillow", specifier = ">=10" },
     { name = "pyarrow", specifier = ">=15" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
     "starlette>=0.36",
     # tests/reflex_adapter exercises the real socket data plane when the
     # `reflex` extra is installed in the main CI job.
-    "aiohttp>=3.9",
+    "aiohttp>=3.14.3",
     "uvicorn>=0.23",
     # Parses .binder/environment.yml in tests/test_binder_config.py so the
     # Binder contract is asserted on structure, not string transcription.

--- a/uv.lock
+++ b/uv.lock
@@ -2228,7 +2228,7 @@ provides-extras = ["reflex"]
 [package.metadata.requires-dev]
 codspeed = [{ name = "pytest-codspeed", specifier = ">=5,<6" }]
 dev = [
-    { name = "aiohttp", specifier = ">=3.9" },
+    { name = "aiohttp", specifier = ">=3.14.3" },
     { name = "hypothesis", specifier = ">=6" },
     { name = "pillow", specifier = ">=10" },
     { name = "pyarrow", specifier = ">=15" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

