### PR TITLE
Use native factorization for object string categories

### DIFF
--- a/python/xy/channels.py
+++ b/python/xy/channels.py
@@ -371,6 +371,25 @@ def _use_native_fixed_factorizer(arr: np.ndarray) -> bool:
     return distinct < near_unique * len(probe)
 
 
+def _normalize_object_strings(arr: np.ndarray) -> Optional[np.ndarray]:
+    """Return object-backed strings as fixed-width Unicode when safe.
+
+    Object arrays can contain values with display-label semantics that cannot
+    be represented by a simple Unicode cast. Restrict this path to exact
+    Python strings so mixed objects, missing values, and custom ``__str__``
+    implementations retain the canonical fallback behavior.
+    """
+    if arr.dtype.kind != "O" or arr.size == 0:
+        return None
+    values = arr.reshape(-1)
+    width = 0
+    for value in values:
+        if type(value) is not str:
+            return None
+        width = max(width, len(value))
+    return np.asarray(arr, dtype=f"<U{max(width, 1)}")
+
+
 def _factorize_categories(
     arr: np.ndarray,
 ) -> tuple[
@@ -388,15 +407,19 @@ def _factorize_categories(
     strings/bytes/bools can identify equal records in Rust without creating N
     Python objects; only their compact unique set crosses the label-policy path.
     """
-    if arr.dtype.kind in ("U", "S", "b") and _use_native_fixed_factorizer(arr):
+    normalized = _normalize_object_strings(arr)
+    factorizer_arr = arr if normalized is None else normalized
+    if factorizer_arr.dtype.kind in ("U", "S", "b") and _use_native_fixed_factorizer(
+        factorizer_arr
+    ):
         compact = (
-            kernels.factorize_unicode1_u8_counts(arr, MAX_CATEGORIES)
-            if arr.dtype.kind == "U" and arr.dtype.itemsize == 4
-            else kernels.factorize_fixed_u8_counts(arr, MAX_CATEGORIES)
+            kernels.factorize_unicode1_u8_counts(factorizer_arr, MAX_CATEGORIES)
+            if factorizer_arr.dtype.kind == "U" and factorizer_arr.dtype.itemsize == 4
+            else kernels.factorize_fixed_u8_counts(factorizer_arr, MAX_CATEGORIES)
         )
         if compact is not None:
             raw_codes, unique_indices, raw_counts = compact
-            unique_labels = [category_label(value) for value in arr[unique_indices]]
+            unique_labels = [category_label(value) for value in factorizer_arr[unique_indices]]
             categories = sorted(set(unique_labels))
             index = {label: i for i, label in enumerate(categories)}
             remap = np.fromiter(
@@ -412,8 +435,8 @@ def _factorize_categories(
                 counts[index[label]] += count
             return categories, raw_codes, counts
 
-        raw_codes, unique_indices = kernels.factorize_fixed(arr)
-        unique_labels = [category_label(value) for value in arr[unique_indices]]
+        raw_codes, unique_indices = kernels.factorize_fixed(factorizer_arr)
+        unique_labels = [category_label(value) for value in factorizer_arr[unique_indices]]
         categories = sorted(set(unique_labels))
         index = {label: i for i, label in enumerate(categories)}
         dtype = _category_code_dtype(len(categories))

--- a/python/xy/channels.py
+++ b/python/xy/channels.py
@@ -342,7 +342,18 @@ def _category_code_dtype(category_count: int) -> type[np.uint8] | type[np.uint32
     return np.uint8 if category_count <= MAX_CATEGORIES else np.uint32
 
 
-def _use_native_fixed_factorizer(arr: np.ndarray) -> bool:
+def _factorize_probe(arr: np.ndarray) -> np.ndarray:
+    """Return the bounded sample used to select the native factorizer."""
+    n = len(arr)
+    if n <= _FACTORIZE_PROBE_ROWS:
+        return arr
+    rows = np.linspace(0, n - 1, _FACTORIZE_PROBE_ROWS, dtype=np.intp)
+    return arr[rows]
+
+
+def _use_native_fixed_factorizer(
+    arr: np.ndarray, *, normalized_itemsize: Optional[int] = None
+) -> bool:
     """Choose the O(N) hash path unless a bounded global probe says it cannot pay.
 
     The native pass earns its keep by keeping N records out of Python: only the
@@ -356,37 +367,40 @@ def _use_native_fixed_factorizer(arr: np.ndarray) -> bool:
     repeats get scarce while narrow ones hold it until the probe is entirely
     distinct. Sampling across the full array keeps the decision independent of N.
     """
-    n = len(arr)
-    if n <= _FACTORIZE_PROBE_ROWS:
-        probe = arr
-    else:
-        rows = np.linspace(0, n - 1, _FACTORIZE_PROBE_ROWS, dtype=np.intp)
-        probe = arr[rows]
+    probe = _factorize_probe(arr)
     distinct = len(np.unique(probe))
     if distinct <= _FACTORIZE_NATIVE_MAX_PROBE_CATEGORIES:
         return True
     near_unique = (
-        1.0 if arr.dtype.itemsize <= _FACTORIZE_NARROW_ITEMSIZE else _FACTORIZE_NEAR_UNIQUE_RATIO
+        1.0
+        if (normalized_itemsize or arr.dtype.itemsize) <= _FACTORIZE_NARROW_ITEMSIZE
+        else _FACTORIZE_NEAR_UNIQUE_RATIO
     )
     return distinct < near_unique * len(probe)
 
 
-def _normalize_object_strings(arr: np.ndarray) -> Optional[np.ndarray]:
-    """Return object-backed strings as fixed-width Unicode when safe.
+def _object_string_width(arr: np.ndarray, *, sample: bool = False) -> Optional[int]:
+    """Return the width of safe Python-string values, or ``None``.
 
     Object arrays can contain values with display-label semantics that cannot
     be represented by a simple Unicode cast. Restrict this path to exact
     Python strings so mixed objects, missing values, and custom ``__str__``
-    implementations retain the canonical fallback behavior.
+    implementations retain the canonical fallback behavior. NUL codepoints
+    are excluded because NumPy treats them as fixed-width string padding.
     """
     if arr.dtype.kind != "O" or arr.size == 0:
         return None
-    values = arr.reshape(-1)
+    values = _factorize_probe(arr) if sample else arr.reshape(-1)
     width = 0
     for value in values:
-        if type(value) is not str:
+        if type(value) is not str or "\x00" in value:
             return None
         width = max(width, len(value))
+    return width
+
+
+def _normalize_object_strings(arr: np.ndarray, width: int) -> np.ndarray:
+    """Normalize validated object-backed strings to fixed-width Unicode."""
     return np.asarray(arr, dtype=f"<U{max(width, 1)}")
 
 
@@ -404,11 +418,25 @@ def _factorize_categories(
     not mutually orderable. Chart labels are strings on the client anyway, so
     canonicalize to display labels first, sort those labels for deterministic
     palettes, and then map each row back to its code. Fixed-width NumPy
-    strings/bytes/bools can identify equal records in Rust without creating N
-    Python objects; only their compact unique set crosses the label-policy path.
+    strings/bytes/bools and safe object-backed Python strings can identify equal
+    records in Rust without creating N Python objects; only their compact unique
+    set crosses the label-policy path. Mixed objects, missing values, custom
+    string semantics, and strings containing NUL codepoints retain the Python
+    fallback so display-label behavior is unchanged.
     """
-    normalized = _normalize_object_strings(arr)
-    factorizer_arr = arr if normalized is None else normalized
+    factorizer_arr = arr
+    if arr.dtype.kind == "O":
+        # Probe object strings before the full validation and Unicode copy so
+        # near-unique columns take the existing Python fallback cheaply.
+        sample_width = _object_string_width(arr, sample=True)
+        if sample_width is not None and _use_native_fixed_factorizer(
+            arr, normalized_itemsize=4 * max(sample_width, 1)
+        ):
+            width = _object_string_width(arr)
+            if width is not None and _use_native_fixed_factorizer(
+                arr, normalized_itemsize=4 * max(width, 1)
+            ):
+                factorizer_arr = _normalize_object_strings(arr, width)
     if factorizer_arr.dtype.kind in ("U", "S", "b") and _use_native_fixed_factorizer(
         factorizer_arr
     ):

--- a/python/xy/channels.py
+++ b/python/xy/channels.py
@@ -352,7 +352,11 @@ def _factorize_probe(arr: np.ndarray) -> np.ndarray:
 
 
 def _use_native_fixed_factorizer(
-    arr: np.ndarray, *, normalized_itemsize: Optional[int] = None
+    arr: np.ndarray,
+    *,
+    normalized_itemsize: Optional[int] = None,
+    probe: Optional[np.ndarray] = None,
+    distinct: Optional[int] = None,
 ) -> bool:
     """Choose the O(N) hash path unless a bounded global probe says it cannot pay.
 
@@ -367,8 +371,8 @@ def _use_native_fixed_factorizer(
     repeats get scarce while narrow ones hold it until the probe is entirely
     distinct. Sampling across the full array keeps the decision independent of N.
     """
-    probe = _factorize_probe(arr)
-    distinct = len(np.unique(probe))
+    probe = _factorize_probe(arr) if probe is None else probe
+    distinct = len(np.unique(probe)) if distinct is None else distinct
     if distinct <= _FACTORIZE_NATIVE_MAX_PROBE_CATEGORIES:
         return True
     near_unique = (
@@ -428,13 +432,23 @@ def _factorize_categories(
     if arr.dtype.kind == "O":
         # Probe object strings before the full validation and Unicode copy so
         # near-unique columns take the existing Python fallback cheaply.
+        probe = distinct = None
         sample_width = _object_string_width(arr, sample=True)
+        if sample_width is not None:
+            probe = _factorize_probe(arr)
+            distinct = len(np.unique(probe))
         if sample_width is not None and _use_native_fixed_factorizer(
-            arr, normalized_itemsize=4 * max(sample_width, 1)
+            arr,
+            normalized_itemsize=4 * max(sample_width, 1),
+            probe=probe,
+            distinct=distinct,
         ):
             width = _object_string_width(arr)
             if width is not None and _use_native_fixed_factorizer(
-                arr, normalized_itemsize=4 * max(width, 1)
+                arr,
+                normalized_itemsize=4 * max(width, 1),
+                probe=probe,
+                distinct=distinct,
             ):
                 factorizer_arr = _normalize_object_strings(arr, width)
     if factorizer_arr.dtype.kind in ("U", "S", "b") and _use_native_fixed_factorizer(

--- a/tests/test_custom_ramps_and_palette.py
+++ b/tests/test_custom_ramps_and_palette.py
@@ -375,6 +375,53 @@ def test_the_literal_color_probe_does_not_materialize_category_columns():
     assert channels._literal_color_rgba(column) is None
 
 
+def test_homogeneous_object_categories_use_native_factorization(monkeypatch):
+    """Object strings use the native path without an N-entry label list."""
+    values = np.array(["group-a", "group-b", "group-a", "group-c"] * 250, dtype=object)
+    seen: list[object] = []
+    original = channels.category_label
+
+    def record(value: object) -> str:
+        seen.append(value)
+        return original(value)
+
+    monkeypatch.setattr(channels, "category_label", record)
+    categories, codes, counts = channels._factorize_categories(values)
+
+    assert categories == ["group-a", "group-b", "group-c"]
+    np.testing.assert_array_equal(codes[:4], [0, 1, 0, 2])
+    np.testing.assert_array_equal(counts, [500, 250, 250])
+    assert len(seen) == len(categories)
+
+
+def test_object_factorization_matches_fixed_width_string_semantics():
+    """The object fast path preserves category order, codes, and counts."""
+    values = np.array(["beta", "alpha", "beta", "gamma", "alpha"], dtype=object)
+    object_result = channels._factorize_categories(values)
+    unicode_result = channels._factorize_categories(values.astype("U5"))
+
+    assert object_result[0] == unicode_result[0]
+    np.testing.assert_array_equal(object_result[1], unicode_result[1])
+    np.testing.assert_array_equal(object_result[2], unicode_result[2])
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        np.array(["a", None, "a"], dtype=object),
+        np.array(["a", 1, "a"], dtype=object),
+        np.array([b"a", b"b", b"a"], dtype=object),
+    ],
+)
+def test_mixed_object_categories_keep_the_fallback(values):
+    """Values without exact string semantics remain on the safe fallback."""
+    categories, codes, counts = channels._factorize_categories(values)
+
+    assert len(categories) == len(set(categories))
+    assert len(codes) == len(values)
+    assert counts is None
+
+
 def test_the_probe_still_reads_a_column_that_actually_looks_like_paint():
     column = np.array(["#ff0000", "#00ff00", "#0000ff"])
     rgba = channels._literal_color_rgba(column)

--- a/tests/test_custom_ramps_and_palette.py
+++ b/tests/test_custom_ramps_and_palette.py
@@ -405,6 +405,33 @@ def test_object_factorization_matches_fixed_width_string_semantics():
     np.testing.assert_array_equal(object_result[2], unicode_result[2])
 
 
+def test_object_factorization_preserves_nul_distinct_categories():
+    """NUL-containing strings retain Python equality semantics."""
+    categories, codes, counts = channels._factorize_categories(
+        np.array(["a", "a\x00", "a", "a\x00"], dtype=object)
+    )
+
+    assert categories == ["a", "a\x00"]
+    np.testing.assert_array_equal(codes, [0, 1, 0, 1])
+    assert counts is None
+
+
+def test_near_unique_object_strings_do_not_run_full_width_scan(monkeypatch):
+    """Near-unique object columns are rejected before full normalization."""
+    values = np.array([f"id-{i}" for i in range(5000)], dtype=object)
+    original = channels._object_string_width
+    calls: list[bool] = []
+
+    def record(arr, *, sample=False):
+        calls.append(sample)
+        return original(arr, sample=sample)
+
+    monkeypatch.setattr(channels, "_object_string_width", record)
+    channels._factorize_categories(values)
+
+    assert calls == [True]
+
+
 @pytest.mark.parametrize(
     "values",
     [

--- a/tests/test_custom_ramps_and_palette.py
+++ b/tests/test_custom_ramps_and_palette.py
@@ -432,6 +432,23 @@ def test_near_unique_object_strings_do_not_run_full_width_scan(monkeypatch):
     assert calls == [True]
 
 
+def test_object_factorization_reuses_the_bounded_probe(monkeypatch):
+    """Object-string eligibility gates share one bounded distinct-count probe."""
+    values = np.array(["group-a", "group-b", "group-a", "group-c"] * 250, dtype=object)
+    original = channels.np.unique
+    object_probe_calls: list[np.ndarray] = []
+
+    def record(arr, *args, **kwargs):
+        if arr.dtype.kind == "O":
+            object_probe_calls.append(arr)
+        return original(arr, *args, **kwargs)
+
+    monkeypatch.setattr(channels.np, "unique", record)
+    channels._factorize_categories(values)
+
+    assert len(object_probe_calls) == 1
+
+
 @pytest.mark.parametrize(
     "values",
     [

--- a/tests/test_custom_ramps_and_palette.py
+++ b/tests/test_custom_ramps_and_palette.py
@@ -434,7 +434,7 @@ def test_near_unique_object_strings_do_not_run_full_width_scan(monkeypatch):
 
 def test_object_factorization_reuses_the_bounded_probe(monkeypatch):
     """Object-string eligibility gates share one bounded distinct-count probe."""
-    values = np.array(["group-a", "group-b", "group-a", "group-c"] * 250, dtype=object)
+    values = np.array(["group-a", "group-b", "group-a", "group-c"] * 1500, dtype=object)
     original = channels.np.unique
     object_probe_calls: list[np.ndarray] = []
 
@@ -447,6 +447,7 @@ def test_object_factorization_reuses_the_bounded_probe(monkeypatch):
     channels._factorize_categories(values)
 
     assert len(object_probe_calls) == 1
+    assert len(object_probe_calls[0]) == channels._FACTORIZE_PROBE_ROWS
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
 ## Summary
Fixes #471
  - Add a safe native factorization path for homogeneous object-backed
    string categories.

  - Preserve existing fallback behavior for mixed objects, null-like values,
    bytes, and custom string semantics.

  - Keep the existing low-cardinality probe as the fast-path gate.
  - Preserve category ordering, codes, and count semantics.
  - Add regression coverage proving only unique labels cross the Python
    label path.

  ## Testing

  - tests/test_custom_ramps_and_palette.py: 92 passed, 1 skipped
  - tests/test_components.py: 103 passed
  - Ruff check and format passed
  - git diff --check passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved categorical factorization for arrays containing only Python strings.
  * Ensured category order, unique labels, counts, and codes remain consistent with fixed-width string behavior.
  * Preserved distinct categories containing NUL characters.
  * Maintained safe fallback handling for mixed values, missing values, bytes, custom string-like values, and unsuitable near-unique arrays.
  * Improved performance by limiting category sampling during factorization.

* **Tests**
  * Added coverage for string-only, mixed-value, missing-value, NUL-containing, and near-unique category scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->