### PR TITLE
Prepare v0.0.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ in the README).
 
 ## [Unreleased]
 
+## [0.0.6] - 2026-08-07
+
 ### Added
+- The primary data-bound Reflex component API is now available. `@reflex_xy.data`
+  publishes typed column sets through `DataHandle[Schema]`; validated,
+  content-addressed plans keep chart structure in page code and bind live or
+  concrete data without routing arrays through Reflex state. Typed figure
+  handles, flat factories for every standalone mark kind,
+  `reflex_xy.chart(*nodes, data=...)` composition, reconnect/rebuild and
+  republish fan-out, compile-time figure probes, and a complete demo make the
+  new tier usable end to end.
 - Funnel charts joined the core declarative API (protocol v13):
   `xy.funnel_chart(stages, values)` / `xy.funnel(...)` draw one centered
   segment per stage in declared order — never sorted — with explicit
@@ -25,13 +35,59 @@ in the README).
   antialiased quads through a dedicated funnel program sharing the ribbon
   fragment stage; SVG/PNG/PDF exports emit the same `_scene.funnel_quad`
   geometry, pinned by golden tests.
+- A production document-scoped WebGL host lets charts share one WebGL2 context
+  and compiled shaders while preserving chart-owned buffers, picking, and view
+  state. Canvas2D presentation keeps normal layout and clipping; governed
+  per-chart fallback and host-wide context-loss recovery protect browsers and
+  dashboards with many charts.
+- The stable CSS, `class_names`, `styles`, and Tailwind chart-chrome surface
+  expanded from 29 to 48 slots, adding modebar internals, Cartesian axes and
+  gesture bands, colorbar details, and the annotation layer.
+- A reproducible dark-mode benchmark image and theme-aware README selection
+  now accompany the published benchmark evidence.
 
 ### Changed
+- Reflex figure state vars, `register()`, and `inline()` now return typed
+  `FigureHandle`s, and live components accept `Var[FigureHandle]` so invalid
+  vars and raw strings fail during page evaluation. Positional live
+  `chart(var)` / `chart(token)` calls warn in favor of `figure=`; positional
+  static `chart(Chart)` remains supported, and legacy token strings remain
+  accepted by helper APIs for one release cycle.
+- The lazy `xy` root now has a complete PEP 561 type surface, including
+  `xy.__version__`. Source, external-consumer, and installed-wheel type checks
+  are release gates.
+- Polar charts disable zoom by default, except for wind roses. Authors can opt
+  in with `interaction_config(zoom=True)`; otherwise wheel events remain
+  available for page scrolling and inert zoom/history controls stay hidden.
+  Polar `default_drag_action` now accepts only `"auto"` and `"none"`, rejecting
+  drag tools that the renderer cannot execute.
 - Native raster exports now resolve categorical palettes through the same
   indexed fallback as SVG and density rendering. Browser-only or otherwise
   unresolvable entries in hand-authored payloads emit a `RuntimeWarning` and
   fall back to the built-in color at the same index, preserving distinct
   categories instead of silently collapsing them onto one shared color.
+- Release verification now drives standalone Chromium smokes through CDP,
+  parses built ESM exports structurally instead of matching minifier-dependent
+  strings, and uses stable-Rust-compatible chunk APIs so the floating stable
+  toolchain remains clean under Clippy.
+
+### Fixed
+- Log axes with an explicit margin no longer underflow their lower bound to
+  zero on very wide positive domains.
+- Invalid mark-fill mappings with incomparable key types now raise the intended
+  unknown-key `ValueError` instead of an internal sorting `TypeError`. Reflex
+  event-handler annotations also remain valid to static type checkers after the
+  dependency updates.
+- Static annotation labels now honor chart annotation/text theme tokens, and a
+  scene/SVG import-order cycle no longer breaks capability generation.
+- Documentation code-copy controls have accessible names, visible keyboard
+  focus, and announced copied/failed states. Route-wide checks now prevent
+  public documentation heading outlines from skipping levels.
+
+### Security
+- Documentation and application dependencies, including PostCSS, were updated
+  to patched versions, with the associated Python and JavaScript lockfiles
+  refreshed.
 
 ## [0.0.5] - 2026-07-31
 
@@ -141,10 +197,6 @@ in the README).
   stay uniform.
 
 ### Changed
-- All Polar charts with the exception of wind rose disable zoom by default.
-- `default_drag_action` accepts only `"auto"`/`"none"` on a polar chart; the
-  values naming drag tools a disc does not have now raise at construction
-  instead of being accepted and silently doing nothing.
 - Default tooltips now lead with the hovered series name, and the radial row of
   a polar readout is labelled `r` rather than presented as a Cartesian `y`. The
   numeric angle row is gone from polar readouts: on most polar charts the angle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,9 +85,12 @@ in the README).
   public documentation heading outlines from skipping levels.
 
 ### Security
-- Documentation and application dependencies, including PostCSS, were updated
-  to patched versions, with the associated Python and JavaScript lockfiles
-  refreshed.
+- The active root environment now resolves `aiohttp==3.14.3`, patched for
+  CVE-2026-69244. Dependabot alert #12 names a lockfile from the
+  retired `python/reflex-xy` project, which is deleted from the repository and
+  excluded from the distribution. Other documentation and application
+  dependencies, including PostCSS, were updated to patched versions, with the
+  associated Python and JavaScript lockfiles refreshed.
 
 ## [0.0.5] - 2026-07-31
 


### PR DESCRIPTION
## Summary

- add the dated `0.0.6` changelog entry covering all user-visible changes since `v0.0.5`
- consolidate the eight-part data-bound Reflex API series and document funnel charts, the shared WebGL host, typing, styling, polar interaction changes, fixes, and dependency security updates
- move two polar behavior notes that were merged after `v0.0.5` out of the already-published `0.0.5` section
- leave a fresh empty `[Unreleased]` section for subsequent work

## Validation

- `python scripts/check_release_version.py --tag v0.0.6`
- `python scripts/verify_ci_workflow.py --release-only`
- `git diff --check`
- current-main full CI: https://github.com/reflex-dev/xy/actions/runs/31206907740
- full non-publishing release dry run: https://github.com/reflex-dev/xy/actions/runs/31209922430

## Release plan

After this PR is reviewed, green, and merged, create the GitHub Release `v0.0.6` at the exact merged `main` SHA. Publishing that release creates the tag and triggers the PyPI artifact matrix and staged docs deployment.

## Security note

GitHub currently reports Dependabot alert #12 for `python/reflex-xy/uv.lock`. That retired project path is deleted from `main` and excluded from the distribution; the active lock resolves patched `aiohttp 3.14.3`, and `xy` does not publish aiohttp as a runtime dependency.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added data-bound components, funnel charts, typed figure handles, and expanded chart styling options.
  - Added production WebGL hosting support and broader typing coverage.
- **Improvements**
  - Updated polar chart interactions and palette fallback behavior.
  - Added benchmark evidence and release verification details.
- **Bug Fixes**
  - Documented rendering, interaction, and documentation fixes.
- **Security**
  - Recorded dependency security updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->