### PR TITLE
Fix type annotations and improve error reporting

### DIFF
--- a/python/reflex_xy/component.py
+++ b/python/reflex_xy/component.py
@@ -38,7 +38,7 @@ chart renders, pans/zooms, and resolves hover tooltips client-side; its small
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Set
-from typing import Any, Optional
+from typing import Annotated, Any, Optional
 
 import reflex as rx
 
@@ -83,17 +83,24 @@ def _build_component_cls() -> Any:
         # Semantic events out (small JSON by construction — §1). Point and
         # selection events are live-only because static charts have no row
         # resolution kernel; view changes are already complete client-side.
-        on_point_hover: rx.EventHandler[lambda row: [row]]
-        on_point_click: rx.EventHandler[lambda row: [row]]
-        on_select_end: rx.EventHandler[lambda selection: [selection]]
-        on_view_change: rx.EventHandler[lambda view: [view]]
-        on_animation_start: rx.EventHandler[lambda event: [event]]
-        on_animation_end: rx.EventHandler[lambda event: [event]]
+        #
+        # Spelled `Annotated[rx.EventHandler, <args spec>]`, not the shorthand
+        # `rx.EventHandler[<args spec>]` — the same object either way, since
+        # `EventHandler.__class_getitem__` returns exactly this form and reflex
+        # reads the spec back out of `__metadata__`. Only the shorthand is a
+        # runtime-only DSL: `EventHandler` is not generic, so subscripting it is
+        # invalid in a type expression and checkers reject it. Don't fold it back.
+        on_point_hover: Annotated[rx.EventHandler, lambda row: [row]]
+        on_point_click: Annotated[rx.EventHandler, lambda row: [row]]
+        on_select_end: Annotated[rx.EventHandler, lambda selection: [selection]]
+        on_view_change: Annotated[rx.EventHandler, lambda view: [view]]
+        on_animation_start: Annotated[rx.EventHandler, lambda event: [event]]
+        on_animation_end: Annotated[rx.EventHandler, lambda event: [event]]
         # Structured hover payload (view-state.md §7.1): resolved fully in the
         # browser — cursor px/data coordinates plus the picked points — so it
         # works on static charts too. `on_point_hover` stays the narrow
         # legacy row form; new code uses this.
-        on_hover: rx.EventHandler[lambda payload: [payload]]
+        on_hover: Annotated[rx.EventHandler, lambda payload: [payload]]
 
     # The class is created lazily inside this function; reflex derives JS
     # identifiers from __qualname__, and "<locals>" would leak an illegal

--- a/python/xy/_validate.py
+++ b/python/xy/_validate.py
@@ -554,7 +554,10 @@ def mark_fill(value: Any, label: str) -> Optional[dict[str, Any]]:
         return None
     space = "mark"
     if isinstance(value, dict):
-        unknown = sorted(set(value) - {"gradient", "space"})
+        # Sort the *rendered* keys: `value` is user input, so its keys need not
+        # be mutually comparable (`{1: ..., "a": ...}` made `sorted` raise a bare
+        # TypeError instead of reporting the unknown key).
+        unknown = sorted(str(key) for key in set(value) - {"gradient", "space"})
         if unknown:
             raise ValueError(f"{label} has unknown key(s) {unknown}; expected gradient, space")
         space = value.get("space", "mark")

--- a/python/xy/pyplot/_axes.py
+++ b/python/xy/pyplot/_axes.py
@@ -21,7 +21,7 @@ from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import suppress
 from datetime import datetime, timedelta
 from itertools import pairwise
-from typing import Any, Literal, Optional, cast
+from typing import Any, Literal, Optional
 
 import numpy as np
 
@@ -1889,12 +1889,12 @@ class Axes(PlotTypeMixin):
         if transform is not None:
             x, y = self._transform_points(x, y, transform)
         if np.ma.isMaskedArray(x):
-            masked_x = cast(np.ma.MaskedArray, np.ma.asarray(x))
+            masked_x = np.ma.asarray(x)
             if masked_x.dtype.kind in "iub":
                 masked_x = masked_x.astype(np.float64)
             x = np.ma.filled(masked_x, np.nan)
         if np.ma.isMaskedArray(y):
-            masked_y = cast(np.ma.MaskedArray, np.ma.asarray(y))
+            masked_y = np.ma.asarray(y)
             if masked_y.dtype.kind in "iub":
                 masked_y = masked_y.astype(np.float64)
             y = np.ma.filled(masked_y, np.nan)

--- a/tests/test_figure.py
+++ b/tests/test_figure.py
@@ -2089,6 +2089,11 @@ def test_mark_fill_rejects_invalid_gradients() -> None:
         fig.area(
             [0.0, 1.0], [1.0, 2.0], fill={"gradient": "linear-gradient(red, blue)", "mode": "x"}
         )
+    # Keys of a user-supplied dict need not be mutually comparable; report the
+    # unknown key rather than letting the sort raise a bare TypeError
+    # (spec/api/styling.md: closed grammars raise ValueError, naming the reason).
+    with pytest.raises(ValueError, match="unknown key"):
+        fig.area([0.0, 1.0], [1.0, 2.0], fill={1: "x", "mode": "y"})
     # validation happens before ingest — the failed call leaves no partial trace
     assert fig.traces == []
 


### PR DESCRIPTION
## Summary

This PR addresses three separate issues: correcting EventHandler type annotations to use `Annotated` for type-checker compatibility, removing unnecessary `cast()` calls that mask type information, and improving error messages when user input contains non-comparable keys.

## Key Changes

- **EventHandler type annotations** (`python/reflex_xy/component.py`):
  - Changed from `rx.EventHandler[<args spec>]` (runtime-only DSL) to `Annotated[rx.EventHandler, <args spec>]` (valid type expression)
  - Added explanatory comment: `EventHandler` is not generic, so subscripting it is invalid in type expressions and rejected by type checkers
  - Reflex reads the spec back out of `__metadata__`, so both forms produce the same runtime object
  - Affects: `on_point_hover`, `on_point_click`, `on_select_end`, `on_view_change`, `on_animation_start`, `on_animation_end`, `on_hover`

- **Removed unnecessary casts** (`python/xy/pyplot/_axes.py`):
  - Removed `cast(np.ma.MaskedArray, ...)` calls in `_plot_series` for masked array handling
  - `np.ma.asarray()` already returns the correct type; explicit casts were redundant and obscured intent
  - Removed unused `cast` import

- **Improved error reporting** (`python/xy/_validate.py`):
  - Fixed `mark_fill` validation to handle user-supplied dicts with non-comparable keys
  - Changed from `sorted(set(value) - {...})` to `sorted(str(key) for key in set(value) - {...})`
  - Prevents bare `TypeError` when dict contains mixed types (e.g., `{1: "x", "mode": "y"}`)
  - Now correctly reports the unknown key via `ValueError` as per spec/api/styling.md
  - Added test case in `tests/test_figure.py` to verify the fix

## Implementation Details

The EventHandler change is purely about type-checker compliance. The runtime behavior is identical because `EventHandler.__class_getitem__` returns the `Annotated` form, and Reflex extracts the spec from `__metadata__`. The comment documents why the shorthand cannot be used in type expressions.

The cast removal simplifies code by trusting NumPy's type system. The error reporting fix ensures user-facing validation errors are consistent and informative, even when input violates assumptions about key comparability.

https://claude.ai/code/session_01VhynvUCNjLBHYVfmHCR2tX

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for chart fill settings with mixed-type keys, providing a clear error for unknown options instead of an internal sorting error.
  * Improved compatibility and consistency for chart event-handler configuration.

* **Tests**
  * Added regression coverage for invalid fill dictionaries with incomparable key types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->