### PR TITLE
Add the data-bound component API to the Reflex integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,44 @@ app = rx.App()
 app.add_page(index)
 ```
 
+For state-driven charts, declare the chart in the page and supply columns from
+a `@reflex_xy.data` state method — the structure (channels, colormaps, axes)
+is validated when `reflex run` compiles the app, while the columns ride the
+app's own websocket as binary buffers, never through Reflex state:
+
+```python
+from typing import TypedDict
+
+import numpy as np
+import reflex as rx
+import reflex_xy
+
+
+class CloudData(TypedDict):
+    x: np.ndarray
+    y: np.ndarray
+    mag: np.ndarray
+
+
+class Dash(rx.State):
+    points: int = 200_000
+
+    @reflex_xy.data
+    def cloud(self) -> CloudData:
+        rng = np.random.default_rng(7)
+        x = rng.normal(size=self.points)
+        y = x * 0.6 + rng.normal(scale=0.6, size=self.points)
+        return {"x": x, "y": y, "mag": np.hypot(x, y)}
+
+
+def dashboard() -> rx.Component:
+    return reflex_xy.scatter_chart(
+        data=Dash.cloud,
+        x="x", y="y", color="mag", colormap="viridis",
+        height="460px",
+    )
+```
+
 Hover, pan, and zoom keep working. For charts driven by Reflex state, events, or
 live streams, see the
 [Reflex integration guide](https://reflex.dev/docs/xy/integrations/reflex/) and

--- a/examples/reflex/README.md
+++ b/examples/reflex/README.md
@@ -6,23 +6,30 @@ section carries a **Code** accordion showing its source via
 `inspect.getsource`.
 
 Chart data rides the app's own websocket as a second socket.io namespace of
-binary columns; Reflex state holds only a token string per chart.
+binary columns; Reflex state holds only a tiny handle per chart. Charts use
+the data-bound component API — structure declared in the page, compiled to a
+validated plan at `reflex run`, columns supplied by `@reflex_xy.data` —
+except where a section demonstrates the tier its behavior genuinely needs.
 
 ## What it shows
 
-1. **Live figure var + events** — a 1M-point drillable scatter from an
-   `@reflex_xy.figure` method, with `on_point_hover` / `on_point_click` /
-   `on_select_end` handlers.
-2. **A chart driven by state vars** — a histogram whose bin count is a slider
-   and whose data is cross-filtered by the selection above; changing either
-   recomputes and re-publishes the figure under a stable token.
+1. **The flagship, data-bound** — a 1M-point drillable scatter composed in
+   the page (`reflex_xy.chart(xy.scatter("x", "y", ...), data=Demo.cloud)`)
+   with `on_point_hover` / `on_point_click` / `on_select_end` handlers;
+   `@reflex_xy.data` supplies only the columns.
+2. **The escape hatch: structure from state** — a histogram whose bin count
+   is a slider. Bins are chart *structure*, not columns, so this is an
+   `@reflex_xy.figure` method; its data is also cross-filtered by the
+   selection above, and changing either re-publishes the figure under a
+   stable token.
 3. **A dynamically updating chart** — a line grown by a background task via
    `reflex_xy.append`.
-4. **Data computed from `on_view_change`** — pan/zoom an overview and a detail
-   histogram recomputes from the points in the reported window.
-5. **Fixed data, two ways** — a `xy.Chart` passed straight to `reflex_xy.chart`
-   (static payload tier) and a `reflex_xy.inline` token (fixed data served
-   through the kernel).
+4. **Data computed from `on_view_change`** — pan/zoom a data-bound overview;
+   a second data var reads the reported window from state and republishes
+   only the in-view column into the detail histogram's fixed plan.
+5. **Fixed data, two ways** — concrete columns passed as `data=` to a
+   composed chart (compiled to a static payload asset, no kernel) and a
+   `reflex_xy.inline` token (fixed data served through the kernel).
 6. **The 100M drilldown, adapter-native** — the live drilldown scatter
    from [`examples/fastapi`](../fastapi) (identical seed-11 data and mark
    config, a density surface that drills into exact points on zoom) as a
@@ -31,6 +38,19 @@ binary columns; Reflex state holds only a token string per chart.
    adapter's websocket namespace and the kernel's density tiers do all of it,
    so behavioral differences between the two apps isolate what that custom
    code adds.
+7. **Legend hover-highlight and click-to-toggle** — named series on the
+   direct-Chart tier (hover dims, click hides client-side) beside a
+   categorical density scatter on an `inline()` token whose category clicks
+   re-bin kernel-side with the category masked out.
+8. **Column republish under a stable handle** — the flat form of the same
+   API as §1 (`reflex_xy.scatter_chart(data=Demo.bound_cloud, x="x", ...)`);
+   a slider republishes only the columns while the compile-validated plan,
+   viewport, and selection stay put.
+9. **`rx.cond` + `rx.foreach`** — a toggle conditionally swaps a composed
+   three-series board for `rx.foreach` small multiples over a
+   `list[DataHandle[SensorCols]]` var: one plan mounted once per handle,
+   column names compile-checked inside the loop, both cond branches
+   validated at `reflex run`.
 
 ## Run
 
@@ -59,15 +79,15 @@ The adapter is wired in one line — `plugins=[reflex_xy.XYPlugin()]` in
 
 ## Interaction contract checks
 
-Section 1's badges are event counters, and its click/select handlers
-deliberately republish the cloud behind its stable token (the title's
-`handler revision`). Together they make the wrapper's restore contract
-manually verifiable:
+Section 1's badges are event counters, §2's histogram republishes on every
+box-selection (the cross-filter), and §8's slider republishes columns under a
+stable handle. Together they make the integration's restore contract manually
+verifiable:
 
-1. Box-select a large area. The `select` readout shows the exact total, the
-   bounded JSON row count, and `truncated`; the §2 histogram cross-filters.
-   The cloud must keep both its viewport and its selection highlight across
-   the republish, and the selection counter must increment exactly once.
+1. Box-select a large area of the cloud. The `select` readout shows the exact
+   total, the bounded JSON row count, and `truncated`; the §2 histogram
+   cross-filters. The cloud must keep both its viewport and its selection
+   highlight, and the selection counter must increment exactly once.
 2. Zoom until density drills into exact points, then click one. The `click`
    readout shows its canonical row ID, f64 data coordinates, and active
    keyboard modifiers; the click counter must increment exactly once.
@@ -75,6 +95,9 @@ manually verifiable:
    the same click readout contract as pointer activation.
 4. Clear the selection. The histogram returns to all points and the select
    counter increments exactly once again.
+5. Drag the §8 slider. The bound scatter repaints at the new point count
+   while keeping its viewport — the plan (and the chart's identity) never
+   changes, only the columns.
 
-A runaway counter or a viewport/selection reset after any of these reveals a
-republish feedback loop or a restore regression.
+A runaway counter or a viewport/selection reset after any of these reveals an
+event feedback loop or a restore regression.

--- a/examples/reflex/xy_reflex_demo/xy_reflex_demo.py
+++ b/examples/reflex/xy_reflex_demo/xy_reflex_demo.py
@@ -1,22 +1,31 @@
 """XY Reflex showcase: ways to link chart data into a Reflex app.
 
-One page of six sections; each has a "Code" accordion showing its own source
-via `inspect.getsource`.
+One page of eight sections; each has a "Code" accordion showing its own source
+via `inspect.getsource`. Charts use the data-bound component API — structure
+declared in the page, compiled to a validated plan at ``reflex run``, columns
+supplied by ``@reflex_xy.data`` state methods — except where a section
+demonstrates the tier that behavior genuinely needs: ``@reflex_xy.figure``
+when the chart *structure* depends on state (§2), ``reflex_xy.append``
+streaming (§3), and ``reflex_xy.inline`` for shared fixed data (§5–§7).
 
-1. **Live figure var + events.** A 1M-point drillable scatter from an
-   ``@reflex_xy.figure`` state method; its data rides the app websocket while
-   Reflex state holds only the token. Hover, click, and box-select arrive as
+1. **The flagship, data-bound.** A 1M-point drillable scatter composed in the
+   page (``reflex_xy.chart(xy.scatter("x", "y", ...), data=Demo.cloud)``);
+   ``@reflex_xy.data`` supplies the columns over the app websocket while
+   Reflex state holds only a handle. Hover, click, and box-select arrive as
    ordinary Reflex events.
-2. **A chart driven by state vars.** A histogram whose bin count is a slider var
-   and whose data is cross-filtered by §1's box-selection; changing either
-   recomputes the figure and re-publishes it under a stable token.
+2. **The escape hatch: structure from state.** A histogram whose bin count is
+   a slider var — bins are chart *structure*, not columns, so this is an
+   ``@reflex_xy.figure`` method; its data is also cross-filtered by §1's
+   box-selection, and changing either re-publishes the figure under a stable
+   token.
 3. **A dynamically updating chart.** A line grown from a background task via
    ``reflex_xy.append``.
-4. **Data computed from ``on_view_change``.** Pan/zoom an overview scatter; a
-   detail figure recomputes from the window the view-change event reports.
-5. **Fixed data, two ways.** A ``xy.Chart`` passed straight to
-   ``reflex_xy.chart`` (static payload tier) and a ``reflex_xy.inline`` token
-   (fixed data served through the kernel).
+4. **Data computed from ``on_view_change``.** Pan/zoom a data-bound overview;
+   a second data var reads the reported window from state and republishes
+   only the in-view columns — the detail histogram's plan never changes.
+5. **Fixed data, two ways.** Concrete columns passed as ``data=`` to a
+   composed chart (compiled to a static payload asset) and a
+   ``reflex_xy.inline`` token (fixed data served through the kernel).
 6. **The drilldown, adapter-native.** The 100M-point live drilldown
    scatter from ``examples/fastapi`` — identical data and mark config — as one
    ``reflex_xy.inline`` token with zero transport code, for A/B-ing the two
@@ -27,6 +36,16 @@ via `inspect.getsource`.
    density scatter behind an ``inline()`` token — clicking a category row
    sends ``legend_toggle`` over the app websocket and the kernel re-bins the
    surface with that category masked out (§34).
+8. **Column republish under a stable handle.** The §8 scatter's slider
+   republishes only the columns (``reflex_xy.scatter_chart(data=..., x="x",
+   ...)``); the compile-validated plan stays put, and viewport and selection
+   survive every republish.
+9. **``rx.cond`` + ``rx.foreach``.** Charts are ordinary Reflex components:
+   a toggle conditionally swaps a composed three-series board for
+   ``rx.foreach`` small multiples over a ``list[DataHandle[...]]`` var —
+   one compile-validated plan, one mount per handle, column names checked
+   inside the loop (fact R7), and both cond branches validated at
+   ``reflex run``.
 
 Run from ``examples/reflex``::
 
@@ -40,14 +59,55 @@ import inspect
 import os
 import warnings
 from functools import lru_cache
-from typing import Any
+from typing import Any, TypedDict
 
 import numpy as np
 import reflex as rx
 
 import reflex_xy
 import xy
+from reflex_xy import DataHandle
 from reflex_xy.tokens import BUILDER_ATTR
+
+
+class CloudCols(TypedDict):
+    """Schema of the §1 and §8 data vars — the factories compile-check the
+    column names in the page against these keys (design fact R7)."""
+
+    x: np.ndarray
+    y: np.ndarray
+    mag: np.ndarray
+
+
+class ScanCols(TypedDict):
+    """Schema of the §4 overview data var."""
+
+    t: np.ndarray
+    value: np.ndarray
+
+
+class InViewCols(TypedDict):
+    """Schema of the §4 detail data var (the windowed values)."""
+
+    value: np.ndarray
+
+
+class SensorCols(TypedDict):
+    """Schema of one §9 sensor — the rx.foreach element var keeps this
+    parametrization, so column names are compile-checked inside the loop."""
+
+    t: np.ndarray
+    reading: np.ndarray
+
+
+class SensorBoard(TypedDict):
+    """Schema of the §9 combined board (all sensors in one table)."""
+
+    t: np.ndarray
+    alpha: np.ndarray
+    beta: np.ndarray
+    gamma: np.ndarray
+
 
 POINTS = 1_000_000
 RNG_SEED = 11
@@ -84,22 +144,19 @@ async def _magnitudes() -> tuple[np.ndarray, np.ndarray]:
     return x, mag
 
 
+@lru_cache(maxsize=1)
+def _sensors() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Three correlated sensor traces for §9 (t, alpha, beta, gamma)."""
+    rng = np.random.default_rng(17)
+    t = np.linspace(0.0, 48.0, 2400)
+    base = 20.0 + 6.0 * np.sin(t / 5.0)
+    alpha = base + rng.normal(0.0, 0.7, t.size)
+    beta = base * 0.8 + 4.0 * np.sin(t / 3.0 + 1.2) + rng.normal(0.0, 0.7, t.size)
+    gamma = base * 1.15 - 3.0 * np.cos(t / 7.0) + rng.normal(0.0, 0.7, t.size)
+    return t, alpha, beta, gamma
+
+
 # --- fixed-data charts (module scope) ---------------------------------------
-
-
-def sparkline_chart() -> xy.Chart:
-    """A fixed chart passed directly to ``reflex_xy.chart``, which compiles it
-    to a static payload asset."""
-    t = np.linspace(0.0, 6.0 * np.pi, 4000)
-    decay = np.exp(-t / 9.0)
-    return xy.line_chart(
-        xy.line(t, np.sin(t) * decay, name="signal"),
-        xy.line(t, decay, name="envelope"),
-        xy.x_axis(label="t"),
-        title="static payload tier",
-        width="100%",
-        height=240,
-    )
 
 
 def orbits_chart() -> xy.Chart:
@@ -121,7 +178,7 @@ def orbits_chart() -> xy.Chart:
 
 # Registered at import; the content-addressed token resolves on any backend
 # worker.
-ORBITS_TOKEN = reflex_xy.inline(orbits_chart())
+ORBITS = reflex_xy.inline(orbits_chart())
 
 
 # --- legend interactivity (§7) ----------------------------------------------
@@ -183,7 +240,7 @@ def legend_category_chart() -> xy.Chart:
 
 # Kernel-served so category toggles reach `legend_toggle` and the masked
 # re-bin path; a static payload would only filter the local sample overlay.
-LEGEND_CATS_TOKEN = reflex_xy.inline(legend_category_chart())
+LEGEND_CATS = reflex_xy.inline(legend_category_chart())
 
 
 # --- the live drilldown, adapter-native (§6) --------------------------
@@ -256,26 +313,22 @@ def drilldown_chart(n: int = DRILLDOWN_POINTS) -> xy.Chart:
 
 # One shared kernel-backed figure for every viewer, expressed as a single
 # inline() token; the registry keeps it process-global.
-DRILLDOWN_TOKEN = reflex_xy.inline(drilldown_chart())
+DRILLDOWN = reflex_xy.inline(drilldown_chart())
 
 
 # --- state ------------------------------------------------------------------
 
 
 class Demo(rx.State):
-    """Charts are figure vars; everything else is ordinary app state."""
+    """Data-bound charts read columns from ``@reflex_xy.data`` vars; the §2
+    histogram is an ``@reflex_xy.figure`` var (its structure reads state);
+    everything else is ordinary app state."""
 
     # §1 semantic events
     hovered: dict = {}
     clicked: dict = {}
     click_events: int = 0
     select_events: int = 0
-    # Click/select handlers bump this and the cloud's title reads it, so every
-    # event deliberately republishes the source figure behind its stable
-    # token. The wrapper must keep the viewport and selection across that
-    # republish without re-dispatching events (no feedback loop) — the
-    # counters above make a violation visible as a runaway count.
-    interaction_revision: int = 0
     # §2 state-driven + cross-filter
     bins: int = 60
     sel_active: bool = False
@@ -291,23 +344,12 @@ class Demo(rx.State):
     view_x1: float = 0.0
     visible: int = 0
 
-    @reflex_xy.figure
-    def cloud(self) -> xy.Chart:
+    @reflex_xy.data
+    def cloud(self) -> CloudCols:
+        # Columns only — the chart structure lives in the page (cloud_view)
+        # as a compile-validated plan; this method never runs at compile.
         x, y, mag = _cloud(POINTS)
-        return xy.scatter_chart(
-            xy.scatter(x, y, color=mag, colormap="viridis", opacity=0.8, density=True),
-            # hover and click are off by default; enable them so the point
-            # events reach the handlers below (select/pan/zoom are on already).
-            xy.interaction_config(hover=True, click=True),
-            xy.x_axis(label="feature A"),
-            xy.y_axis(label="feature B"),
-            title=(
-                f"{POINTS // 1_000_000}M points, drillable · "
-                f"handler revision {self.interaction_revision}"
-            ),
-            width="100%",
-            height=460,
-        )
+        return {"x": x, "y": y, "mag": mag}
 
     @reflex_xy.figure
     async def histogram(self) -> xy.Chart:
@@ -334,38 +376,20 @@ class Demo(rx.State):
             height=240,
         )
 
-    @reflex_xy.figure
-    def overview(self) -> xy.Chart:
-        x, y = _scan(120_000)
-        return xy.scatter_chart(
-            xy.scatter(x, y, opacity=0.5, density=True),
-            xy.interaction_config(zoom_axes=("x",)),
-            xy.x_axis(label="t"),
-            xy.y_axis(label="value"),
-            title="overview — zoom the x range",
-            width="100%",
-            height=240,
-        )
+    @reflex_xy.data
+    def scan_points(self) -> ScanCols:
+        t, value = _scan(120_000)
+        return {"t": t, "value": value}
 
-    @reflex_xy.figure
-    def detail(self) -> xy.Chart:
-        # Recomputed from the window the overview last reported through
-        # `on_view_change`: a histogram of only the y-values currently in view.
-        x, y = _scan(120_000)
+    @reflex_xy.data
+    def in_view(self) -> InViewCols:
+        # Republished from the window the overview last reported through
+        # `on_view_change`: only the values currently in view. The detail
+        # histogram's plan is fixed; this data var is what changes.
+        t, value = _scan(120_000)
         if self.view_ready and self.view_x1 > self.view_x0:
-            y = y[(x >= self.view_x0) & (x <= self.view_x1)]
-        title = (
-            f"detail — {y.size:,} points in view"
-            if self.view_ready
-            else "detail — pan/zoom the overview"
-        )
-        return xy.histogram_chart(
-            xy.histogram(y, bins=48, color="#7c3aed"),
-            xy.x_axis(label="value in view"),
-            title=title,
-            width="100%",
-            height=240,
-        )
+            value = value[(t >= self.view_x0) & (t <= self.view_x1)]
+        return {"value": value}
 
     @rx.event
     def on_hover(self, event: reflex_xy.PointHoverEvent):
@@ -375,7 +399,6 @@ class Demo(rx.State):
     @rx.event
     def on_click(self, event: reflex_xy.PointClickEvent):
         self.click_events += 1
-        self.interaction_revision += 1
         modifiers = event.get("modifiers", {})
         self.clicked = {
             "row": event.get("canonical_row_id"),
@@ -386,7 +409,6 @@ class Demo(rx.State):
     @rx.event
     def on_select(self, event: reflex_xy.SelectEndEvent):
         self.select_events += 1
-        self.interaction_revision += 1
         selection = event.get("selection", {})
         total = int(selection.get("total_count") or 0)
         bounds = selection.get("data_bounds") or {}
@@ -419,6 +441,54 @@ class Demo(rx.State):
         x, _ = _scan(120_000)
         self.visible = int(((x >= self.view_x0) & (x <= self.view_x1)).sum())
 
+    # §8 data-bound component: state supplies columns, the page declares the
+    # chart. The slider republishes only the columns; the chart structure is
+    # a compile-validated plan baked into the JSX.
+    bound_points: int = 150_000
+
+    @reflex_xy.data
+    def bound_cloud(self) -> CloudCols:
+        rng = np.random.default_rng(23)
+        x = rng.normal(size=self.bound_points)
+        y = x * 0.6 + rng.normal(scale=0.6, size=self.bound_points)
+        return {"x": x, "y": y, "mag": np.hypot(x, y)}
+
+    @rx.event
+    def set_bound_points(self, value: list[int | float]):
+        self.bound_points = int(value[0])
+
+    # §9 cond + foreach: one combined board or per-sensor small multiples.
+    split: bool = False
+
+    @reflex_xy.data
+    def board(self) -> SensorBoard:
+        t, alpha, beta, gamma = _sensors()
+        return {"t": t, "alpha": alpha, "beta": beta, "gamma": gamma}
+
+    @reflex_xy.data
+    def sensor_alpha(self) -> SensorCols:
+        t, alpha, _, _ = _sensors()
+        return {"t": t, "reading": alpha}
+
+    @reflex_xy.data
+    def sensor_beta(self) -> SensorCols:
+        t, _, beta, _ = _sensors()
+        return {"t": t, "reading": beta}
+
+    @reflex_xy.data
+    def sensor_gamma(self) -> SensorCols:
+        t, _, _, gamma = _sensors()
+        return {"t": t, "reading": gamma}
+
+    @rx.var
+    def sensor_handles(self) -> list[DataHandle[SensorCols]]:
+        """A typed handle list: rx.foreach charts stay schema-checked (R7)."""
+        return [self.sensor_alpha, self.sensor_beta, self.sensor_gamma]
+
+    @rx.event
+    def toggle_split(self):
+        self.split = not self.split
+
     @rx.event(background=True)
     async def stream(self):
         async with self:
@@ -447,6 +517,9 @@ class Demo(rx.State):
 def _source(obj: Any) -> str:
     """Source of a plain function, an ``@reflex_xy.figure`` var, or an
     ``@rx.event`` handler."""
+    # Class-level access to an object-valued computed var hands back reflex's
+    # casted wrapper; the declared var (with its fget) sits behind _original.
+    obj = getattr(obj, "_original", obj)
     fget = getattr(obj, "_fget", None)
     if fget is not None:  # a @reflex_xy.figure / computed var
         builder = getattr(fget, BUILDER_ATTR, None)
@@ -514,10 +587,19 @@ def kv(label: str, value: Any) -> rx.Component:
     )
 
 
-# §1 wiring — the live figure var and its semantic events
+# §1 wiring — the chart composed in the page, bound to the cloud data var.
+# Marks and chrome are plain xy nodes compiled to a validated plan at
+# `reflex run`; a wrong column, colormap, or kwarg fails the compile.
 def cloud_view() -> rx.Component:
     return reflex_xy.chart(
-        Demo.cloud,
+        xy.scatter("x", "y", color="mag", colormap="viridis", opacity=0.8, density=True),
+        # hover and click are off by default; enable them so the point
+        # events reach the state handlers (select/pan/zoom are on already).
+        xy.interaction_config(hover=True, click=True),
+        xy.x_axis(label="feature A"),
+        xy.y_axis(label="feature B"),
+        data=Demo.cloud,
+        title=f"{POINTS // 1_000_000}M points, drillable — declared in the page",
         on_point_hover=Demo.on_hover,
         on_point_click=Demo.on_click,
         on_select_end=Demo.on_select,
@@ -529,7 +611,7 @@ def cloud_view() -> rx.Component:
 # §2 wiring — a chart driven by a slider and another chart's selection
 def histogram_view() -> rx.Component:
     return rx.vstack(
-        reflex_xy.chart(Demo.histogram, height="240px", id="hist"),
+        reflex_xy.chart(figure=Demo.histogram, height="240px", id="hist"),
         rx.hstack(
             rx.text("bins", size="2", color_scheme="gray"),
             rx.slider(
@@ -549,7 +631,7 @@ def histogram_view() -> rx.Component:
 # §3 wiring — a chart that grows from a background task
 def live_view() -> rx.Component:
     return rx.vstack(
-        reflex_xy.chart(Demo.live, height="240px", id="live"),
+        reflex_xy.chart(figure=Demo.live, height="240px", id="live"),
         rx.button(
             rx.cond(Demo.streaming, "stop stream", "go live"),
             on_click=Demo.stream,
@@ -560,22 +642,59 @@ def live_view() -> rx.Component:
     )
 
 
-# §4 wiring — a detail chart computed from the overview's view-change events
+# §4 wiring — two data-bound charts: the overview reports its window through
+# on_view_change; the in_view data var reads that window from state and
+# republishes the filtered column into the detail histogram's fixed plan.
 def viewport_view() -> rx.Component:
     return rx.grid(
-        reflex_xy.chart(Demo.overview, on_view_change=Demo.on_view, height="240px", id="overview"),
-        reflex_xy.chart(Demo.detail, height="240px", id="detail"),
+        reflex_xy.chart(
+            xy.scatter("t", "value", opacity=0.5, density=True),
+            xy.interaction_config(zoom_axes=("x",)),
+            xy.x_axis(label="t"),
+            xy.y_axis(label="value"),
+            data=Demo.scan_points,
+            title="overview — zoom the x range",
+            on_view_change=Demo.on_view,
+            height="240px",
+            id="overview",
+        ),
+        reflex_xy.histogram_chart(
+            data=Demo.in_view,
+            values="value",
+            bins=48,
+            color="#7c3aed",
+            x_axis=xy.x_axis(label="value in view"),
+            title="detail — the points in view",
+            height="240px",
+            id="detail",
+        ),
         columns="2",
         gap="1rem",
         width="100%",
     )
 
 
-# §5 wiring — the two fixed-data tiers
+# §5 wiring — the two fixed-data tiers. Concrete columns as data= compile the
+# composed chart to a static payload asset (renders kernel-less, works under
+# `reflex export`); the inline() token serves fixed data through the kernel.
+def sparkline_view() -> rx.Component:
+    t = np.linspace(0.0, 6.0 * np.pi, 4000)
+    decay = np.exp(-t / 9.0)
+    return reflex_xy.chart(
+        xy.line("t", "signal", name="signal"),
+        xy.line("t", "envelope", name="envelope"),
+        xy.x_axis(label="t"),
+        data={"t": t, "signal": np.sin(t) * decay, "envelope": decay},
+        title="static payload tier",
+        height="240px",
+        id="inline",
+    )
+
+
 def fixed_view() -> rx.Component:
     return rx.grid(
-        reflex_xy.chart(sparkline_chart(), height="240px", id="inline"),
-        reflex_xy.chart(ORBITS_TOKEN, height="240px", id="orbits"),
+        sparkline_view(),
+        reflex_xy.chart(figure=ORBITS, height="240px", id="orbits"),
         columns="2",
         gap="1rem",
         width="100%",
@@ -584,14 +703,97 @@ def fixed_view() -> rx.Component:
 
 # §6 wiring — the whole drilldown integration is this one line
 def drilldown_view() -> rx.Component:
-    return reflex_xy.chart(DRILLDOWN_TOKEN, height="430px", id="drilldown")
+    return reflex_xy.chart(figure=DRILLDOWN, height="430px", id="drilldown")
+
+
+# §8 wiring — the data-bound component: chart declared where it renders,
+# state supplies only columns. Channels, colormap, and column names are all
+# validated at compile (`reflex run` fails on a typo, not the browser).
+def bound_view() -> rx.Component:
+    return rx.vstack(
+        reflex_xy.scatter_chart(
+            data=Demo.bound_cloud,
+            x="x",
+            y="y",
+            color="mag",
+            colormap="viridis",
+            mark_opacity=0.75,
+            density=True,
+            x_axis=xy.x_axis(label="feature A"),
+            y_axis=xy.y_axis(label="feature B"),
+            title="declared in the page, fed by @reflex_xy.data",
+            height="300px",
+            id="bound",
+        ),
+        rx.hstack(
+            rx.text("points", size="2", color_scheme="gray"),
+            rx.slider(
+                default_value=[150_000],
+                min=10_000,
+                max=1_000_000,
+                step=10_000,
+                on_change=Demo.set_bound_points,
+                id="bound-points",
+            ),
+            rx.text(Demo.bound_points, font_family="monospace", size="2", width="5.5rem"),
+            width="100%",
+            align="center",
+            spacing="3",
+        ),
+        width="100%",
+        spacing="2",
+    )
+
+
+# §9 wiring — charts are ordinary components, so rx.cond and rx.foreach just
+# work. Both cond branches are built at page evaluation (both plans compile-
+# validate); the foreach lambda runs once against the element var, producing
+# ONE plan that mounts once per handle in the list.
+def cond_foreach_view() -> rx.Component:
+    combined = reflex_xy.chart(
+        xy.line("t", "alpha", name="alpha"),
+        xy.line("t", "beta", name="beta"),
+        xy.line("t", "gamma", name="gamma"),
+        xy.legend(),
+        xy.x_axis(label="hours"),
+        data=Demo.board,
+        title="all sensors — one composed board",
+        height="260px",
+        id="board",
+    )
+    multiples = rx.grid(
+        rx.foreach(
+            Demo.sensor_handles,
+            lambda handle: reflex_xy.area_chart(
+                data=handle,
+                x="t",
+                y="reading",
+                color="#0284c7",
+                mark_opacity=0.5,
+                height="180px",
+            ),
+        ),
+        columns="3",
+        gap="1rem",
+        width="100%",
+    )
+    return rx.vstack(
+        rx.cond(Demo.split, multiples, combined),
+        rx.button(
+            rx.cond(Demo.split, "one combined board", "small multiples"),
+            on_click=Demo.toggle_split,
+            id="split-btn",
+        ),
+        width="100%",
+        spacing="2",
+    )
 
 
 # §7 wiring — legend interactivity ships with the charts; no handlers needed
 def legend_view() -> rx.Component:
     return rx.grid(
         reflex_xy.chart(legend_series_chart(), height="300px", id="legend-series"),
-        reflex_xy.chart(LEGEND_CATS_TOKEN, height="300px", id="legend-cats"),
+        reflex_xy.chart(figure=LEGEND_CATS, height="300px", id="legend-cats"),
         columns="2",
         gap="1rem",
         width="100%",
@@ -609,11 +811,12 @@ def index() -> rx.Component:
                 size="3",
             ),
             section(
-                "1 · Live figure var + events",
-                "A 1M-point drillable scatter from an @reflex_xy.figure method. "
-                "Zoom to drill density into exact points; hover, click, and box-select. "
-                "Click and select handlers republish the chart itself (the title's "
-                "revision) — viewport and selection must survive each republish.",
+                "1 · The flagship, data-bound",
+                "A 1M-point drillable scatter declared in the page: composed xy "
+                "marks compile to a validated plan at reflex run, and "
+                "@reflex_xy.data supplies only the columns. Zoom to drill "
+                "density into exact points; hover, click, and box-select "
+                "arrive as ordinary Reflex events.",
                 rx.vstack(
                     cloud_view(),
                     kv(
@@ -635,8 +838,7 @@ def index() -> rx.Component:
                     ),
                     kv(
                         "events",
-                        f"{Demo.click_events} clicks · {Demo.select_events} selections · "
-                        f"republish revision {Demo.interaction_revision}",
+                        f"{Demo.click_events} clicks · {Demo.select_events} selections",
                     ),
                     width="100%",
                     spacing="3",
@@ -646,10 +848,12 @@ def index() -> rx.Component:
                 ),
             ),
             section(
-                "2 · A chart driven by state vars",
-                "The histogram's bin count is a slider var, and its data is "
-                "cross-filtered by the box-selection above. Changing either "
-                "re-publishes the figure under a stable token.",
+                "2 · The escape hatch: structure from state",
+                "The histogram's bin count is a slider var — bins are chart "
+                "structure, not columns, so this chart is an @reflex_xy.figure "
+                "method rather than a plan. Its data is also cross-filtered by "
+                "the box-selection above; changing either re-publishes the "
+                "figure under a stable token.",
                 histogram_view(),
                 code_accordion(Demo.histogram, Demo.set_bins, histogram_view),
             ),
@@ -662,8 +866,10 @@ def index() -> rx.Component:
             ),
             section(
                 "4 · Data computed from on_view_change",
-                "Zoom the overview's x range; the detail histogram recomputes from "
-                "only the points in view, driven by the view-change event.",
+                "Zoom the overview's x range; the in_view data var reads the "
+                "reported window from state and republishes only the in-view "
+                "column — the detail histogram's plan never changes, its data "
+                "does.",
                 rx.vstack(
                     viewport_view(),
                     kv(
@@ -677,15 +883,16 @@ def index() -> rx.Component:
                     width="100%",
                     spacing="3",
                 ),
-                code_accordion(Demo.overview, Demo.detail, Demo.on_view, viewport_view),
+                code_accordion(Demo.scan_points, Demo.in_view, Demo.on_view, viewport_view),
             ),
             section(
                 "5 · Fixed data, two ways",
-                "Left: a xy.Chart passed straight to reflex_xy.chart, compiled to "
-                "a static payload asset. Right: a reflex_xy.inline token, whose "
-                "fixed data answers hover/pick from the kernel.",
+                "Left: concrete columns passed as data= to a composed chart, "
+                "compiled to a static payload asset (no kernel, works under "
+                "reflex export). Right: a reflex_xy.inline token, whose fixed "
+                "data answers hover/pick from the kernel.",
                 fixed_view(),
-                code_accordion(sparkline_chart, orbits_chart, fixed_view),
+                code_accordion(sparkline_view, orbits_chart, fixed_view),
             ),
             section(
                 f"6 · The {_point_label(DRILLDOWN_POINTS)} drilldown, adapter-native",
@@ -709,6 +916,28 @@ def index() -> rx.Component:
                 "opt out.",
                 legend_view(),
                 code_accordion(legend_series_chart, legend_category_chart, legend_view),
+            ),
+            section(
+                "8 · Column republish under a stable handle",
+                "The flat single-mark form of the same API as §1: "
+                "reflex_xy.scatter_chart(data=Demo.bound_cloud, x='x', y='y', ...). "
+                "The slider republishes only the columns under a stable handle; "
+                "the compile-validated plan stays put, and viewport and "
+                "selection survive every republish.",
+                bound_view(),
+                code_accordion(Demo.bound_cloud, Demo.set_bound_points, bound_view),
+            ),
+            section(
+                "9 · rx.cond + rx.foreach",
+                "Charts are ordinary Reflex components. The toggle swaps a "
+                "composed three-series board for rx.foreach small multiples "
+                "over a list[DataHandle[SensorCols]] var: one compile-validated "
+                "plan, mounted once per handle, column names checked inside "
+                "the loop — and both cond branches validate at reflex run.",
+                cond_foreach_view(),
+                code_accordion(
+                    Demo.sensor_alpha, Demo.sensor_handles, Demo.toggle_split, cond_foreach_view
+                ),
             ),
             spacing="5",
             width="100%",

--- a/python/reflex_xy/__init__.py
+++ b/python/reflex_xy/__init__.py
@@ -3,38 +3,55 @@
 The integration in one paragraph (full design:
 spec/design/reflex-integration.md in the xy repo): chart data rides
 the app's *existing* websocket as a second socket.io namespace — binary
-columns, no JSON numbers, no extra endpoints to proxy. Figures live in a
-per-process registry keyed by tokens; the tokens live in Reflex state. A
-`@reflex_xy.figure` state method is both the chart definition and the
-recovery recipe: any worker can rebuild the figure from state when a
+columns, no JSON numbers, no extra endpoints to proxy. Figures and columns
+live in a per-process registry keyed by tokens; Reflex state holds only
+small typed handles. State methods are both the definition and the
+recovery recipe: any worker can rebuild what it serves from state when a
 reconnect lands somewhere new, so there is no central figure store to
 operate.
 
-Quickstart::
+Quickstart (the data-bound component API — structure is declared in the
+page and validated at ``reflex run``; state supplies only columns)::
 
     # rxconfig.py
     config = rx.Config(app_name="dash", plugins=[reflex_xy.XYPlugin()])
 
     # dash/dash.py
+    from typing import TypedDict
     import numpy as np
     import reflex as rx
-    import xy
     import reflex_xy
+
+    class CloudData(TypedDict):
+        x: np.ndarray
+        y: np.ndarray
+        mag: np.ndarray
 
     class Dash(rx.State):
         points: int = 200_000
 
-        @reflex_xy.figure
-        def chart(self) -> xy.Chart:
+        @reflex_xy.data
+        def cloud(self) -> CloudData:
             rng = np.random.default_rng(7)
-            xs = rng.normal(size=self.points)
-            ys = xs * 0.6 + rng.normal(scale=0.6, size=self.points)
-            return xy.scatter_chart(xy.scatter(xs, ys), width="100%", height=460)
+            x = rng.normal(size=self.points)
+            y = x * 0.6 + rng.normal(scale=0.6, size=self.points)
+            return {"x": x, "y": y, "mag": np.hypot(x, y)}
 
     def index() -> rx.Component:
-        return reflex_xy.chart(Dash.chart, height="460px")
+        return reflex_xy.scatter_chart(
+            data=Dash.cloud,
+            x="x", y="y", color="mag", colormap="viridis",
+            height="460px",
+        )
 
     app = rx.App()
+
+Multi-mark charts compose xy nodes around the same data var
+(``reflex_xy.chart(reflex_xy.scatter("x", "y"), reflex_xy.line("x", "t"),
+data=Dash.cloud)``), and charts whose *structure* depends on state keep the
+escape hatch: an ``@reflex_xy.figure`` method returning an ``xy.Chart``,
+rendered with ``reflex_xy.chart(figure=Dash.built)`` and probed at compile
+(§3.1 of the design).
 """
 
 from __future__ import annotations
@@ -53,7 +70,23 @@ _EXPORTS = {
     "select": ".app",
     "set_view": ".app",
     "setup": ".app",
-    "chart": ".component",
+    "chart": ".factories",
+    "area_chart": ".factories",
+    "bar_chart": ".factories",
+    "column_chart": ".factories",
+    "error_band_chart": ".factories",
+    "errorbar_chart": ".factories",
+    "histogram_chart": ".factories",
+    "line_chart": ".factories",
+    "scatter_chart": ".factories",
+    "segments_chart": ".factories",
+    "stem_chart": ".factories",
+    "step_chart": ".factories",
+    "AsyncDataVar": ".data_vars",
+    "DataVar": ".data_vars",
+    "data": ".data_vars",
+    "DataHandle": ".handles",
+    "FigureHandle": ".handles",
     "CanonicalRowIdGroup": ".events",
     "DataBounds": ".events",
     "Modifiers": ".events",
@@ -74,11 +107,74 @@ _EXPORTS = {
     "figure": ".vars",
 }
 
+#: Curated re-exports of xy node constructors: `reflex_xy.scatter` *is*
+#: `xy.scatter`, so composed data-bound charts read uniformly
+#: (`reflex_xy.chart(reflex_xy.scatter("x", "y"), data=...)`) and a
+#: hallucinated constructor dies at import against this explicit map
+#: instead of surviving to hydrate. Marks whose validators need data
+#: (box, violin, hexbin, …) are still listed — the plan probe refuses them
+#: with the recorded Phase 3 guidance rather than a misleading
+#: AttributeError. Chart factories are deliberately absent: the flat
+#: `*_chart` names above are reflex-native factories, not xy's.
+_XY_REEXPORTS = frozenset(
+    {
+        # marks
+        "scatter",
+        "line",
+        "area",
+        "step",
+        "stairs",
+        "stem",
+        "column",
+        "bar",
+        "histogram",
+        "errorbar",
+        "error_band",
+        "segments",
+        "ecdf",
+        "box",
+        "violin",
+        "hexbin",
+        "contour",
+        "heatmap",
+        # annotations
+        "vline",
+        "hline",
+        "x_band",
+        "y_band",
+        "text",
+        "label",
+        "marker",
+        "arrow",
+        "threshold",
+        "threshold_zone",
+        "callout",
+        # chrome + config constructors
+        "x_axis",
+        "y_axis",
+        "theta_axis",
+        "r_axis",
+        "legend",
+        "tooltip",
+        "colorbar",
+        "modebar",
+        "export_config",
+        "theme",
+        "interaction_config",
+        "animation",
+        "spring",
+    }
+)
+
 __all__ = [
     "XY_NAMESPACE",
+    "AsyncDataVar",
     "AsyncFigureVar",
     "CanonicalRowIdGroup",
     "DataBounds",
+    "DataHandle",
+    "DataVar",
+    "FigureHandle",
     "FigureRegistry",
     "FigureVar",
     "Modifiers",
@@ -91,25 +187,85 @@ __all__ = [
     "ViewChangeEvent",
     "XYNamespace",
     "XYPlugin",
+    "animation",
     "append",
+    "area",
+    "area_chart",
+    "arrow",
+    "bar",
+    "bar_chart",
+    "box",
+    "callout",
     "chart",
     "clear_selection",
+    "colorbar",
+    "column",
+    "column_chart",
+    "contour",
+    "data",
+    "ecdf",
+    "error_band",
+    "error_band_chart",
+    "errorbar",
+    "errorbar_chart",
+    "export_config",
     "figure",
+    "heatmap",
+    "hexbin",
+    "histogram",
+    "histogram_chart",
+    "hline",
     "inline",
+    "interaction_config",
+    "label",
+    "legend",
+    "line",
+    "line_chart",
+    "marker",
+    "modebar",
+    "r_axis",
     "register",
     "registry",
     "release",
     "reset_view",
     "resolve_selection",
+    "scatter",
+    "scatter_chart",
+    "segments",
+    "segments_chart",
     "select",
     "set_view",
     "setup",
+    "spring",
+    "stairs",
+    "stem",
+    "stem_chart",
+    "step",
+    "step_chart",
+    "text",
+    "theme",
+    "theta_axis",
+    "threshold",
+    "threshold_zone",
+    "tooltip",
+    "violin",
+    "vline",
+    "x_axis",
+    "x_band",
+    "y_axis",
+    "y_band",
 ]
 
 
 def _load_export(name: str) -> Any:
     module_name = _EXPORTS.get(name)
     if module_name is None:
+        if name in _XY_REEXPORTS:
+            import xy
+
+            value = getattr(xy, name)
+            globals()[name] = value
+            return value
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
     value = getattr(import_module(module_name, __name__), name)
 
@@ -154,22 +310,25 @@ def __dir__() -> list[str]:
     return sorted(set(globals()) | set(__all__))
 
 
-def register(chart_or_figure: Any) -> str:
-    """Imperatively register a chart; returns an opaque token for state.
+def register(chart_or_figure: Any) -> "FigureHandle":
+    """Imperatively register a chart; returns a typed handle for state.
 
-    Dev-tier API: the figure lives only in this process and cannot be
-    rebuilt after a worker restart or on another node — prefer
-    `@reflex_xy.figure` for anything long-lived (see the module doc).
+    The handle's ``.token`` is the registry key; pass the handle itself to
+    ``chart(figure=...)`` (or store it in state). Dev-tier API: the figure
+    lives only in this process and cannot be rebuilt after a worker restart
+    or on another node — prefer `@reflex_xy.figure` for anything long-lived
+    (see the module doc).
     """
+    from .handles import FigureHandle
     from .registry import _figure_of, registry
 
     globals()["registry"] = registry
 
-    return registry.register(_figure_of(chart_or_figure))
+    return FigureHandle(registry.register(_figure_of(chart_or_figure)))
 
 
-def inline(chart_or_figure: Any) -> str:
-    """Register a fixed, kernel-backed chart at module scope; returns its token.
+def inline(chart_or_figure: Any) -> "FigureHandle":
+    """Register a fixed, kernel-backed chart at module scope; returns its handle.
 
     For charts whose data never changes but which still want server-side
     drilldown/picks on the shared websocket. Call at **module scope** so the
@@ -179,12 +338,13 @@ def inline(chart_or_figure: Any) -> str:
         cloud = reflex_xy.inline(xy.scatter_chart(xy.scatter(x, y)))
 
         def index():
-            return reflex_xy.chart(cloud, height="460px")
+            return reflex_xy.chart(figure=cloud, height="460px")
 
-    The token is content-addressed — every worker independently derives the
-    same one, so the frontend's baked-in token resolves everywhere without
-    state or rebuild hooks. The entry is pinned (exempt from the TTL sweep):
-    there is no recipe to rebuild it from, so it lives with the process.
+    The handle's token is content-addressed — every worker independently
+    derives the same one, so the frontend's baked-in token resolves
+    everywhere without state or rebuild hooks. The entry is pinned (exempt
+    from the TTL sweep): there is no recipe to rebuild it from, so it lives
+    with the process.
 
     Shared by design: one figure object serves every viewer, so kernel-side
     drill state is shared too (like N notebook views of one widget). Data
@@ -192,6 +352,7 @@ def inline(chart_or_figure: Any) -> str:
     no kernel at all can be passed straight to `reflex_xy.chart()` (static
     payload tier).
     """
+    from .handles import FigureHandle
     from .registry import _figure_of, registry
 
     globals()["registry"] = registry
@@ -202,21 +363,22 @@ def inline(chart_or_figure: Any) -> str:
     digest = hashlib.sha256(canonical + blob).hexdigest()[:20]
     token = f"xyin-{digest}"
     registry.publish(token, fig, broadcast=False, pinned=True)
-    return token
+    return FigureHandle(token)
 
 
-def release(token: str) -> None:
-    """Drop a registered figure (idempotent)."""
+def release(token: "str | FigureHandle") -> None:
+    """Drop a registered figure (idempotent). Takes a handle or its token."""
+    from .handles import token_of
     from .registry import registry
 
     globals()["registry"] = registry
 
-    registry.release(token)
+    registry.release(token_of(token) or "")
 
 
 if TYPE_CHECKING:
     from .app import XYPlugin, append, clear_selection, reset_view, select, set_view, setup
-    from .component import chart
+    from .data_vars import AsyncDataVar, DataVar, data
     from .events import (
         CanonicalRowIdGroup,
         DataBounds,
@@ -229,6 +391,8 @@ if TYPE_CHECKING:
         SelectionPayload,
         ViewChangeEvent,
     )
+    from .factories import bar_chart, chart, histogram_chart, line_chart, scatter_chart
+    from .handles import DataHandle, FigureHandle
     from .namespace import XY_NAMESPACE, XYNamespace
     from .registry import FigureRegistry, registry
     from .selections import resolve_selection

--- a/python/reflex_xy/app.py
+++ b/python/reflex_xy/app.py
@@ -21,18 +21,25 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from typing import Any, Optional
+import inspect
+import warnings
+from typing import Any, Optional, cast
 
 from reflex.plugins import Plugin
 
+from .handles import FigureHandle, token_of
 from .namespace import XYNamespace
-from .registry import registry
+from .registry import _figure_of, registry
 from .state_bridge import make_rebuild_hook
+from .tokens import BUILDER_ATTR, PROBE_ATTR
+from .vars import AsyncFigureVar, FigureVar
 
 __all__ = [
+    "FigureProbeError",
     "XYPlugin",
     "append",
     "clear_selection",
+    "probe_figure_builders",
     "reset_view",
     "select",
     "set_view",
@@ -57,15 +64,57 @@ def setup(app: Any) -> XYNamespace:
     namespace = XYNamespace(registry, rebuild=make_rebuild_hook(app))
     sio.register_namespace(namespace)
     wire(namespace)
-    app.register_lifespan_task(_xy_lifespan)
+
+    async def _lifespan() -> None:
+        # The lifespan runs at server startup: every page has been added and
+        # the serving loop exists, in *every* worker — including backend-only
+        # workers that never ran the frontend compile. Register the plans
+        # there before serving (see _ensure_page_plans), then run the sweep.
+        _ensure_page_plans(app)
+        await _xy_lifespan()
+
+    app.register_lifespan_task(_lifespan)
     _namespace = namespace
     return namespace
+
+
+def _ensure_page_plans(app: Any) -> None:
+    """Evaluate the app's page component functions so chart plans register.
+
+    The data-bound tier's plan map is process-local and populated by the
+    chart factories *as page bodies run* (reflex-integration.md §3.6). A
+    backend-only worker — dev backend subprocesses and prod workers alike —
+    imports the app module but skips the frontend compile, so its pages sit
+    unevaluated and every plan subscription would answer `err {resync}`
+    forever. Running the page functions here makes "the plan map is
+    populated in every worker" true by construction; the built component
+    trees are discarded (plans and payload assets are content-addressed and
+    idempotent). A failing page degrades to a warning: it would have failed
+    the real compile in the compile process, and one broken page must not
+    take down the data plane for the others.
+    """
+    pages = getattr(app, "_unevaluated_pages", None) or {}
+    for route, page in dict(pages).items():
+        component = getattr(page, "component", None)
+        if not callable(component):
+            continue  # already-built component instances registered at add_page
+        try:
+            component()
+        except Exception as exc:  # noqa: BLE001 - user page code is an input boundary
+            warnings.warn(
+                f"reflex_xy: evaluating page {route!r} for chart-plan "
+                f"registration failed: {exc!r}. Data-bound charts declared on "
+                "this page cannot be served by this worker.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
 
 def wire(namespace: XYNamespace) -> None:
     """Point the registry's fan-out seams at a namespace (setup and tests)."""
     registry.on_publish(namespace.broadcast_payload)
     registry.on_push(namespace.broadcast_message)
+    registry.on_error(namespace.broadcast_error)
 
 
 async def _xy_lifespan() -> None:
@@ -75,22 +124,129 @@ async def _xy_lifespan() -> None:
         await registry.sweep_forever()
 
 
+class FigureProbeError(Exception):
+    """A `@reflex_xy.figure` builder failed its compile-time probe."""
+
+
+def _builder_location(builder: Any) -> str:
+    try:
+        filename = inspect.getsourcefile(builder)
+        _, line = inspect.getsourcelines(builder)
+    except (OSError, TypeError):
+        return "<source unavailable>"
+    return f"{filename}:{line}"
+
+
+def _touches_session(builder: Any) -> bool:
+    """Heuristic escape valve (constraint 2): builders that read the session
+    (`self.router`) cannot be expected to run against default state — their
+    probe failures degrade to a warning instead of failing the compile."""
+    try:
+        source = inspect.getsource(builder)
+    except (OSError, TypeError):
+        return False
+    return "self.router" in source
+
+
+def _iter_probed_figure_vars(state_cls: Any, seen: set[Any]):
+    if state_cls in seen:
+        return
+    seen.add(state_cls)
+    computed = getattr(state_cls, "computed_vars", {})
+    for name, var in computed.items():
+        if isinstance(var, (FigureVar, AsyncFigureVar)):
+            yield state_cls, name, var
+    for subclass in state_cls.get_substates():
+        yield from _iter_probed_figure_vars(subclass, seen)
+
+
+def probe_figure_builders(root_cls: Any = None) -> list[str]:
+    """Run every probe-enabled `@reflex_xy.figure` builder against default
+    state (reflex-integration.md §3.1): the compile gate of the escape-hatch
+    tier. Returns the probed var full names; raises :class:`FigureProbeError`
+    (wrapping the original) on the first failing builder.
+
+    Level ``"build"`` runs the builder body — hallucinated `xy.*` names,
+    wrong kwargs, and eager chrome errors fail here. ``"figure"`` also
+    compiles the returned chart. ``False`` (and, by default, async builders)
+    are skipped. Builders whose source touches ``self.router`` degrade
+    failures to a `RuntimeWarning`: they are session-dependent by
+    declaration and only a live session can validate them.
+    """
+    import reflex as rx
+
+    root_cls = root_cls if root_cls is not None else cast("Any", rx.State)
+    root = root_cls(_reflex_internal_init=True)
+    probed: list[str] = []
+    for state_cls, name, var in _iter_probed_figure_vars(root_cls, set()):
+        fget = var._fget
+        level = getattr(fget, PROBE_ATTR, False)
+        builder = getattr(fget, BUILDER_ATTR, None)
+        if not level or builder is None:
+            continue
+        full_name = f"{state_cls.get_full_name()}.{name}"
+        try:
+            substate = root.get_substate(tuple(state_cls.get_full_name().split("."))[1:])
+        except (KeyError, ValueError):
+            continue  # not reachable from this root (e.g. mixin scaffolding)
+        try:
+            if inspect.iscoroutinefunction(builder):
+                chart = asyncio.run(builder(substate))
+            else:
+                chart = builder(substate)
+            if level == "figure" and chart is not None:
+                _figure_of(chart)
+        except Exception as exc:
+            location = _builder_location(builder)
+            if _touches_session(builder):
+                warnings.warn(
+                    f"@reflex_xy.figure probe: {full_name} ({location}) reads the "
+                    f"session and failed against default state: {exc!r}. Probes "
+                    "validate what they can; pass probe=False to silence.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                continue
+            msg = (
+                f"@reflex_xy.figure probe failed for {full_name} ({location}): "
+                f"{type(exc).__name__}: {exc}. The builder ran against default "
+                "state at compile so this error would not wait for a browser "
+                "session; pass @reflex_xy.figure(probe=False) if this builder "
+                "cannot run outside a live session."
+            )
+            raise FigureProbeError(msg) from exc
+        probed.append(full_name)
+    return probed
+
+
 class XYPlugin(Plugin):
     """Reflex plugin: `plugins=[reflex_xy.XYPlugin()]` in rxconfig.py.
 
     `post_compile` is the one plugin hook that receives the live App, and it
     fires at backend worker startup — after the socket server exists, before
-    any client connects, and never during frontend-only compiles.
+    any client connects, and never during frontend-only compiles. It wires
+    the data plane and then runs the figure-builder compile probes (§3.1) so
+    escape-hatch builders fail `reflex run`, not the browser.
     """
 
     def post_compile(self, **context: Any) -> None:
         app = context.get("app")
         if app is not None:
             setup(app)
+            probe_figure_builders()
+
+
+def _token(source: "str | FigureHandle") -> str:
+    """Normalize a public figure argument (handle or bare token string)."""
+    token = token_of(source)
+    if token is None:
+        msg = f"expected a FigureHandle or figure token string, got {type(source).__name__}"
+        raise TypeError(msg)
+    return token
 
 
 def append(
-    token: str,
+    token: "str | FigureHandle",
     x: Any,
     y: Any,
     *,
@@ -103,26 +259,28 @@ def append(
     Thin alias for `registry.append` — see its docstring for the threading
     contract.
     """
-    registry.append(token, x, y, color=color, size=size, trace=trace)
+    registry.append(_token(token), x, y, color=color, size=size, trace=trace)
 
 
-def set_view(token: str, ranges: Any, *, animate: bool = True, history: bool = True) -> None:
+def set_view(
+    token: "str | FigureHandle", ranges: Any, *, animate: bool = True, history: bool = True
+) -> None:
     """Out-of-band programmatic view patch (view-state.md §5.2).
 
     Mirrors `append`: callable from any event handler, background task, or
     thread; one wire message pushed room-wide, applied by every client
     through the same clamped mutation path as a gesture, `source: "api"`.
     """
-    registry.set_view(token, ranges, animate=animate, history=history)
+    registry.set_view(_token(token), ranges, animate=animate, history=history)
 
 
-def reset_view(token: str, axes: Any = None) -> None:
+def reset_view(token: "str | FigureHandle", axes: Any = None) -> None:
     """Out-of-band navigation to the home ranges (room-wide)."""
-    registry.reset_view(token, axes)
+    registry.reset_view(_token(token), axes)
 
 
 def select(
-    token: str,
+    token: "str | FigureHandle",
     *,
     range: Any = None,
     polygon: Any = None,
@@ -132,12 +290,12 @@ def select(
     """Out-of-band programmatic selection (room-wide). Geometric forms
     resolve client-side like a gesture; `rows=` resolves kernel-side and is
     non-durable (see view-state.md §5.1)."""
-    registry.select(token, range=range, polygon=polygon, rows=rows, history=history)
+    registry.select(_token(token), range=range, polygon=polygon, rows=rows, history=history)
 
 
-def clear_selection(token: str) -> None:
+def clear_selection(token: "str | FigureHandle") -> None:
     """Out-of-band selection clear (room-wide)."""
-    registry.clear_selection(token)
+    registry.clear_selection(_token(token))
 
 
 def reset_setup_for_tests() -> None:

--- a/python/reflex_xy/assets/XYChart.jsx
+++ b/python/reflex_xy/assets/XYChart.jsx
@@ -1,8 +1,12 @@
 // XYChart: mount a xy figure inside a Reflex app.
 //
-// Two modes, one prop apart (spec/design/reflex-integration.md):
+// Two modes (spec/design/reflex-integration.md). Live subscriptions have
+// three spellings that reduce to one token: `figure` ({token} — the typed
+// FigureHandle), the deprecated bare `token` string, and the plan tier's
+// `plan` digest + `data` ({token} DataHandle), composed client-side as
+// `xyp1|<plan>|<data.token>` once the data handle hydrates.
 //
-// `token` (live) — this component does NOT open its own connection.
+// Live — this component does NOT open its own connection.
 // socket.io multiplexing reuses the app's engine.io websocket when the
 // manager options match, so `xySocket()` below constructs its `/_xy`
 // namespace socket with exactly the options Reflex's own `connect()` uses
@@ -259,6 +263,9 @@ const pointEnvelope = (type, token, row, extra = {}) => {
 export function XYChart(props) {
   const {
     token,
+    figure,
+    plan,
+    data,
     src,
     onPointHover,
     onPointClick,
@@ -276,6 +283,14 @@ export function XYChart(props) {
     ...divProps
   } = props;
   void _tailwindClassTokens;
+  // One subscription token from the three live spellings. `figure` is the
+  // typed handle ({token}); the bare `token` string is the deprecated wire.
+  // A plan digest + data handle compose the plan-tier token client-side, and
+  // only once the data handle is hydrated (empty token = not ready).
+  const figureToken = (figure && figure.token) || token || null;
+  const liveToken = (plan && data && data.token)
+    ? `xyp1|${plan}|${data.token}`
+    : figureToken;
   const elRef = useRef(null); // inner chart mount (wiped on payload swaps)
   const outerRef = useRef(null); // stable wrapper: events, tooltip slot
   const tooltipSlotRef = useRef(null);
@@ -284,7 +299,7 @@ export function XYChart(props) {
   const [hoverPayload, setHoverPayload] = useState(null);
   const hasTooltipChildrenRef = useRef(false);
   hasTooltipChildrenRef.current = Boolean(children);
-  dbg("render", { id: divProps.id, token: String(token).slice(0, 30), src });
+  dbg("render", { id: divProps.id, token: String(liveToken).slice(0, 30), src });
   // Live callback refs so socket handlers never close over stale props.
   const cbRef = useRef({});
   cbRef.current = {
@@ -398,8 +413,8 @@ export function XYChart(props) {
   // Live mode: subscribe on the shared websocket.
   useEffect(() => {
     const el = elRef.current;
-    dbg("effect run", { token: token && token.slice(0, 24), hasEl: !!el });
-    if (!token || src || !el) return undefined;
+    dbg("effect run", { token: liveToken && liveToken.slice(0, 24), hasEl: !!el });
+    if (!liveToken || src || !el) return undefined;
     const socket = xySocket();
     const mid = `m${nextMountId++}`;
     let view = null;
@@ -420,6 +435,11 @@ export function XYChart(props) {
     const viewCallbacks = [];
     const pendingStatePushes = [];
     let awaitingPayload = true;
+    // Consecutive server-initiated resyncs without an intervening payload.
+    // Bounds the retry loop when a resync can never succeed (e.g. a stale
+    // plan digest after hot-reload drift; the remount with the new digest
+    // resubscribes on its own).
+    let errResyncs = 0;
 
     const resetEpoch = () => {
       // Timer callbacks capture row/domain data from the preceding figure
@@ -445,14 +465,14 @@ export function XYChart(props) {
       // A reconnect can land on a fresh worker whose rebuilt figure starts at
       // version 1. Versions are monotonic only within this subscription epoch.
       resetEpoch();
-      socket.emit("sub", { fig: token, px: el.clientWidth || null, mid });
+      socket.emit("sub", { fig: liveToken, px: el.clientWidth || null, mid });
     };
 
     const emitMessage = (m) => {
       // socket.io flushes its sendBuffer before firing `connect`; never queue
       // an old-epoch request while the namespace is disconnected.
       if (awaitingPayload || !socket.connected) return;
-      const envelope = { fig: token, mid, m };
+      const envelope = { fig: liveToken, mid, m };
       if (payloadVersion !== null) envelope.v = payloadVersion;
       socket.emit("msg", envelope);
     };
@@ -499,7 +519,7 @@ export function XYChart(props) {
         const latest = pendingHover;
         pendingHover = null;
         if (!destroyed && latest && cbRef.current.onPointHover) {
-          cbRef.current.onPointHover(pointEnvelope("point_hover", token, latest));
+          cbRef.current.onPointHover(pointEnvelope("point_hover", liveToken, latest));
         }
       }, HOVER_THROTTLE_MS);
     };
@@ -509,7 +529,7 @@ export function XYChart(props) {
       cbRef.current.onViewChange({
         version: 1,
         type: "view_change",
-        token,
+        token: liveToken,
         x_domain: [m.x0, m.x1],
         y_domain: [m.y0, m.y1],
         source: m.source,
@@ -673,7 +693,7 @@ export function XYChart(props) {
       );
 
     const onPayload = (data) => {
-      if (destroyed || !data || data.fig !== token) return;
+      if (destroyed || !data || data.fig !== liveToken) return;
       // Direct subscription replies are mount-addressed; room-wide rebuild
       // broadcasts intentionally omit mid and remain visible to every mount.
       if (data.mid !== undefined && data.mid !== null && data.mid !== mid) return;
@@ -698,6 +718,7 @@ export function XYChart(props) {
         && payloadVersion !== null
         && data.version < payloadVersion
       ) return;
+      errResyncs = 0; // an applied payload proves resubscription works again
       const nextPayloadVersion = Number.isInteger(data.version) ? data.version : null;
       const sameGenerationAddressedReplacement =
         data.mid != null &&
@@ -781,7 +802,7 @@ export function XYChart(props) {
     };
 
     const onMsg = (data) => {
-      if (destroyed || !data || data.fig !== token) return;
+      if (destroyed || !data || data.fig !== liveToken) return;
       // Replies are mount-addressed; pushes (append) carry no mid.
       if (data.mid !== undefined && data.mid !== null && data.mid !== mid) return;
       const message = data.message;
@@ -831,7 +852,7 @@ export function XYChart(props) {
         if (!clickWasPending) return;
         if (message.type === "pick_result" && message.row) {
           cbRef.current.onPointClick?.(
-            pointEnvelope("point_click", token, message.row, clickInput || {}),
+            pointEnvelope("point_click", liveToken, message.row, clickInput || {}),
           );
         }
         return; // synthetic pick — not for the view
@@ -857,7 +878,7 @@ export function XYChart(props) {
           cbRef.current.onSelectEnd({
             version: 1,
             type: "select_end",
-            token,
+            token: liveToken,
             selection: {
               kind: cleared ? "clear" : (message.kind || "box"),
               mode: message.mode || "replace",
@@ -890,9 +911,12 @@ export function XYChart(props) {
     };
 
     const onErr = (data) => {
-      if (destroyed || !data || data.fig !== token) return;
+      if (destroyed || !data || data.fig !== liveToken) return;
       console.warn(`xy: ${data.error} (fig ${data.fig})`);
-      if (data.resync === true && socket.connected) subscribe();
+      if (data.resync === true && socket.connected && errResyncs < 5) {
+        errResyncs += 1;
+        subscribe();
+      }
     };
 
     const onDisconnect = () => {
@@ -907,7 +931,7 @@ export function XYChart(props) {
     // shared manager, rooms are gone and — on another backend node — the
     // figure itself may need a state-driven rebuild. `sub` triggers both.
     socket.on("connect", subscribe);
-    subCounts.set(token, (subCounts.get(token) || 0) + 1);
+    subCounts.set(liveToken, (subCounts.get(liveToken) || 0) + 1);
     if (socket.connected) subscribe();
 
     const rememberClick = (event) => {
@@ -938,12 +962,12 @@ export function XYChart(props) {
       socket.off("err", onErr);
       socket.off("disconnect", onDisconnect);
       socket.off("connect", subscribe);
-      const remaining = (subCounts.get(token) || 1) - 1;
+      const remaining = (subCounts.get(liveToken) || 1) - 1;
       if (remaining <= 0) {
-        subCounts.delete(token);
-        if (socket.connected) socket.emit("unsub", { fig: token, mid });
+        subCounts.delete(liveToken);
+        if (socket.connected) socket.emit("unsub", { fig: liveToken, mid });
       } else {
-        subCounts.set(token, remaining);
+        subCounts.set(liveToken, remaining);
       }
       reclaimTooltipSlot();
       if (view) view.destroy();
@@ -951,7 +975,7 @@ export function XYChart(props) {
       window.__xy_views?.delete(outerRef.current?.id || mid);
       el.replaceChildren();
     };
-  }, [token, src]);
+  }, [liveToken, src]);
 
   // One DOM node, two consumers: our mount logic and reflex's ref registry.
   const mergedRef = (node) => {

--- a/python/reflex_xy/component.py
+++ b/python/reflex_xy/component.py
@@ -1,12 +1,15 @@
 """The Reflex component: `reflex_xy.chart(...)`.
 
-One factory, three chart sources (spec/design/reflex-integration.md §5):
+One factory, two chart sources (spec/design/reflex-integration.md §5):
 
-    reflex_xy.chart(Dash.chart)            # @reflex_xy.figure state var (live)
-    reflex_xy.chart(some_token_string)     # register()/inline() token (live)
+    reflex_xy.chart(figure=Dash.chart)     # @reflex_xy.figure var / handle (live)
     reflex_xy.chart(xy.scatter_chart(...)) # a Chart directly (static tier)
 
-A live source compiles to the `token` prop and rides the shared-websocket
+The pre-handle positional forms — `chart(Dash.chart)` and
+`chart(token_string)` — remain as a deprecation shim for one release cycle.
+
+A live source compiles to the typed `figure` prop (`Var[FigureHandle]` —
+wrong vars and raw strings fail at compile) and rides the shared-websocket
 data plane. A `xy` Chart (or internal Figure) passed directly is
 compiled to a static payload asset (payload_asset.py) and lands in the
 `src` prop: the wrapper fetches the binary frame and runs the render client
@@ -37,6 +40,7 @@ chart renders, pans/zooms, and resolves hover tooltips client-side; its small
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Iterable, Mapping, Set
 from typing import Annotated, Any, Optional
 
@@ -45,10 +49,17 @@ import reflex as rx
 from xy.facets import FacetGrid
 
 from .assets import WRAPPER_TAG, register
+from .handles import DataHandle, FigureHandle
 from .payload_asset import payload_asset
 from .registry import _figure_of
 
 __all__ = ["chart"]
+
+#: Event props that need the interaction kernel: they only ever fire for
+#: live (token/figure) sources. A static payload (``src``) renders and
+#: navigates client-side, so these would be silent no-ops — refused at
+#: create() instead (see _validate_source_events).
+_KERNEL_EVENT_PROPS = ("on_point_hover", "on_point_click", "on_select_end")
 
 # Lazily-built component class (see module doc); Any because reflex Component
 # metaclasses defeat static typing of the create() classmethod.
@@ -66,9 +77,19 @@ def _build_component_cls() -> Any:
         library = wrapper_library
         tag = WRAPPER_TAG
 
-        # Live mode: the figure token minted by @reflex_xy.figure /
-        # register() / inline(). Exactly one of token/src is ever set.
+        # Live mode: the typed figure handle minted by @reflex_xy.figure /
+        # register() / inline(). ``Var[FigureHandle]`` makes a wrong var
+        # (``Dash.points``) or a raw string fail at create() — compile time
+        # (fact R1). Exactly one of figure/token/src is ever set.
+        figure: rx.Var[FigureHandle]
+        # Deprecated live mode: the bare token string. Kept for one release
+        # cycle; the wrapper accepts both (figure wins).
         token: rx.Var[str]
+        # Data-bound mode (plan tier): a compile-validated chart plan digest
+        # plus the DataHandle var whose columns it binds. The wrapper
+        # composes the ``xyp1|<digest>|<data token>`` subscription itself.
+        plan: rx.Var[str]
+        data: rx.Var[DataHandle]
         # Static mode: URL of a payload asset (XYBF frame) to render
         # kernel-less.
         src: rx.Var[str]
@@ -101,6 +122,26 @@ def _build_component_cls() -> Any:
         # works on static charts too. `on_point_hover` stays the narrow
         # legacy row form; new code uses this.
         on_hover: Annotated[rx.EventHandler, lambda payload: [payload]]
+
+        @classmethod
+        def create(cls, *children: Any, **props: Any) -> Any:
+            # Compile-time validation the framework can't do for us
+            # (recharts pattern, fact R5): kernel-backed events on a static
+            # source would be silent no-ops at runtime — fail the compile
+            # with the reason instead.
+            if props.get("src") is not None:
+                offenders = [name for name in _KERNEL_EVENT_PROPS if name in props]
+                if offenders:
+                    msg = (
+                        f"{', '.join(offenders)} need the interaction kernel and never "
+                        "fire on a static chart source (a Chart/Figure compiled to a "
+                        "payload asset). Serve the figure live instead — a "
+                        "@reflex_xy.figure state var, a data-bound factory chart, or "
+                        "register()/inline() — or drop the handler(s). Client-side "
+                        "events (on_hover, on_view_change) work on static charts."
+                    )
+                    raise ValueError(msg)
+            return super().create(*children, **props)
 
     # The class is created lazily inside this function; reflex derives JS
     # identifiers from __qualname__, and "<locals>" would leak an illegal
@@ -267,19 +308,41 @@ def _facet_grid(
     )
 
 
+def _is_handle_var(source: Any) -> bool:
+    """A Reflex Var whose declared value type is FigureHandle."""
+    var_type = getattr(source, "_var_type", None)
+    return isinstance(var_type, type) and issubclass(var_type, FigureHandle)
+
+
+def _warn_positional(replacement: str) -> None:
+    warnings.warn(
+        f"positional reflex_xy.chart(source) is deprecated for live sources; use {replacement}",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
 def chart(
-    source: Any,
+    source: Any = None,
     *,
+    figure: Any = None,
     tooltip: Any = None,
     tailwind_classes: Optional[str | Iterable[str]] = None,
     **props: Any,
 ) -> Any:
     """Place a xy chart.
 
-    `source` is a figure token (a `@reflex_xy.figure` state var, or a
-    `register()`/`inline()` token string) for a live, kernel-backed chart —
-    or a `xy` Chart/Figure directly, which renders as a static
-    payload asset with client-side interactivity only (see module doc).
+    ``figure=`` is the live, kernel-backed form: a ``@reflex_xy.figure``
+    state var, or the :class:`~reflex_xy.handles.FigureHandle` returned by
+    ``register()``/``inline()``. The prop is typed ``Var[FigureHandle]``, so
+    the wrong var or a raw string fails at compile with the framework's own
+    ``TypeError``.
+
+    A positional `source` remains supported: an ``xy`` Chart/Figure renders
+    as a static payload asset with client-side interactivity only (see
+    module doc; this is the static tier and stays positional), while
+    var/handle/token-string sources are the deprecated pre-handle spelling
+    of ``figure=`` and warn.
 
     `tooltip=` mounts a Reflex component as the chart tooltip: the render
     client positions it with the built-in tooltip's placement logic (the
@@ -299,7 +362,31 @@ def chart(
     """
     component_cls = _component()
     tailwind_manifest = _tailwind_class_tokens(tailwind_classes)
-    if isinstance(source, (str, rx.Var)):
+    if figure is not None and source is not None:
+        msg = "reflex_xy.chart() takes a positional source or figure=, not both"
+        raise TypeError(msg)
+    if figure is None and source is None:
+        msg = "reflex_xy.chart() needs a chart source: figure=, or a positional Chart/Figure"
+        raise TypeError(msg)
+    if figure is None and (
+        isinstance(source, FigureHandle) or (isinstance(source, rx.Var) and _is_handle_var(source))
+    ):
+        # Pre-handle spelling: the var/handle used to land in the str `token`
+        # prop. Handles ride the typed prop now; legacy str-typed vars keep
+        # the old wire path below.
+        _warn_positional("chart(figure=...)")
+        figure, source = source, None
+    if figure is not None:
+        props.setdefault("width", "100%")
+        props.setdefault("height", "420px")
+        props["figure"] = figure
+        if tailwind_manifest:
+            props["tailwind_class_tokens"] = _tailwind_scan_literal(tailwind_manifest)
+    elif isinstance(source, (str, rx.Var)):
+        _warn_positional(
+            "chart(figure=...) — register()/inline() return a FigureHandle, and "
+            "@reflex_xy.figure vars are FigureHandle-valued"
+        )
         props.setdefault("width", "100%")
         props.setdefault("height", "420px")
         props["token"] = source
@@ -310,8 +397,9 @@ def chart(
         # payload and its Tailwind scan manifest.  In particular, do not call
         # build_payload() just to discover classes: that would duplicate the
         # largest part of static-chart compilation.
-        if tooltip is None and callable(getattr(source, "chrome_components", None)):
-            tooltip = source.chrome_components().get("tooltip")
+        chrome_components = getattr(source, "chrome_components", None)
+        if tooltip is None and callable(chrome_components):
+            tooltip = chrome_components().get("tooltip")
         figure = _figure_of(source)
         if isinstance(figure, FacetGrid):
             return _facet_grid(
@@ -331,8 +419,9 @@ def chart(
             props["tailwind_class_tokens"] = _tailwind_scan_literal(class_manifest)
     else:
         msg = (
-            "reflex_xy.chart() takes a figure token (state var or string) or a "
-            f"xy Chart/Figure, got {type(source).__name__}"
+            "reflex_xy.chart() takes figure= (a @reflex_xy.figure var or "
+            "FigureHandle) or a positional xy Chart/Figure, got "
+            f"{type(source).__name__}"
         )
         raise TypeError(msg)
     if tooltip is not None:

--- a/python/reflex_xy/data_vars.py
+++ b/python/reflex_xy/data_vars.py
@@ -1,0 +1,233 @@
+"""`@reflex_xy.data`: a computed var that *is* the dataset registration.
+
+The data-plane sibling of `@reflex_xy.figure` (vars.py) for the data-bound
+component tier: the state method returns **columns only** — a mapping of
+column name to array-likes — so there is no chart API inside it to get
+wrong. Evaluating the var publishes the columns into the per-process
+registry under a deterministic token (`xyd1|<client>|<state>|<var>`) and
+its value is a tiny typed :class:`~reflex_xy.handles.DataHandle`. Reflex's
+dependency tracking watches the method body; a state change republishes the
+columns, and the registry rebuilds + broadcasts every mounted chart plan
+bound to them.
+
+The method's return annotation is the compile-time schema channel (fact
+R7): annotate a ``TypedDict`` and the class-level var carries
+``DataHandle[Schema]``, which the chart factories read column names from —
+without executing any user code. A plain ``dict[str, ...]`` annotation
+degrades gracefully to first-execution validation.
+
+Like figure builders, data methods must be pure functions of their state
+instance: the token is the rebuild recipe (state_bridge.py re-runs the
+method when a fresh worker needs the columns back), and purity is what
+makes the column set a rebuildable cache instead of precious process state.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable, Mapping
+from typing import Any, Optional, get_type_hints, is_typeddict, overload
+
+from reflex_base.vars.base import AsyncComputedVar, ComputedVar
+
+from .handles import DataHandle
+from .registry import registry
+from .tokens import BUILDER_ATTR, build_data_token
+
+__all__ = ["AsyncDataVar", "DataVar", "data", "validate_columns"]
+
+
+def _builder_target(var: Any, obj: Any) -> Any:
+    """Point dependency tracking at the *data method*, not the token wrapper
+    (same reason as vars.py: the wrapper fget reads nothing but the router)."""
+    if obj is not None:
+        return obj
+    return getattr(var._fget, BUILDER_ATTR, None)
+
+
+class DataVar(ComputedVar):
+    """ComputedVar whose value is a DataHandle (sync data method)."""
+
+    def _deps(self, objclass: Any, obj: Any = None) -> dict[str, set[str]]:
+        return ComputedVar._deps(self, objclass, obj=_builder_target(self, obj))
+
+
+class AsyncDataVar(AsyncComputedVar):
+    """AsyncComputedVar whose value is a DataHandle (async data method)."""
+
+    def _deps(self, objclass: Any, obj: Any = None) -> dict[str, set[str]]:
+        return AsyncComputedVar._deps(self, objclass, obj=_builder_target(self, obj))
+
+
+def validate_columns(columns: Any, *, source: str) -> dict[str, Any]:
+    """The only checks that need real data: a mapping of named, equal-length
+    array-like columns. Everything structural was validated at compile by the
+    plan's zero-row probe; dtype/shape details stay with figure compilation."""
+    if not isinstance(columns, Mapping):
+        raise TypeError(
+            f"{source} must return a mapping of column name -> values "
+            f"(e.g. a TypedDict of arrays), got {type(columns).__name__}"
+        )
+    validated: dict[str, Any] = {}
+    lengths: dict[str, int] = {}
+    for key, values in columns.items():
+        if not isinstance(key, str):
+            raise TypeError(f"{source} column names must be strings, got {key!r}")
+        if isinstance(values, (str, bytes, Mapping)):
+            raise TypeError(
+                f"{source} column {key!r} must be an array-like of values, "
+                f"got {type(values).__name__}"
+            )
+        try:
+            lengths[key] = len(values)
+        except TypeError as exc:
+            raise TypeError(
+                f"{source} column {key!r} must be an array-like with a length, "
+                f"got {type(values).__name__}"
+            ) from exc
+        validated[key] = values
+    if len(set(lengths.values())) > 1:
+        detail = ", ".join(f"{key}={length}" for key, length in lengths.items())
+        raise ValueError(f"{source} columns must share one length, got {detail}")
+    return validated
+
+
+def _mint_token(state: Any, var_name: str) -> Optional[str]:
+    client_token = state.router.session.client_token
+    if not client_token:
+        return None
+    return build_data_token(client_token, type(state).get_full_name(), var_name)
+
+
+def _publish(token: str, columns: Any, *, source: str) -> DataHandle:
+    if columns is None:
+        registry.release_columns(token)
+        return DataHandle("")
+    registry.publish_columns(token, validate_columns(columns, source=source))
+    return DataHandle(token)
+
+
+def _source_label(method: Callable[..., Any]) -> str:
+    qualname = getattr(method, "__qualname__", None) or getattr(method, "__name__", "data method")
+    return qualname.rsplit(".<locals>.", 1)[-1]
+
+
+def _adopt_identity(fget: Any, method: Callable[..., Any], name: str) -> None:
+    fget.__name__ = name
+    fget.__qualname__ = getattr(method, "__qualname__", name)
+    fget.__module__ = getattr(method, "__module__", fget.__module__)
+    fget.__doc__ = method.__doc__
+    setattr(fget, BUILDER_ATTR, method)
+
+
+def _make_fget(method: Callable[[Any], Any]) -> Callable[[Any], DataHandle]:
+    name = _fn_name(method)
+    source = _source_label(method)
+
+    def fget(self: Any) -> DataHandle:
+        token = _mint_token(self, name)
+        if token is None:
+            return DataHandle("")
+        return _publish(token, method(self), source=source)
+
+    _adopt_identity(fget, method, name)
+    return fget
+
+
+def _make_async_fget(method: Callable[[Any], Any]) -> Callable[[Any], Any]:
+    name = _fn_name(method)
+    source = _source_label(method)
+
+    async def fget(self: Any) -> DataHandle:
+        token = _mint_token(self, name)
+        if token is None:
+            return DataHandle("")
+        return _publish(token, await method(self), source=source)
+
+    _adopt_identity(fget, method, name)
+    return fget
+
+
+def _fn_name(fn: Callable[..., Any]) -> str:
+    name = getattr(fn, "__name__", "")
+    if not name:
+        msg = f"@reflex_xy.data methods must be named functions, got {fn!r}"
+        raise TypeError(msg)
+    return name
+
+
+def _return_type(method: Callable[..., Any]) -> Any:
+    """``DataHandle[Schema]`` when the return annotation is a TypedDict —
+    the schema survives as the class-level var's ``_var_type`` (R7) and is
+    how the factories compile-check column names. Anything else (plain
+    dicts, missing or unresolvable annotations) degrades to ``DataHandle``:
+    columns are then validated on first execution instead."""
+    try:
+        hints = get_type_hints(method)
+    except Exception:  # noqa: BLE001 - annotations may reference unimportable names
+        return DataHandle
+    annotation = hints.get("return")
+    if annotation is not None and is_typeddict(annotation):
+        return DataHandle[annotation]
+    return DataHandle
+
+
+@overload
+def data(method: Callable[[Any], Any]) -> "DataVar | AsyncDataVar": ...
+
+
+@overload
+def data(
+    method: None = None, **var_kwargs: Any
+) -> Callable[[Callable[[Any], Any]], "DataVar | AsyncDataVar"]: ...
+
+
+def data(
+    method: Optional[Callable[[Any], Any]] = None, **var_kwargs: Any
+) -> "DataVar | AsyncDataVar | Callable[[Callable[[Any], Any]], DataVar | AsyncDataVar]":
+    """Declare a chart dataset on a Reflex state class.
+
+    Usage::
+
+        class CloudData(TypedDict):
+            x: np.ndarray
+            y: np.ndarray
+            mag: np.ndarray
+
+        class Dash(rx.State):
+            points: int = 200_000
+
+            @reflex_xy.data
+            def cloud(self) -> CloudData:
+                rng = np.random.default_rng(7)
+                x = rng.normal(size=self.points)
+                return {"x": x, "y": x * 0.6, "mag": np.abs(x)}
+
+        # in the page:
+        #   reflex_xy.scatter_chart(data=Dash.cloud, x="x", y="y", color="mag")
+
+    The method must return a mapping of column name -> equal-length
+    array-likes, or ``None`` for "no data right now" (which releases the
+    registered columns and yields the empty handle). ``async def`` methods
+    become ``AsyncDataVar``s (same dispatch rule as ``rx.var``); keyword
+    arguments pass through to reflex's computed var (``deps=``,
+    ``interval=``, ...).
+    """
+
+    def _decorate(fn: Callable[[Any], Any]) -> "DataVar | AsyncDataVar":
+        if _fn_name(fn).startswith("_"):
+            # Same rule as figure vars: the handle must sync to the client,
+            # and backend (underscore) vars never do.
+            msg = (
+                "@reflex_xy.data vars must not start with '_' (the handle must sync to the client)"
+            )
+            raise ValueError(msg)
+        var_kwargs.setdefault("cache", True)
+        return_type = _return_type(fn)
+        if inspect.iscoroutinefunction(fn):
+            return AsyncDataVar(fget=_make_async_fget(fn), return_type=return_type, **var_kwargs)
+        return DataVar(fget=_make_fget(fn), return_type=return_type, **var_kwargs)
+
+    if method is None:
+        return _decorate
+    return _decorate(method)

--- a/python/reflex_xy/factories.py
+++ b/python/reflex_xy/factories.py
@@ -1,0 +1,489 @@
+"""Data-bound chart factories: the component-shaped `reflex_xy` chart API.
+
+The flat, single-mark form (Level 1 of
+spec/design/reflex-component-api-options.md §5.6)::
+
+    reflex_xy.scatter_chart(
+        data=Dash.cloud,                 # @reflex_xy.data var (columns only)
+        x="x", y="y", color="mag",       # channels: column-name strings
+        colormap="viridis",              # mark options, validated at compile
+        x_axis=reflex_xy.x_axis(label="σ"),
+        height="460px",
+        on_select_end=Dash.select,
+    )
+
+and the composed, multi-mark form (Level 2)::
+
+    reflex_xy.chart(
+        reflex_xy.scatter(x="x", y="y", color="mag"),
+        reflex_xy.line(x="x", y="trend", width=2),
+        reflex_xy.x_axis(label="Time"),
+        data=Dash.cloud,
+        height="460px",
+    )
+
+Both compile the real xy tree at page evaluation, run the zero-row probe
+(`plan.py` — the full mark/config validation gate, X1/X2), check channel
+names against the data var's TypedDict schema (R7), and mount the private
+component with a `plan` digest plus the `data` handle var. Marks and chrome
+are plain xy dataclass nodes — they never enter the Reflex tree
+(Reflex child validation would refuse them; design decision 1 in the
+options doc §5.6), which is why `chart(...)` here is a factory consuming
+nodes, not a component taking children.
+
+The kwarg partition of the flat form is **derived from signatures**, not
+hand-listed: positional mark params are channels, keyword-only params are
+options (xy's uniform convention), `Chart.__init__` provides the
+chart-level names, and a small reserved set belongs to the component.
+Colliding mark options get flat aliases (`stroke_width` for `line`'s
+`width`, `mark_<name>` otherwise); the resulting table is pinned by
+`tests/reflex_adapter/test_factories.py` as public contract. Unknown
+kwargs near a known name error with a suggestion; anything else falls
+through to the component as CSS, preserving Reflex's style convention
+(the R8 hazard this partition exists to compensate for).
+"""
+
+from __future__ import annotations
+
+import difflib
+import inspect
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Optional, get_args, get_origin, get_type_hints, is_typeddict
+
+import reflex as rx
+
+import xy as _xy
+from xy.components import Axis, Chart, Component, Legend, Theme
+
+from .component import (
+    _component,
+    _merge_tailwind_class_tokens,
+    _tailwind_class_manifest,
+    _tailwind_class_tokens,
+    _tailwind_scan_literal,
+)
+from .data_vars import validate_columns
+from .handles import DataHandle
+from .payload_asset import payload_asset
+from .plan import ChartPlan, build_plan
+
+__all__ = [
+    "area_chart",
+    "bar_chart",
+    "chart",
+    "column_chart",
+    "error_band_chart",
+    "errorbar_chart",
+    "histogram_chart",
+    "line_chart",
+    "scatter_chart",
+    "segments_chart",
+    "step_chart",
+]
+
+#: Event triggers of the private XYChart component. Pinned against the
+#: component class by tests so the two can never drift.
+EVENT_TRIGGERS = frozenset(
+    {
+        "on_point_hover",
+        "on_point_click",
+        "on_select_end",
+        "on_view_change",
+        "on_hover",
+        "on_animation_start",
+        "on_animation_end",
+    }
+)
+
+#: Names the component level owns in the flat form (the collision table's
+#: "component/chart level wins" rule). A mark option with one of these names
+#: is reachable through its generated alias instead.
+COMPONENT_RESERVED = frozenset(
+    {
+        "width",
+        "height",
+        "opacity",
+        "style",
+        "class_name",
+        "key",
+        "animation",
+        "id",
+        "data",
+        "figure",
+        "token",
+        "plan",
+        "src",
+        "tooltip",
+        "tailwind_classes",
+    }
+)
+
+#: Chrome slots the flat form accepts as kwargs. x_axis/y_axis are
+#: type-dispatched: an Axis node is chrome, a string is the mark's axis id.
+_CHROME_KWARGS = ("x_axis", "y_axis", "legend", "theme")
+
+#: Chart.__init__ params that never partition to the chart tier: identity /
+#: children / data are factory-owned; width/height/class_name/style collide
+#: with the component (which wins); the on_* callables are the notebook
+#: callback API — in Reflex, on_* means event-trigger props.
+_CHART_EXCLUDED = frozenset(
+    {
+        "self",
+        "kind",
+        "children",
+        "data",
+        "width",
+        "height",
+        "class_name",
+        "style",
+        "on_hover",
+        "on_click",
+        "on_brush",
+        "on_select",
+        "on_view_change",
+    }
+)
+
+CHART_PARAMS = frozenset(
+    name for name in inspect.signature(Chart.__init__).parameters if name not in _CHART_EXCLUDED
+)
+
+
+def _mark_aliases(mark_params: frozenset[str]) -> dict[str, str]:
+    """Generated flat aliases for mark options shadowed by the component.
+
+    ``width`` prefers the natural ``stroke_width`` when the mark hasn't
+    already claimed it (line's stroke width *is* its width); everything else
+    is uniformly ``mark_<name>``.
+    """
+    aliases: dict[str, str] = {}
+    for name in sorted(mark_params & COMPONENT_RESERVED):
+        if name == "width" and "stroke_width" not in mark_params:
+            aliases["stroke_width"] = name
+        else:
+            aliases[f"mark_{name}"] = name
+    return aliases
+
+
+@dataclass(frozen=True)
+class _FlatKind:
+    """One flat factory's derived partition."""
+
+    chart_kind: str
+    mark_factory: Any
+    mark_params: frozenset[str]  # real mark kwargs (data excluded)
+    aliases: dict[str, str]  # flat alias -> real mark param
+
+    @property
+    def flat_mark_params(self) -> frozenset[str]:
+        plain = self.mark_params - COMPONENT_RESERVED - {"x_axis", "y_axis"}
+        return plain | frozenset(self.aliases)
+
+    @property
+    def known(self) -> frozenset[str]:
+        return (
+            self.flat_mark_params
+            | CHART_PARAMS
+            | COMPONENT_RESERVED
+            | frozenset(_CHROME_KWARGS)
+            | EVENT_TRIGGERS
+        )
+
+
+def _flat_kind(chart_kind: str, mark_factory: Any) -> _FlatKind:
+    params = frozenset(inspect.signature(mark_factory).parameters) - {"data"}
+    return _FlatKind(
+        chart_kind=chart_kind,
+        mark_factory=mark_factory,
+        mark_params=params,
+        aliases=_mark_aliases(params),
+    )
+
+
+FLAT_KINDS: dict[str, _FlatKind] = {
+    kind.chart_kind: kind
+    for kind in (
+        _flat_kind("scatter_chart", _xy.scatter),
+        _flat_kind("line_chart", _xy.line),
+        _flat_kind("histogram_chart", _xy.histogram),
+        _flat_kind("bar_chart", _xy.bar),
+        _flat_kind("area_chart", _xy.area),
+        _flat_kind("step_chart", _xy.step),
+        _flat_kind("stem_chart", _xy.stem),
+        _flat_kind("column_chart", _xy.column),
+        _flat_kind("errorbar_chart", _xy.errorbar),
+        _flat_kind("error_band_chart", _xy.error_band),
+        _flat_kind("segments_chart", _xy.segments),
+    )
+}
+
+
+def _suggest(name: str, candidates: frozenset[str]) -> Optional[str]:
+    matches = difflib.get_close_matches(name, sorted(candidates), n=1, cutoff=0.8)
+    return matches[0] if matches else None
+
+
+def _partition_flat(
+    kind: _FlatKind, kwargs: dict[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any], list[Component], dict[str, Any]]:
+    """Split flat kwargs into (mark, chart, chrome children, component)."""
+    mark_kwargs: dict[str, Any] = {}
+    chart_kwargs: dict[str, Any] = {}
+    chrome: list[Component] = []
+    component_kwargs: dict[str, Any] = {}
+    for name, value in kwargs.items():
+        if name in ("x_axis", "y_axis"):
+            # Type-dispatched collision: an Axis node is a chrome child, a
+            # string is the mark's axis-id option.
+            if isinstance(value, Axis):
+                chrome.append(value)
+            elif isinstance(value, str):
+                mark_kwargs[name] = value
+            else:
+                msg = (
+                    f"{kind.chart_kind}() {name}= takes an axis node "
+                    f"(reflex_xy.{name}(...)) or an axis-id string, got {type(value).__name__}"
+                )
+                raise TypeError(msg)
+        elif name == "legend":
+            if isinstance(value, Legend):
+                chrome.append(value)
+            elif isinstance(value, bool):
+                chrome.append(_xy.legend(show=value))
+            else:
+                msg = (
+                    f"{kind.chart_kind}() legend= takes reflex_xy.legend(...) or a bool, "
+                    f"got {type(value).__name__}"
+                )
+                raise TypeError(msg)
+        elif name == "theme":
+            if not isinstance(value, Theme):
+                msg = (
+                    f"{kind.chart_kind}() theme= takes reflex_xy.theme(...), "
+                    f"got {type(value).__name__}"
+                )
+                raise TypeError(msg)
+            chrome.append(value)
+        elif name in EVENT_TRIGGERS or name in COMPONENT_RESERVED:
+            component_kwargs[name] = value
+        elif name in kind.aliases:
+            mark_kwargs[kind.aliases[name]] = value
+        elif name in kind.mark_params:
+            mark_kwargs[name] = value
+        elif name in CHART_PARAMS:
+            chart_kwargs[name] = value
+        elif name.startswith("on_"):
+            # Let the framework's create() raise its ValueError listing the
+            # valid triggers (R8) — unless a near-miss lets us say better.
+            suggestion = _suggest(name, EVENT_TRIGGERS)
+            if suggestion is not None:
+                msg = (
+                    f"{kind.chart_kind}() got an unexpected event {name!r}; "
+                    f"did you mean {suggestion!r}?"
+                )
+                raise TypeError(msg)
+            component_kwargs[name] = value
+        else:
+            suggestion = _suggest(name, kind.known)
+            if suggestion is not None:
+                msg = (
+                    f"{kind.chart_kind}() got an unexpected keyword {name!r}; "
+                    f"did you mean {suggestion!r}?"
+                )
+                raise TypeError(msg)
+            # Far from everything chart-shaped: Reflex's CSS convention.
+            component_kwargs[name] = value
+    return mark_kwargs, chart_kwargs, chrome, component_kwargs
+
+
+def _data_var_label(data: Any) -> str:
+    declared = getattr(data, "_original", data)
+    name = getattr(declared, "_name", None)
+    return f"data var {name!r}" if isinstance(name, str) and name else "the data var"
+
+
+def _schema_columns(data: Any) -> Optional[frozenset[str]]:
+    """Column names carried by a ``DataHandle[Schema]``-typed var, if any."""
+    var_type = getattr(data, "_var_type", None)
+    if var_type is None or get_origin(var_type) is not DataHandle:
+        return None
+    args = get_args(var_type)
+    if len(args) != 1 or not is_typeddict(args[0]):
+        return None
+    try:
+        return frozenset(get_type_hints(args[0]))
+    except Exception:  # noqa: BLE001 - schema annotations may not resolve here
+        return None
+
+
+def _check_schema(plan: ChartPlan, data: Any) -> None:
+    """R7 compile check: every bound channel exists in the declared schema."""
+    schema = _schema_columns(data)
+    if schema is None:
+        return
+    unknown = [name for name in plan.columns if name not in schema]
+    if unknown:
+        label = _data_var_label(data)
+        names = ", ".join(repr(name) for name in unknown)
+        available = ", ".join(sorted(schema))
+        noun = "columns" if len(unknown) > 1 else "column"
+        msg = f"unknown {noun} {names} for {label}. Available columns: {available}"
+        raise ValueError(msg)
+
+
+def _mount(plan: ChartPlan, data: Any, component_kwargs: dict[str, Any]) -> Any:
+    """Attach a compiled plan to its data source and build the component."""
+    component_cls = _component()
+    tooltip = component_kwargs.pop("tooltip", None)
+    explicit_tailwind = _tailwind_class_tokens(component_kwargs.pop("tailwind_classes", None))
+    component_kwargs.setdefault("width", "100%")
+    component_kwargs.setdefault("height", "420px")
+
+    if isinstance(data, (rx.Var, DataHandle)):
+        # Live plan tier: digest baked into the JSX, columns resolved from
+        # the handle at hydrate. The zero-row probe already inventoried the
+        # chart's DOM classes, so live charts get automatic Tailwind
+        # discovery (merged with any explicit inventory).
+        component_kwargs["plan"] = plan.digest
+        component_kwargs["data"] = data
+        manifest = _merge_tailwind_class_tokens(plan.tailwind_classes, explicit_tailwind)
+        if manifest:
+            component_kwargs["tailwind_class_tokens"] = _tailwind_scan_literal(manifest)
+    elif isinstance(data, Mapping):
+        # Static tier: concrete columns bind now; the figure compiles to a
+        # payload asset and renders kernel-less (works under `reflex export`).
+        columns = validate_columns(data, source="data=")
+        figure = plan.bind(columns, source="data=").figure()
+        component_kwargs["src"] = payload_asset(figure)
+        manifest = _merge_tailwind_class_tokens(_tailwind_class_manifest(figure), explicit_tailwind)
+        if manifest:
+            component_kwargs["tailwind_class_tokens"] = _tailwind_scan_literal(manifest)
+    elif data is None:
+        msg = (
+            "data= is required: pass a @reflex_xy.data state var for a live "
+            "chart, or a concrete mapping of columns for a static one"
+        )
+        raise TypeError(msg)
+    else:
+        msg = (
+            "data= takes a @reflex_xy.data state var, a DataHandle, or a "
+            f"concrete mapping of columns, got {type(data).__name__}"
+        )
+        raise TypeError(msg)
+    if tooltip is not None:
+        return component_cls.create(tooltip, **component_kwargs)
+    return component_cls.create(**component_kwargs)
+
+
+def _flat_chart(kind: _FlatKind, data: Any, kwargs: dict[str, Any]) -> Any:
+    mark_kwargs, chart_kwargs, chrome, component_kwargs = _partition_flat(kind, kwargs)
+    mark = kind.mark_factory(**mark_kwargs)
+    plan = build_plan(kind.chart_kind, (mark, *chrome), chart_kwargs)
+    _check_schema(plan, data)
+    return _mount(plan, data, component_kwargs)
+
+
+def scatter_chart(*, data: Any = None, **kwargs: Any) -> Any:
+    """A data-bound scatter chart (flat form; see module doc)."""
+    return _flat_chart(FLAT_KINDS["scatter_chart"], data, kwargs)
+
+
+def line_chart(*, data: Any = None, **kwargs: Any) -> Any:
+    """A data-bound line chart (flat form; see module doc)."""
+    return _flat_chart(FLAT_KINDS["line_chart"], data, kwargs)
+
+
+def histogram_chart(*, data: Any = None, **kwargs: Any) -> Any:
+    """A data-bound histogram (flat form; see module doc)."""
+    return _flat_chart(FLAT_KINDS["histogram_chart"], data, kwargs)
+
+
+def bar_chart(*, data: Any = None, **kwargs: Any) -> Any:
+    """A data-bound bar chart (flat form; see module doc)."""
+    return _flat_chart(FLAT_KINDS["bar_chart"], data, kwargs)
+
+
+def area_chart(*, data: Any = None, **kwargs: Any) -> Any:
+    """A data-bound area chart (flat form; see module doc)."""
+    return _flat_chart(FLAT_KINDS["area_chart"], data, kwargs)
+
+
+def step_chart(*, data: Any = None, **kwargs: Any) -> Any:
+    """A data-bound step chart (flat form; see module doc)."""
+    return _flat_chart(FLAT_KINDS["step_chart"], data, kwargs)
+
+
+def stem_chart(*, data: Any = None, **kwargs: Any) -> Any:
+    """A data-bound stem chart (flat form; see module doc)."""
+    return _flat_chart(FLAT_KINDS["stem_chart"], data, kwargs)
+
+
+def column_chart(*, data: Any = None, **kwargs: Any) -> Any:
+    """A data-bound column chart (flat form; see module doc)."""
+    return _flat_chart(FLAT_KINDS["column_chart"], data, kwargs)
+
+
+def errorbar_chart(*, data: Any = None, **kwargs: Any) -> Any:
+    """A data-bound errorbar chart (flat form; see module doc)."""
+    return _flat_chart(FLAT_KINDS["errorbar_chart"], data, kwargs)
+
+
+def error_band_chart(*, data: Any = None, **kwargs: Any) -> Any:
+    """A data-bound error-band chart (flat form; see module doc)."""
+    return _flat_chart(FLAT_KINDS["error_band_chart"], data, kwargs)
+
+
+def segments_chart(*, data: Any = None, **kwargs: Any) -> Any:
+    """A data-bound segments chart (flat form; see module doc)."""
+    return _flat_chart(FLAT_KINDS["segments_chart"], data, kwargs)
+
+
+def chart(*sources: Any, data: Any = None, **kwargs: Any) -> Any:
+    """Place a chart: composed xy nodes (data-bound), or the component tiers.
+
+    With xy mark/annotation/chrome nodes, this is the composed data-bound
+    form (Level 2): the nodes are compiled into a plan against ``data=``.
+    With ``figure=`` or a positional Chart/Figure/token source, it is the
+    rendering component of the escape hatch and static tiers —
+    `component.chart` (§5 of reflex-integration.md), unchanged.
+    """
+    if sources and all(isinstance(source, Component) for source in sources):
+        first = sources[0]
+        if not (callable(getattr(first, "figure", None)) or isinstance(first, Chart)):
+            return _composed_chart(sources, data, kwargs)
+    from .component import chart as component_chart
+
+    if data is not None:
+        msg = (
+            "chart() with data= takes xy mark/chrome nodes "
+            "(e.g. chart(reflex_xy.scatter('x', 'y'), data=Dash.cloud))"
+        )
+        raise TypeError(msg)
+    return component_chart(*sources, **kwargs)
+
+
+def _composed_chart(nodes: tuple[Component, ...], data: Any, kwargs: dict[str, Any]) -> Any:
+    """Level 2: consume plain xy nodes, compile the plan, mount the component."""
+    chart_kwargs: dict[str, Any] = {}
+    component_kwargs: dict[str, Any] = {}
+    for name, value in kwargs.items():
+        if name in EVENT_TRIGGERS or name in COMPONENT_RESERVED:
+            component_kwargs[name] = value
+        elif name in CHART_PARAMS:
+            chart_kwargs[name] = value
+        elif name.startswith("on_"):
+            suggestion = _suggest(name, EVENT_TRIGGERS)
+            if suggestion is not None:
+                msg = f"chart() got an unexpected event {name!r}; did you mean {suggestion!r}?"
+                raise TypeError(msg)
+            component_kwargs[name] = value
+        else:
+            suggestion = _suggest(name, CHART_PARAMS | COMPONENT_RESERVED | EVENT_TRIGGERS)
+            if suggestion is not None:
+                msg = f"chart() got an unexpected keyword {name!r}; did you mean {suggestion!r}?"
+                raise TypeError(msg)
+            component_kwargs[name] = value
+    plan = build_plan("chart", tuple(nodes), chart_kwargs)
+    _check_schema(plan, data)
+    return _mount(plan, data, component_kwargs)

--- a/python/reflex_xy/handles.py
+++ b/python/reflex_xy/handles.py
@@ -1,0 +1,82 @@
+"""Typed handles: the values chart-related state vars carry.
+
+The integration keeps figures and columns in the per-process registry;
+Reflex state only ever holds a small *handle* wrapping the registry token
+(spec/design/reflex-integration.md §5). Wrapping the token in a frozen
+dataclass instead of a bare ``str`` is what gives the component seam a
+compile-time type: ``XYChart.figure`` / ``XYChart.data`` are ``Var[T]``
+props, so passing the wrong var (``Dash.points``) or a raw string fails at
+``create()`` — page evaluation — with the framework's own ``TypeError``
+(design facts R1/R7, pinned in tests/reflex_adapter/test_framework_contracts.py).
+
+``DataHandle`` is generic over the data method's return annotation:
+``DataHandle[CloudData]`` survives as the class-level Var's ``_var_type``,
+which is the schema channel the flat factories read column names from —
+without executing any user code.
+
+The empty token is the "not ready / no chart" sentinel (pre-hydration, or a
+builder returning ``None``), so the var types stay non-optional.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+import reflex as rx
+
+__all__ = ["DataHandle", "FigureHandle"]
+
+S = TypeVar("S")
+
+
+@dataclass(frozen=True)
+class FigureHandle:
+    """Reference to a registered figure; ``token`` is the registry key."""
+
+    token: str = ""
+
+    def __bool__(self) -> bool:
+        return bool(self.token)
+
+
+@dataclass(frozen=True)
+class DataHandle(Generic[S]):
+    """Reference to a registered column set; ``token`` is the registry key.
+
+    The type parameter carries the data method's declared schema (a
+    ``TypedDict``) purely at the annotation level.
+    """
+
+    token: str = ""
+
+    def __bool__(self) -> bool:
+        return bool(self.token)
+
+
+# Serializers keep the state-delta path a plain dict (and make reflex's
+# guess_type treat handle-valued vars as object vars).
+
+
+@rx.serializer
+def serialize_figure_handle(handle: FigureHandle) -> dict:
+    return {"token": handle.token}
+
+
+@rx.serializer
+def serialize_data_handle(handle: DataHandle) -> dict:
+    return {"token": handle.token}
+
+
+def token_of(source: object) -> str | None:
+    """The token string of a handle or raw-string source; None otherwise.
+
+    The one-cycle compatibility seam: public helpers that take "a figure"
+    (``append``, ``set_view``, ``release``, ...) accept both a handle and the
+    old-style bare token string through this normalizer.
+    """
+    if isinstance(source, (FigureHandle, DataHandle)):
+        return source.token
+    if isinstance(source, str):
+        return source
+    return None

--- a/python/reflex_xy/namespace.py
+++ b/python/reflex_xy/namespace.py
@@ -39,14 +39,16 @@ from __future__ import annotations
 import asyncio
 import urllib.parse
 from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
 from socketio import AsyncNamespace
 
 from xy.channel import handle_message
 
+from .plan import PlanError, PlanMissError
 from .registry import FigureEntry, FigureRegistry
-from .tokens import parse_token
+from .tokens import parse_plan_token, parse_token
 
 if TYPE_CHECKING:
     from xy._figure import Figure
@@ -104,7 +106,43 @@ def _handle_entry_message(entry: FigureEntry, content: Any) -> Any:
 
 # An async callable(token) -> Figure | None: given a parseable figure token,
 # rebuild the figure from Reflex state (wired by app.setup; see state_bridge).
+# May raise PlanError subclasses for spec-aware err frames.
 RebuildHook = Callable[[str], Awaitable[Optional["Figure"]]]
+
+
+@dataclass(frozen=True)
+class _RebuildFailure:
+    """Client-facing outcome of a failed rebuild attempt."""
+
+    error: str
+    resync: bool = False
+
+
+@dataclass(frozen=True)
+class _TokenIdentity:
+    """What a figure token reveals: session affinity and rebuildability."""
+
+    affinity_client: Optional[str]
+    rebuildable: bool
+    plan_bound: Optional[tuple[str, str]] = None  # (data_token, digest)
+
+
+def _token_identity(token: str) -> _TokenIdentity:
+    composite = parse_plan_token(token)
+    if composite is not None:
+        return _TokenIdentity(
+            affinity_client=composite.data.client_token,
+            rebuildable=True,
+            plan_bound=(composite.data_token, composite.digest),
+        )
+    parsed = parse_token(token)
+    if parsed is not None and parsed.kind == "figure":
+        return _TokenIdentity(affinity_client=parsed.client_token, rebuildable=True)
+    if parsed is not None:
+        # A bare data token names columns, never a figure: enforce affinity
+        # (it embeds a session) but never serve or rebuild it as one.
+        return _TokenIdentity(affinity_client=parsed.client_token, rebuildable=False)
+    return _TokenIdentity(affinity_client=None, rebuildable=False)
 
 
 def _plain(value: Any) -> Any:
@@ -159,7 +197,7 @@ class XYNamespace(AsyncNamespace):
         # room fan-out, so one cancelled waiter cannot cancel the attempt and
         # a failed builder is not rerun serially by every existing waiter.
         self._rebuild_attempts: dict[
-            str, asyncio.Task[tuple[Optional[FigureEntry], Optional[str]]]
+            str, asyncio.Task[tuple[Optional[FigureEntry], Optional[_RebuildFailure]]]
         ] = {}
 
     # -- connection lifecycle ------------------------------------------------
@@ -208,7 +246,13 @@ class XYNamespace(AsyncNamespace):
                 # path has proved the SID is still live. A concurrent
                 # disconnect can now only remove this record, never precede
                 # and be undone by it.
-                self.registry.subscribe(token, sid, rebuildable=parse_token(token) is not None)
+                identity = _token_identity(token)
+                self.registry.subscribe(token, sid, rebuildable=identity.rebuildable)
+                if identity.plan_bound is not None:
+                    # Index the mounted plan before serving, so a column
+                    # republish racing this subscribe rebuilds it (the
+                    # re-read below then serves that fresher generation).
+                    self.registry.bind_plan(*identity.plan_bound)
                 # A normal state publish can replace a just-rebuilt entry
                 # while its room-wide broadcast is still completing, before
                 # this SID joins. Re-read after the join: replacements before
@@ -438,7 +482,7 @@ class XYNamespace(AsyncNamespace):
 
     def _start_rebuild_attempt(
         self, token: str
-    ) -> asyncio.Task[tuple[Optional[FigureEntry], Optional[str]]]:
+    ) -> asyncio.Task[tuple[Optional[FigureEntry], Optional[_RebuildFailure]]]:
         """Start and retain one shared cache-miss attempt for ``token``."""
         # Install the guard before publishing the task in ``_rebuild_attempts``.
         # A concurrent waiter can then distinguish this live attempt from one
@@ -447,7 +491,9 @@ class XYNamespace(AsyncNamespace):
         task = asyncio.create_task(self._run_rebuild_attempt(token, entry, guard))
         self._rebuild_attempts[token] = task
 
-        def forget(completed: asyncio.Task[tuple[Optional[FigureEntry], Optional[str]]]) -> None:
+        def forget(
+            completed: asyncio.Task[tuple[Optional[FigureEntry], Optional[_RebuildFailure]]],
+        ) -> None:
             if self._rebuild_attempts.get(token) is completed:
                 self._rebuild_attempts.pop(token, None)
 
@@ -459,19 +505,26 @@ class XYNamespace(AsyncNamespace):
         token: str,
         entry: Optional[FigureEntry],
         guard: Optional[object],
-    ) -> tuple[Optional[FigureEntry], Optional[str]]:
+    ) -> tuple[Optional[FigureEntry], Optional[_RebuildFailure]]:
         """Build, conditionally publish, and fan out one total rebuild attempt."""
+        unknown = _RebuildFailure("unknown figure token")
         if entry is not None:
             return entry, None
         if guard is None:  # defensive: a miss always receives one bounded guard
-            return None, "unknown figure token"
+            return None, unknown
 
         try:
             rebuild = self._rebuild
             if rebuild is None:
-                return None, "unknown figure token"
+                return None, unknown
             try:
                 figure = await rebuild(token)
+            except PlanError as exc:
+                # Spec-aware failures of the data-bound tier: a stale plan
+                # digest asks the client to resync (the recompiled page
+                # carries the new digest); a bind mismatch names both sides
+                # and is not retryable as-is.
+                return None, _RebuildFailure(str(exc), resync=isinstance(exc, PlanMissError))
             except Exception:  # noqa: BLE001 - user builder code is an input boundary
                 figure = None
 
@@ -480,12 +533,12 @@ class XYNamespace(AsyncNamespace):
                 # awaiting. Use it instead of reporting a stale rebuild failure.
                 entry = self.registry.get(token)
                 if entry is None:
-                    return None, "unknown figure token"
+                    return None, unknown
                 return entry, None
 
             entry, inserted = self.registry.publish_if_missing(token, figure, guard=guard)
             if entry is None:
-                return None, "unknown figure token"
+                return None, unknown
             if not inserted:
                 return entry, None
 
@@ -499,7 +552,7 @@ class XYNamespace(AsyncNamespace):
                     current = self.registry.get(token)
                     if current is not None:
                         return current, None
-                return None, "rebuild failed"
+                return None, _RebuildFailure("rebuild failed")
 
             # ``broadcast_payload`` intentionally no-ops when its generation
             # went stale. Resolve that race explicitly: a replacement wins,
@@ -507,7 +560,7 @@ class XYNamespace(AsyncNamespace):
             if not self.registry.is_current(token, entry):
                 current = self.registry.get(token)
                 if current is None:
-                    return None, "unknown figure token"
+                    return None, unknown
                 return current, None
             return entry, None
         finally:
@@ -527,10 +580,10 @@ class XYNamespace(AsyncNamespace):
         token = self._token_of(data)
         if token is None:
             return None, None, False
-        parsed = parse_token(token)
-        if parsed is not None:
+        identity = _token_identity(token)
+        if identity.affinity_client is not None:
             session = await self.get_session(sid)
-            if session.get("client_token") != parsed.client_token:
+            if session.get("client_token") != identity.affinity_client:
                 await self._err(sid, token, "figure belongs to another session")
                 return token, None, False
         entry, rebuild_guarded = self.registry.get_with_rebuild_guard(token)
@@ -541,7 +594,12 @@ class XYNamespace(AsyncNamespace):
         # forever for older user rebuild code. An entry whose guard is still
         # valid remains provisional until its rebuild fan-out completes.
         initially_missing = entry is None or (attempt is not None and rebuild_guarded)
-        if parsed is not None and allow_rebuild and self._rebuild is not None and initially_missing:
+        if (
+            identity.rebuildable
+            and allow_rebuild
+            and self._rebuild is not None
+            and initially_missing
+        ):
             # The task spans builder, conditional insertion, and existing-room
             # fan-out. All requests that observed this in-flight miss share its
             # result and must drop pre-payload interactions, even when another
@@ -553,14 +611,27 @@ class XYNamespace(AsyncNamespace):
                 attempt = None
             if attempt is None:
                 attempt = self._start_rebuild_attempt(token)
-            entry, error = await asyncio.shield(attempt)
-            if error is not None:
-                await self._err(sid, token, error)
+            entry, failure = await asyncio.shield(attempt)
+            if failure is not None:
+                await self._err(sid, token, failure.error, resync=failure.resync)
                 return token, None, initially_missing
         if entry is None:
             await self._err(sid, token, "unknown figure token")
             return token, None, False
         return token, entry, initially_missing
 
-    async def _err(self, sid: str, token: Optional[str], error: str) -> None:
-        await self.emit("err", {"fig": token, "error": error}, to=sid)
+    async def _err(
+        self, sid: str, token: Optional[str], error: str, *, resync: bool = False
+    ) -> None:
+        envelope: dict[str, Any] = {"fig": token, "error": error}
+        if resync:
+            envelope["resync"] = True
+        await self.emit("err", envelope, to=sid)
+
+    async def broadcast_error(self, token: str, error: str, resync: bool = False) -> None:
+        """Room-wide err frame for server-side failures with no request to
+        answer (e.g. a column republish whose plan bind fails)."""
+        envelope: dict[str, Any] = {"fig": token, "error": error}
+        if resync:
+            envelope["resync"] = True
+        await self.emit("err", envelope, room=self._room(token))

--- a/python/reflex_xy/plan.py
+++ b/python/reflex_xy/plan.py
@@ -1,0 +1,237 @@
+"""Chart plans: validated, data-free chart structure for the data-bound tier.
+
+A plan is the server-side half of the composite figure identity
+``xyp1|<digest>|<data token>`` (spec/design/reflex-integration.md): the xy
+node tree with **string channels only**, compiled once at page evaluation.
+
+- **Build** (factory call = page evaluation = Reflex compile): construct the
+  real xy tree, bind a zero-row placeholder column for every referenced
+  channel name, and call ``.figure()`` once — the full mark/config
+  validation gate (facts X1/X2, pinned in tests/test_validation_timing.py)
+  runs in milliseconds with no real data. The probe figure is discarded;
+  what is kept is the digest, the recorded column names, and (for live
+  charts) the probe's Tailwind class inventory.
+- **Serialize**: nodes → canonical JSON (sorted keys, ``plan_version``) →
+  sha256 prefix = ``digest``. The digest is a *content address*: every
+  worker that evaluates the page derives the same digest and holds the plan
+  in this process-local map — and backend-only workers, which skip the
+  frontend compile, get the same evaluation from ``setup(app)``'s startup
+  lifespan (app.py `_ensure_page_plans`). A lookup miss is hot-reload
+  drift and answers ``err {resync}`` naming the digest.
+- **Bind** (serve time): columns + plan → a **fresh** ``Chart`` (never
+  reuse — ``Chart.figure()`` memoizes, X3) → ``Figure``. Column mismatches
+  raise :class:`PlanBindError` naming both sides.
+
+Plans hold no data and no session identity; they are pure functions of page
+source. Everything session-shaped lives in the data token half.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+from collections.abc import Mapping
+from typing import Any, Optional
+
+import numpy as np
+
+from xy.components import Chart, Component, Mark
+
+__all__ = [
+    "PLAN_VERSION",
+    "ChartPlan",
+    "PlanBindError",
+    "PlanError",
+    "PlanMissError",
+    "build_plan",
+    "plan_of",
+    "register_plan",
+]
+
+PLAN_VERSION = 1
+_DIGEST_CHARS = 20  # sha256 hex prefix; content address for a process-local map
+
+#: Mark kinds whose figure-compile validators require at least one finite
+#: value (they aggregate: quantiles, bins, meshes). The zero-row probe
+#: cannot compile them, so they are excluded from the plan tier — the
+#: Phase 3 decision recorded in reflex-component-api-implementation.md.
+_NEEDS_DATA_MARKS = frozenset({"box", "violin", "hexbin", "contour", "heatmap", "stairs", "ecdf"})
+
+
+class PlanError(ValueError):
+    """A chart plan could not be built, resolved, or bound."""
+
+
+class PlanMissError(PlanError):
+    """No plan registered under a digest (hot-reload drift — client resyncs)."""
+
+    def __init__(self, digest: str) -> None:
+        super().__init__(
+            f"unknown chart plan {digest!r} on this worker (stale page after a "
+            "hot reload?); re-subscribe against the recompiled page"
+        )
+        self.digest = digest
+
+
+class PlanBindError(PlanError):
+    """The data var's columns do not satisfy the plan's bindings."""
+
+
+class _ProbeTable(Mapping):
+    """Zero-row placeholder table that records every column it resolves.
+
+    ``Chart.figure()`` resolves string channels through ``data[name]``
+    (the exact production code path), so the recorded names are *derived*
+    from the real resolution logic — the plan's column list can never drift
+    from what binding will actually look up.
+    """
+
+    def __init__(self) -> None:
+        self.seen: list[str] = []
+
+    def __getitem__(self, key: str) -> np.ndarray:
+        if key not in self.seen:
+            self.seen.append(key)
+        return np.empty(0, dtype=np.float64)
+
+    def __iter__(self):  # pragma: no cover - Mapping protocol completeness
+        return iter(self.seen)
+
+    def __len__(self) -> int:  # pragma: no cover - Mapping protocol completeness
+        return len(self.seen)
+
+
+def _plain(value: Any, context: str) -> Any:
+    """Canonical JSON-able copy of one plan node field (fail closed)."""
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        node: dict[str, Any] = {"~node": type(value).__name__}
+        for field in dataclasses.fields(value):
+            node[field.name] = _plain(getattr(value, field.name), f"{context}.{field.name}")
+        return node
+    if isinstance(value, Mapping):
+        return {str(key): _plain(item, f"{context}.{key}") for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_plain(item, context) for item in value]
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    raise PlanError(
+        f"{context} holds a {type(value).__name__}, which cannot be part of a "
+        "data-bound chart plan. Plans are data-free structure: bind columns "
+        "by name (strings) and keep arrays in the @reflex_xy.data method; "
+        "components (e.g. legend/tooltip render=) belong to the escape "
+        "hatch (@reflex_xy.figure) or the static tier."
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class ChartPlan:
+    """One validated, data-free chart structure, addressed by content."""
+
+    kind: str
+    children: tuple[Component, ...]
+    chart_props: dict[str, Any]
+    columns: tuple[str, ...]  # channel names the probe resolved, in order
+    tailwind_classes: str  # probe figure's DOM class inventory (live-tier scan)
+    digest: str
+
+    def chart(self, data: Any) -> Chart:
+        """A fresh ``Chart`` over ``data`` (X3: never reuse a compiled one)."""
+        return Chart(self.kind, self.children, data=data, **self.chart_props)
+
+    def bind(self, columns: Mapping[str, Any], *, source: str = "the data var") -> Chart:
+        """Bind real columns; missing bindings name both sides."""
+        missing = [name for name in self.columns if name not in columns]
+        if missing:
+            bound = ", ".join(repr(name) for name in missing)
+            produced = ", ".join(sorted(str(key) for key in columns)) or "no columns"
+            noun = "columns" if len(missing) > 1 else "column"
+            raise PlanBindError(f"plan binds {noun} {bound}; {source} produced {{{produced}}}")
+        return self.chart(columns)
+
+
+def build_plan(
+    kind: str, children: tuple[Component, ...], chart_props: dict[str, Any]
+) -> ChartPlan:
+    """Compile + validate a plan and register it in this worker's map."""
+    for child in children:
+        if isinstance(child, Mark) and child.data is not None:
+            raise PlanError(
+                "per-mark data= is not supported in data-bound charts; bind one "
+                "chart-level data source (this is tracked as deferred work in "
+                "spec/design/reflex-component-api-implementation.md)"
+            )
+    serialized = {
+        "plan_version": PLAN_VERSION,
+        "kind": kind,
+        "chart": {key: _plain(value, f"{kind}() {key}") for key, value in chart_props.items()},
+        "children": [_plain(child, f"{kind}() child {i}") for i, child in enumerate(children)],
+    }
+    canonical = json.dumps(serialized, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode()).hexdigest()[:_DIGEST_CHARS]
+
+    # The compile-time validation gate: bind zero-row placeholders for every
+    # string channel and compile once. Errors surface here — at page
+    # evaluation — with the ordinary xy messages.
+    probe = _ProbeTable()
+    try:
+        probe_figure = Chart(kind, children, data=probe, **chart_props).figure()
+    except ValueError as exc:
+        needy = sorted(
+            {
+                child.kind
+                for child in children
+                if isinstance(child, Mark) and child.kind in _NEEDS_DATA_MARKS
+            }
+        )
+        if needy:
+            raise PlanError(
+                f"{', '.join(needy)} marks aggregate their values, so their "
+                "validators need at least one row — the zero-row plan probe "
+                "cannot compile them. Data-bound charts exclude these kinds "
+                "(recorded in reflex-component-api-implementation.md, Phase 3 "
+                "decision); build the chart with @reflex_xy.figure, or pass "
+                "a concrete xy Chart to reflex_xy.chart() for the static tier."
+            ) from exc
+        raise
+    tailwind_classes = " ".join(probe_figure.dom_class_strings())
+
+    plan = ChartPlan(
+        kind=kind,
+        children=children,
+        chart_props=chart_props,
+        columns=tuple(probe.seen),
+        tailwind_classes=tailwind_classes,
+        digest=digest,
+    )
+    return register_plan(plan)
+
+
+#: Process-local {digest: plan}, populated wherever page bodies evaluate:
+#: the frontend compile, and — for backend-only workers that skip it — the
+#: setup(app) startup lifespan (app.py `_ensure_page_plans`). Entries are
+#: tiny (node dataclasses with string channels) and bounded by page code.
+_PLANS: dict[str, ChartPlan] = {}
+
+
+def register_plan(plan: ChartPlan) -> ChartPlan:
+    """Idempotently register a plan under its digest; returns the canonical one."""
+    return _PLANS.setdefault(plan.digest, plan)
+
+
+def plan_of(digest: str) -> Optional[ChartPlan]:
+    return _PLANS.get(digest)
+
+
+def require_plan(digest: str) -> ChartPlan:
+    plan = _PLANS.get(digest)
+    if plan is None:
+        raise PlanMissError(digest)
+    return plan
+
+
+def reset_plans_for_tests() -> None:
+    """Forget every registered plan (test isolation only)."""
+    _PLANS.clear()

--- a/python/reflex_xy/registry.py
+++ b/python/reflex_xy/registry.py
@@ -17,6 +17,7 @@ loop captured at setup time; see `schedule_broadcast`.
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 import time
 import uuid
@@ -28,7 +29,9 @@ from typing import TYPE_CHECKING, Any, Optional
 if TYPE_CHECKING:
     from xy._figure import Figure
 
-__all__ = ["FigureEntry", "FigureRegistry", "registry"]
+__all__ = ["ColumnEntry", "FigureEntry", "FigureRegistry", "registry"]
+
+_logger = logging.getLogger("reflex_xy")
 
 # Idle figures are swept after this long without a subscribe/message/publish.
 # Deterministic (state-backed) figures rebuild transparently on the next
@@ -94,11 +97,38 @@ class FigureEntry:
         self.last_access = time.monotonic()
 
 
+@dataclass
+class ColumnEntry:
+    """One registered column set (the data half of the data-bound tier).
+
+    Column entries are pure rebuildable caches of Reflex state — the
+    `@reflex_xy.data` method is the recipe — so they carry none of the
+    figure entry's kernel machinery: no locks (a republish replaces the
+    whole immutable generation), no pins, always sweepable.
+    """
+
+    columns: dict[str, Any]
+    token: str
+    version: int = 1
+    last_access: float = field(default_factory=time.monotonic)
+
+    def touch(self) -> None:
+        self.last_access = time.monotonic()
+
+
 class FigureRegistry:
     """token -> FigureEntry map with versioning and TTL sweep."""
 
     def __init__(self, ttl_seconds: float = DEFAULT_TTL_SECONDS) -> None:
         self._entries: dict[str, FigureEntry] = {}
+        # Data-bound tier: column sets published by @reflex_xy.data vars,
+        # and the data-token -> {plan digest} index that lets a column
+        # republish rebuild + broadcast every mounted dependent figure. The
+        # index is bounded by mounted plans: entries are added when a
+        # composite figure binds and dropped when a republish finds neither
+        # a cached figure nor live subscribers under the composite token.
+        self._column_entries: dict[str, ColumnEntry] = {}
+        self._digests_by_data_token: dict[str, set[str]] = {}
         # A mounted client remains in its socket room when a TTL sweep evicts
         # a rebuildable figure. Retain only the evicted scalar version while
         # at least one such client is subscribed, so a state-driven rebuild on
@@ -134,6 +164,11 @@ class FigureRegistry:
         # async callback(token, message, buffers, version) -> None for append
         # and view-state pushes — the message-shaped data-plane seam.
         self._on_push: Optional[PushHook] = None
+        # async callback(token, error, resync) -> None: room-wide err frames
+        # for server-side failures with no request to answer (a data
+        # republish whose plan bind fails must not leave stale pixels
+        # silently frozen).
+        self._on_error: Optional[Callable[[str, str, bool], Awaitable[None]]] = None
 
     # -- wiring ------------------------------------------------------------
 
@@ -148,6 +183,28 @@ class FigureRegistry:
         callback: PushHook,
     ) -> None:
         self._on_push = callback
+
+    def on_error(self, callback: Callable[[str, str, bool], Awaitable[None]]) -> None:
+        self._on_error = callback
+
+    def _schedule_error(self, token: str, error: str, *, resync: bool) -> None:
+        """Fan an out-of-band failure to a figure room from any thread."""
+        callback = self._on_error
+        loop = self._loop
+        if callback is None or loop is None:
+            return
+
+        async def _run() -> None:
+            await callback(token, error, resync)
+
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        if running is loop:
+            loop.create_task(_run())
+        else:
+            asyncio.run_coroutine_threadsafe(_run(), loop)
 
     def _enqueue_push(
         self,
@@ -478,6 +535,92 @@ class FigureRegistry:
         with self._mutex:
             return len(self._entries)
 
+    # -- data-bound tier: column entries + plan index ------------------------
+
+    def publish_columns(self, token: str, columns: dict[str, Any]) -> ColumnEntry:
+        """Insert or replace a column set, then rebuild every mounted plan
+        bound to it (fresh figures under the composite tokens, broadcast by
+        the ordinary publish fan-out). Entries are immutable generations: a
+        republish replaces the whole entry and bumps its version."""
+        with self._mutex:
+            previous = self._column_entries.get(token)
+            version = 1 if previous is None else previous.version + 1
+            entry = ColumnEntry(columns=columns, token=token, version=version)
+            self._column_entries[token] = entry
+            digests = sorted(self._digests_by_data_token.get(token, ()))
+        for digest in digests:
+            self._rebuild_dependent(token, digest, columns)
+        return entry
+
+    def get_columns(self, token: str) -> Optional[ColumnEntry]:
+        with self._mutex:
+            entry = self._column_entries.get(token)
+            if entry is not None:
+                entry.touch()
+            return entry
+
+    def release_columns(self, token: str) -> None:
+        """Drop a column set and every dependent composite figure entry.
+
+        The "no data right now" path (`@reflex_xy.data` returning None): the
+        empty handle unmounts subscribed charts client-side, and dropping
+        the dependent figure caches here keeps a later re-mount rebuilding
+        from current state instead of serving pre-release columns.
+        """
+        from .tokens import build_plan_token
+
+        with self._mutex:
+            self._column_entries.pop(token, None)
+            digests = self._digests_by_data_token.pop(token, set())
+        for digest in sorted(digests):
+            self.release(build_plan_token(digest, token))
+
+    def bind_plan(self, data_token: str, digest: str) -> None:
+        """Record that a mounted plan binds this data token (idempotent)."""
+        with self._mutex:
+            self._digests_by_data_token.setdefault(data_token, set()).add(digest)
+
+    def _rebuild_dependent(self, data_token: str, digest: str, columns: dict[str, Any]) -> None:
+        """Re-bind one dependent plan against freshly published columns."""
+        from .plan import plan_of
+        from .tokens import build_plan_token, parse_token
+
+        composite = build_plan_token(digest, data_token)
+        with self._mutex:
+            mounted = composite in self._entries or bool(
+                self._rebuildable_subscribers.get(composite)
+            )
+            if not mounted:
+                # Nothing serves or watches this plan anymore: forget the
+                # binding (this is what keeps the index bounded by mounts);
+                # a later subscribe rebuilds from scratch and re-indexes.
+                digests = self._digests_by_data_token.get(data_token)
+                if digests is not None:
+                    digests.discard(digest)
+                    if not digests:
+                        self._digests_by_data_token.pop(data_token, None)
+                return
+        parsed = parse_token(data_token)
+        source = (
+            f"{parsed.state_full_name}.{parsed.var_name}" if parsed is not None else "the data var"
+        )
+        plan = plan_of(digest)
+        try:
+            if plan is None:
+                from .plan import PlanMissError
+
+                raise PlanMissError(digest)
+            figure = plan.bind(columns, source=source).figure()
+        except Exception as exc:  # noqa: BLE001 - user data meets page structure here
+            # Fail loud on both sides: the server log carries the bind error,
+            # and subscribers get an err frame instead of silently frozen
+            # pixels (their bounded resync retries against current state).
+            _logger.warning("republish of %s failed: %s", composite, exc)
+            self.release(composite)
+            self._schedule_error(composite, str(exc), resync=True)
+            return
+        self.publish(composite, figure)
+
     # -- version bump + fan-out ---------------------------------------------
 
     def bump(self, token: str, *, expected: Optional[FigureEntry] = None) -> Optional[FigureEntry]:
@@ -703,7 +846,12 @@ class FigureRegistry:
     # -- TTL sweep -----------------------------------------------------------
 
     def sweep(self, *, now: Optional[float] = None) -> list[str]:
-        """Drop unpinned entries idle past the TTL; returns dropped tokens."""
+        """Drop unpinned entries idle past the TTL; returns dropped tokens.
+
+        Column entries sweep under the same TTL: they are state-rebuildable
+        caches exactly like state-token figures (a later subscribe re-runs
+        the data method), so the sweep bounds column memory, not correctness.
+        """
         now = time.monotonic() if now is None else now
         dropped: list[str] = []
         with self._mutex:
@@ -716,6 +864,10 @@ class FigureRegistry:
                     self._invalidate_rebuild_guards_locked(token)
                     self._retain_removed_version_locked(token, entry)
                     del self._entries[token]
+                    dropped.append(token)
+            for token, column_entry in list(self._column_entries.items()):
+                if now - column_entry.last_access > self._ttl:
+                    del self._column_entries[token]
                     dropped.append(token)
         return dropped
 
@@ -734,6 +886,8 @@ registry: FigureRegistry = FigureRegistry()
 def reset_registry_for_tests() -> FigureRegistry:
     """Reset the process registry in place (test isolation only)."""
     registry._entries.clear()
+    registry._column_entries.clear()
+    registry._digests_by_data_token.clear()
     registry._evicted_versions.clear()
     registry._rebuildable_subscribers.clear()
     registry._rebuildable_tokens_by_sid.clear()
@@ -742,6 +896,7 @@ def reset_registry_for_tests() -> FigureRegistry:
     registry._loop = None
     registry._on_publish = None
     registry._on_push = None
+    registry._on_error = None
     registry._ttl = DEFAULT_TTL_SECONDS
     return registry
 

--- a/python/reflex_xy/state_bridge.py
+++ b/python/reflex_xy/state_bridge.py
@@ -1,17 +1,25 @@
-"""Rebuild figures from Reflex state: the distributed-deployment answer.
+"""Rebuild figures and datasets from Reflex state: the distributed answer.
 
 The figure registry is process-local. What makes that safe in a
-multi-worker / reconnecting world is this module: given a state token
-(`xyv1|client|state|var`) and the app's state manager, we can always
-recover the figure by re-running the builder against the session's state —
-which Reflex already stores durably (memory/disk/redis) and already knows
-how to hand to any worker. No figure server, no data in Redis beyond the
-state that was there anyway (§27 applied to processes: the figure is a
-rebuildable cache, Reflex state is canonical).
+multi-worker / reconnecting world is this module: given a state token, we
+can always recover the served object by re-running the decorated state
+method against the session's state — which Reflex already stores durably
+(memory/disk/redis) and already knows how to hand to any worker. No figure
+server, no data in Redis beyond the state that was there anyway (§27
+applied to processes: the served object is a rebuildable cache, Reflex
+state is canonical).
+
+Three recipes, one contract:
+
+- `xyv1|client|state|var` — re-run the `@reflex_xy.figure` builder → Figure.
+- `xyd1|client|state|var` — re-run the `@reflex_xy.data` method → columns.
+- `xyp1|digest|xyd1|…` — plan lookup (process-local; every worker's map
+  is populated at startup, see app.py `_ensure_page_plans`) + column
+  resolve (registry hit, else the xyd1 recipe) + bind → Figure.
 
 Read-only by design: rebuilds use `state_manager.get_state` (no state lock,
-no delta emission). Builders must therefore be pure functions of state —
-the same contract cached computed vars already impose.
+no delta emission). Builders and data methods must therefore be pure
+functions of state — the same contract cached computed vars already impose.
 """
 
 from __future__ import annotations
@@ -19,13 +27,15 @@ from __future__ import annotations
 import inspect
 from typing import TYPE_CHECKING, Any, Optional
 
-from .registry import _figure_of
-from .tokens import ParsedToken, builder_of, parse_token
+from .data_vars import validate_columns
+from .plan import require_plan
+from .registry import _figure_of, registry
+from .tokens import ParsedPlanToken, ParsedToken, builder_of, parse_plan_token, parse_token
 
 if TYPE_CHECKING:
     from xy._figure import Figure
 
-__all__ = ["make_rebuild_hook", "rebuild_figure"]
+__all__ = ["make_rebuild_hook", "rebuild_data", "rebuild_figure", "rebuild_plan_figure"]
 
 
 def _resolve_state_cls(state_full_name: str) -> Any:
@@ -40,40 +50,81 @@ def _resolve_state_cls(state_full_name: str) -> Any:
     return rx.State.get_class_substate(tuple(state_full_name.split(".")))
 
 
-async def rebuild_figure(app: Any, parsed: ParsedToken) -> Optional["Figure"]:
-    """Re-run a figure var's builder against the session's stored state."""
+async def _run_state_method(app: Any, parsed: ParsedToken) -> Any:
+    """Re-run a decorated state method against the session's stored state."""
     import reflex as rx
-
-    from xy._figure import Figure
 
     try:
         state_cls = _resolve_state_cls(parsed.state_full_name)
     except (KeyError, ValueError):
         return None
-    builder = builder_of(state_cls, parsed.var_name)
-    if builder is None:
+    method = builder_of(state_cls, parsed.var_name)
+    if method is None:
         return None
     token = rx.BaseStateToken(ident=parsed.client_token, cls=rx.State)
     root = await app.state_manager.get_state(token)
     substate = await root.get_state(state_cls)
-    # Async builders (AsyncFigureVar) await their data source here exactly
-    # as they would during normal var evaluation.
-    if inspect.iscoroutinefunction(builder):
-        chart = await builder(substate)
-    else:
-        chart = builder(substate)
+    # Async builders/data methods await their data source here exactly as
+    # they would during normal var evaluation.
+    if inspect.iscoroutinefunction(method):
+        return await method(substate)
+    return method(substate)
+
+
+async def rebuild_figure(app: Any, parsed: ParsedToken) -> Optional["Figure"]:
+    """Re-run a figure var's builder against the session's stored state."""
+    from xy._figure import Figure
+
+    if parsed.kind != "figure":
+        return None
+    chart = await _run_state_method(app, parsed)
     if chart is None:
         return None
     figure = _figure_of(chart)
     return figure if isinstance(figure, Figure) else None
 
 
+async def rebuild_data(app: Any, parsed: ParsedToken) -> Optional[dict[str, Any]]:
+    """Re-run a data var's method against the session's stored state."""
+    if parsed.kind != "data":
+        return None
+    columns = await _run_state_method(app, parsed)
+    if columns is None:
+        return None
+    return validate_columns(
+        columns, source=f"{parsed.state_full_name.rsplit('.', 1)[-1]}.{parsed.var_name}"
+    )
+
+
+async def rebuild_plan_figure(app: Any, composite: ParsedPlanToken) -> Optional["Figure"]:
+    """Recover a data-bound figure: plan (local map) + columns (registry or
+    state) + bind. Raises PlanMissError / PlanBindError for spec-aware `err`
+    frames; anything else fails closed in the namespace."""
+    plan = require_plan(composite.digest)
+    entry = registry.get_columns(composite.data_token)
+    if entry is not None:
+        columns = entry.columns
+    else:
+        columns = await rebuild_data(app, composite.data)
+        if columns is None:
+            return None
+        # Future binds (other plans over the same data var) hit the cache;
+        # bind_plan below is the subscribe path's job, not the rebuild's.
+        registry.publish_columns(composite.data_token, columns)
+    source = f"{composite.data.state_full_name.rsplit('.', 1)[-1]}.{composite.data.var_name}"
+    return plan.bind(columns, source=source).figure()
+
+
 def make_rebuild_hook(app: Any) -> Any:
     """The namespace's RebuildHook, bound to one app instance."""
 
     async def _rebuild(token_str: str) -> Optional["Figure"]:
+        composite = parse_plan_token(token_str)
+        if composite is not None:
+            return await rebuild_plan_figure(app, composite)
         parsed = parse_token(token_str)
-        if parsed is None:
+        if parsed is None or parsed.kind != "figure":
+            # Bare data tokens never serve figures; fail closed.
             return None
         return await rebuild_figure(app, parsed)
 

--- a/python/reflex_xy/tokens.py
+++ b/python/reflex_xy/tokens.py
@@ -1,22 +1,31 @@
-"""Figure tokens: the only chart-related value that lives in Reflex state.
+"""Chart tokens: the only chart-related values that live in Reflex state.
 
-Two token families, one namespace:
+Three token families, one namespace:
 
-- **State tokens** (`xyv1|<client_token>|<state_full_name>|<var_name>`) are
-  minted by the `@reflex_xy.figure` computed var. They are *deterministic*:
-  any backend worker holding the same Reflex state can re-derive the figure
-  from the token alone, which is what makes reconnects and multi-worker
-  deployments work without a central figure store (the token IS the recipe;
-  Reflex state is the pantry).
-- **Opaque tokens** (`xyfig-<uuid>`) come from imperative
-  `reflex_xy.register(...)`. They cannot be rebuilt elsewhere — dev-tier by
-  design, documented in spec/design/reflex-integration.md.
+- **Figure state tokens** (`xyv1|<client_token>|<state_full_name>|<var_name>`)
+  are minted by the `@reflex_xy.figure` computed var. They are
+  *deterministic*: any backend worker holding the same Reflex state can
+  re-derive the figure from the token alone, which is what makes reconnects
+  and multi-worker deployments work without a central figure store (the
+  token IS the recipe; Reflex state is the pantry).
+- **Data state tokens** (`xyd1|<client_token>|<state_full_name>|<var_name>`)
+  are minted by the `@reflex_xy.data` computed var under the same grammar
+  and rebuild contract, naming a registered *column set* instead of a
+  figure. They never subscribe alone: the wrapper composes them with a plan
+  digest into a **plan token** (`xyp1|<digest>|<data token>`), the composite
+  figure identity of the data-bound tier — plan digest for the structure,
+  data token for the columns; both halves independently recoverable.
+- **Opaque tokens** (`xyfig-<uuid>` / `xyin-<digest>`) come from imperative
+  `reflex_xy.register(...)` / `inline(...)`. They cannot be rebuilt
+  elsewhere — dev/fixed tiers by design, documented in
+  spec/design/reflex-integration.md.
 
 Tokens are visible to their own client (they ride through state deltas), so
 they must not carry anything the client doesn't already know: the client
-token is the browser tab's own session id, and state/var names already
-appear in every state delta. Cross-client use is refused by the namespace's
-affinity check, not by token secrecy.
+token is the browser tab's own session id, state/var names already appear
+in every state delta, and a plan digest is a content address of page code
+the client was compiled from. Cross-client use is refused by the
+namespace's affinity check, not by token secrecy.
 """
 
 from __future__ import annotations
@@ -27,47 +36,91 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 __all__ = [
+    "ParsedPlanToken",
     "ParsedToken",
+    "build_data_token",
+    "build_plan_token",
     "build_state_token",
     "builder_of",
+    "parse_plan_token",
     "parse_token",
 ]
 
-_PREFIX = "xyv1"
+_FIGURE_PREFIX = "xyv1"
+_DATA_PREFIX = "xyd1"
+_PLAN_PREFIX = "xyp1"
 _SEP = "|"
 # Client tokens are UUID-ish; state full names and var names are dotted
 # Python identifiers. Nothing here may contain the separator.
-_TOKEN_RE = re.compile(
-    r"^xyv1\|(?P<client>[A-Za-z0-9_-]{8,64})"
+_STATE_TOKEN_BODY = (
+    r"(?P<client>[A-Za-z0-9_-]{8,64})"
     r"\|(?P<state>[A-Za-z0-9_.]{1,512})"
     r"\|(?P<var>[A-Za-z_][A-Za-z0-9_]{0,255})$"
 )
+_TOKEN_RE = re.compile(r"^(?P<prefix>xyv1|xyd1)\|" + _STATE_TOKEN_BODY)
+# Plan digests are lowercase sha256 hex prefixes (plan.py).
+_PLAN_RE = re.compile(r"^xyp1\|(?P<digest>[0-9a-f]{8,64})\|(?P<data>xyd1\|.+)$")
 
-#: Attribute stashed on a figure var's fget carrying the user's builder.
+#: Attribute stashed on a figure/data var's fget carrying the user's builder.
 #: It lives on the *function* (not the ComputedVar) so it survives reflex's
 #: `_replace` copies, which re-instantiate the var but thread fget through.
 BUILDER_ATTR = "__xy_builder__"
+#: Attribute stashed beside it carrying the figure var's compile-probe level
+#: ("build" | "figure" | False); same placement rationale.
+PROBE_ATTR = "__xy_probe__"
 
 
 @dataclass(frozen=True)
 class ParsedToken:
+    """A parsed state token; ``kind`` is ``"figure"`` (xyv1) or ``"data"`` (xyd1)."""
+
     client_token: str
     state_full_name: str
     var_name: str
+    kind: str = "figure"
+
+
+@dataclass(frozen=True)
+class ParsedPlanToken:
+    """A parsed composite plan token: plan digest + the embedded data token."""
+
+    digest: str
+    data: ParsedToken
+    data_token: str  # the verbatim xyd1|… substring (registry key for columns)
+
+
+def _build_state_token(prefix: str, client_token: str, state_full_name: str, var_name: str) -> str:
+    token = _SEP.join((prefix, client_token, state_full_name, var_name))
+    if _TOKEN_RE.match(token) is None:
+        # Defensive: a state or client token that defeats the grammar would
+        # otherwise mint a token the namespace can never resolve.
+        msg = f"cannot build a valid {prefix} token from {client_token!r}/{state_full_name!r}/{var_name!r}"
+        raise ValueError(msg)
+    return token
 
 
 def build_state_token(client_token: str, state_full_name: str, var_name: str) -> str:
-    token = _SEP.join((_PREFIX, client_token, state_full_name, var_name))
-    if parse_token(token) is None:
-        # Defensive: a state or client token that defeats the grammar would
-        # otherwise mint a token the namespace can never resolve.
-        msg = f"cannot build a valid figure token from {client_token!r}/{state_full_name!r}/{var_name!r}"
+    """Mint a figure token (`xyv1|…`)."""
+    return _build_state_token(_FIGURE_PREFIX, client_token, state_full_name, var_name)
+
+
+def build_data_token(client_token: str, state_full_name: str, var_name: str) -> str:
+    """Mint a data token (`xyd1|…`)."""
+    return _build_state_token(_DATA_PREFIX, client_token, state_full_name, var_name)
+
+
+def build_plan_token(digest: str, data_token: str) -> str:
+    """Compose the data-bound tier's figure identity (`xyp1|<digest>|<data>`)."""
+    token = _SEP.join((_PLAN_PREFIX, digest, data_token))
+    if parse_plan_token(token) is None:
+        msg = f"cannot build a valid plan token from {digest!r}/{data_token!r}"
         raise ValueError(msg)
     return token
 
 
 def parse_token(token: str) -> Optional[ParsedToken]:
-    """Parse a state token; None for opaque/foreign strings (fail closed)."""
+    """Parse a state token (figure or data); None for opaque/foreign strings
+    (fail closed). Composite plan tokens parse via :func:`parse_plan_token`."""
     if not isinstance(token, str):
         return None
     match = _TOKEN_RE.match(token)
@@ -77,11 +130,26 @@ def parse_token(token: str) -> Optional[ParsedToken]:
         client_token=match["client"],
         state_full_name=match["state"],
         var_name=match["var"],
+        kind="figure" if match["prefix"] == _FIGURE_PREFIX else "data",
     )
 
 
+def parse_plan_token(token: str) -> Optional[ParsedPlanToken]:
+    """Parse a composite plan token; None for anything else (fail closed)."""
+    if not isinstance(token, str):
+        return None
+    match = _PLAN_RE.match(token)
+    if match is None:
+        return None
+    data = parse_token(match["data"])
+    if data is None or data.kind != "data":
+        return None
+    return ParsedPlanToken(digest=match["digest"], data=data, data_token=match["data"])
+
+
 def builder_of(state_cls: Any, var_name: str) -> Optional[Callable[[Any], Any]]:
-    """Find the figure builder a `@reflex_xy.figure` var attached to a state class."""
+    """Find the builder a `@reflex_xy.figure` / `@reflex_xy.data` var
+    attached to a state class."""
     computed = getattr(state_cls, "computed_vars", None)
     var = computed.get(var_name) if isinstance(computed, dict) else None
     fget = getattr(var, "_fget", None)

--- a/python/reflex_xy/vars.py
+++ b/python/reflex_xy/vars.py
@@ -1,11 +1,12 @@
 """`@reflex_xy.figure`: a computed var that *is* the chart registration.
 
 The pattern (spec/design/reflex-integration.md): the state method builds the
-chart from state, the computed var's value is only the figure *token*, and
+chart from state, the computed var's value is only a typed
+:class:`~reflex_xy.handles.FigureHandle` wrapping the figure *token*, and
 evaluating the var is what (re)registers the figure in the per-process
 registry. Reflex's own dependency tracking decides when that happens:
 
-- first render: var evaluates -> figure built -> token into state.
+- first render: var evaluates -> figure built -> handle into state.
 - a dependency changes: reflex marks the var dirty, the next delta
   evaluation rebuilds the figure and re-publishes it; subscribers get the
   fresh payload pushed over the data plane. The token itself is stable, so
@@ -37,10 +38,13 @@ from typing import Any, Optional, overload
 
 from reflex_base.vars.base import AsyncComputedVar, ComputedVar
 
+from .handles import FigureHandle
 from .registry import _figure_of, registry
-from .tokens import BUILDER_ATTR, build_state_token
+from .tokens import BUILDER_ATTR, PROBE_ATTR, build_state_token
 
 __all__ = ["AsyncFigureVar", "FigureVar", "figure"]
+
+_PROBE_LEVELS = ("build", "figure", False)
 
 
 def _builder_target(var: Any, obj: Any) -> Any:
@@ -53,14 +57,14 @@ def _builder_target(var: Any, obj: Any) -> Any:
 
 
 class FigureVar(ComputedVar):
-    """ComputedVar whose value is a figure token (sync builder)."""
+    """ComputedVar whose value is a FigureHandle (sync builder)."""
 
     def _deps(self, objclass: Any, obj: Any = None) -> dict[str, set[str]]:
         return ComputedVar._deps(self, objclass, obj=_builder_target(self, obj))
 
 
 class AsyncFigureVar(AsyncComputedVar):
-    """AsyncComputedVar whose value is a figure token (async builder)."""
+    """AsyncComputedVar whose value is a FigureHandle (async builder)."""
 
     def _deps(self, objclass: Any, obj: Any = None) -> dict[str, set[str]]:
         return AsyncComputedVar._deps(self, objclass, obj=_builder_target(self, obj))
@@ -69,19 +73,20 @@ class AsyncFigureVar(AsyncComputedVar):
 def _mint_token(state: Any, builder_name: str) -> Optional[str]:
     """Deterministic token for this (session, state, var) — or None
     pre-hydration (no session yet, so no figure to serve; the component
-    treats "" as "not ready" and waits for the hydrated value)."""
+    treats the empty-token handle as "not ready" and waits for the
+    hydrated value)."""
     client_token = state.router.session.client_token
     if not client_token:
         return None
     return build_state_token(client_token, type(state).get_full_name(), builder_name)
 
 
-def _publish(token: str, chart: Any) -> str:
+def _publish(token: str, chart: Any) -> FigureHandle:
     if chart is None:
         registry.release(token)
-        return ""
+        return FigureHandle("")
     registry.publish(token, _figure_of(chart))
-    return token
+    return FigureHandle(token)
 
 
 def _adopt_identity(fget: Any, builder: Callable[..., Any], name: str) -> None:
@@ -92,13 +97,13 @@ def _adopt_identity(fget: Any, builder: Callable[..., Any], name: str) -> None:
     setattr(fget, BUILDER_ATTR, builder)
 
 
-def _make_fget(builder: Callable[[Any], Any]) -> Callable[[Any], str]:
+def _make_fget(builder: Callable[[Any], Any]) -> Callable[[Any], FigureHandle]:
     builder_name = _fn_name(builder)
 
-    def fget(self: Any) -> str:
+    def fget(self: Any) -> FigureHandle:
         token = _mint_token(self, builder_name)
         if token is None:
-            return ""
+            return FigureHandle("")
         return _publish(token, builder(self))
 
     _adopt_identity(fget, builder, builder_name)
@@ -108,10 +113,10 @@ def _make_fget(builder: Callable[[Any], Any]) -> Callable[[Any], str]:
 def _make_async_fget(builder: Callable[[Any], Any]) -> Callable[[Any], Any]:
     builder_name = _fn_name(builder)
 
-    async def fget(self: Any) -> str:
+    async def fget(self: Any) -> FigureHandle:
         token = _mint_token(self, builder_name)
         if token is None:
-            return ""
+            return FigureHandle("")
         return _publish(token, await builder(self))
 
     _adopt_identity(fget, builder, builder_name)
@@ -132,12 +137,15 @@ def figure(builder: Callable[[Any], Any]) -> "FigureVar | AsyncFigureVar": ...
 
 @overload
 def figure(
-    builder: None = None, **var_kwargs: Any
+    builder: None = None, *, probe: "str | bool | None" = None, **var_kwargs: Any
 ) -> Callable[[Callable[[Any], Any]], "FigureVar | AsyncFigureVar"]: ...
 
 
 def figure(
-    builder: Optional[Callable[[Any], Any]] = None, **var_kwargs: Any
+    builder: Optional[Callable[[Any], Any]] = None,
+    *,
+    probe: "str | bool | None" = None,
+    **var_kwargs: Any,
 ) -> "FigureVar | AsyncFigureVar | Callable[[Callable[[Any], Any]], FigureVar | AsyncFigureVar]":
     """Declare a chart on a Reflex state class.
 
@@ -164,7 +172,20 @@ def figure(
     Keyword arguments pass through to reflex's computed var (``deps=``,
     ``auto_deps=``, ``interval=``, ...); dependencies are auto-tracked from
     the builder's body by default, exactly like a normal ``@rx.var``.
+
+    ``probe=`` sets the compile-time probe level (spec
+    reflex-integration.md §3.1): at app compile the plugin runs the builder
+    once against default state, so hallucinated chart APIs and bad kwargs
+    fail ``reflex run`` instead of a silent blank mount at hydrate.
+    ``"build"`` (the sync default) runs the body only; ``"figure"``
+    additionally compiles the result (full config/shape validation at the
+    price of one real figure); ``False`` opts out — the default for
+    ``async def`` builders, whose data sources should not be awaited at
+    compile.
     """
+    if probe not in (*_PROBE_LEVELS, None):
+        msg = f"@reflex_xy.figure probe= must be 'build', 'figure', or False, got {probe!r}"
+        raise ValueError(msg)
 
     def _decorate(fn: Callable[[Any], Any]) -> "FigureVar | AsyncFigureVar":
         if _fn_name(fn).startswith("_"):
@@ -176,9 +197,14 @@ def figure(
             )
             raise ValueError(msg)
         var_kwargs.setdefault("cache", True)
-        if inspect.iscoroutinefunction(fn):
-            return AsyncFigureVar(fget=_make_async_fget(fn), return_type=str, **var_kwargs)
-        return FigureVar(fget=_make_fget(fn), return_type=str, **var_kwargs)
+        is_async = inspect.iscoroutinefunction(fn)
+        if is_async:
+            var = AsyncFigureVar(fget=_make_async_fget(fn), return_type=FigureHandle, **var_kwargs)
+        else:
+            var = FigureVar(fget=_make_fget(fn), return_type=FigureHandle, **var_kwargs)
+        level = probe if probe is not None else (False if is_async else "build")
+        setattr(var._fget, PROBE_ATTR, level)
+        return var
 
     if builder is None:
         return _decorate

--- a/scripts/reflex_ws_smoke.py
+++ b/scripts/reflex_ws_smoke.py
@@ -14,6 +14,9 @@ design:
    point closes the semantic loop: kernel pick -> reflex event -> state
    delta -> DOM readout.
 4. Streaming: clicking "go live" grows the live trace via `append` pushes.
+5. Composition: toggling the §9 cond swaps the composed board for
+   `rx.foreach` small multiples over a `list[DataHandle]` var — new plan
+   charts mount and subscribe live.
 
 Usage:
     python3 scripts/reflex_ws_smoke.py [--frontend http://localhost:3100]
@@ -242,9 +245,11 @@ def main() -> None:
     with ChromiumSession(chromium, gl="software", sandbox=False) as session:
         probe = Probe(session, args.frontend)
 
-        # 1) every chart mounts a view (seven live sources + one static Chart)
+        # 1) every chart mounts a view (ten live sources + two static charts;
+        #    composite plan views mount as their data handles hydrate; the §9
+        #    foreach multiples mount only after the cond toggle, step 6)
         probe.wait_for(
-            "window.__xy_views && window.__xy_views.size >= 7",
+            "window.__xy_views && window.__xy_views.size >= 10",
             timeout_s=120.0,
             label="mounted chart views",
         )
@@ -257,13 +262,16 @@ def main() -> None:
         if len(ws) != 1:
             failures.append(f"expected exactly 1 backend websocket (shared transport), got {ws}")
 
-        # 2b) the direct-Chart mount is truly static: it never subscribes. The
-        #     seven live sources (five figure vars + two inline() tokens: the
-        #     orbits and the §6 drilldown) each sub.
+        # 2b) the static mounts (the §5 payload-asset chart and the §7 direct
+        #     Chart) never subscribe. The ten live sources — two figure vars
+        #     (§2 histogram, §3 live), three inline() tokens (orbits, §6
+        #     drilldown, legend-cats), and five data-bound plan charts (§1
+        #     cloud, §4 overview + detail, §8 bound, §9 board), whose composed
+        #     xyp1 tokens sub once their data handles hydrate — each sub.
         subs = probe.sent_ws_frames('"sub"')
         print(f"sub frames sent: {len(subs)}")
-        if len(subs) < 7:
-            failures.append(f"expected >= 7 sub frames (live sources), got {len(subs)}")
+        if len(subs) < 10:
+            failures.append(f"expected >= 10 sub frames (live sources), got {len(subs)}")
 
         # 3) pixels: every chart paints ink inside its rect (full-page shot,
         #    rects in page coordinates so below-the-fold charts count too).
@@ -283,6 +291,7 @@ def main() -> None:
             ("live", 0.005),
             ("inline", 0.005),
             ("drilldown", 0.02),
+            ("bound", 0.02),
         )
         for chart_id, min_ink in checks:
             frac = ink_fraction(png, probe.rect(chart_id, page_coords=True), 1.0)
@@ -353,6 +362,28 @@ def main() -> None:
         )
         n_after = probe.eval("window.__xy_views.get('live').gpuTraces[0].n")
         print(f"live stream: {n_before} -> {n_after} vertices (append pushes)")
+
+        # 6) §9 cond/foreach: toggling the split swaps the cond branch from
+        #    the composed board to an rx.foreach grid of plan charts bound to
+        #    a list[DataHandle] var — the board unmounts, three multiples
+        #    mount and sub (net +2 views).
+        views_before = probe.eval("window.__xy_views.size")
+        probe.scroll_to("split-btn")
+        split = probe.eval(
+            "(() => { const b = document.getElementById('split-btn');"
+            " const r = b.getBoundingClientRect();"
+            " return {x: r.x + r.width / 2, y: r.y + r.height / 2}; })()"
+        )
+        probe.mouse("mouseMoved", split["x"], split["y"])
+        probe.mouse("mousePressed", split["x"], split["y"], button="left", buttons=1, clickCount=1)
+        probe.mouse("mouseReleased", split["x"], split["y"], button="left", buttons=0, clickCount=1)
+        probe.wait_for(
+            f"window.__xy_views.size >= {views_before} + 2",
+            timeout_s=30.0,
+            label="foreach small multiples mounting after the cond toggle",
+        )
+        views_after = probe.eval("window.__xy_views.size")
+        print(f"cond/foreach: {views_before} -> {views_after} mounted views after split toggle")
 
         if args.screenshot:
             Path(args.screenshot).write_bytes(probe.screenshot())

--- a/spec/design/reflex-component-api-implementation.md
+++ b/spec/design/reflex-component-api-implementation.md
@@ -1,0 +1,380 @@
+# Data-bound chart components — implementation plan
+
+**Status: implemented — Phases 0–4 landed (2026-08); this document is the
+executed work plan plus its completion record (see "Completion record"
+at the end).** Design authority:
+[`reflex-component-api-options.md`](reflex-component-api-options.md)
+(Option 6 + Option 2 for the escape hatch; §7 phasing; decision record in
+its §8). The shipped behavior is specified in
+[`reflex-integration.md`](reflex-integration.md) — §3.1 (handles + compile
+probe), §3.6 (data vars, plans, composite tokens), §5 (component tiers and
+deprecations). Each phase was implemented as written unless the completion
+record notes otherwise; every phase landed with its spec updates in the
+same change (repo rule: a change is incomplete while its spec is stale).
+
+Target DX (recap):
+
+```python
+class CloudData(TypedDict):
+    x: np.ndarray; y: np.ndarray; mag: np.ndarray
+
+class Dash(rx.State):
+    points: int = 200_000
+
+    @rxy.data
+    def cloud(self) -> CloudData: ...
+
+def index():
+    return rxy.scatter_chart(data=Dash.cloud, x="x", y="y",
+                             color="mag", colormap="viridis",
+                             height="460px", on_select_end=Dash.select)
+```
+
+---
+
+## Phase 0 — pin the ground (tests only)
+
+Everything later rests on behavior verified by probe but not yet pinned.
+These tests fail loudly when a Reflex or grammar upgrade moves the ground.
+
+**New: `tests/reflex_adapter/test_framework_contracts.py`**
+(runs under the `reflex` extra job, like the rest of `tests/reflex_adapter/`)
+
+- A computed var may return a parametrized generic frozen dataclass
+  (`Handle[SomeTypedDict]`); the class-level Var's `_var_type` preserves the
+  full alias; `typing.get_args` recovers the TypedDict; `get_type_hints`
+  yields its keys (fact R7).
+- Same preservation for a base var `list[Handle[Schema]]` and for the
+  element Var produced by indexing / `rx.foreach` (R7, foreach half).
+- A component prop annotated `rx.Var[Handle]` accepts the parametrized var
+  and raises `TypeError` at `create()` for an int var and for a raw string
+  (R1).
+- An unknown `on_*` kwarg raises `ValueError` at `create()`; an unknown
+  non-event kwarg is silently absorbed into `style` (R8 — this test
+  *documents the hazard* the factories must compensate for; if Reflex ever
+  starts rejecting these, our partition layer gets simpler).
+
+**New core-side test (beside the existing composition-API tests in
+`tests/`): validation-timing pins (facts X1–X3)**
+
+- Zero-row construction compiles: for every mark kind Phase 2/3 will cover,
+  `xy.<kind>_chart(xy.<mark>([], ...)).figure()` succeeds.
+- Mark config validates at `.figure()`, not construction
+  (`xy.scatter([1], [1], colormap="bogus")` constructs; `.figure()` raises).
+- Chrome nodes validate eagerly (`xy.x_axis(type_="bogus")` raises at call).
+- `Chart.figure()` memoizes; data rebinding requires a fresh `Chart`.
+
+**Acceptance:** suite green in CI on the pinned Reflex floor; a comment in
+each test names the design fact (R1/R7/R8/X1–X3) it pins.
+
+---
+
+## Phase 1 — typed seam (small, non-breaking)
+
+Make the component a real, exported, prop-typed Reflex component and the
+figure var's value a typed handle.
+
+**New: `python/reflex_xy/handles.py`**
+
+- `@dataclass(frozen=True) class FigureHandle: token: str = ""` and
+  `class DataHandle(Generic[S]): token: str = ""`.
+- One-line `@rx.serializer` each → `dict` (delta-path safety; also makes
+  `guess_type` produce an `ObjectVar`).
+- Empty token = "not ready / no chart" — the existing `""` sentinel wrapped,
+  so the var type stays non-optional.
+
+**`python/reflex_xy/vars.py`**
+
+- `FigureVar` / `AsyncFigureVar`: `return_type=FigureHandle`; `_publish`
+  returns `FigureHandle(token)` / `FigureHandle("")`.
+
+**`python/reflex_xy/component.py`**
+
+- Component class gains `figure: rx.Var[FigureHandle]`; the wrapper reads
+  `figure.token`. Keep the `token: rx.Var[str]` prop for one deprecation
+  cycle (wire/JSX accepts both).
+- `chart()` gains keyword form `chart(figure=Dash.cloud, ...)`. The
+  positional `chart(source, ...)` stays as a shim: state-var/handle sources
+  route to `figure=`, str tokens and Chart/Figure objects keep today's
+  behavior; emit a deprecation warning for the positional form.
+- `create()`-override validation (recharts pattern): semantic-event props on
+  a static (`src`) source → clear error instead of silent no-op; malformed
+  `tailwind_classes` keeps its existing eager errors.
+
+**`python/reflex_xy/__init__.py`** — `register()` / `inline()` return
+`FigureHandle` (their token remains inside; `.token` documented). The shim
+accepts old-style str for one cycle.
+
+**`python/reflex_xy/assets/XYChart.jsx`** — accept `figure` object prop
+(`{token}`) alongside legacy `token` string.
+
+**Tests:** extend `tests/reflex_adapter/test_component.py` (typed-prop
+rejection cases mirror Phase 0's contract test but through the real
+component) and `test_figure_var.py` (handle-valued var; empty-token
+sentinel).
+
+**Spec:** `reflex-integration.md` §5 — `figure=` prop, handle type,
+deprecation note.
+
+**Acceptance:** existing demo app (`examples/reflex/`) runs unmodified;
+`chart(figure=Dash.points)` fails at compile with the framework's
+`TypeError`; full gate (`pre-commit`, `ruff`, `ty`, `pytest`) green.
+
+---
+
+## Phase 2 — `@rxy.data` + flat factories (the headline)
+
+### 2.1 `@rxy.data` — new `python/reflex_xy/data.py`
+
+`DataVar` / `AsyncDataVar`, structurally a sibling of `FigureVar` (same
+`_deps` builder-targeting, same `iscoroutinefunction` dispatch, same
+pre-session short-circuit):
+
+- fget: mint `xyd1|<client>|<state>|<var>` token; run the data method;
+  validate the returned mapping (str keys; array-likes; consistent lengths —
+  the only checks that need real data); publish **columns** to the registry;
+  return `DataHandle(token)`.
+- `return_type` set from the method's return annotation:
+  `DataHandle[CloudData]` when it's a TypedDict, plain `DataHandle`
+  otherwise — this is the schema channel (R7); nothing executes to read it.
+- `None` return → release + `DataHandle("")`, mirroring figure vars.
+- Underscore names refused at decoration (same reason as figure vars: the
+  handle must sync to the client).
+
+**`python/reflex_xy/tokens.py`** — add the `xyd1` grammar
+(`xyd1|client|state|var`, same charset rules as `xyv1`); `parse_token`
+learns the new prefix; `builder_of` works unchanged (DataVars are computed
+vars on the state class).
+
+### 2.2 Plans — new `python/reflex_xy/plan.py`
+
+`ChartPlan`: the validated, data-free chart structure.
+
+- **Build** (at factory call = page evaluation): construct the real xy tree
+  (marks with string channels, chrome nodes, chart props); bind zero-row
+  placeholder columns for every referenced channel name; call `.figure()`
+  once — the full mark/config validation gate at compile (X2). Discard the
+  probe figure.
+- **Serialize**: dataclass nodes → canonical JSON (sorted keys, versioned
+  `plan_version: 1`) → sha256 → `digest`. Register in a process-local
+  `{digest: ChartPlan}` map. Page bodies run in every worker (X4 — but see
+  the completion record: backend-only workers needed this made true by
+  construction), so the map is populated everywhere; a lookup miss
+  (hot-reload drift) answers `err {resync}` with a message naming the
+  digest.
+- **Bind** (at serve time): columns + plan → fresh `Chart` (never reuse — X3)
+  → `.figure()` → `Figure`. Column-mismatch errors name both sides:
+  *"plan binds column 'mag'; Dash.cloud produced {x, y}"*.
+- Bonus wired here: the zero-row probe figure's `dom_class_strings()` gives
+  live charts automatic Tailwind discovery — mirror into the existing
+  `tailwind_class_tokens` scan prop (today live sources need the manual
+  inventory).
+
+### 2.3 Flat factories — new `python/reflex_xy/factories.py`
+
+Phase 2 kinds: `scatter_chart`, `line_chart`, `histogram_chart`,
+`bar_chart`. Each flat factory:
+
+1. **Partitions kwargs** — derived from `inspect.signature` of the xy mark
+   (positional params = channels, keyword-only = options; the convention is
+   uniform across `components.py`) plus chart props, component fields,
+   event triggers, and style passthrough.
+   - Collision table (component/chart level wins): `width`, `height`,
+     `opacity`, `style`, `class_name`, `key`, `animation`. Colliding mark
+     options get flat aliases (`stroke_width` for `line.width`); the table
+     is *generated* into the docs and pinned by a test — public contract.
+   - Unknown kwarg close to a known name (difflib) → error with suggestion;
+     far from everything → style passthrough (preserves Reflex's CSS
+     convention). The Phase 0 R8 test documents why this layer must exist.
+2. **Checks columns** — `get_args(data_var._var_type)` → TypedDict →
+   channel strings validated with the *Available columns* error. Untyped
+   `dict[str, ...]` → skip; checked at first execution.
+3. **Builds the plan** (2.2) and returns the component with props
+   `plan` (literal digest, baked into JSX) + `data` (`Var[DataHandle]`).
+4. **Static tier:** `data=` given concrete arrays/mapping (not a Var) →
+   bind immediately and route to the existing `payload_asset` path
+   (`src` prop) — works under `reflex export`.
+
+### 2.4 Transport & registry
+
+Composite figure identity, minimal wire change:
+
+- The wrapper subscribes with `fig = "xyp1|<digest>|<xyd1-token>"`,
+  assembled client-side once `data.token` is non-empty. Rooms, `mid`
+  addressing, versioning, and the attachment-cap logic in
+  `namespace.py` are reused unchanged — one new token prefix to parse.
+- **`registry.py`**: column entries (token → columns + version) beside
+  figure entries; figure cache keyed by the composite token, plus an index
+  `data_token → {digests}` so a data republish rebuilds and broadcasts
+  every dependent figure. Figure entries stay derived caches: TTL-sweepable,
+  rebuildable from (plan map, data rebuild).
+- **`namespace.py`**: `sub`/`msg` on `xyp1|…` → plan lookup; data resolve
+  (registry hit, else rebuild); bind → publish → serve. Affinity check uses
+  the client token embedded in the `xyd1` half.
+- **`state_bridge.py`**: `rebuild_data(app, parsed)` mirroring
+  `rebuild_figure` — resolve state class, find the DataVar's method, run it
+  (await if async), return columns.
+- **`assets/XYChart.jsx`**: accept `plan` + `data` props; compose the
+  subscription token; everything downstream (payload epochs, appends,
+  view-state) unchanged.
+
+### 2.5 Tests
+
+- `test_data_var.py` — handle value, schema in `_var_type`, pre-session
+  short-circuit, `None` release, underscore refusal, async variant.
+- `test_plan.py` — digest stability (goldens), zero-row validation catches
+  bad colormap/enum/axis-ref at build, bind produces fresh figures,
+  version field.
+- `test_factories.py` — partition + collision table, did-you-mean,
+  TypedDict column errors (including through a foreach item var), untyped
+  fallback, static-tier routing.
+- Extend `test_socket_data_plane.py` — composite `sub`, payload, pick;
+  data republish fans out to all dependent plans; rebuild-on-miss for both
+  halves; affinity refusal; plan-miss `err {resync}`.
+- Demo app: add one data-bound chart to `examples/reflex/` beside the
+  existing figure-var charts (both models exercised by
+  `scripts/reflex_ws_smoke.py`).
+
+**Spec:** `reflex-integration.md` — new section for the data plane vars +
+plan tier + composite tokens; `wire-protocol.md` touched only if the
+envelope grows a field (target: it doesn't — composite token rides `fig`).
+Decision record added to `reflex-component-api-options.md`.
+
+**Acceptance:** the target-DX snippet at the top of this file runs; every
+row of the error-catalog table in the options doc §5.6 reproduces at the
+stated phase (import/compile/hydrate); 100M-point state delta is still just
+the handle; full gate green.
+
+---
+
+## Phase 3 — composed `rxy.chart(...)` + remaining kinds
+
+- `factories.py`: `rxy.chart(*nodes, data=..., **props)` consuming xy
+  mark/annotation/chrome nodes (plain xy dataclasses — they never enter the
+  Reflex tree; the factory builds the plan before any component exists).
+- `__init__.py` lazy exports: curated re-exports of mark + chrome
+  constructors (`rxy.scatter` *is* `xy.scatter`, etc.) so hallucinated
+  names die at import against the explicit export map.
+- Remaining `*_chart` kinds via the same signature derivation.
+- **Decision point (resolve during this phase):** the data-taking composite
+  factories (`pie_chart`, `radar_chart`, `wind_rose`, `sankey`) do eager
+  numeric work at call time — they don't fit the plan/zero-row model.
+  Options: (a) static-tier / concrete-data only, (b) escape hatch only,
+  (c) column-ref variants in core xy. Record the choice in the spec.
+- Facets: static facet grid already works; live data-bound facets deferred
+  (tracked in the options doc's open questions).
+- Plan format frozen: goldens + a compatibility note in the spec.
+
+**Acceptance:** the composed example from the options doc runs; `rx.cond`
+between two composed charts compiles and validates both.
+
+---
+
+## Phase 4 — compile probe for the escape hatch
+
+- `vars.py`: `@rxy.figure(probe="build" | "figure" | False)` — default
+  `"build"` for sync builders, `False` for async.
+- `app.py` (`XYPlugin` compile hook): walk state classes, find FigureVars,
+  default-construct the substate, run the builder; `probe="figure"`
+  additionally compiles the result. Errors re-raise wrapped with state
+  class, var name, and source location. Builders touching
+  `self.router`/session degrade to a warning, not a compile failure
+  (constraint 2's escape valve).
+- Tests: hallucinated-API builder fails compile; session-dependent builder
+  downgrades; opt-out honored; async skipped by default.
+
+**Spec:** `reflex-integration.md` §3.1 — probe semantics and defaults.
+
+---
+
+## Deferred (tracked, do not start without a design pass)
+
+- Keyed dataset collections for `foreach` (one data var = one dataset
+  today; a runtime-length collection needs a keyed extension).
+- Per-mark `data=` (two sources, one chart).
+- Core-xy metadata registry (stubs/docs generation) — nice-to-have, not a
+  prerequisite; signature derivation covers v1.
+- Upstream Reflex PRs, both sites located in the monorepo:
+  generic attribute access
+  (`packages/reflex-base/src/reflex_base/utils/types.py`,
+  `get_attribute_access_type` ~:436 — `get_origin()` unwrap) enabling
+  `x=Dash.cloud.x`; Var-type child coercion
+  (`packages/reflex-base/src/reflex_base/components/component.py` ~:1314)
+  enabling bare `rx.card(State.cloud)`.
+
+## Rollout & deprecation
+
+- Phases 1–4 are additive. Deprecations (positional `chart(source)`, str
+  tokens in public returns, legacy `token` JSX prop) warn for one release
+  cycle after Phase 2 ships, then tighten. The `@rxy.figure` tier is
+  permanent (escape hatch), not deprecated.
+- CI order unchanged: `abi_smoke` / `render_smoke_nonumpy` /
+  `append_stream_smoke` first (none are affected), adapter suite under the
+  `reflex` extra, browser E2E via `scripts/reflex_ws_smoke.py`.
+- Every phase: run the full pre-commit + ruff + ty + pytest gate before
+  commit (repo rule); spec updates land in the same PR as the code.
+
+## Risks
+
+| risk | mitigation |
+|---|---|
+| Reflex upgrade changes Var/prop machinery | Phase 0 contract tests fail first, named after the design facts |
+| Grammar change alters plan JSON → digest churn | digests are content addresses: old subscribers get `err {resync}` and re-sub against the new plan; goldens catch *accidental* churn |
+| Kwarg partition drifts from xy signatures | partition is derived from `inspect.signature` at import, not hand-listed; collision table pinned by test |
+| Data republish fan-out amplifies (one data var, many plans) | reuse the existing coalescing broadcast machinery; index bounded by mounted plans; measure in the §12 harness before optimizing |
+| Attachment cap on column-heavy payloads | unchanged: the namespace's `_MAX_WIRE_ATTACHMENTS` single-blob fallback applies to bound figures exactly as today |
+
+---
+
+## Completion record (2026-08)
+
+All five phases landed together; the acceptance criteria of each phase hold
+(the target-DX snippet at the top runs verbatim; every row of the options
+doc §5.6 error catalog reproduces at its stated phase; the demo app runs on
+the modern API; the full gate is green). Deviations from the letter of the
+plan, all recorded in the options doc §8 decision record:
+
+- **Phase 0** — as written: `tests/reflex_adapter/test_framework_contracts.py`
+  (R1/R7/R8) and `tests/test_validation_timing.py` (X1–X3, plus the exact
+  zero-row kind list the factories rely on). Verified against reflex 0.9.8.
+- **Phase 1** — as written, except the deprecation warning fires only for
+  positional *live* sources; the positional static Chart/Figure form stays
+  undeprecated (it is the only route for arbitrary Charts, e.g. facet
+  grids). Kernel-only events on static sources now fail `create()`.
+- **Phase 2** — as written, with `data.py` renamed `data_vars.py`
+  (submodule/export shadowing) and one addition beyond the plan: a
+  registry→namespace error seam (`err {resync}` room fan-out) so a column
+  republish whose bind fails cannot freeze subscribers silently; the
+  wrapper bounds consecutive err-driven resyncs.
+- **Phase 3** — composed `chart(*nodes, data=...)`, curated re-exports
+  (`reflex_xy.scatter` *is* `xy.scatter`), and seven more flat kinds (area,
+  step, stem, column, errorbar, error_band, segments). **Decision point
+  resolved:** aggregating marks (box, violin, hexbin, contour, heatmap,
+  stairs, ecdf) and the data-taking composite factories (pie, radar,
+  wind_rose, sankey) are excluded from the plan tier — options (a)+(b):
+  static tier or `@reflex_xy.figure` — because their validators need real
+  values and a synthetic-row probe would validate against made-up data;
+  the probe refuses them with an error naming both routes
+  (reflex-integration.md §3.6 "Kind coverage"). Plan format frozen:
+  `PLAN_VERSION = 1`, golden digest pinned in `test_plan.py`.
+- **Phase 4** — as written (`probe="build"`/`"figure"`/`False`, async off
+  by default with explicit opt-in via `asyncio.run`); the
+  session-dependence downgrade uses a source-text heuristic
+  (`self.router`), documented in reflex-integration.md §3.1.
+
+**Post-landing correction (X4).** First real `reflex run` of a data-bound
+app surfaced that fact X4 holds only where the frontend compile runs:
+backend-only workers (the dev backend subprocess, prod workers) import the
+app module but leave pages unevaluated, so their plan maps were empty and
+every plan subscription answered `err {resync}` until the bounded retry
+gave up. Fixed structurally, not by weakening the model: `setup(app)`'s
+startup lifespan evaluates the app's unevaluated page component functions
+once per worker (`app.py _ensure_page_plans`, pinned by
+`tests/reflex_adapter/test_page_plan_registration.py`), making "the plan
+map is populated in every worker" a guarantee of the integration instead
+of an assumption about Reflex. Recorded in reflex-integration.md §3.6 and
+the options doc §8.
+
+Deferred items remain deferred and tracked (keyed dataset collections for
+`foreach`, per-mark `data=`, the core-xy metadata registry, both upstream
+Reflex PR sites).

--- a/spec/design/reflex-component-api-options.md
+++ b/spec/design/reflex-component-api-options.md
@@ -1,0 +1,905 @@
+# A component-shaped, compile-checked API for `reflex_xy` — options
+
+**Status: decided — Option 6 adopted (with Options 1 and 2 as its subsumed
+parts), implemented.** See the decision record at the end of this document.
+This document records the design space for that revision of the `reflex_xy`
+public API. The shipped integration is specified in
+[`reflex-integration.md`](reflex-integration.md) (the adopted tier: §3.6),
+and the framework-agnostic composition contract in
+[`reflex-shaped-api.md`](reflex-shaped-api.md). The file-level work plan
+that guided the implementation lives in
+[`reflex-component-api-implementation.md`](reflex-component-api-implementation.md).
+
+It is written to be self-contained: §1 gives a new engineer everything they
+need about Reflex, xy, and the current integration; §2 states the problem;
+§3 the constraints; §4 the verified framework facts the designs build on;
+§5 the six candidate designs (§5.6, the synthesis, is the recommended one);
+§6 the comparison; §7 the recommendation.
+
+---
+
+## 1. Background: the three systems involved
+
+### 1.1 What xy is
+
+xy is a high-performance charting engine for Python (this repository). Three
+layers matter here:
+
+- **The composition API** (`python/xy/components.py`) — the only public
+  chart-building surface. Users compose charts declaratively:
+
+  ```python
+  import xy
+  chart = xy.scatter_chart(
+      xy.scatter(x, y, color=mag, colormap="viridis"),
+      xy.x_axis(label="σ"),
+      width="100%", height=460,
+  )
+  ```
+
+  `xy.scatter(...)` returns a `Mark` — a plain dataclass holding whatever you
+  passed (arrays, lists, or **column-name strings** resolved later against a
+  `data=` table). `xy.scatter_chart(...)` returns a `Chart` — a lightweight
+  tree of these dataclass nodes. **Nothing heavy happens at construction**:
+  no copies, no shape checks, no rendering.
+
+- **The figure compiler** — `Chart.figure()` compiles the tree into the
+  internal `Figure` (canonical f64 columns, trace state, the wire spec).
+  **This is where almost all validation fires**: shape mismatches, bad
+  colormaps/enums, unresolvable column names, missing axis ids. The split is
+  bimodal and worth memorizing:
+
+  | fails at construction (eager) | fails at `.figure()` (lazy) |
+  |---|---|
+  | unknown kwargs (`TypeError` — no `**kwargs` sinks anywhere) | data shape/length mismatches |
+  | chrome nodes: `x_axis`, `legend`, `theme`, … validate every field | mark config: `colormap=`, `symbol=`, `bins=`, `mode=`, … |
+  | unknown attribute on the lazy `xy` module (`AttributeError`) | column-name resolution against `data=` |
+  | chart-level `class_names` slot allowlist | axis-id references (`y_axis="y2"`) |
+
+  A useful verified fact: `xy.scatter_chart(xy.scatter([], [])).figure()`
+  builds a valid empty figure — so **binding zero-row columns and calling
+  `.figure()` exercises the full validation gate without any real data**.
+
+- **The render client** (`js/src/`, bundled into `python/xy/static/`) — a
+  WebGL2 client that renders a binary payload (spec JSON + raw f32 buffers,
+  never JSON numbers) and talks to a Python-side kernel for drilldown,
+  picking, and selection. The same client serves notebooks, static HTML
+  export, and Reflex.
+
+### 1.2 What Reflex is
+
+[Reflex](https://reflex.dev) is a Python full-stack web framework. You write
+Python; it compiles a React frontend and runs a Python backend. The concepts
+this document leans on:
+
+- **State** — a class with typed fields; lives on the backend, synced to the
+  browser as JSON deltas over one websocket:
+
+  ```python
+  class Dash(rx.State):
+      points: int = 200_000          # a base var
+
+      @rx.var
+      def label(self) -> str:        # a computed var: re-derived when deps change
+          return f"{self.points:,} points"
+
+      @rx.event
+      def more(self):                # an event handler: called from the browser
+          self.points *= 2
+  ```
+
+- **Components** — Python classes that compile to React/JSX. A page is a
+  Python function returning a component tree; props are typed class fields:
+
+  ```python
+  def index() -> rx.Component:
+      return rx.vstack(
+          rx.heading(Dash.label),                    # a Var in the tree → reactive text
+          rx.button("more", on_click=Dash.more),     # event prop → handler
+      )
+  ```
+
+- **Vars** — `Dash.label` accessed on the *class* is not a value; it is a
+  `Var` object: a typed reference (`_var_type=str`) that compiles to a JS
+  expression. Components accept Vars as props and children; that is what
+  makes the tree reactive.
+
+- **`rx.cond` / `rx.foreach`** — conditionals and loops over state, resolved
+  in the browser. Crucially, `rx.foreach(Dash.items, render_fn)` calls
+  `render_fn` **exactly once at compile** with a *placeholder* Var (typed
+  from the list annotation); the browser instantiates it per row. You cannot
+  branch in Python on the item's value inside `render_fn` — only `rx.cond`.
+
+- **The compile timeline.** "Compile" is when `reflex run`/`reflex export`
+  evaluates your app. What runs when (verified against reflex 0.9.6):
+
+  | phase | what executes | what can fail here |
+  |---|---|---|
+  | **import** | module bodies; state classes are built | invalid state var types; anything at module scope |
+  | **compile** | every page function runs; every `Component.create()` runs; **the default state is instantiated and computed vars are evaluated** (unless `initial_value=` opts out) | prop type errors; event-handler arity/type errors; child whitelist errors; computed-var exceptions |
+  | **hydrate** | browser loads; real session state is created; deltas flow | everything else |
+
+  Two facts from `Component._post_init` shape every design below:
+  1. **Prop type checking happens only for props annotated `Var[T]`** — the
+     incoming Var's `_var_type` is checked structurally at `create()` (i.e.
+     at compile). A bare `T` annotation gets no check at all.
+  2. **Unknown kwargs are silently absorbed into `style`** — a typo'd prop
+     becomes a CSS property, not an error.
+
+  Custom Python types become legal state-var values and prop types by
+  registering an `@rx.serializer` (dataclasses work even without one).
+
+### 1.3 What reflex_xy is, and how it works today
+
+`python/reflex_xy/` (import name `reflex_xy`) is the bundled integration.
+Its central problem: **chart data can be huge, and Reflex state sync is JSON
+diffing** — putting a million rows in state (as e.g. recharts integrations
+do) would be catastrophic. The design (full detail:
+[`reflex-integration.md`](reflex-integration.md)) splits every chart into two
+planes:
+
+- **Control plane** (Reflex-native): which figure a component shows, style
+  props, and small semantic events (`on_point_click`, `on_select_end`, …) —
+  ordinary Reflex state and event handlers. Never data buffers.
+- **Data plane** (xy-native): binary payloads, drilldown round-trips, and
+  streaming appends on a second socket.io namespace (`/_xy`) **multiplexed
+  onto the app's existing websocket**. Reflex state never sees a data byte.
+
+The pieces, end to end:
+
+```python
+class Dash(rx.State):
+    points: int = 200_000
+
+    @reflex_xy.figure                 # ← a computed var in disguise
+    def cloud(self) -> xy.Chart:
+        x, y = load(self.points)
+        return xy.scatter_chart(xy.scatter(x, y))
+
+def index():
+    return reflex_xy.chart(Dash.cloud, height="460px")   # ← the wrapper call
+```
+
+1. **`@reflex_xy.figure`** wraps the method in a `FigureVar` (a Reflex
+   computed var). Its *value* is only a token string —
+   `xyv1|<client_token>|<state_name>|<var_name>` — and **evaluating the var
+   is what builds the chart**: the builder runs, the resulting `Figure` is
+   published into a **per-process registry** under the token, and the token
+   goes into state. Reflex's dependency tracking re-runs the builder when
+   state it reads changes; subscribers get a fresh payload pushed over the
+   data plane. The token is stable, so the DOM never re-renders — pixels
+   move, DOM doesn't.
+2. **The registry** (`registry.py`) is deliberately process-local and *not*
+   a distributed store. A registry miss (worker restart, reconnect landing
+   on another node) is recovered by **re-running the builder against session
+   state** (`state_bridge.py`) — Reflex state is the durable source of
+   truth; every registered figure is a rebuildable cache. The token *is* the
+   rebuild recipe.
+3. **`reflex_xy.chart(source)`** (`component.py`) is a factory that builds a
+   private `rx.Component` (`XYChart`). A token/Var source lands in the
+   `token` prop and rides the socket; an `xy.Chart` passed directly is
+   compiled to a static payload asset (`src` prop) rendered kernel-less —
+   works under `reflex export` with no backend.
+4. At **hydrate**, the JSX wrapper subscribes (`sub {fig: token}`) on the
+   `/_xy` namespace; the backend serves the registered figure's binary
+   payload (or rebuilds it from state on a miss), and interaction messages
+   round-trip to the kernel.
+
+One accidental property matters enormously for this document: at compile,
+Reflex evaluates computed vars against a default state — but `FigureVar`'s
+getter first tries to mint a token from the session's `client_token`, finds
+none (no session at compile), and returns `""` **without ever executing the
+builder body**. That is why the current design does no data work at compile
+(good) — and also why nothing in the builder body is ever checked at compile
+(the problem).
+
+---
+
+## 2. The problem
+
+Two complaints, one root cause (the chart-building code executes at hydrate,
+not at compile, and the component seam is untyped):
+
+### Problem 1 — it doesn't feel like a Reflex component
+
+Every other Reflex component composes in the tree, takes typed props, and
+works inside `rx.cond`/`rx.foreach` with a uniform mental model.
+`reflex_xy.chart(State.cloud)` is a special wrapper call around a state var —
+a different mental model, and the component class itself is private (built
+lazily, no importable type, props not part of the public surface).
+
+### Problem 2 — no compile-time validation
+
+If code references a chart API that doesn't exist — say an LLM agent
+hallucinates `xy.polar_scatter(...)` inside a builder — **nothing fails at
+compile**. The builder body is dead code until a browser session hydrates and
+the var evaluates; only then does the `AttributeError` fire, surfacing as an
+`err` frame on the data plane and an empty mount. Wrong kwargs, invalid
+colormaps, bad axis references: all the same. For a human iterating with
+`reflex run` this is slow feedback; for an agent loop (write → compile →
+check) it is invisible — the compile is green and the page is silently blank.
+
+Additionally, the component seam itself is unchecked: passing the wrong var
+(`Dash.points`) or a garbage string as the chart source is accepted at
+compile, because the `token` prop is `Var[str]` and unknown kwargs become CSS.
+
+---
+
+## 3. Constraints (what must not regress)
+
+1. **State stays lean.** Chart data must never be serialized into Reflex
+   state. The registry + token indirection is the whole point of the
+   integration — every design keeps figures (and their columns) in the
+   per-process registry, with only a small token/handle in state.
+2. **No data ingestion at compile.** Reflex evaluates computed vars at
+   compile against default state; today the figure var deliberately
+   short-circuits (returns `""`) so no chart is built just to render a dead
+   placeholder. Designs that execute anything at compile must bound what
+   runs (structure-only, zero-row, or explicit opt-in/out).
+3. **Rebuildability.** Any worker must be able to recover a figure from
+   session state alone (the multi-worker/reconnect story). Whatever a design
+   puts between state and figure must remain a deterministic recipe.
+4. **`reflex-shaped-api.md` boundaries.** xy must not grow a parallel
+   reactive DSL (no xy-owned `field()`/`condition()`); Reflex owns Vars,
+   conditionals, events, layout. The core `python/xy` package never imports
+   Reflex.
+
+---
+
+## 4. What the frameworks give us to build on
+
+Facts verified against reflex 0.9.6 and the current xy codebase, load-bearing
+for the designs:
+
+- **R1.** Prop type checks fire at `create()` (= page evaluation = compile),
+  but only for `Var[T]`-annotated props; the Var's `_var_type` is compared
+  structurally. This is how `rx.plotly(data=State.fig)` gets a typed seam.
+- **R2.** `@rx.serializer` (or being a dataclass) makes a custom type legal
+  as a state-var value and usable as `Var[MyType]`.
+- **R3.** Computed vars execute at compile against default state unless
+  `initial_value=` is set. `FigureVar` currently dodges this via the missing
+  client token — the builder body never runs before hydrate.
+- **R4.** `rx.foreach` builds its child once with a placeholder Var typed
+  from the list annotation; an untyped iterable is a hard compile error.
+  `rx.cond` builds (and therefore validates) both branches eagerly.
+  `rx.ComponentState` is explicitly unsupported inside `foreach`.
+- **R5.** Custom compile-time validation belongs in a `create()` override
+  (the pattern reflex's own recharts wrapper uses); there is no post-init
+  validation hook.
+- **R6.** A bare Var as a *child* (`rx.card(State.cloud)`) always renders as
+  a text node; Reflex has no Var-type→component coercion hook in child
+  normalization. "No call at all" is not implementable from outside the
+  framework.
+- **X1.** The xy tree is cheap to build without data; string channels are
+  late-bound column refs; unknown kwargs `TypeError` at call; chrome nodes
+  validate eagerly; marks validate at `.figure()`.
+- **X2.** Zero-row columns compile: binding empty placeholder columns for
+  every named channel and calling `.figure()` runs the full mark/config
+  validation gate in milliseconds, with no real data.
+- **X3.** `Chart.figure()` memoizes and is never invalidated — rebinding
+  data means constructing a fresh `Chart`, never mutating one.
+- **X4.** Prod backend workers re-evaluate page bodies (the static payload
+  tier already relies on this) — anything registered during page evaluation
+  exists in every worker.
+
+Three more facts were verified empirically for Option 6 — on **both** the
+released reflex 0.9.6.post1 and the framework's development checkout
+(0.9.7.post41.dev0, `~/code/reflex`), with identical results (a probe
+script exercising each; pin these as adapter tests before building on
+them):
+
+- **R7.** A computed var may return a **parametrized generic dataclass** —
+  `DataHandle[CloudData]` — and the full alias survives as the Var's
+  `_var_type`: `get_args(...)` recovers the `TypedDict`, `get_type_hints`
+  on it yields the column names. This holds for base vars too
+  (`list[DataHandle[CloudData]]`), **and the element Var inside
+  `rx.foreach` keeps the parametrized type** — so schema-aware compile
+  checks work per-item inside loops. A prop annotated `Var[DataHandle]`
+  accepts the parametrized var and rejects an `int` var or a raw string
+  with a compile-time `TypeError`.
+- **R8.** An unknown `on_*` kwarg **already fails at compile** with a
+  framework `ValueError` listing valid triggers (so "did you mean
+  `on_select_end`" only needs a better message, not new machinery). An
+  unknown *non-event* kwarg (`colormapp=`) is still silently absorbed into
+  `style` — factories must partition kwargs themselves to catch config
+  typos.
+- **R9.** Attribute access on a Var whose `_var_type` is a *parametrized*
+  generic (`Dash.cloud.token`) currently raises `VarAttributeError` —
+  reflex's attribute-type resolver does not unwrap generic origins. Root
+  cause located in the reflex monorepo: `get_attribute_access_type`
+  (`packages/reflex-base/src/reflex_base/utils/types.py`, the function at
+  ~:436) ends with an `isinstance(cls, type)` bare-class branch; a
+  parametrized alias is not a `type`, falls through, and returns `None`.
+  The fix is a `get_origin()` unwrap (ideally with TypeVar substitution
+  from `get_args`) before that branch. Typed column *references*
+  (`x=Dash.cloud.x`) therefore need that upstream fix and are correctly
+  deferred; nothing in Option 6's v1 reads attributes off the handle Var.
+
+The design space then reduces to two questions: **when does the
+chart-building expression execute** (import / compile / hydrate), and **how
+much of the chart's identity is a typed Var** at the component seam?
+
+---
+
+## 5. The options
+
+### Option 1 — Typed figure handle + first-class component (the plotly pattern)
+
+Make the chart component a real, exported, prop-typed `rx.Component`, and
+make the figure var's value a typed handle instead of a bare `str`.
+
+```python
+class Dash(rx.State):
+    points: int = 200_000
+
+    @reflex_xy.figure
+    def cloud(self) -> xy.Chart:
+        x, y, mag = load(self.points)
+        return xy.scatter_chart(xy.scatter(x, y, color=mag))
+
+def index():
+    return rx.card(
+        reflex_xy.chart(                # a real component, like rx.plotly
+            figure=Dash.cloud,          # Var[FigureHandle] — typed prop
+            on_select_end=Dash.on_select,
+            height="460px",
+        ),
+    )
+```
+
+**Compile-time validation.** `FigureVar` gets
+`return_type=FigureHandle` — a frozen dataclass `{token: str}` with a
+serializer (R2). The component declares `figure: rx.Var[FigureHandle]`
+(R1), so at compile:
+
+- `reflex_xy.chart(figure=Dash.points)` → `TypeError: Invalid var passed for
+  prop XYChart.figure, expected FigureHandle, got int`.
+- A raw string → compile `TypeError`; `register()`/`inline()` return
+  `FigureHandle` too, so legitimate paths keep working.
+- A `create()` override (R5) rejects semantic-event props on static sources
+  and malformed options with real errors, instead of the silent
+  absorb-into-style behavior.
+
+**Not checked:** the builder body. `xy.polar_scatter` inside `cloud()` still
+fails at hydrate. This option fixes the component feel and the seam, not the
+builder — pair with Option 2.
+
+**Plumbing.** Unchanged. The handle serializes to `{"token": "xyv1|..."}` in
+deltas; the wrapper reads `.token`. Registry, namespace, rebuild: untouched.
+
+**cond/foreach.** `rx.cond` works as today. `rx.foreach(Dash.handles,
+lambda h: reflex_xy.chart(figure=h))` works and is now type-safe: with
+`handles: list[FigureHandle]` the item Var is typed (R4).
+
+**Migration.** Non-breaking. The positional `chart(source)` form stays as a
+deprecated shim; strings accepted one release via `Var[FigureHandle | str]`,
+then tightened (the union weakens the check — keep it temporary).
+
+**Variant 1b (upstream).** The literal "pass `State.cloud` bare into any
+slot" needs a Var-type→component coercion hook in Reflex's child
+normalization (R6). Both repos live under reflex-dev, so a small framework
+hook is proposable — but it is a framework feature, not something the
+adapter can fake, and should not gate anything here.
+
+---
+
+### Option 2 — Compile-time builder probe (a gate, not an API)
+
+Make the builder body execute once at compile. Orthogonal to every other
+option.
+
+```python
+@reflex_xy.figure                      # probed at compile by default
+def cloud(self) -> xy.Chart: ...
+
+@reflex_xy.figure(probe=False)         # opt out: builder needs a live session
+def heavy(self) -> xy.Chart: ...
+```
+
+**Mechanics.** `XYPlugin`'s compile hook walks state classes, finds
+`FigureVar`s, constructs a default state instance (Reflex already does this
+for `initialState`), and calls the builder directly — bypassing the
+token-minting short-circuit that currently keeps it dead (R3). Three levels:
+
+- `probe="build"` (default): run the body only. Catches hallucinated `xy.*`
+  names (`AttributeError`), wrong kwargs (`TypeError`), eager chrome-node
+  errors (X1). Cost = the builder's own cost against *default* state.
+- `probe="figure"`: additionally call `.figure()` — full config/shape
+  validation, at the price of compiling one real figure per var at compile.
+- `probe=False`: today's behavior. The default for `async def` builders
+  (compile is sync; awaiting a DB at compile is what constraint 2 forbids).
+
+Errors re-raise wrapped with state class, var name, and source location, so
+the failure reads like a native Reflex compile error. Builders that touch
+`self.router` (session-dependent) degrade to a warning, not a compile
+failure.
+
+**The tension, stated plainly:** the probe runs user code that may generate
+`self.points = 200_000` rows at compile. That is bounded by *default* state,
+happens once per compile, and mirrors the cost Reflex already accepts for
+ordinary computed vars — but it is a behavior change, hence the escape
+hatch and the session-access downgrade.
+
+**Plumbing / cond / foreach / migration:** no changes anywhere; additive.
+The only decision with teeth is defaulting `probe="build"` on.
+
+---
+
+### Option 3 — Chart components: structure in the tree, data by reference
+
+*Kept for the record; subsumed by Option 6, which realizes this grammar as
+its Level 2 with marks as plain xy nodes instead of components.*
+
+The maximal option, anticipated by [`reflex-shaped-api.md`](reflex-shaped-api.md)
+§6 ("a thin codegen layer... each factory maps 1:1 to a component"). Split
+the chart into **structure** (built and validated at page evaluation, as real
+Reflex components) and **data** (a state-backed source resolved at hydrate
+through the existing registry).
+
+```python
+class Dash(rx.State):
+    points: int = 200_000
+
+    @reflex_xy.data                    # columns only — no chart API to hallucinate
+    def cloud(self) -> dict[str, Any]:
+        rng = np.random.default_rng(7)
+        xs = rng.normal(size=self.points)
+        return {"x": xs, "y": xs * 0.6 + rng.normal(scale=0.6, size=self.points),
+                "mag": abs(xs)}
+
+def index():
+    return reflex_xy.scatter_chart(        # real components, mirroring xy 1:1
+        reflex_xy.scatter(x="x", y="y", color="mag", colormap="viridis"),
+        reflex_xy.x_axis(label="σ"),
+        data=Dash.cloud,                   # Var[DataHandle] — the only reactive input
+        on_select_end=Dash.on_select,
+        height="460px",
+    )
+```
+
+**Compile-time validation — the strongest of any option, all of it existing
+xy validation moved to page-evaluation time:**
+
+- `reflex_xy.polar_scatter(...)` → `AttributeError` at import of the page
+  module. Hallucinations die where they are written.
+- Wrong kwargs → `TypeError` from the real `xy.scatter(...)` factory, which
+  each component factory calls underneath to build the actual dataclass tree
+  (string channels, no data — X1).
+- Bad enums/colormaps/axis refs → the factory binds zero-row placeholder
+  columns for every named channel and calls `.figure()` once (X2): the full
+  mark validation gate runs at compile, in milliseconds, with no data.
+- **Cannot be checked without data:** whether the named columns exist in the
+  runtime table, and real shapes/dtypes. Those surface at first publish with
+  a spec-aware error ("mark `scatter` binds column `'mag'`; data var
+  `Dash.cloud` produced columns {x, y}") — a far better hydrate failure than
+  today's, because the spec is known.
+
+**Plumbing.** The factory serializes the validated tree (dataclass nodes →
+canonical data-free JSON) and content-addresses it: `spec_digest`. Because
+prod workers re-evaluate page bodies (X4), every worker's spec registry is
+populated at startup by the same evaluation. The token becomes
+`xysp1|<client>|<state>|<data_var>|<spec_digest>`. On `sub`: look up the
+spec by digest, run the data var against session state (the existing
+`state_bridge` machinery, fetching columns instead of a Chart), bind columns
+into a fresh Chart (X3), `figure()`, register under the token. Data lives in
+the registry exactly as today; state holds only the small handle. The
+rebuild recipe = spec (deterministic from source, present in every worker) +
+data var (state) — strictly *more* recoverable than an opaque builder.
+
+**cond/foreach.** These *are* components: composition is native, and eager
+`rx.cond` branches mean both structures get validated. In `rx.foreach`, the
+structure is fixed per render function (built once with the placeholder Var
+— R4) and the `data` prop is the typed item Var. Structure *varying per
+item* is impossible — but that is Reflex's universal foreach contract, not a
+chart limitation; `rx.cond`/`rx.match` inside the render fn covers discrete
+cases.
+
+**Side benefits.** Live charts get automatic Tailwind class discovery
+(class strings are structure, not data — today live sources need the manual
+`tailwind_classes=` inventory). Later, scalar config props could accept Vars
+compiled into a small spec-patch channel (Reflex-owned reactivity, no data
+in state) without changing the transport.
+
+**Migration.** Additive: `@reflex_xy.figure` + the Option-1 component remain
+as the "full-Python tier" for charts whose *structure* genuinely depends on
+state (dynamic mark counts, data-driven annotations). Cost is real: a
+generated factory layer (~90 factories mirroring `components.py`), a spec
+serialization format that must track the grammar, and a second token family
+in the namespace.
+
+---
+
+### Option 4 — `ChartState`: a ComponentState fusion
+
+A chart as a self-contained, instantiable component with its own state — the
+Reflex-native answer to "a chart is a thing I drop into a page".
+
+```python
+class Cloud(reflex_xy.ChartState):
+    points: int = 200_000
+
+    def build(self) -> xy.Chart:
+        x, y = make(self.points)
+        return xy.scatter_chart(xy.scatter(x, y))
+
+    @rx.event
+    def more(self):
+        self.points *= 2
+
+def index():
+    return rx.vstack(
+        Cloud.create(height="460px"),
+        Cloud.create(height="200px"),   # an independent second instance
+        rx.button("more", on_click=Cloud.more),
+    )
+```
+
+**Mechanics.** `ChartState` subclasses `rx.ComponentState`; `get_component`
+wires the Option-1 typed component to a figure var auto-derived from
+`build`. Each `.create()` mints a fresh state class (`Cloud_n1`, `Cloud_n2`)
+at compile — Reflex's own per-instance mechanism — so the token
+(`xyv1|client|Cloud_n1|cloud`) resolves through the existing rebuild path
+(minted classes are registered for pickling; resolution needs a test, not
+new machinery). Uniquely, this gives **per-mount isolation**: today all
+mounts of one figure var share kernel drill state.
+
+**Compile-time validation.** Class creation checks `build`'s signature and
+return annotation; the body is still deferred — pair with Option 2's probe.
+Prop checks come from the underlying Option-1 component.
+
+**cond/foreach.** `rx.cond`: fine. `rx.foreach`: **hard-blocked by Reflex**
+(R4) — the framework cannot mint N state classes for a runtime-length list.
+That hole disqualifies this as the primary API; it is sugar for the
+dashboard-widget case.
+
+**Migration.** Pure sugar over Options 1+2; nothing breaks.
+
+---
+
+### Option 5 — Eager spec on the state class (structure at import, data by method)
+
+*Kept for the record; subsumed by Option 6, which keeps this option's
+structure/data split but moves the declaration into the page tree and hides
+the spec object entirely.*
+
+Option 3's structure/data split, but keeping the declaration on the state
+class — and moving execution from hydrate to **import**.
+
+```python
+class Dash(rx.State):
+    points: int = 200_000
+
+    cloud = reflex_xy.figure_spec(
+        xy.scatter_chart(                  # ← real xy call, executes AT IMPORT
+            xy.scatter(x="x", y="y", color="mag"),
+            width="100%",
+        )
+    )
+
+    @cloud.data                            # columns only, resolved at hydrate
+    def _cloud_data(self) -> dict[str, Any]:
+        ...
+
+def index():
+    return reflex_xy.chart(figure=Dash.cloud, height="460px")   # Option-1 component
+```
+
+**Compile-time validation.** The spec expression is module-level Python:
+`xy.polar_scatter` → `AttributeError` **at import**, before Reflex even
+starts compiling — the earliest failure any option achieves, and the
+friendliest to agent loops (`python -c "import app"` catches it).
+`figure_spec` runs the zero-row `.figure()` probe (X2) at construction, so
+config errors are import errors too. The uncheckable remainder matches
+Option 3: column existence and shapes in real data, which fail at publish
+with spec-aware messages.
+
+**Plumbing.** `figure_spec` is a descriptor that installs a `FigureVar`
+whose builder is *derived*: run the data method, bind the columns into a
+fresh copy of the spec tree (fresh `Chart`, never mutation — X3),
+`figure()`, publish under the standard `xyv1|...` token. No new token
+family, no spec-distribution question — the spec is a module-level object
+present in every worker by definition. Registry, namespace, rebuild:
+byte-identical to today.
+
+**cond/foreach.** Identical to Option 1 (the tree side *is* the Option-1
+component). No new composition power — the trade against Option 3.
+
+**Migration.** Additive. `@reflex_xy.figure` keeps covering
+structure-from-state charts; `figure_spec` becomes the recommended default
+for the majority case where only data is reactive.
+
+---
+
+### Option 6 — Data-bound chart components (the synthesis; recommended)
+
+Review feedback on Options 3 and 5 converged on a sharper shape: the chart
+should be declared **exactly once, where it is rendered**, with state
+supplying only reactive data. No figure method for the common case, no
+spec/template object in user code, no manual handle. Two user-visible
+levels, plus the existing builder as escape hatch.
+
+**Level 1 — flat, single-mark (the common case):**
+
+```python
+from typing import TypedDict
+import numpy as np
+import reflex as rx
+import reflex_xy as rxy
+
+class CloudData(TypedDict):
+    x: np.ndarray
+    y: np.ndarray
+    mag: np.ndarray
+
+class Dash(rx.State):
+    points: int = 200_000
+
+    @rxy.data                          # columns only — no chart API to hallucinate
+    def cloud(self) -> CloudData:
+        rng = np.random.default_rng(7)
+        x = rng.normal(size=self.points)
+        return {"x": x, "y": x * 0.6 + rng.normal(scale=0.6, size=self.points),
+                "mag": np.abs(x)}
+
+def index() -> rx.Component:
+    return rxy.scatter_chart(
+        data=Dash.cloud,
+        x="x", y="y", color="mag", colormap="viridis",
+        x_axis=rxy.x_axis(label="σ"),
+        height="460px",
+        on_select_end=Dash.select,
+    )
+```
+
+**Level 2 — composed, multi-mark:**
+
+```python
+def index() -> rx.Component:
+    return rxy.chart(
+        rxy.scatter(x="x", y="y", color="mag", colormap="viridis"),
+        rxy.line(x="x", y="trend", width=2),
+        rxy.x_axis(label="Time"),
+        rxy.y_axis(label="Value"),
+        data=Dash.cloud,
+        height="460px",
+    )
+```
+
+**Level 3 — escape hatch (unchanged, structure genuinely from state):**
+
+```python
+class Dash(rx.State):
+    @rxy.figure
+    def dynamic(self) -> xy.Chart:
+        return xy.scatter_chart(...) if self.mode == "scatter" else xy.line_chart(...)
+
+def index():
+    return rxy.chart(figure=Dash.dynamic)      # Option 1's typed component
+```
+
+**`@rxy.data` and the handle.** The decorator produces a `DataVar` — a
+computed var in the exact mold of today's `FigureVar` — whose *value* is a
+tiny `DataHandle` (`{"token": "xyd1|<client>|Dash|cloud"}`; frozen
+dataclass with a one-line `@rx.serializer` → dict for the delta path).
+Evaluating the var runs the data method and publishes the **columns** into
+the per-process registry under the token; dependency tracking points at the
+method body, so a state change republishes columns and pushes fresh
+payloads to every chart bound to that data. Like `FigureVar`, the getter
+short-circuits before a session exists — **user data code never executes at
+compile** (constraint 2 holds by the same mechanism that holds today).
+
+The generic annotation is the schema channel (R7, verified): the class-level
+`Dash.cloud` Var carries `_var_type = DataHandle[CloudData]`; the factory
+recovers `CloudData` via `get_args` and its column names via
+`get_type_hints` — *without executing anything*. A data method annotated
+plain `dict[str, np.ndarray]` degrades gracefully: no compile-time column
+check, validated on first execution with a spec-aware error.
+
+**Compile-time validation timeline** (each mechanism labeled):
+
+| failure | fires at | mechanism |
+|---|---|---|
+| `rxy.polar_scatter_chart(...)` | **import** | explicit export surface (`AttributeError`) |
+| unknown mark/chart kwarg, near-miss typo (`colormapp=`, `on_selection_end=`) | **compile** | factory kwarg partition + difflib suggestion (R8: events already error; others need the partition) |
+| `colormap="virids"`, bad enums, bad axis refs | **compile** | build the real xy tree, bind zero-row placeholder columns, `.figure()` once (X1/X2) |
+| `x="timestamp"` against a `TypedDict`-annotated data var | **compile** | schema from `_var_type` (R7): *Unknown column "timestamp" for Dash.cloud. Available: x, y, mag* |
+| `data=Dash.points` / `data="raw string"` | **compile** | `Var[DataHandle]` prop check (R1/R7, verified) |
+| column existence (untyped data), lengths, shapes, dtypes | **hydrate/publish** | inherent — requires real data; error names the spec's bindings vs the produced columns |
+
+**Plumbing.** The factory compiles kwargs → real xy tree → validated,
+data-free plan → canonical JSON → `spec_digest`, registered in a
+process-local spec registry during page evaluation (every worker evaluates
+pages — X4). The component carries two props: `spec` (literal digest, baked
+into the JSX at compile) and `data` (the handle Var, resolved from state at
+runtime). On `sub {spec, data_token}`: look up the plan by digest, resolve
+columns (registry hit, or rebuild via the state bridge running the data
+method against session state), bind columns into a fresh `Chart` (X3),
+`figure()`, cache per `(spec_digest, data_token)`, serve binary payload.
+Rebuild recipe = plan (deterministic from source, present in every worker) +
+data method (state) — the same two-plane, registry-as-cache architecture as
+today, with the figure split into its two independently-cacheable halves.
+Users never see `ChartPlan`, digests, or the spec registry.
+
+**cond/foreach.** Both levels return ordinary components: `rx.cond` between
+two charts works (and eagerly validates both). `rx.foreach(Dash.handles,
+lambda h: rxy.scatter_chart(data=h, x="x", y="y"))` type-checks per item —
+the element Var keeps `DataHandle[CloudData]` (R7), so even column names
+are compile-checked inside the loop.
+
+**Design decisions the review forced, recorded:**
+
+1. **Marks are xy nodes, not Reflex components.** Reflex child validation
+   rejects arbitrary dataclasses (`ChildrenTypeError`), so `rxy.chart(...)`
+   is a *factory* that consumes mark/chrome nodes before any component is
+   created — they never enter the Reflex tree. `rxy.scatter` can literally
+   re-export `xy.scatter` (zero duplication; hallucinated names still die
+   at import). Consequence: `rx.cond` cannot switch marks *inside* one
+   chart — the spec is server-compiled, so conditional structure is
+   `rx.cond` between two chart calls, or Level 3. Same boundary as
+   Option 3, now explicit.
+2. **The flat form needs a kwarg partition rule.** `scatter` is clean, but
+   the collision set is real and small: `width` (chart size vs `line`
+   stroke), `opacity`, `style`, `class_name`, `key`, `animation` exist at
+   both mark and component level. Rule: component/chart level wins;
+   colliding mark options get flat-form aliases (`stroke_width=` — hence
+   the Level-2 example) or use the composed form. The partition table is
+   part of the public contract and must be generated, not hand-listed.
+3. **Generate the flat layer from signatures, not a new registry.** xy's
+   own convention — positional params are data channels, keyword-only are
+   options, uniformly across every mark — means `inspect.signature`
+   mechanically yields the flat form's accepted kwargs, and the zero-row
+   probe reuses the real validators in `marks.py` (no parallel enum
+   tables to drift). A full `ScatterDefinition`-style metadata registry in
+   core xy (also generating stubs and docs) remains attractive, but it is
+   a separate core investment, not a prerequisite — this defuses the
+   "~90 handwritten parallel factories" objection to Option 3 without it.
+4. **Typed column references (`x=Dash.cloud.x`) are deferred.** Verified
+   broken today (R9: attribute access on a parametrized-generic Var raises
+   `VarAttributeError`); needs an upstream reflex fix. Strings + TypedDict
+   give nearly the same validation with none of the machinery.
+
+**Open questions (tracked, not hand-waved):**
+
+- **Dynamic dataset collections.** `foreach` over charts works when a
+  `list[DataHandle[...]]` exists in state — but handles are minted by
+  computed vars (one var = one dataset). A runtime-length *collection* of
+  datasets needs either a keyed-dataset extension (a data var returning a
+  dict of tables, charts binding `(handle, key)`) or N declared vars.
+  Design before implementing; do not ship an accidental contract.
+- **Per-mark `data=`** (two marks, two sources, one chart): the xy grammar
+  allows it; v1 binds one chart-level data var. Extend the spec format
+  only when a real use case lands.
+- **Static tier symmetry**: `data=` accepting concrete arrays (not a Var)
+  could route to the existing static payload asset tier, mirroring
+  `chart(xy.Chart)` today. Cheap, optional.
+
+**Migration.** Additive: today's `chart(source)` and `@rxy.figure` keep
+working (Level 3 *is* the current model behind Option 1's typed seam).
+Options 3 and 5 are subsumed — 3's grammar survives as Level 2 with marks
+as re-exports instead of components; 5's structure/data split survives as
+the plan/data-var split, minus the user-visible spec object.
+
+---
+
+## 6. Comparison
+
+| | 1 · Typed handle | 2 · Compile probe | 3 · Chart components | 4 · ChartState | 5 · Eager spec | 6 · Data-bound |
+|---|---|---|---|---|---|---|
+| Feels like a Reflex component | ✅ (plotly-style) | — (no API change) | ✅✅ (is the tree) | ✅✅ per-instance | ✅ (via 1) | ✅✅ (declared where rendered) |
+| Hallucinated chart API fails at | hydrate ✗ | **compile** | **import/compile** | hydrate (compile w/ 2) | **import** | **import/compile** |
+| Wrong kwargs / bad config fails at | hydrate ✗ | compile | **compile** (zero-row probe) | via 2 | **import** (zero-row probe) | **compile** (partition + zero-row probe) |
+| Wrong var into chart slot | **compile** ✅ | — | **compile** ✅ | **compile** ✅ | **compile** ✅ | **compile** ✅ (verified) |
+| Column names | hydrate | via `probe="figure"` | hydrate, spec-aware error | hydrate | hydrate, spec-aware error | **compile** (TypedDict, R7) |
+| Data shapes / lengths / dtypes | hydrate (inherent) | via `probe="figure"` | hydrate | hydrate | hydrate | hydrate (inherent) |
+| Constraint 1 (no data in state) | ✅ unchanged | ✅ unchanged | ✅ (data registry) | ✅ unchanged | ✅ unchanged | ✅ (data registry) |
+| Constraint 2 (no compile ingestion) | ✅ | ⚠️ builder runs on default state (opt-out) | ✅ zero-row only | ✅/⚠️ with 2 | ✅ zero-row only | ✅ zero-row only |
+| `rx.cond` | ✅ | — | ✅ | ✅ | ✅ | ✅ (between charts) |
+| `rx.foreach` | ✅ typed item | — | ✅ (fixed structure per item) | ❌ framework-blocked | ✅ typed item | ✅ schema-checked per item (R7) |
+| Structure reactive to state | ✅ (builder) | ✅ | ❌ (data/cond only) | ✅ | ❌ (data only) | ❌ (Level 3 escape hatch) |
+| Breaking changes | none (deprecations) | none | none (additive tier) | none | none | none (additive; old forms become Level 3) |
+| Implementation cost | small | small | **large** (factory layer + spec format + token family) | medium | medium | medium-large (signature-derived flat layer + plan format + data vars) |
+
+*"Compile" = page evaluation during `reflex run`/`export`; "import" = plain
+`import app`, even earlier.*
+
+## 7. Recommendation
+
+**Build Option 6 as the primary API. It subsumes the others**: Option 1's
+typed component seam becomes Level 3's rendering path, Option 5's
+structure/data split becomes the internal plan/data-var split (minus the
+user-visible spec object), and Option 3's grammar becomes Level 2 with
+marks as plain xy re-exports instead of components. Option 2's probe
+remains valuable for exactly one tier — the Level 3 `@rxy.figure` escape
+hatch, the only place left where chart-building user code is deferred to
+hydrate. Option 4 stays on the shelf as later sugar for self-contained
+dashboard widgets.
+
+Phasing that keeps every step shippable:
+
+1. **Seam first** (Option 1 mechanics): typed `DataHandle`/`FigureHandle`,
+   the public component, compile-time prop rejection. Small, non-breaking,
+   immediately kills the wrong-var-in-the-slot class.
+2. **`@rxy.data` + Level 1 flat factories** for the top few chart kinds
+   (scatter, line, histogram, bar), generated from `inspect.signature`,
+   with the kwarg partition, zero-row probe, and TypedDict column checks.
+   This is the DX headline and proves the plan/data split end to end.
+3. **Level 2 composed `rxy.chart(...)`** + the remaining chart kinds +
+   spec-format stabilization.
+4. **Probe for Level 3** (Option 2), so the escape hatch fails at compile
+   too.
+5. Revisit: keyed dataset collections for `foreach`, per-mark `data=`,
+   the core-xy metadata registry (stubs/docs), upstream reflex fixes.
+   Both upstream sites are located in the reflex monorepo: generic
+   attribute access (R9) in `get_attribute_access_type`
+   (`packages/reflex-base/src/reflex_base/utils/types.py` ~:436 — add a
+   `get_origin()` unwrap before the bare-class branch), and Var-type
+   child coercion (R6) in `Component.create`'s child normalization
+   (`packages/reflex-base/src/reflex_base/components/component.py`
+   ~:1314, where a Var child currently becomes
+   `Bare.create(contents=...)` — a `_var_type` → component-factory
+   registry consulted just before that fallback would make
+   `rx.card(State.cloud)` render a chart).
+
+**The "pass it directly in the component tree" instinct** is Option 6
+literally: the chart is declared once, in the tree, and the state var
+passes directly into its `data=` slot — the `rx.plotly(data=State.fig)`
+shape generalized. The only unimplementable reading remains the bare
+`rx.card(State.cloud)` with no call at all (R6); the upstream coercion
+hook is worth proposing but gates nothing.
+
+**Implementation cautions.** Option 6 rests on verified-but-unpinned
+behavior in two systems: reflex carrying parametrized generics through
+vars, foreach element inference, and `Var[T]` prop rejection (R7); xy
+compiling zero-row figures and validating marks only at `.figure()`
+(X1/X2). Pin all of it as adapter tests *before* building, so a reflex or
+grammar upgrade fails loudly. `DataHandle` needs its one-line serializer
+registered. The flat-form kwarg partition table is public contract:
+generate it and test it. When any option ships,
+[`reflex-integration.md`](reflex-integration.md) §5 must record the new
+API tiers and the validation-timing table, per the spec-first rule.
+
+---
+
+## 8. Decision record (2026-08)
+
+**Adopted: Option 6 — data-bound chart components — as the primary API**,
+with Option 1's typed seam as the rendering path of every tier and
+Option 2's compile probe for the Level 3 escape hatch. Options 3 and 5 are
+subsumed as anticipated in §7; Option 4 stays on the shelf.
+
+Implementation notes recorded against the plan (deviations are deliberate
+and small):
+
+- The `@reflex_xy.data` module is **`data_vars.py`**, not `data.py`: a
+  `reflex_xy.data` submodule shadows the `reflex_xy.data` function export
+  the moment any sibling imports it (Python submodule-attribute collision).
+  The public name is unchanged.
+- The flat-form collision aliases are generated as `mark_<name>`, with one
+  natural special case: a mark `width` becomes `stroke_width` when the mark
+  hasn't already claimed that name (so `line`'s width is `stroke_width=`,
+  `bar`'s is `mark_width=` — `bar` natively owns `stroke_width`). The table
+  is pinned in `tests/reflex_adapter/test_factories.py`.
+- `x_axis=`/`y_axis=` in the flat form are type-dispatched: an Axis node is
+  chrome, a string is the mark's axis-id option; `legend=` takes a Legend
+  node or bool, `theme=` a Theme node. Other chrome composes via
+  `reflex_xy.chart(*nodes, ...)`.
+- The positional `chart(source)` shim warns only for live sources
+  (vars/handles/token strings). The positional **static** Chart/Figure form
+  is not deprecated — it remains the only route for arbitrary Charts (e.g.
+  facet grids) and predates no replacement.
+- The client bounds consecutive server-initiated `err {resync}` retries
+  (5 per mount without an intervening payload), so a permanently stale
+  plan digest or failing bind degrades to a visible console error, not a
+  subscribe loop.
+- Kernel-only event props on a static source now fail `create()` with a
+  `ValueError` (previously silent no-ops), completing the §5.6 error
+  catalog; every row of that catalog is reproduced by the adapter tests at
+  the stated phase.
+- **Fact X4 needed narrowing.** "Page bodies run in every worker" is true
+  of workers that run the frontend compile, but backend-only workers (dev
+  backend subprocess, prod workers) import the app without evaluating
+  pages — verified live when the first data-bound app served nothing but
+  plan-miss errs from a dev backend. The adapter now evaluates the app's
+  unevaluated pages in its startup lifespan, making the plan-distribution
+  property a guarantee of the integration rather than an observed Reflex
+  behavior.

--- a/spec/design/reflex-integration.md
+++ b/spec/design/reflex-integration.md
@@ -233,27 +233,34 @@ class Dash(rx.State):
         return xy.line_chart(xy.line(rows.t, rows.value), width="100%", height=220)
 ```
 
-`@reflex_xy.figure` is a computed var whose **value is only the token
-string** — `xyv1|<client_token>|<state_full_name>|<var_name>` — and whose
-evaluation is what (re)registers the figure in the per-process registry.
+`@reflex_xy.figure` is a computed var whose **value is only a typed
+`FigureHandle`** — a frozen dataclass wrapping the token string
+`xyv1|<client_token>|<state_full_name>|<var_name>` (serialized to
+`{"token": …}` on the delta path by a registered `@rx.serializer`) — and
+whose evaluation is what (re)registers the figure in the per-process
+registry. The handle type is what makes the component seam compile-checked:
+the component's `figure` prop is `Var[FigureHandle]`, so the wrong var or a
+raw string fails at `create()` with the framework's own `TypeError`
+(design fact R1, pinned in `tests/reflex_adapter/test_framework_contracts.py`).
 Reflex's own dependency tracker watches the *builder's* body (the var
 subclass points dependency analysis at it), so:
 
-- First render: var evaluates → figure built and registered → token into
+- First render: var evaluates → figure built and registered → handle into
   state.
 - A dependency changes: Reflex marks the var dirty; the next delta
   evaluation rebuilds the figure and re-publishes; every subscriber gets a
   fresh payload pushed over the data plane. The token is deterministic, so
   the frontend sees **no prop change at all** — pixels move, DOM doesn't.
-- Reconnect (same node or another): the cached token comes back with the
+- Reconnect (same node or another): the cached handle comes back with the
   state; the component re-`sub`s; hit → serve, miss → §3.2.
 
-Two values are not tokens. Before session hydration there is no client
-token to mint from, so the var evaluates to `""`; and a builder may return
-`None` for "no chart right now", which **releases** any existing registry
-entry and likewise yields `""`. The wrapper treats `""` as "not ready / no
-chart" and mounts nothing, so both cases are a blank mount rather than an
-error.
+Two values carry no token. Before session hydration there is no client
+token to mint from, so the var evaluates to `FigureHandle("")`; and a
+builder may return `None` for "no chart right now", which **releases** any
+existing registry entry and likewise yields the empty handle. The wrapper
+treats the empty token as "not ready / no chart" and mounts nothing, so
+both cases are a blank mount rather than an error — and the var type stays
+non-optional.
 
 Async builders are first-class, mirroring reflex's own
 `ComputedVar`/`AsyncComputedVar` split with the same
@@ -277,6 +284,32 @@ async builders: deterministic given state — refetching the rows state
 points at is exactly the recovery contract). This is §27 applied to
 processes: canonical data is Reflex state; every registered figure is a
 derived buffer.
+
+**Compile probe.** With the data-bound tier (§3.6) validating everything at
+page evaluation, the figure var is the one place chart-building user code
+still defers to hydrate — so it gets a compile gate of its own.
+`XYPlugin.post_compile` walks the state tree, and for every figure var runs
+the builder once against a default state instance
+(`@reflex_xy.figure(probe=...)` sets the level):
+
+- `probe="build"` — the default for sync builders: run the body only.
+  Hallucinated `xy.*` names, wrong kwargs, and eager chrome errors fail
+  `reflex run` with the state class, var name, and source location
+  (`FigureProbeError` wrapping the original), instead of an `err` frame
+  and a silently blank mount at hydrate.
+- `probe="figure"` — additionally compile the result: full config/shape
+  validation at the price of building one real figure per var at startup.
+- `probe=False` — opt out; the default for `async def` builders (compile
+  is sync, and awaiting a data source at compile is what constraint 2
+  forbids). An async builder may opt in explicitly and runs under
+  `asyncio.run`.
+
+The escape valve for constraint 2: a builder whose source reads
+`self.router` is session-dependent by declaration — its probe failure
+degrades to a `RuntimeWarning` instead of failing the compile, because only
+a live session can validate it. The probe's cost is the builder's own cost
+against *default* state, once per backend worker start — the same order of
+work Reflex already accepts evaluating ordinary computed vars at compile.
 
 ### 3.2 Registry miss: rebuild from state
 
@@ -418,6 +451,126 @@ generations are leased; the sweep skips them until the mutation and version
 bump finish. Rapid re-publishes coalesce: an un-started broadcast absorbs newer
 publishes and always ships the latest payload.
 
+### 3.6 The data-bound tier: `@reflex_xy.data`, plans, composite tokens
+
+The primary component API (adopted design: Option 6 of
+[`reflex-component-api-options.md`](reflex-component-api-options.md); work
+plan in [`reflex-component-api-implementation.md`](reflex-component-api-implementation.md))
+splits the figure var's job in two: **structure is declared in the page**,
+**state supplies only columns**.
+
+```python
+class CloudData(TypedDict):
+    x: np.ndarray; y: np.ndarray; mag: np.ndarray
+
+class Dash(rx.State):
+    points: int = 200_000
+
+    @reflex_xy.data                     # columns only — no chart API inside
+    def cloud(self) -> CloudData: ...
+
+def index():
+    return reflex_xy.scatter_chart(     # flat form; reflex_xy.chart(*nodes)
+        data=Dash.cloud,                # is the composed multi-mark form
+        x="x", y="y", color="mag", colormap="viridis",
+        height="460px", on_select_end=Dash.select,
+    )
+```
+
+**`@reflex_xy.data`** (`data_vars.py` — the module is named `data_vars`
+because a `data.py` submodule would shadow the `reflex_xy.data` export) is
+the exact sibling of `@reflex_xy.figure`: a computed var whose value is a
+typed `DataHandle` wrapping `xyd1|<client>|<state>|<var>` (same grammar,
+charset, purity contract, pre-session short-circuit, underscore refusal,
+async dispatch, and `None`-releases semantics as figure vars). Evaluating
+it validates the returned mapping — string keys, array-likes, one shared
+length; the only checks that need real data — and publishes the **columns**
+into the registry. The method's return annotation is the compile-time
+schema channel (fact R7): a `TypedDict` parametrizes the handle
+(`DataHandle[CloudData]`), and the factories read the column names from the
+class-level var without executing anything; a plain `dict` annotation
+degrades to first-execution validation.
+
+**Plans** (`plan.py`). A chart factory call at page evaluation compiles its
+xy nodes (string channels only) into a `ChartPlan`: the real tree is built,
+zero-row placeholder columns are bound for every referenced channel through
+the production resolution path (a recording table — the column list cannot
+drift from what binding will look up), and `.figure()` runs once — the full
+mark/config validation gate (X1/X2) at compile time, in milliseconds, with
+no data ingestion (constraint 2). The canonical JSON of the tree
+(`plan_version: 1`) is content-addressed into a sha256-prefix `digest` and
+registered in a process-local `{digest: plan}` map. Fact X4 ("page bodies
+run in every worker") turned out to hold only for processes that run the
+frontend compile — **backend-only workers (dev backend subprocesses and
+prod workers) import the app module but leave pages unevaluated**, which
+would leave their plan maps empty and every plan subscription answering
+`err {resync}`. The integration therefore makes X4 true by construction:
+`setup(app)`'s lifespan evaluates the app's unevaluated page component
+functions once at worker startup (`_ensure_page_plans`), before serving —
+factories register their plans as a side effect and the built trees are
+discarded (plans and payload assets are content-addressed and idempotent;
+a failing page degrades to a warning rather than taking down the data
+plane). Errors this
+tier catches at `reflex run`: hallucinated factory names (import), unknown
+kwargs with a did-you-mean (partition), bad colormaps/enums/axis refs
+(zero-row probe), unknown column names against a typed data var (schema
+channel), and the wrong var or a raw string in `data=` (typed prop, R1).
+Plans refuse concrete arrays, per-mark `data=`, and `render=` components —
+data-free structure only. The probe figure also yields
+`dom_class_strings()`, so **live data-bound charts get automatic Tailwind
+discovery** (previously live sources needed the manual inventory).
+
+**Composite tokens.** The wrapper composes the two halves client-side into
+one figure identity — `xyp1|<digest>|<xyd1 token>` — and subscribes once
+the data handle hydrates. Rooms, versions, `mid` addressing, the
+attachment cap, and every message below the subscribe path treat it as an
+ordinary `fig` string; the envelope grew no fields. Serving it =
+`plan_of(digest)` + columns (registry hit, else `rebuild_data` re-runs the
+data method against session state) + bind into a **fresh** `Chart` (X3) →
+`figure()` → cached under the composite token as a normal, TTL-sweepable
+`FigureEntry`. The rebuild recipe is (plan map, data method): both halves
+independently recoverable on any worker.
+
+**Republish fan-out.** The registry keeps a `data token → {digests}` index,
+added when a composite figure binds and dropped when a republish finds the
+plan unmounted (bounded by mounted plans). A data var recompute publishes
+new columns and re-binds every mounted dependent — fresh figures, bumped
+versions, coalesced room broadcasts, exactly the figure-var republish
+machinery. Failure stays loud: a bind that stops matching (possible only
+for untyped data vars) logs server-side, releases the composite entry, and
+answers the room `err {resync}`; a stale digest (hot-reload drift) answers
+`err {resync}` naming the digest. The client bounds consecutive
+err-triggered resyncs (5 without an intervening payload), so a permanently
+failing identity settles into a visible console error instead of a loop.
+
+**Static tier symmetry.** `data=` given a concrete mapping (not a Var)
+binds immediately and routes to the §3.4 payload-asset path — same
+validation, same spec-aware bind errors, works under `reflex export`,
+never touches the registry.
+
+**Kind coverage (the Phase 3 decision, recorded).** Flat factories exist
+for every mark kind whose validators compile zero-row — scatter, line,
+histogram, bar, area, step, stem, column, errorbar, error_band, segments —
+each derived from the mark's signature, and the composed
+`reflex_xy.chart(*nodes, data=...)` accepts any mix of those marks plus
+annotations and chrome. Aggregating kinds whose validators require at
+least one finite value (box, violin, hexbin, contour, heatmap, stairs,
+ecdf) and the data-taking composite factories (pie, radar, wind_rose,
+sankey — eager numeric work at call time) are **excluded from the plan
+tier**: the probe refuses them with an error naming the two supported
+routes (`@reflex_xy.figure`, or a concrete xy Chart on the static tier).
+Extending them would need value-independent validation or a synthetic-row
+probe whose failures could depend on made-up values — rejected as a silent
+decimation of the compile guarantee (§28 spirit).
+
+**Plan format stability.** `plan_version: 1` is part of the canonical
+serialization and a golden digest is pinned in
+`tests/reflex_adapter/test_plan.py`. Digests are content addresses, not a
+migration surface: after a format (or grammar) change, old subscribers'
+digests simply miss and resync against the recompiled page — the golden
+exists to catch *accidental* churn, and an intentional change bumps
+`PLAN_VERSION` and re-records it.
+
 ## 4. Updates and streaming
 
 - **State-driven rebuild** (filter changed): the figure var recomputes,
@@ -459,7 +612,7 @@ publishes and always ships the latest payload.
 
 ```python
 reflex_xy.chart(
-    Dash.cloud,                      # a figure var / inline() / register() token…
+    figure=Dash.cloud,               # a figure var, or an inline()/register() handle
     on_point_hover=Dash.on_hover,    # semantic events -> normal handlers
     on_select_end=Dash.on_select,
     tailwind_classes="rounded-xl dark:bg-slate-950",  # build-time scan inventory
@@ -469,12 +622,31 @@ reflex_xy.chart(
 reflex_xy.chart(xy.line_chart(...))  # …or a Chart directly: static tier (§3.4)
 ```
 
-One factory, dispatched on the source: tokens (state vars or strings)
-compile to the `token` prop and ride the socket data plane; a Chart/Figure
-passed directly compiles to a payload asset and lands in the `src` prop,
-which the wrapper fetches and renders kernel-less. Semantic-event props
-apply to live sources; a static chart resolves hover tooltips client-side
-but dispatches no backend events.
+One factory, dispatched on the source. `figure=` takes the live tier: a
+`@reflex_xy.figure` state var or the `FigureHandle` returned by
+`register()`/`inline()`, landing in the typed `figure` prop
+(`Var[FigureHandle]`) and riding the socket data plane. Because the prop is
+`Var`-typed, `chart(figure=Dash.points)` and `chart(figure="raw string")`
+fail at compile with the framework's `TypeError` (R1). A Chart/Figure
+passed positionally compiles to a payload asset and lands in the `src`
+prop, which the wrapper fetches and renders kernel-less — the static tier
+stays positional (it is the only route for arbitrary Charts, e.g. facet
+grids) and is not deprecated.
+
+**Deprecation (one release cycle).** The pre-handle positional spellings —
+`chart(Dash.cloud)` and `chart(token_string)` — remain as a shim and warn:
+handle-typed sources (vars or `FigureHandle`s) are routed to `figure=`;
+legacy `str`-typed vars and raw token strings keep the old `Var[str]`
+`token` prop, which the wrapper still accepts alongside `figure`
+(`figure` wins when both are set). Public APIs that take "a figure"
+(`append`, `set_view`, `reset_view`, `select`, `clear_selection`,
+`release`) accept both a `FigureHandle` and its bare `.token` string.
+
+Kernel-backed event props (`on_point_hover`, `on_point_click`,
+`on_select_end`) on a static `src` source are refused at `create()` with a
+`ValueError` naming the live alternatives — previously they compiled and
+silently never fired. Client-resolved events (`on_hover`,
+`on_view_change`, animation events) stay valid on every tier.
 
 Static Chart/Figure sources mirror every class string from
 `Figure.dom_class_strings()` into the scan-only `tailwindClassTokens` JSX prop,
@@ -550,7 +722,7 @@ def inspect_point(self, event: dict):
     self.last_id = event["canonical_row_id"]
     self.last_xy = event["data"]
 
-reflex_xy.chart(Dash.cloud, on_point_click=Dash.inspect_point)
+reflex_xy.chart(figure=Dash.cloud, on_point_click=Dash.inspect_point)
 ```
 
 Selection events use the following shape. P0 supports deterministic `replace`
@@ -649,7 +821,7 @@ def remember_view(self, event: dict):
     self.x_domain = event["x_domain"]
     self.y_domain = event["y_domain"]
 
-reflex_xy.chart(Dash.cloud, on_view_change=Dash.remember_view)
+reflex_xy.chart(figure=Dash.cloud, on_view_change=Dash.remember_view)
 ```
 
 Every kernel request echoes the last payload version as `v`; the namespace
@@ -685,37 +857,59 @@ demo app models.
 ```
 python/reflex_xy/
   registry.py                token -> FigureEntry(figure, version, lock); TTL;
-                             publish/push fan-out seams; append
-  tokens.py                  xyv1 token grammar; builder discovery on vars
+                             publish/push/error fan-out seams; append; column
+                             entries + data-token -> digest index (§3.6)
+  tokens.py                  xyv1/xyd1/xyp1 token grammar; builder discovery
+  handles.py                 FigureHandle / DataHandle[S] (+ serializers):
+                             the typed values chart state vars carry
   vars.py                    @reflex_xy.figure (FigureVar: builder-tracked deps)
-  state_bridge.py            token -> state_manager -> builder rebuild hook
+  data_vars.py               @reflex_xy.data (DataVar: columns in, handle out)
+  plan.py                    ChartPlan: zero-row probe, canonical digest,
+                             process-local plan map, bind (§3.6)
+  factories.py               scatter/line/histogram/bar_chart flat factories +
+                             composed chart(*nodes): signature-derived kwarg
+                             partition, schema checks, plan/data/static mount
+  state_bridge.py            token -> state_manager -> builder/data/plan
+                             rebuild hooks
   namespace.py               XYNamespace: sub/unsub/msg, payload/msg/err,
-                             affinity, rebuild-on-miss, binary attachments
+                             affinity (incl. composite), rebuild-on-miss,
+                             binary attachments
   app.py                     setup(app), XYPlugin (post_compile), lifespan
-  component.py               chart() -> rx.Component (local-JSX library);
-                             dispatches token (live) vs Chart (static tier)
+  component.py               chart(figure=...) -> rx.Component (local-JSX
+                             library); typed figure/data props; static tier
   payload_asset.py           static tier: Chart -> content-addressed XYBF
                              asset in assets/xy/ (§3.4)
   assets/                    XYChart.jsx; links xy's installed render client
-examples/reflex/  (repo root) Reflex showcase: figure-var drilldown with
-                             hover/click/select events, a slider-driven +
-                             cross-filtered histogram, a streaming line, an
-                             on_view_change-computed detail chart, both
-                             fixed-data tiers (direct Chart + inline() token),
-                             and the fastapi live drilldown served adapter-
-                             natively from an inline() token (same data and
-                             XY_LIVE_POINTS override, zero transport code —
-                             the cross-host A/B for that chart), plus legend
-                             hover-highlight and click-to-toggle (named series
-                             client-side; a categorical density inline() token
-                             whose category toggles re-bin kernel-side, §34)
+examples/reflex/  (repo root) Reflex showcase on the §3.6 data-bound API: a
+                             composed 1M drillable scatter with hover/click/
+                             select events, an on_view_change data var
+                             republishing in-view columns into a fixed
+                             histogram plan, a flat scatter whose slider
+                             republishes columns under a stable handle, and
+                             an rx.cond toggle between a composed board and
+                             rx.foreach small multiples over a
+                             list[DataHandle] var; the
+                             @reflex_xy.figure escape hatch where structure
+                             reads state (slider-driven + cross-filtered
+                             histogram), a streaming line (append), both
+                             fixed-data tiers (concrete data= columns ->
+                             payload asset; inline() token), the fastapi live
+                             drilldown served adapter-natively from an
+                             inline() token (same data and XY_LIVE_POINTS
+                             override, zero transport code — the cross-host
+                             A/B for that chart), plus legend hover-highlight
+                             and click-to-toggle (named series client-side; a
+                             categorical density inline() token whose category
+                             toggles re-bin kernel-side, §34)
 examples/fastapi/ (repo root) the same charts + a live 100M drilldown served
                              from a plain FastAPI app (no committed HTML)
-tests/reflex_adapter/        token/registry/var/bridge/payload-asset units,
-                             component compile, and a real-websocket
+tests/reflex_adapter/        token/registry/var/data-var/plan/factory/bridge/
+                             payload-asset units, component compile, framework
+                             contract pins (R1/R7/R8), and a real-websocket
                              integration suite (uvicorn + socketio client)
                              covering payload/pick/select/affinity/rebuild/
-                             publish-broadcast/append/unsub
+                             publish-broadcast/append/unsub + the composite
+                             plan tier (fan-out, plan-miss resync, bind errs)
 ```
 
 `inline()` (content-addressed pinned tokens, §3.4) lives in the package

--- a/tests/reflex_adapter/conftest.py
+++ b/tests/reflex_adapter/conftest.py
@@ -14,16 +14,19 @@ reflex = pytest.importorskip("reflex")
 pytest.importorskip("reflex_xy")
 
 import reflex_xy.app as adapter_app  # noqa: E402
+from reflex_xy.plan import reset_plans_for_tests  # noqa: E402
 from reflex_xy.registry import reset_registry_for_tests  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
 def _fresh_registry():
-    """Isolate registry + wiring between tests."""
+    """Isolate registry + plan map + wiring between tests."""
     registry = reset_registry_for_tests()
+    reset_plans_for_tests()
     adapter_app.reset_setup_for_tests()
     yield registry
     reset_registry_for_tests()
+    reset_plans_for_tests()
     adapter_app.reset_setup_for_tests()
 
 

--- a/tests/reflex_adapter/test_async_figure_var.py
+++ b/tests/reflex_adapter/test_async_figure_var.py
@@ -77,22 +77,23 @@ def test_await_registers_caches_and_rebuilds(_fresh_registry, client_token):
     calls_before = BUILDER_CALLS["count"]
 
     async def main():
-        token = await state.chart
-        entry = _fresh_registry.get(token)
+        handle = await state.chart
+        assert isinstance(handle, reflex_xy.FigureHandle)
+        entry = _fresh_registry.get(handle.token)
         assert entry is not None
         assert entry.figure.traces[0].n_points == 50
 
         # cache hit: the builder (and its awaited fetch) must not rerun
-        assert await state.chart == token
+        assert await state.chart == handle
         assert BUILDER_CALLS["count"] == calls_before + 1
 
-        # dependency change -> dirty -> re-await rebuilds, token stable
+        # dependency change -> dirty -> re-await rebuilds, handle stable
         state.n = 120
         type(state).computed_vars["chart"].mark_dirty(state)
-        assert await state.chart == token
+        assert await state.chart == handle
         assert BUILDER_CALLS["count"] == calls_before + 2
-        assert _fresh_registry.get(token).version == 2
-        assert _fresh_registry.get(token).figure.traces[0].n_points == 120
+        assert _fresh_registry.get(handle.token).version == 2
+        assert _fresh_registry.get(handle.token).figure.traces[0].n_points == 120
 
     asyncio.run(main())
 
@@ -100,7 +101,7 @@ def test_await_registers_caches_and_rebuilds(_fresh_registry, client_token):
 def test_pre_hydration_returns_empty(_fresh_registry):
     root = rx.State(_reflex_internal_init=True)
     state = root.get_substate(tuple(AsyncVarDemo.get_full_name().split("."))[1:])
-    assert asyncio.run(state.chart) == ""
+    assert asyncio.run(state.chart) == reflex_xy.FigureHandle("")
     assert len(_fresh_registry) == 0
 
 
@@ -108,11 +109,11 @@ def test_none_chart_unregisters(_fresh_registry, client_token):
     state = hydrated_substate(client_token)
 
     async def main():
-        token = await state.maybe_chart
+        token = (await state.maybe_chart).token
         assert _fresh_registry.get(token) is not None
         state.n = -1
         type(state).computed_vars["maybe_chart"].mark_dirty(state)
-        assert await state.maybe_chart == ""
+        assert await state.maybe_chart == reflex_xy.FigureHandle("")
         assert _fresh_registry.get(token) is None
 
     asyncio.run(main())

--- a/tests/reflex_adapter/test_component.py
+++ b/tests/reflex_adapter/test_component.py
@@ -40,11 +40,16 @@ def app_cwd(tmp_path, monkeypatch):
 
 
 def test_component_compiles_with_events(app_cwd):
-    comp = reflex_xy.chart("tok-abc", on_point_hover=CompState.picked, height="300px", id="chart1")
+    comp = reflex_xy.chart(
+        figure=reflex_xy.FigureHandle("tok-abc"),
+        on_point_hover=CompState.picked,
+        height="300px",
+        id="chart1",
+    )
     assert comp.tag == "XYChart"
     assert str(comp.library).startswith("$/public/external/reflex_xy/assets/XYChart")
     rendered = str(comp)
-    assert 'token:"tok-abc"' in rendered
+    assert '"tok-abc"' in rendered  # the handle's token reaches the figure prop
     assert "onPointHover" in rendered
     assert "picked" in rendered  # the reflex event dispatch is in the prop
 
@@ -56,19 +61,61 @@ def test_component_compiles_with_events(app_cwd):
     assert (ext / "xy_client.js").resolve().read_bytes()[:16]
 
 
-def test_component_accepts_var_token(app_cwd):
-    class TokState(rx.State):
-        tok: str = ""
+def test_component_accepts_figure_var(app_cwd):
+    class FigState(rx.State):
+        @reflex_xy.figure
+        def fig(self):
+            return None
 
-    comp = reflex_xy.chart(TokState.tok)
+    comp = reflex_xy.chart(figure=FigState.fig, height="300px")
     rendered = str(comp)
-    assert "tok" in rendered
+    assert "figure" in rendered
+    assert "fig" in rendered
     # default sizing keeps the mount visible before the first payload
     assert "height" in rendered.lower()
 
 
+def test_component_rejects_wrong_var_and_raw_string_at_compile(app_cwd):
+    """The Phase-0 R1 contract, through the real component: the typed
+    ``figure`` prop fails the compile for a non-handle var or a string."""
+
+    class WrongVarState(rx.State):
+        points: int = 5
+
+    with pytest.raises(TypeError, match="figure"):
+        reflex_xy.chart(figure=WrongVarState.points)
+    with pytest.raises(TypeError, match="figure"):
+        reflex_xy.chart(figure="xyv1|raw|token|string")
+
+
+def test_positional_var_source_warns_and_routes_to_figure(app_cwd):
+    class ShimState(rx.State):
+        @reflex_xy.figure
+        def fig(self):
+            return None
+
+    with pytest.warns(DeprecationWarning, match="figure="):
+        comp = reflex_xy.chart(ShimState.fig)
+    assert "figure" in str(comp)
+
+
+def test_positional_token_string_warns_but_keeps_the_token_prop(app_cwd):
+    with pytest.warns(DeprecationWarning, match="figure="):
+        comp = reflex_xy.chart("tok-abc")
+    assert 'token:"tok-abc"' in str(comp)
+
+
+def test_kernel_events_on_static_source_fail_at_compile(app_cwd):
+    static_chart = xy.line_chart(xy.line([0, 1], [1, 2]))
+    with pytest.raises(ValueError, match=r"on_select_end.*static"):
+        reflex_xy.chart(static_chart, on_select_end=CompState.picked)
+    # client-side events stay valid on the static tier
+    comp = reflex_xy.chart(static_chart, on_view_change=CompState.picked, on_hover=CompState.picked)
+    assert "onViewChange" in str(comp)
+
+
 def test_component_import_is_local_library(app_cwd):
-    comp = reflex_xy.chart("tok")
+    comp = reflex_xy.chart(figure=reflex_xy.FigureHandle("tok"))
     imports = comp._get_all_imports()
     lib = [k for k in imports if "XYChart" in k]
     assert lib, f"wrapper import missing from {list(imports)}"
@@ -155,7 +202,7 @@ def test_static_facet_chart_compiles_as_grid_of_panel_payloads(app_cwd):
 
 
 def test_live_chart_does_not_claim_runtime_classes_are_compile_time_known(app_cwd):
-    rendered = str(reflex_xy.chart("xyfig-runtime"))
+    rendered = str(reflex_xy.chart(figure=reflex_xy.FigureHandle("xyfig-runtime")))
     assert "tailwindClassTokens" not in rendered
 
 
@@ -163,7 +210,7 @@ def test_live_chart_accepts_explicit_tailwind_scan_inventory(app_cwd):
     """Token payloads are runtime-only; callers can expose complete utilities."""
     rendered = str(
         reflex_xy.chart(
-            "xyfig-runtime",
+            figure=reflex_xy.FigureHandle("xyfig-runtime"),
             tailwind_classes=[
                 "rounded-[28px] border-fuchsia-500",
                 "dark:bg-slate-950 hover:bg-fuchsia-100",
@@ -181,7 +228,7 @@ def test_tailwind_scan_inventory_is_verbatim_for_live_and_static_charts(app_cwd)
     manifest = " ".join(TAILWIND_SCAN_EDGE_CLASSES)
     live_rendered = str(
         reflex_xy.chart(
-            "xyfig-runtime",
+            figure=reflex_xy.FigureHandle("xyfig-runtime"),
             tailwind_classes=TAILWIND_SCAN_EDGE_CLASSES,
         )
     )
@@ -257,4 +304,4 @@ def test_tailwind_inventory_requires_literal_strings(app_cwd, value):
         match=r"tailwind_classes must be a string or ordered iterable of strings|"
         "tailwind_classes must contain only strings",
     ):
-        reflex_xy.chart("xyfig-runtime", tailwind_classes=value)
+        reflex_xy.chart(figure=reflex_xy.FigureHandle("xyfig-runtime"), tailwind_classes=value)

--- a/tests/reflex_adapter/test_data_var.py
+++ b/tests/reflex_adapter/test_data_var.py
@@ -1,0 +1,219 @@
+"""The @reflex_xy.data computed var: columns in, typed handle out."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TypedDict, get_args
+
+import numpy as np
+import pytest
+import reflex as rx
+from reflex_base.vars.base import AsyncComputedVar
+
+import reflex_xy
+import xy
+from reflex_xy.data_vars import AsyncDataVar, DataVar, validate_columns
+from reflex_xy.handles import DataHandle
+from reflex_xy.plan import build_plan
+from reflex_xy.tokens import build_plan_token, builder_of, parse_token
+
+from .conftest import make_router_data
+
+
+class DataSchema(TypedDict):
+    x: np.ndarray
+    y: np.ndarray
+    mag: np.ndarray
+
+
+class DataDemo(rx.State):
+    n: int = 16
+    _scale: float = 2.0
+
+    @reflex_xy.data
+    def cloud(self) -> DataSchema:
+        xs = np.linspace(0.0, 1.0, self.n)
+        return {"x": xs, "y": xs * self._scale, "mag": np.abs(xs)}
+
+    @reflex_xy.data
+    def maybe(self):
+        if self.n < 0:
+            return None
+        return {"x": [1.0], "y": [2.0]}
+
+    @reflex_xy.data
+    async def remote(self) -> DataSchema:
+        await asyncio.sleep(0)
+        xs = np.linspace(0.0, 1.0, self.n)
+        return {"x": xs, "y": xs, "mag": xs}
+
+
+def hydrated_substate(client_token: str) -> DataDemo:
+    root = rx.State(_reflex_internal_init=True)
+    root.router = make_router_data(client_token)
+    return root.get_substate(tuple(DataDemo.get_full_name().split("."))[1:])
+
+
+def test_dispatch_and_schema_channel():
+    """R7: the TypedDict return annotation parametrizes the var's value type;
+    async methods dispatch to AsyncDataVar exactly like rx.var."""
+    assert isinstance(DataDemo.computed_vars["cloud"], DataVar)
+    assert DataDemo.cloud._var_type == DataHandle[DataSchema]
+    assert get_args(DataDemo.cloud._var_type) == (DataSchema,)
+    # untyped methods degrade to the plain handle (columns checked at runtime)
+    assert DataDemo.maybe._var_type is DataHandle
+    assert isinstance(DataDemo.computed_vars["remote"], AsyncDataVar)
+    assert isinstance(DataDemo.computed_vars["remote"], AsyncComputedVar)
+    assert DataDemo.remote._var_type == DataHandle[DataSchema]
+
+
+def test_deps_track_the_data_method_not_the_wrapper():
+    deps = DataDemo.computed_vars["cloud"]._deps(DataDemo)
+    assert deps == {DataDemo.get_full_name(): {"n", "_scale"}}
+
+
+def test_evaluation_publishes_columns_and_returns_handle(_fresh_registry, client_token):
+    state = hydrated_substate(client_token)
+    handle = state.cloud
+    assert isinstance(handle, DataHandle)
+    parsed = parse_token(handle.token)
+    assert parsed is not None and parsed.kind == "data"
+    assert parsed.client_token == client_token
+    assert parsed.var_name == "cloud"
+    entry = _fresh_registry.get_columns(handle.token)
+    assert entry is not None
+    assert sorted(entry.columns) == ["mag", "x", "y"]
+    assert len(entry.columns["x"]) == 16
+
+
+def test_republish_keeps_handle_bumps_column_version(_fresh_registry, client_token):
+    state = hydrated_substate(client_token)
+    handle = state.cloud
+    state.n = 32
+    DataDemo.computed_vars["cloud"].mark_dirty(state)
+    assert state.cloud == handle  # stable identity, like figure vars
+    entry = _fresh_registry.get_columns(handle.token)
+    assert entry.version == 2
+    assert len(entry.columns["x"]) == 32
+
+
+def test_pre_session_short_circuit(_fresh_registry):
+    root = rx.State(_reflex_internal_init=True)
+    state = root.get_substate(tuple(DataDemo.get_full_name().split("."))[1:])
+    assert state.cloud == DataHandle("")  # data method never ran
+    assert len(_fresh_registry._column_entries) == 0
+
+
+def test_none_releases_columns(_fresh_registry, client_token):
+    state = hydrated_substate(client_token)
+    token = state.maybe.token
+    assert _fresh_registry.get_columns(token) is not None
+    state.n = -1
+    DataDemo.computed_vars["maybe"].mark_dirty(state)
+    assert state.maybe == DataHandle("")
+    assert _fresh_registry.get_columns(token) is None
+
+
+def test_async_variant_awaits_and_publishes(_fresh_registry, client_token):
+    state = hydrated_substate(client_token)
+
+    async def main():
+        handle = await state.remote
+        assert _fresh_registry.get_columns(handle.token) is not None
+        return handle
+
+    handle = asyncio.run(main())
+    assert handle.token.startswith("xyd1|")
+
+
+def test_underscore_name_refused():
+    with pytest.raises(ValueError, match="must not start with '_'"):
+
+        class BadData(rx.State):  # noqa: F841 - definition is the assertion
+            @reflex_xy.data
+            def _hidden(self):
+                return None
+
+
+def test_method_resolvable_from_class(client_token):
+    method = builder_of(DataDemo, "cloud")
+    assert method is not None
+    state = hydrated_substate(client_token)
+    assert sorted(method(state)) == ["mag", "x", "y"]
+
+
+@pytest.mark.parametrize(
+    ("columns", "match"),
+    [
+        ([1, 2, 3], "mapping"),
+        ({1: [1.0]}, "column names must be strings"),
+        ({"x": "not-values"}, "array-like"),
+        ({"x": {"nested": 1}}, "array-like"),
+        ({"x": 3.5}, "with a length"),
+        ({"x": [1.0, 2.0], "y": [1.0]}, "share one length"),
+    ],
+)
+def test_validate_columns_rejects_malformed(columns, match):
+    with pytest.raises((TypeError, ValueError), match=match):
+        validate_columns(columns, source="Demo.cloud")
+
+
+def test_republish_rebuilds_and_bumps_mounted_dependents(_fresh_registry, client_token):
+    """The data-token -> digest index: a column republish re-binds every
+    mounted plan into a fresh figure generation (broadcast by publish)."""
+    state = hydrated_substate(client_token)
+    handle = state.cloud
+    plan = build_plan("scatter_chart", (xy.scatter("x", "y"),), {})
+    composite = build_plan_token(plan.digest, handle.token)
+    # mount: first bind, as the namespace does on sub
+    entry = _fresh_registry.publish(
+        composite,
+        plan.bind(_fresh_registry.get_columns(handle.token).columns).figure(),
+        broadcast=False,
+    )
+    _fresh_registry.bind_plan(handle.token, plan.digest)
+    assert entry.figure.traces[0].n_points == 16
+
+    state.n = 48
+    DataDemo.computed_vars["cloud"].mark_dirty(state)
+    assert state.cloud == handle
+    rebuilt = _fresh_registry.get(composite)
+    assert rebuilt.version == entry.version + 1
+    assert rebuilt.figure.traces[0].n_points == 48
+
+
+def test_republish_drops_unmounted_dependents_from_the_index(_fresh_registry, client_token):
+    state = hydrated_substate(client_token)
+    handle = state.cloud
+    plan = build_plan("scatter_chart", (xy.scatter("x", "y"),), {})
+    _fresh_registry.bind_plan(handle.token, plan.digest)  # indexed, never mounted
+
+    state.n = 20
+    DataDemo.computed_vars["cloud"].mark_dirty(state)
+    assert state.cloud == handle
+    assert _fresh_registry._digests_by_data_token.get(handle.token) is None
+
+
+def test_release_columns_releases_dependent_figures(_fresh_registry, client_token):
+    state = hydrated_substate(client_token)
+    handle = state.maybe.token
+    plan = build_plan("scatter_chart", (xy.scatter("x", "y"),), {})
+    composite = build_plan_token(plan.digest, handle)
+    columns = _fresh_registry.get_columns(handle).columns
+    _fresh_registry.publish(composite, plan.bind(columns).figure(), broadcast=False)
+    _fresh_registry.bind_plan(handle, plan.digest)
+
+    state.n = -1
+    DataDemo.computed_vars["maybe"].mark_dirty(state)
+    assert state.maybe == DataHandle("")
+    assert _fresh_registry.get(composite) is None
+    assert _fresh_registry.get_columns(handle) is None
+
+
+def test_column_entries_sweep_like_figures(_fresh_registry, client_token):
+    state = hydrated_substate(client_token)
+    token = state.cloud.token
+    entry = _fresh_registry.get_columns(token)
+    dropped = _fresh_registry.sweep(now=entry.last_access + 10**9)
+    assert token in dropped
+    assert _fresh_registry.get_columns(token) is None

--- a/tests/reflex_adapter/test_factories.py
+++ b/tests/reflex_adapter/test_factories.py
@@ -1,0 +1,320 @@
+"""The data-bound chart factories: partition, schema checks, mounting."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+import numpy as np
+import pytest
+import reflex as rx
+
+import reflex_xy
+import xy
+from reflex_xy.factories import EVENT_TRIGGERS, FLAT_KINDS
+from reflex_xy.handles import DataHandle
+
+
+class FactorySchema(TypedDict):
+    x: np.ndarray
+    y: np.ndarray
+    mag: np.ndarray
+
+
+class FactoryDash(rx.State):
+    points: int = 32
+    handles: list[DataHandle[FactorySchema]] = []
+
+    @reflex_xy.data
+    def cloud(self) -> FactorySchema:
+        xs = np.linspace(0.0, 1.0, self.points)
+        return {"x": xs, "y": xs * 0.5, "mag": np.abs(xs)}
+
+    @reflex_xy.data
+    def untyped(self):
+        return {"x": [1.0], "y": [2.0]}
+
+    @rx.event
+    def select(self, selection: dict):
+        pass
+
+
+@pytest.fixture
+def app_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    import reflex_xy.component as component_mod
+
+    monkeypatch.setattr(component_mod, "_component_cls", None)
+    return tmp_path
+
+
+def test_partition_table_is_the_public_contract():
+    """The generated collision table (options doc §5.6 decision 2): the
+    component level owns the reserved names; shadowed mark options get
+    derived aliases — `stroke_width` when free and natural, `mark_<name>`
+    otherwise. Failing here means the public flat-form surface moved."""
+    base = {
+        "mark_class_name": "class_name",
+        "mark_opacity": "opacity",
+        "mark_style": "style",
+    }
+    keyed = {**base, "mark_animation": "animation", "mark_key": "key"}
+    aliases = {kind: FLAT_KINDS[kind].aliases for kind in sorted(FLAT_KINDS)}
+    assert aliases == {
+        "area_chart": keyed,
+        "bar_chart": {**keyed, "mark_width": "width"},  # stroke_width is native
+        "column_chart": {**keyed, "mark_width": "width"},  # stroke_width is native
+        "error_band_chart": keyed,
+        "errorbar_chart": {**keyed, "stroke_width": "width"},
+        "histogram_chart": base,
+        "line_chart": {**keyed, "stroke_width": "width"},
+        "scatter_chart": keyed,
+        "segments_chart": {**base, "stroke_width": "width"},
+        "stem_chart": {**base, "stroke_width": "width"},
+        "step_chart": {**base, "stroke_width": "width"},
+    }
+
+
+def test_event_trigger_set_matches_the_component(app_cwd):
+    """EVENT_TRIGGERS is derived by hand; pin it against the real component
+    class so the two can never drift."""
+    from reflex_xy.component import _component
+
+    component_triggers = {
+        name for name in _component().get_event_triggers() if name.startswith("on_")
+    }
+    assert component_triggers >= EVENT_TRIGGERS
+
+
+def test_flat_factory_compiles_plan_and_data_props(app_cwd):
+    comp = reflex_xy.scatter_chart(
+        data=FactoryDash.cloud,
+        x="x",
+        y="y",
+        color="mag",
+        colormap="viridis",
+        height="460px",
+        on_select_end=FactoryDash.select,
+    )
+    rendered = str(comp)
+    assert "plan:" in rendered
+    assert "data:" in rendered
+    assert "cloud" in rendered
+    assert "onSelectEnd" in rendered
+    assert "src" not in rendered
+
+
+def test_flat_factory_validates_mark_config_at_compile(app_cwd):
+    with pytest.raises(ValueError, match="colormap"):
+        reflex_xy.scatter_chart(data=FactoryDash.cloud, x="x", y="y", colormap="virids")
+
+
+def test_unknown_kwarg_near_a_known_name_suggests(app_cwd):
+    with pytest.raises(TypeError, match="did you mean 'colormap'"):
+        reflex_xy.scatter_chart(data=FactoryDash.cloud, x="x", y="y", colormapp="viridis")
+    with pytest.raises(TypeError, match="did you mean 'on_select_end'"):
+        reflex_xy.scatter_chart(
+            data=FactoryDash.cloud, x="x", y="y", on_selection_end=FactoryDash.select
+        )
+
+
+def test_far_off_kwargs_stay_css_passthrough(app_cwd):
+    """R8's convention, preserved deliberately: unknown non-chart-shaped
+    kwargs are style props (border_radius here reaches the DOM styles)."""
+    comp = reflex_xy.scatter_chart(data=FactoryDash.cloud, x="x", y="y", border_radius="12px")
+    assert "borderRadius" in {str(key) for key in comp.style}
+
+
+def test_typed_schema_rejects_unknown_columns_at_compile(app_cwd):
+    with pytest.raises(
+        ValueError, match=r"unknown column 'timestamp'.*Available columns: mag, x, y"
+    ):
+        reflex_xy.scatter_chart(data=FactoryDash.cloud, x="timestamp", y="y")
+
+
+def test_schema_check_reaches_foreach_item_vars(app_cwd):
+    """R7 (foreach half): the element var of list[DataHandle[Schema]] keeps
+    the schema, so column names are compile-checked inside loops."""
+    good = rx.foreach(
+        FactoryDash.handles,
+        lambda handle: reflex_xy.scatter_chart(data=handle, x="x", y="y"),
+    )
+    good.render()
+
+    with pytest.raises(ValueError, match="unknown column 'timestamp'"):
+        rx.foreach(
+            FactoryDash.handles,
+            lambda handle: reflex_xy.scatter_chart(data=handle, x="timestamp", y="y"),
+        ).render()
+
+
+def test_untyped_data_var_skips_the_compile_column_check(app_cwd):
+    comp = reflex_xy.scatter_chart(data=FactoryDash.untyped, x="anything", y="y")
+    assert "plan:" in str(comp)
+
+
+def test_wrong_var_and_raw_string_fail_at_compile(app_cwd):
+    with pytest.raises(TypeError, match="data"):
+        reflex_xy.scatter_chart(data=FactoryDash.points, x="x", y="y")
+    with pytest.raises(TypeError, match="data="):
+        reflex_xy.scatter_chart(data="xyd1|raw|token|string", x="x", y="y")
+
+
+def test_static_tier_routes_concrete_columns_to_payload_asset(app_cwd, _fresh_registry):
+    comp = reflex_xy.scatter_chart(
+        data={"x": np.array([1.0, 2.0]), "y": np.array([2.0, 1.0])}, x="x", y="y"
+    )
+    rendered = str(comp)
+    assert 'src:"/xy/' in rendered
+    assert "plan:" not in rendered
+    assert len(_fresh_registry) == 0  # static tier never touches the registry
+
+
+def test_static_tier_bind_errors_name_both_sides(app_cwd):
+    with pytest.raises(ValueError, match=r"plan binds column 'y'; data= produced \{x\}"):
+        reflex_xy.scatter_chart(data={"x": [1.0]}, x="x", y="y")
+
+
+def test_static_tier_refuses_kernel_events(app_cwd):
+    with pytest.raises(ValueError, match=r"on_select_end.*static"):
+        reflex_xy.scatter_chart(
+            data={"x": [1.0], "y": [1.0]}, x="x", y="y", on_select_end=FactoryDash.select
+        )
+
+
+def test_missing_data_is_an_error(app_cwd):
+    with pytest.raises(TypeError, match="data= is required"):
+        reflex_xy.scatter_chart(x="x", y="y")
+
+
+def test_live_charts_discover_tailwind_classes_from_the_probe(app_cwd):
+    """The zero-row probe figure's class inventory reaches the JSX scan
+    literal automatically — live plan charts no longer need the manual
+    tailwind_classes= inventory (the Phase-2 'bonus' in the plan doc)."""
+    rendered = str(
+        reflex_xy.scatter_chart(
+            data=FactoryDash.cloud,
+            x="x",
+            y="y",
+            legend=xy.legend(class_name="max-h-24 overflow-y-auto"),
+            class_names={"title": "text-base font-semibold"},
+        )
+    )
+    assert "tailwindClassTokens" in rendered
+    assert "max-h-24 overflow-y-auto" in rendered
+    assert "text-base font-semibold" in rendered
+
+
+def test_chrome_kwargs_type_dispatch(app_cwd):
+    comp = reflex_xy.scatter_chart(
+        data=FactoryDash.cloud,
+        x="x",
+        y="y",
+        x_axis=xy.x_axis(label="sigma"),
+        legend=True,
+    )
+    assert "plan:" in str(comp)
+    # a string is the mark's axis-id option, and an undeclared id fails the
+    # probe exactly like xy itself would at .figure()
+    with pytest.raises(ValueError, match="axis"):
+        reflex_xy.scatter_chart(data=FactoryDash.cloud, x="x", y="y", y_axis="y2")
+    with pytest.raises(TypeError, match="axis node"):
+        reflex_xy.scatter_chart(data=FactoryDash.cloud, x="x", y="y", x_axis=42)
+
+
+def test_line_stroke_width_alias_and_bar_mark_width(app_cwd):
+    line = reflex_xy.line_chart(data=FactoryDash.cloud, x="x", y="y", stroke_width=3.0)
+    assert "plan:" in str(line)
+    bar = reflex_xy.bar_chart(data=FactoryDash.cloud, x="x", y="y", mark_width=0.5)
+    assert "plan:" in str(bar)
+    hist = reflex_xy.histogram_chart(data=FactoryDash.cloud, values="mag", bins=32)
+    assert "plan:" in str(hist)
+
+
+def test_composed_chart_consumes_xy_nodes(app_cwd):
+    comp = reflex_xy.chart(
+        xy.scatter(x="x", y="y", color="mag", colormap="viridis"),
+        xy.line(x="x", y="y", width=2),
+        xy.x_axis(label="t"),
+        data=FactoryDash.cloud,
+        height="300px",
+    )
+    assert "plan:" in str(comp)
+
+
+def test_composed_chart_checks_schema_across_all_marks(app_cwd):
+    with pytest.raises(ValueError, match="unknown column 'trend'"):
+        reflex_xy.chart(
+            xy.scatter(x="x", y="y"),
+            xy.line(x="x", y="trend"),
+            data=FactoryDash.cloud,
+        )
+
+
+def test_cond_between_two_composed_charts_validates_both(app_cwd):
+    """rx.cond builds both branches eagerly (R4), so both plans compile."""
+    comp = rx.cond(
+        FactoryDash.points > 10,
+        reflex_xy.scatter_chart(data=FactoryDash.cloud, x="x", y="y"),
+        reflex_xy.line_chart(data=FactoryDash.cloud, x="x", y="y"),
+    )
+    assert "plan:" in str(comp.render())
+
+    with pytest.raises(ValueError, match="unknown column"):
+        rx.cond(
+            FactoryDash.points > 10,
+            reflex_xy.scatter_chart(data=FactoryDash.cloud, x="x", y="y"),
+            reflex_xy.line_chart(data=FactoryDash.cloud, x="x", y="bogus"),
+        )
+
+
+def test_component_tier_still_reachable_through_chart(app_cwd):
+    """chart() keeps dispatching the escape hatch and static tiers."""
+    static = reflex_xy.chart(xy.line_chart(xy.line([0.0, 1.0], [1.0, 2.0])))
+    assert 'src:"/xy/' in str(static)
+    live = reflex_xy.chart(figure=reflex_xy.FigureHandle("tok"))
+    assert "figure" in str(live)
+    with pytest.raises(TypeError, match="data="):
+        reflex_xy.chart(figure=reflex_xy.FigureHandle("tok"), data=FactoryDash.cloud)
+
+
+def test_curated_reexports_are_the_xy_constructors():
+    """`reflex_xy.scatter` *is* `xy.scatter` (zero duplication), and a
+    hallucinated constructor dies at import against the explicit map."""
+    assert reflex_xy.scatter is xy.scatter
+    assert reflex_xy.x_axis is xy.x_axis
+    assert reflex_xy.legend is xy.legend
+    assert reflex_xy.vline is xy.vline
+    with pytest.raises(AttributeError, match="polar_scatter"):
+        reflex_xy.polar_scatter  # noqa: B018 - the access is the assertion
+
+
+def test_every_flat_kind_compiles_a_plan(app_cwd):
+    """The signature-derived factories cover every zero-row-safe mark kind."""
+    from reflex_xy.factories import FLAT_KINDS
+
+    calls = {
+        "scatter_chart": dict(x="x", y="y"),
+        "line_chart": dict(x="x", y="y"),
+        "histogram_chart": dict(values="x"),
+        "bar_chart": dict(x="x", y="y"),
+        "area_chart": dict(x="x", y="y"),
+        "step_chart": dict(x="x", y="y"),
+        "stem_chart": dict(x="x", y="y"),
+        "column_chart": dict(x="x", y="y"),
+        "errorbar_chart": dict(x="x", y="y", yerr="mag"),
+        "error_band_chart": dict(x="x", lower="y", upper="mag"),
+        "segments_chart": dict(x0="x", y0="y", x1="x", y1="mag"),
+    }
+    assert set(calls) == set(FLAT_KINDS)
+    for kind, channels in calls.items():
+        comp = getattr(reflex_xy, kind)(data=FactoryDash.cloud, **channels)
+        assert "plan:" in str(comp), kind
+
+
+def test_needs_data_marks_are_refused_with_guidance(app_cwd):
+    """The Phase 3 decision: aggregating marks whose validators need at
+    least one row are excluded from the plan tier, with the escape hatch
+    and static tier named in the error."""
+    with pytest.raises(ValueError, match=r"box.*@reflex_xy\.figure"):
+        reflex_xy.chart(xy.box("mag"), data=FactoryDash.cloud)
+    assert not hasattr(reflex_xy, "box_chart")

--- a/tests/reflex_adapter/test_figure_probe.py
+++ b/tests/reflex_adapter/test_figure_probe.py
@@ -1,0 +1,113 @@
+"""The @reflex_xy.figure compile probe: escape-hatch builders fail at compile.
+
+The probed states below raise only while their module flag is armed, so the
+process-wide state walk stays healthy for every other test in the session.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import numpy as np
+import pytest
+import reflex as rx
+
+import reflex_xy
+import xy
+from reflex_xy.app import FigureProbeError, probe_figure_builders
+
+#: Armed per-test; every probed builder below is a no-op otherwise.
+_ARM = {"hallucinated": False, "bad_config": False, "session": False, "async_ran": False}
+
+
+class ProbeDemo(rx.State):
+    n: int = 8
+
+    @reflex_xy.figure
+    def healthy(self) -> xy.Chart:
+        xs = np.linspace(0.0, 1.0, self.n)
+        return xy.scatter_chart(xy.scatter(xs, xs))
+
+    @reflex_xy.figure
+    def hallucinated(self):
+        if not _ARM["hallucinated"]:
+            return None
+        return xy.polar_scatter([1.0], [1.0])  # no such factory
+
+    @reflex_xy.figure(probe="figure")
+    def bad_config(self):
+        if not _ARM["bad_config"]:
+            return None
+        return xy.scatter_chart(xy.scatter([1.0], [1.0], colormap="virids"))
+
+    @reflex_xy.figure
+    def session_bound(self):
+        if not _ARM["session"]:
+            return None
+        # Session-dependent by declaration: reads self.router. Against the
+        # probe's default state this raises; the probe must downgrade.
+        raise RuntimeError(f"no session for {self.router.session.client_token!r}")
+
+    @reflex_xy.figure(probe=False)
+    def opted_out(self):
+        raise AssertionError("probe=False builders must never run at compile")
+
+    @reflex_xy.figure
+    async def async_default(self):
+        raise AssertionError("async builders are not probed by default")
+
+    @reflex_xy.figure(probe="build")
+    async def async_opted_in(self):
+        _ARM["async_ran"] = True
+        await asyncio.sleep(0)
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _disarm():
+    yield
+    for key in _ARM:
+        _ARM[key] = False
+
+
+def test_probe_runs_sync_builders_and_skips_optouts():
+    probed = probe_figure_builders()
+    names = {name.rsplit(".", 1)[-1] for name in probed if "probe_demo" in name}
+    assert "healthy" in names
+    assert "opted_out" not in names
+    assert "async_default" not in names
+    assert "async_opted_in" in names  # explicit opt-in runs under asyncio.run
+    assert _ARM["async_ran"]
+
+
+def test_hallucinated_chart_api_fails_the_compile():
+    """Problem 2 of the options doc, closed for the escape hatch: the
+    builder body is no longer dead code until hydrate."""
+    _ARM["hallucinated"] = True
+    with pytest.raises(FigureProbeError, match="hallucinated") as excinfo:
+        probe_figure_builders()
+    assert "polar_scatter" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, AttributeError)
+
+
+def test_probe_figure_level_compiles_the_result():
+    _ARM["bad_config"] = True
+    with pytest.raises(FigureProbeError, match="bad_config") as excinfo:
+        probe_figure_builders()
+    assert "colormap" in str(excinfo.value)
+
+
+def test_session_dependent_builder_downgrades_to_warning():
+    _ARM["session"] = True
+    with pytest.warns(RuntimeWarning, match="session_bound.*reads the session"):
+        probed = probe_figure_builders()
+    assert not any(name.endswith("session_bound") for name in probed)
+
+
+def test_invalid_probe_level_is_refused_at_decoration():
+    with pytest.raises(ValueError, match="probe="):
+
+        class BadProbe(rx.State):  # noqa: F841 - definition is the assertion
+            @reflex_xy.figure(probe="everything")
+            def chart(self):
+                return None

--- a/tests/reflex_adapter/test_figure_var.py
+++ b/tests/reflex_adapter/test_figure_var.py
@@ -45,26 +45,27 @@ def test_deps_track_the_builder_not_the_wrapper():
     assert deps == {VarDemo.get_full_name(): {"n", "_scale"}}
 
 
-def test_evaluation_registers_and_token_parses(_fresh_registry, client_token):
+def test_evaluation_registers_and_returns_a_parsing_handle(_fresh_registry, client_token):
     state = hydrated_substate(client_token)
-    token = state.chart
-    parsed = parse_token(token)
+    handle = state.chart
+    assert isinstance(handle, reflex_xy.FigureHandle)
+    parsed = parse_token(handle.token)
     assert parsed is not None
     assert parsed.client_token == client_token
     assert parsed.state_full_name == VarDemo.get_full_name()
     assert parsed.var_name == "chart"
-    entry = _fresh_registry.get(token)
+    entry = _fresh_registry.get(handle.token)
     assert entry is not None
     assert entry.figure.traces[0].n_points == 100
 
 
-def test_dep_change_keeps_token_bumps_version(_fresh_registry, client_token):
+def test_dep_change_keeps_handle_bumps_version(_fresh_registry, client_token):
     state = hydrated_substate(client_token)
-    token = state.chart
+    handle = state.chart
     state.n = 250
     VarDemo.computed_vars["chart"].mark_dirty(state)
-    assert state.chart == token  # stable identity: frontend never re-renders
-    entry = _fresh_registry.get(token)
+    assert state.chart == handle  # stable identity: frontend never re-renders
+    entry = _fresh_registry.get(handle.token)
     assert entry.version == 2
     assert entry.figure.traces[0].n_points == 250
 
@@ -79,31 +80,33 @@ def test_recompute_broadcasts_to_publish_hook(_fresh_registry, client_token):
         _fresh_registry.attach_loop(asyncio.get_running_loop())
         _fresh_registry.on_publish(hook)
         state = hydrated_substate(client_token)
-        token = state.chart  # first registration: new entry, no fan-out needed yet
+        handle = state.chart  # first registration: new entry, no fan-out needed yet
         state.n = 300
         VarDemo.computed_vars["chart"].mark_dirty(state)
-        assert state.chart == token
+        assert state.chart == handle
         await asyncio.sleep(0.02)
-        return token
+        return handle.token
 
     token = asyncio.run(main())
     assert published == [(token, 2)]
 
 
-def test_pre_hydration_returns_empty(_fresh_registry):
+def test_pre_hydration_returns_empty_handle(_fresh_registry):
     root = rx.State(_reflex_internal_init=True)
     state = root.get_substate(tuple(VarDemo.get_full_name().split("."))[1:])
-    assert state.chart == ""  # no client token yet -> no figure, no crash
+    # no client token yet -> the empty-token "not ready" sentinel, no crash
+    assert state.chart == reflex_xy.FigureHandle("")
+    assert not state.chart
     assert len(_fresh_registry) == 0
 
 
 def test_none_chart_unregisters(_fresh_registry, client_token):
     state = hydrated_substate(client_token)
-    token = state.maybe_chart
+    token = state.maybe_chart.token
     assert _fresh_registry.get(token) is not None
     state.n = -1
     VarDemo.computed_vars["maybe_chart"].mark_dirty(state)
-    assert state.maybe_chart == ""
+    assert state.maybe_chart == reflex_xy.FigureHandle("")
     assert _fresh_registry.get(token) is None
 
 
@@ -125,16 +128,16 @@ def test_underscore_var_rejected():
 
 
 def test_var_value_survives_state_serialization(_fresh_registry, client_token):
-    """Simulates the reconnect-on-another-node handoff: the token rides the
+    """Simulates the reconnect-on-another-node handoff: the handle rides the
     state serializer (as it would through redis); the figure does not."""
     state = hydrated_substate(client_token)
-    token = state.chart
+    handle = state.chart
     payload = state._serialize()
     assert payload  # pickles fine with a registered figure in play
 
-    _fresh_registry.release(token)  # "another node": no local figure
+    _fresh_registry.release(handle.token)  # "another node": no local figure
     restored = VarDemo._deserialize(payload)
     # The cached var value comes back verbatim WITHOUT re-running the
     # builder — exactly why the namespace needs the rebuild-from-state path.
-    assert restored.chart == token
-    assert _fresh_registry.get(token) is None
+    assert restored.chart == handle
+    assert _fresh_registry.get(handle.token) is None

--- a/tests/reflex_adapter/test_framework_contracts.py
+++ b/tests/reflex_adapter/test_framework_contracts.py
@@ -1,0 +1,107 @@
+"""Pins for the Reflex framework facts the component API design rests on.
+
+Facts R1/R7/R8 from spec/design/reflex-component-api-options.md §4, verified
+against reflex 0.9.6-0.9.8. These tests use a local ``Handle`` type (not the
+shipped ``reflex_xy`` handles) on purpose: they pin the *framework* contract
+itself, so a Reflex upgrade that moves the ground fails here first, named
+after the design fact that broke — independent of any adapter code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, TypedDict, TypeVar, get_args, get_type_hints
+
+import pytest
+import reflex as rx
+
+S = TypeVar("S")
+
+
+@dataclass(frozen=True)
+class ContractHandle(Generic[S]):
+    """Stand-in for reflex_xy's handle types: frozen, generic, tiny."""
+
+    token: str = ""
+
+
+@rx.serializer
+def _serialize_contract_handle(handle: ContractHandle) -> dict:
+    return {"token": handle.token}
+
+
+class ContractSchema(TypedDict):
+    x: list[float]
+    y: list[float]
+    mag: list[float]
+
+
+class ContractState(rx.State):
+    points: int = 5
+    handles: list[ContractHandle[ContractSchema]] = []
+
+    @rx.var
+    def cloud(self) -> ContractHandle[ContractSchema]:
+        return ContractHandle("tok")
+
+
+class ContractComponent(rx.Component):
+    """Minimal component with one ``Var[T]``-typed prop (the R1 seam)."""
+
+    tag = "ContractComponent"
+    figure: rx.Var[ContractHandle]
+
+
+def test_computed_var_preserves_parametrized_generic_alias():
+    """R7: the class-level Var of a computed var returning a parametrized
+    generic frozen dataclass carries the full alias; ``get_args`` recovers
+    the TypedDict and ``get_type_hints`` its column names — the schema
+    channel, readable without executing anything."""
+    var_type = ContractState.cloud._var_type
+    args = get_args(var_type)
+    assert args == (ContractSchema,)
+    assert set(get_type_hints(args[0])) == {"x", "y", "mag"}
+
+
+def test_list_base_var_and_loop_element_keep_the_alias():
+    """R7 (foreach half): a base var annotated ``list[Handle[Schema]]``
+    keeps the alias, and so do the element Vars produced by indexing and by
+    ``rx.foreach`` — schema-aware checks work per item inside loops."""
+    assert get_args(ContractState.handles._var_type) == (ContractHandle[ContractSchema],)
+    assert ContractState.handles[0]._var_type == ContractHandle[ContractSchema]
+
+    element_types: list[object] = []
+
+    def render(item: rx.Var) -> rx.Component:
+        element_types.append(item._var_type)
+        return rx.text("item")
+
+    rx.foreach(ContractState.handles, render).render()
+    assert element_types == [ContractHandle[ContractSchema]]
+
+
+def test_var_typed_prop_checks_fire_at_create():
+    """R1: a prop annotated ``rx.Var[Handle]`` accepts the parametrized var
+    and rejects an int var and a raw string with ``TypeError`` at
+    ``create()`` — i.e. at page evaluation, which is compile time."""
+    ContractComponent.create(figure=ContractState.cloud)
+
+    with pytest.raises(TypeError, match="figure"):
+        ContractComponent.create(figure=ContractState.points)
+    with pytest.raises(TypeError, match="figure"):
+        ContractComponent.create(figure="raw-token-string")
+
+
+def test_unknown_event_kwarg_fails_but_unknown_prop_becomes_style():
+    """R8: an unknown ``on_*`` kwarg already raises ``ValueError`` at
+    ``create()`` (framework machinery, only the message needs help). An
+    unknown *non-event* kwarg is silently absorbed into ``style`` — this
+    half documents the hazard the flat factories' kwarg partition exists to
+    compensate for. If Reflex ever starts rejecting these, the partition
+    layer gets simpler; this test failing on the second clause is that
+    signal."""
+    with pytest.raises(ValueError, match="on_select_typo"):
+        ContractComponent.create(on_select_typo=rx.console_log("x"))
+
+    absorbed = ContractComponent.create(colormapp="viridis")
+    assert "colormapp" in absorbed.style

--- a/tests/reflex_adapter/test_page_plan_registration.py
+++ b/tests/reflex_adapter/test_page_plan_registration.py
@@ -1,0 +1,74 @@
+"""Worker-startup plan registration: X4 made true by construction.
+
+Backend-only Reflex workers (dev backend subprocesses, prod workers) import
+the app module but never run the frontend compile, so page bodies — and the
+chart-factory calls inside them that register plans — would never execute
+there. `setup(app)`'s lifespan evaluates the app's unevaluated pages once at
+startup; these tests pin that seam (reflex-integration.md §3.6).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TypedDict
+
+import numpy as np
+import pytest
+import reflex as rx
+
+import reflex_xy
+from reflex_xy.app import _ensure_page_plans
+from reflex_xy.plan import _PLANS
+
+
+class PageSchema(TypedDict):
+    x: np.ndarray
+    y: np.ndarray
+
+
+class PagePlanState(rx.State):
+    @reflex_xy.data
+    def table(self) -> PageSchema:
+        return {"x": np.array([1.0]), "y": np.array([2.0])}
+
+
+@pytest.fixture
+def app_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    import reflex_xy.component as component_mod
+
+    monkeypatch.setattr(component_mod, "_component_cls", None)
+    return tmp_path
+
+
+def test_backend_worker_page_evaluation_registers_plans(app_cwd, _fresh_registry):
+    def index() -> rx.Component:
+        return reflex_xy.scatter_chart(data=PagePlanState.table, x="x", y="y")
+
+    app = SimpleNamespace(_unevaluated_pages={"index": SimpleNamespace(component=index)})
+    assert not _PLANS  # the worker imported the module; nothing evaluated pages
+    _ensure_page_plans(app)
+    assert len(_PLANS) == 1  # the factory ran and content-addressed its plan
+
+
+def test_failing_page_warns_and_spares_the_others(app_cwd, _fresh_registry):
+    def good() -> rx.Component:
+        return reflex_xy.line_chart(data=PagePlanState.table, x="x", y="y")
+
+    def broken() -> rx.Component:
+        raise RuntimeError("page body exploded")
+
+    app = SimpleNamespace(
+        _unevaluated_pages={
+            "broken": SimpleNamespace(component=broken),
+            "good": SimpleNamespace(component=good),
+        }
+    )
+    with pytest.warns(RuntimeWarning, match="'broken'"):
+        _ensure_page_plans(app)
+    assert len(_PLANS) == 1
+
+
+def test_apps_without_unevaluated_pages_are_a_noop():
+    _ensure_page_plans(SimpleNamespace())  # nothing to do, nothing raised
+    assert not _PLANS

--- a/tests/reflex_adapter/test_payload_asset.py
+++ b/tests/reflex_adapter/test_payload_asset.py
@@ -110,43 +110,53 @@ def test_chart_component_accepts_figure_directly(app_cwd, _fresh_registry):
 
 
 def test_chart_component_rejects_junk(app_cwd):
-    with pytest.raises(TypeError, match=r"figure token .* or a"):
+    with pytest.raises(TypeError, match=r"figure=.*or a positional"):
         reflex_xy.chart(42)
 
 
-def test_inline_token_is_stable_and_pinned(_fresh_registry):
-    token = reflex_xy.inline(make_chart(seed=3.0))
-    assert token.startswith("xyin-")
-    assert parse_token(token) is None  # opaque: no session affinity, shared
+def test_inline_handle_is_stable_and_pinned(_fresh_registry):
+    handle = reflex_xy.inline(make_chart(seed=3.0))
+    assert isinstance(handle, reflex_xy.FigureHandle)
+    assert handle.token.startswith("xyin-")
+    assert parse_token(handle.token) is None  # opaque: no session affinity, shared
     # same content, e.g. another worker importing the module -> same token
-    assert reflex_xy.inline(make_chart(seed=3.0)) == token
-    assert reflex_xy.inline(make_chart(seed=4.0)) != token
+    assert reflex_xy.inline(make_chart(seed=3.0)) == handle
+    assert reflex_xy.inline(make_chart(seed=4.0)) != handle
 
-    entry = _fresh_registry.get(token)
+    entry = _fresh_registry.get(handle.token)
     assert entry is not None and entry.pinned
     # pinned entries survive the TTL sweep (no rebuild recipe exists)
     assert _fresh_registry.sweep(now=entry.last_access + 10**9) == []
-    assert _fresh_registry.get(token) is not None
+    assert _fresh_registry.get(handle.token) is not None
 
 
 def test_unpinned_entries_still_sweep(_fresh_registry):
-    token = reflex_xy.register(make_chart())
-    entry = _fresh_registry.get(token)
+    handle = reflex_xy.register(make_chart())
+    entry = _fresh_registry.get(handle.token)
     dropped = _fresh_registry.sweep(now=entry.last_access + 10**9)
-    assert dropped == [token]
+    assert dropped == [handle.token]
 
 
-def test_inline_chart_component_uses_token(app_cwd, _fresh_registry):
-    token = reflex_xy.inline(make_chart())
-    comp = reflex_xy.chart(token)
+def test_inline_chart_component_uses_figure_prop(app_cwd, _fresh_registry):
+    handle = reflex_xy.inline(make_chart())
+    comp = reflex_xy.chart(figure=handle)
     rendered = str(comp)
-    assert f'token:"{token}"' in rendered
+    assert f'"{handle.token}"' in rendered
+    assert "figure" in rendered
     assert "src" not in rendered
 
 
-def test_component_var_still_routes_to_token(app_cwd):
+def test_positional_handle_routes_to_figure_prop_with_warning(app_cwd, _fresh_registry):
+    handle = reflex_xy.inline(make_chart())
+    with pytest.warns(DeprecationWarning, match="figure="):
+        comp = reflex_xy.chart(handle)
+    assert f'"{handle.token}"' in str(comp)
+
+
+def test_component_str_var_still_routes_to_token(app_cwd):
     class SrcTokState(rx.State):
         tok: str = ""
 
-    comp = reflex_xy.chart(SrcTokState.tok)
+    with pytest.warns(DeprecationWarning, match="figure="):
+        comp = reflex_xy.chart(SrcTokState.tok)
     assert "token:" in str(comp)

--- a/tests/reflex_adapter/test_plan.py
+++ b/tests/reflex_adapter/test_plan.py
@@ -1,0 +1,113 @@
+"""Chart plans: compile-time validation, content addressing, binding."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import xy
+from reflex_xy.plan import (
+    PLAN_VERSION,
+    PlanBindError,
+    PlanError,
+    PlanMissError,
+    build_plan,
+    plan_of,
+    require_plan,
+)
+
+
+def scatter_plan(**mark_options):
+    return build_plan(
+        "scatter_chart",
+        (xy.scatter("x", "y", color="mag", **mark_options), xy.x_axis(label="sigma")),
+        {"title": "cloud"},
+    )
+
+
+def test_plan_records_probed_columns_in_resolution_order():
+    plan = scatter_plan()
+    assert plan.columns == ("x", "y", "mag")
+
+
+def test_digest_is_stable_across_identical_builds():
+    """Content addressing: separately constructed identical trees agree, so
+    every worker evaluating the same page derives the same digest (X4)."""
+    assert scatter_plan().digest == scatter_plan().digest
+    assert scatter_plan().digest != scatter_plan(opacity=0.5).digest
+
+
+def test_digest_golden_pins_the_plan_format():
+    """plan_version is part of the serialization: accidental format churn
+    shows up here as a digest change. An *intentional* format change bumps
+    PLAN_VERSION and re-records this golden (old digests are content
+    addresses — stale subscribers resync, nothing migrates)."""
+    assert PLAN_VERSION == 1
+    plan = build_plan("scatter_chart", (xy.scatter("x", "y"),), {})
+    assert plan.digest == "b7d0b4245b686130e37d"
+
+
+def test_zero_row_probe_fires_the_full_validation_gate():
+    with pytest.raises(ValueError, match="colormap"):
+        scatter_plan(colormap="virids")
+    with pytest.raises(ValueError, match="symbol"):
+        scatter_plan(symbol="marsian")
+    # unresolved axis-id references are figure-compile errors too (X2)
+    with pytest.raises(ValueError, match="axis"):
+        build_plan("scatter_chart", (xy.scatter("x", "y", y_axis="y2"),), {})
+
+
+def test_plans_refuse_concrete_arrays():
+    with pytest.raises(PlanError, match="data-free"):
+        build_plan("scatter_chart", (xy.scatter(np.array([1.0]), np.array([2.0])),), {})
+
+
+def test_plans_refuse_per_mark_data():
+    with pytest.raises(PlanError, match="per-mark data="):
+        build_plan("scatter_chart", (xy.scatter("x", "y", data={"x": [], "y": []}),), {})
+
+
+def test_plans_refuse_render_components():
+    with pytest.raises(PlanError, match="render"):
+        build_plan(
+            "scatter_chart",
+            (xy.scatter("x", "y"), xy.legend(render=object())),
+            {},
+        )
+
+
+def test_bind_produces_fresh_figures_per_call():
+    """X3: Chart.figure() memoizes, so bind() must mint a fresh Chart —
+    two binds with different columns give independent figures."""
+    plan = build_plan("scatter_chart", (xy.scatter("x", "y"),), {})
+    small = plan.bind({"x": [1.0], "y": [2.0]}).figure()
+    large = plan.bind({"x": [1.0, 2.0, 3.0], "y": [2.0, 3.0, 4.0]}).figure()
+    assert small is not large
+    assert small.traces[0].n_points == 1
+    assert large.traces[0].n_points == 3
+
+
+def test_bind_error_names_both_sides():
+    plan = scatter_plan()
+    with pytest.raises(
+        PlanBindError, match=r"plan binds column 'mag'; Dash.cloud produced \{x, y\}"
+    ):
+        plan.bind({"x": [1.0], "y": [2.0]}, source="Dash.cloud")
+
+
+def test_probe_collects_the_tailwind_inventory():
+    plan = build_plan(
+        "scatter_chart",
+        (xy.scatter("x", "y"), xy.legend(class_name="max-h-24 overflow-y-auto")),
+        {"class_name": "rounded-xl"},
+    )
+    assert "rounded-xl" in plan.tailwind_classes
+    assert "max-h-24" in plan.tailwind_classes
+
+
+def test_registry_lookup_and_miss():
+    plan = scatter_plan()
+    assert plan_of(plan.digest) is plan
+    assert plan_of("feedfacefeedfacefeed") is None
+    with pytest.raises(PlanMissError, match="feedfacefeedfacefeed"):
+        require_plan("feedfacefeedfacefeed")

--- a/tests/reflex_adapter/test_registry.py
+++ b/tests/reflex_adapter/test_registry.py
@@ -309,8 +309,8 @@ def test_figure_accepts_chart_or_figure(_fresh_registry):
 
     import reflex_xy
 
-    token = reflex_xy.register(chart)  # public API accepts the composed Chart
-    assert reflex_xy.registry.get(token) is not None
+    handle = reflex_xy.register(chart)  # public API accepts the composed Chart
+    assert reflex_xy.registry.get(handle.token) is not None
 
 
 def test_entry_lock_serializes(_fresh_registry):

--- a/tests/reflex_adapter/test_socket_data_plane.py
+++ b/tests/reflex_adapter/test_socket_data_plane.py
@@ -17,18 +17,24 @@ import json
 import socket
 import threading
 from types import SimpleNamespace
+from typing import TypedDict
 
 import numpy as np
 import pytest
+import reflex as rx
 import socketio
 import uvicorn
+from reflex.istate.manager.memory import StateManagerMemory
 from reflex_base.utils import format as reflex_format
 
+import reflex_xy
 import xy
 from reflex_xy.app import wire
 from reflex_xy.namespace import XYNamespace
+from reflex_xy.plan import build_plan
 from reflex_xy.registry import registry
-from reflex_xy.tokens import build_state_token
+from reflex_xy.state_bridge import make_rebuild_hook
+from reflex_xy.tokens import build_data_token, build_plan_token, build_state_token
 
 CLIENT_TOKEN = "11111111-2222-4333-8444-555566667777"
 OTHER_TOKEN = "99999999-8888-4777-8666-555544443333"
@@ -758,7 +764,7 @@ def test_failed_rebuild_attempt_is_shared_then_later_request_retries(_fresh_regi
     async def get_session(sid):
         return {"client_token": CLIENT_TOKEN}
 
-    async def send_error(sid, token, error):
+    async def send_error(sid, token, error, resync=False):
         errors.append((sid, token, error))
 
     async def broadcast(token, entry):
@@ -835,7 +841,7 @@ def test_rebuild_broadcast_failure_removes_generation_and_later_sub_retries(
         if len(broadcasts) == 1:
             raise RuntimeError("transport failed")
 
-    async def send_error(sid, token, error):
+    async def send_error(sid, token, error, resync=False):
         errors.append((sid, token, error))
 
     async def enter_room(sid, room):
@@ -908,7 +914,7 @@ def test_rebuild_failure_cleanup_does_not_remove_a_concurrent_replacement(
         replacement = registry.publish(token, replacement_figure, broadcast=False)
         raise RuntimeError("old generation transport failed")
 
-    async def send_error(sid, token, error):
+    async def send_error(sid, token, error, resync=False):
         errors.append((sid, token, error))
 
     monkeypatch.setattr(namespace, "get_session", get_session)
@@ -971,7 +977,7 @@ def test_rebuild_failure_cleanup_preserves_same_object_authoritative_publish(
         assert registry._rebuildable_subscribers[state_token] == {"sid-existing"}
         delivered.set()
 
-    async def send_error(sid, token, error):
+    async def send_error(sid, token, error, resync=False):
         errors.append((sid, token, error))
 
     monkeypatch.setattr(namespace, "get_session", get_session)
@@ -1176,7 +1182,7 @@ def test_rebuild_completion_does_not_resurrect_after_a_newer_release(_fresh_regi
     async def get_session(sid):
         return {"client_token": CLIENT_TOKEN}
 
-    async def send_error(sid, token, error):
+    async def send_error(sid, token, error, resync=False):
         errors.append((sid, token, error))
 
     async def broadcast(token, entry):
@@ -1646,5 +1652,240 @@ def test_subscription_departure_releases_evicted_version(_fresh_registry, depart
             if client.connected:
                 await client.disconnect()
         assert replacement.version == 1
+
+    run(main())
+
+
+# -- the data-bound (plan) tier over the same wire ---------------------------
+#
+# Composite figure identity xyp1|<digest>|<xyd1 token>: rooms, versioning,
+# mid addressing, and the attachment-cap logic are reused unchanged — the
+# composite token is just another `fig` string to everything below the
+# subscribe path.
+
+
+class PlaneSchema(TypedDict):
+    x: np.ndarray
+    y: np.ndarray
+
+
+class PlaneData(rx.State):
+    n: int = 24
+
+    @reflex_xy.data
+    def table(self) -> PlaneSchema:
+        xs = np.linspace(0.0, 1.0, self.n)
+        return {"x": xs, "y": xs * 2.0}
+
+
+def make_plane_app():
+    return SimpleNamespace(state_manager=StateManagerMemory())
+
+
+def plane_plan():
+    return build_plan("scatter_chart", (xy.scatter("x", "y"),), {})
+
+
+def plane_data_token(client_token: str = CLIENT_TOKEN) -> str:
+    return build_data_token(client_token, PlaneData.get_full_name(), "table")
+
+
+def test_composite_sub_serves_bound_payload_and_interactions(_fresh_registry):
+    """sub/msg on a composite token: plan lookup + column resolve + bind,
+    then the ordinary payload/pick machinery."""
+    app = make_plane_app()
+
+    async def main():
+        plan = plane_plan()
+        data_token = plane_data_token()
+        composite = build_plan_token(plan.digest, data_token)
+        async with data_plane_server(rebuild=make_rebuild_hook(app)) as (url, _):
+            client = await connect_client(url)
+            collector = Collector(client)
+            await client.emit("sub", {"fig": composite, "mid": "m1"}, namespace="/_xy")
+            payload = await collector.next(collector.payloads)
+            assert payload["fig"] == composite
+            assert payload["spec"]["traces"][0]["n_points"] == 24
+            # interactions round-trip against the bound figure
+            await client.emit(
+                "msg",
+                {
+                    "fig": composite,
+                    "v": payload["version"],
+                    "mid": "m1",
+                    "m": {"type": "pick", "trace": 0, "index": 3, "seq": "pick:1"},
+                },
+                namespace="/_xy",
+            )
+            reply = await collector.next(collector.messages)
+            assert reply["message"]["type"] == "pick_result"
+            await client.disconnect()
+        # both halves are cached now: columns and the bound figure
+        assert registry.get_columns(data_token) is not None
+        assert registry.get(composite) is not None
+
+    run(main())
+
+
+def test_composite_rebuild_reads_session_state(_fresh_registry):
+    """The data half is rebuilt through the state bridge (mutated session
+    state, not defaults) when neither half is cached."""
+    app = make_plane_app()
+    token_obj = rx.BaseStateToken(ident=CLIENT_TOKEN, cls=rx.State)
+
+    async def main():
+        async with app.state_manager.modify_state(token_obj) as root:
+            sub = await root.get_state(PlaneData)
+            sub.n = 7
+        plan = plane_plan()
+        composite = build_plan_token(plan.digest, plane_data_token())
+        async with data_plane_server(rebuild=make_rebuild_hook(app)) as (url, _):
+            client = await connect_client(url)
+            collector = Collector(client)
+            await client.emit("sub", {"fig": composite, "mid": "m1"}, namespace="/_xy")
+            payload = await collector.next(collector.payloads)
+            assert payload["spec"]["traces"][0]["n_points"] == 7
+            await client.disconnect()
+
+    run(main())
+
+
+def test_column_republish_fans_out_to_every_dependent_plan(_fresh_registry):
+    """One data var, two mounted plans: a republish rebuilds and broadcasts
+    both composite figures."""
+    app = make_plane_app()
+
+    async def main():
+        scatter_plan = plane_plan()
+        line_plan = build_plan("line_chart", (xy.line("x", "y"),), {})
+        data_token = plane_data_token()
+        scatter_fig = build_plan_token(scatter_plan.digest, data_token)
+        line_fig = build_plan_token(line_plan.digest, data_token)
+        async with data_plane_server(rebuild=make_rebuild_hook(app)) as (url, _):
+            client = await connect_client(url)
+            collector = Collector(client)
+            await client.emit("sub", {"fig": scatter_fig, "mid": "m1"}, namespace="/_xy")
+            first = await collector.next(collector.payloads)
+            await client.emit("sub", {"fig": line_fig, "mid": "m2"}, namespace="/_xy")
+            second = await collector.next(collector.payloads)
+            assert {first["fig"], second["fig"]} == {scatter_fig, line_fig}
+
+            # the data var recomputes (as a state delta evaluation would)
+            registry.publish_columns(
+                data_token,
+                {"x": np.linspace(0.0, 1.0, 5), "y": np.linspace(0.0, 1.0, 5)},
+            )
+            refreshed = {}
+            for _ in range(2):
+                payload = await collector.next(collector.payloads)
+                refreshed[payload["fig"]] = payload["spec"]["traces"][0]["n_points"]
+            assert refreshed == {scatter_fig: 5, line_fig: 5}
+            await client.disconnect()
+
+    run(main())
+
+
+def test_composite_affinity_uses_the_embedded_data_client(_fresh_registry):
+    app = make_plane_app()
+
+    async def main():
+        plan = plane_plan()
+        composite = build_plan_token(plan.digest, plane_data_token(CLIENT_TOKEN))
+        async with data_plane_server(rebuild=make_rebuild_hook(app)) as (url, _):
+            thief = await connect_client(url, client_token=OTHER_TOKEN)
+            thief_collector = Collector(thief)
+            await thief.emit("sub", {"fig": composite, "mid": "m1"}, namespace="/_xy")
+            error = await thief_collector.next(thief_collector.errors)
+            assert "another session" in error["error"]
+            await thief.disconnect()
+
+    run(main())
+
+
+def test_plan_miss_answers_err_resync_naming_the_digest(_fresh_registry):
+    """Hot-reload drift: a subscriber holding a stale digest is asked to
+    resync (the recompiled page carries the new digest)."""
+    app = make_plane_app()
+
+    async def main():
+        composite = build_plan_token("feedfacefeedfacefeed", plane_data_token())
+        async with data_plane_server(rebuild=make_rebuild_hook(app)) as (url, _):
+            client = await connect_client(url)
+            collector = Collector(client)
+            await client.emit("sub", {"fig": composite, "mid": "m1"}, namespace="/_xy")
+            error = await collector.next(collector.errors)
+            assert "feedfacefeedfacefeed" in error["error"]
+            assert error["resync"] is True
+            await client.disconnect()
+
+    run(main())
+
+
+def test_bind_mismatch_answers_err_without_resync(_fresh_registry):
+    """An untyped data var producing the wrong columns: the err frame names
+    both sides and does not ask for a pointless resync."""
+
+    class MismatchData(rx.State):
+        @reflex_xy.data
+        def rows(self):
+            return {"only": [1.0, 2.0]}
+
+    app = make_plane_app()
+
+    async def main():
+        plan = plane_plan()
+        data_token = build_data_token(CLIENT_TOKEN, MismatchData.get_full_name(), "rows")
+        composite = build_plan_token(plan.digest, data_token)
+        async with data_plane_server(rebuild=make_rebuild_hook(app)) as (url, _):
+            client = await connect_client(url)
+            collector = Collector(client)
+            await client.emit("sub", {"fig": composite, "mid": "m1"}, namespace="/_xy")
+            error = await collector.next(collector.errors)
+            assert "plan binds" in error["error"]
+            assert "'x'" in error["error"]
+            assert error.get("resync") is None
+            await client.disconnect()
+
+    run(main())
+
+
+def test_republish_bind_failure_broadcasts_err_and_releases(_fresh_registry):
+    """A republish whose columns stop satisfying a mounted plan must not
+    freeze subscribers silently: the composite entry is released and the
+    room gets an err frame asking for a bounded resync."""
+    app = make_plane_app()
+
+    async def main():
+        plan = plane_plan()
+        data_token = plane_data_token()
+        composite = build_plan_token(plan.digest, data_token)
+        async with data_plane_server(rebuild=make_rebuild_hook(app)) as (url, _):
+            client = await connect_client(url)
+            collector = Collector(client)
+            await client.emit("sub", {"fig": composite, "mid": "m1"}, namespace="/_xy")
+            await collector.next(collector.payloads)
+
+            registry.publish_columns(data_token, {"wrong": [1.0]})
+            error = await collector.next(collector.errors)
+            assert "plan binds" in error["error"]
+            assert error["resync"] is True
+            assert registry.get(composite) is None
+            await client.disconnect()
+
+    run(main())
+
+
+def test_bare_data_token_is_not_a_figure(_fresh_registry):
+    """A raw xyd1 token names columns, never a figure: closed, no rebuild."""
+    app = make_plane_app()
+
+    async def main():
+        async with data_plane_server(rebuild=make_rebuild_hook(app)) as (url, _):
+            client = await connect_client(url)
+            collector = Collector(client)
+            await client.emit("sub", {"fig": plane_data_token(), "mid": "m1"}, namespace="/_xy")
+            error = await collector.next(collector.errors)
+            assert error["error"] == "unknown figure token"
+            await client.disconnect()
 
     run(main())

--- a/tests/test_example_apps.py
+++ b/tests/test_example_apps.py
@@ -145,11 +145,18 @@ def test_fastapi_app_serves_live_charts_and_code() -> None:
 def test_reflex_app_shows_every_linking_method_and_event() -> None:
     src = REFLEX_APP.read_text(encoding="utf-8")
     required = [
-        "@reflex_xy.figure",  # live figure var
-        "reflex_xy.chart(",  # the component
+        "@reflex_xy.data",  # data-bound columns (§1/§4/§8/§9)
+        "data=Demo.cloud",  # composed chart bound to a data var (§1)
+        "reflex_xy.scatter_chart(",  # flat data-bound factory (§8)
+        "rx.cond(Demo.split",  # conditional chart rendering (§9)
+        "rx.foreach(",  # chart-per-handle rendering (§9)
+        "list[DataHandle[SensorCols]]",  # the typed handle collection (R7)
+        "@reflex_xy.figure",  # escape hatch: chart structure from state (§2)
+        "reflex_xy.chart(",  # the component / composed factory
         "reflex_xy.append(",  # streaming
         "reflex_xy.inline(",  # inline() token tier
-        "sparkline_chart()",  # static Chart tier passed directly
+        'data={"t": t',  # static tier: concrete columns -> payload asset (§5)
+        "legend_series_chart()",  # static Chart tier passed directly (§7)
         # the FastAPI 100M drilldown, served adapter-natively (§6); both apps
         # honor the same point-count override for side-by-side comparison.
         "def drilldown_chart",
@@ -189,14 +196,16 @@ def test_reflex_app_introspection_and_composition(tmp_path, monkeypatch) -> None
     sys.path.insert(0, str(REFLEX_DIR))
     module = _load(REFLEX_APP, "xy_reflex_demo_under_test")
 
-    # The Code accordion reads live source: figure vars unwrap to their builder,
-    # event handlers to their function — both include the decorator line.
-    assert "@reflex_xy.figure" in module._source(module.Demo.cloud)
+    # The Code accordion reads live source: figure/data vars unwrap to their
+    # builder, event handlers to their function — both include the decorator.
+    assert "@reflex_xy.data" in module._source(module.Demo.cloud)
     assert "def cloud" in module._source(module.Demo.cloud)
+    assert "@reflex_xy.figure" in module._source(module.Demo.histogram)
     assert "def on_view" in module._source(module.Demo.on_view)
-    # The page composes without error and mints inline() tokens at import.
-    assert module.ORBITS_TOKEN.startswith("xyin-")
-    assert module.DRILLDOWN_TOKEN.startswith("xyin-")
+    assert "@reflex_xy.data" in module._source(module.Demo.bound_cloud)
+    # The page composes without error and mints inline() handles at import.
+    assert module.ORBITS.token.startswith("xyin-")
+    assert module.DRILLDOWN.token.startswith("xyin-")
     assert module.DRILLDOWN_POINTS == 50000
     assert module.index() is not None
 

--- a/tests/test_validation_timing.py
+++ b/tests/test_validation_timing.py
@@ -1,0 +1,99 @@
+"""Pins for the composition API's validation timing (facts X1-X3).
+
+The Reflex component API (spec/design/reflex-component-api-options.md §4,
+implementation plan in reflex-component-api-implementation.md) compiles
+chart *plans* by binding zero-row placeholder columns and calling
+``.figure()`` once at page evaluation. That only works while:
+
+- X1: the tree is cheap to build without data; chrome nodes validate
+  eagerly; mark config validates at ``.figure()``.
+- X2: zero-row columns compile — the probe exercises the full validation
+  gate with no real data.
+- X3: ``Chart.figure()`` memoizes and is never invalidated — rebinding data
+  means a fresh ``Chart``, never mutating one.
+
+A grammar change that moves any of these fails here first, named after the
+fact it broke.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import xy
+
+EMPTY = np.empty(0, dtype=np.float64)
+
+# Every mark kind the flat/composed Reflex factories cover with the zero-row
+# probe (Phase 2 kinds first, then the Phase 3 signature-derived set). Kinds
+# whose validators require at least one finite value (stairs, ecdf, box,
+# violin, hexbin, heatmap, contour) are excluded from the plan/zero-row model
+# by the Phase 3 decision recorded in the implementation plan.
+ZERO_ROW_CHARTS = {
+    "scatter": lambda: xy.scatter_chart(xy.scatter(EMPTY, EMPTY)),
+    "line": lambda: xy.line_chart(xy.line(EMPTY, EMPTY)),
+    "histogram": lambda: xy.histogram_chart(xy.histogram(EMPTY)),
+    "bar": lambda: xy.bar_chart(xy.bar(EMPTY, EMPTY)),
+    "area": lambda: xy.area_chart(xy.area(EMPTY, EMPTY)),
+    "step": lambda: xy.step_chart(xy.step(EMPTY, EMPTY)),
+    "stem": lambda: xy.stem_chart(xy.stem(EMPTY, EMPTY)),
+    "column": lambda: xy.column_chart(xy.column(EMPTY, EMPTY)),
+    "errorbar": lambda: xy.errorbar_chart(xy.errorbar(EMPTY, EMPTY, yerr=EMPTY)),
+    "error_band": lambda: xy.error_band_chart(xy.error_band(EMPTY, EMPTY, upper=EMPTY)),
+    "segments": lambda: xy.segments_chart(xy.segments(EMPTY, EMPTY, x1=EMPTY, y1=EMPTY)),
+}
+
+
+@pytest.mark.parametrize("kind", sorted(ZERO_ROW_CHARTS))
+def test_zero_row_construction_compiles(kind):
+    """X2: binding empty columns and calling .figure() runs the full mark
+    validation gate without any real data."""
+    figure = ZERO_ROW_CHARTS[kind]().figure()
+    assert figure is not None
+
+
+def test_zero_row_columns_resolve_through_chart_data():
+    """X2, the form the plan tier uses: string channels resolved against a
+    chart-level table of zero-row columns."""
+    data = {"x": EMPTY, "y": EMPTY, "mag": EMPTY}
+    figure = xy.scatter_chart(xy.scatter("x", "y", color="mag"), data=data).figure()
+    assert figure is not None
+
+
+def test_mark_config_validates_at_figure_not_construction():
+    """X1: mark factories are lazy about config — a bad colormap constructs
+    fine and fails only at .figure()."""
+    mark = xy.scatter([1.0], [1.0], colormap="bogus")  # constructs
+    with pytest.raises(ValueError, match="colormap"):
+        xy.scatter_chart(mark).figure()
+
+
+def test_unknown_mark_kwarg_fails_at_construction():
+    """X1: no ``**kwargs`` sinks anywhere — a typo'd mark option is an
+    immediate TypeError, before any figure exists."""
+    with pytest.raises(TypeError):
+        xy.scatter([1.0], [1.0], colormapp="viridis")
+
+
+def test_chrome_nodes_validate_eagerly():
+    """X1: chrome constructors validate every field at call time."""
+    with pytest.raises(ValueError, match="type_"):
+        xy.x_axis(type_="bogus")
+
+
+def test_figure_memoizes_and_rebinding_needs_a_fresh_chart():
+    """X3: .figure() is built once and cached; swapping the data table on an
+    existing Chart does not rebuild — a fresh Chart does."""
+    mark = xy.scatter("x", "y")
+    chart = xy.scatter_chart(mark, data={"x": [1.0], "y": [2.0]})
+    figure = chart.figure()
+    assert chart.figure() is figure
+
+    chart.data = {"x": [1.0, 3.0], "y": [2.0, 4.0]}
+    assert chart.figure() is figure  # memoized: rebind must not rely on mutation
+    assert chart.figure().traces[0].n_points == 1
+
+    rebound = xy.scatter_chart(mark, data={"x": [1.0, 3.0], "y": [2.0, 4.0]})
+    assert rebound.figure() is not figure
+    assert rebound.figure().traces[0].n_points == 2


### PR DESCRIPTION
Charts are now declared in the page and validated when `reflex run` compiles the app: the flat `reflex_xy.scatter_chart(data=Dash.cloud, x="x", ...)` and composed `reflex_xy.chart(...)` factories compile the xy node tree to a digest-addressed plan via a zero-row probe and check channel names against the `@reflex_xy.data` method's TypedDict schema. Columns ride the app websocket under composite plan|data identities and republish under stable handles, so viewport and selection survive data updates. `@reflex_xy.figure` stays as the escape hatch for state-dependent structure and gains the same compile-time probe; backend-only workers evaluate page plans at startup so plan lookups never miss. The demo app, specs, and design records are updated to the new tiers.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added data-bound charts with typed column data and live updates.
  * Added chart factories for scatter, line, bar, area, histogram, and other chart types.
  * Added conditional and iterative chart composition, including dynamic small multiples.
  * Added stable typed handles for live figures and data sources.
* **Bug Fixes**
  * Improved chart validation, error reporting, and automatic recovery from synchronization issues.
* **Documentation**
  * Expanded examples and guides covering data binding, chart plans, interactions, and composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->