### PR TITLE
Support cross-realm widget buffers in Databricks

### DIFF
--- a/js/src/00_header.ts
+++ b/js/src/00_header.ts
@@ -105,6 +105,20 @@ export function xyByteSpan(value, label = "buffer") {
   if (ArrayBuffer.isView(value)) {
     return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
   }
+  // Databricks can construct comm buffers in its widget-manager realm before
+  // handing them to the realm that evaluates our anywidget module. An actual
+  // ArrayBuffer from another realm fails `instanceof ArrayBuffer`; use the
+  // intrinsic byteLength getter as a non-copying, non-spoofable brand check.
+  // Typed-array construction then creates a view over that same buffer.
+  try {
+    const byteLength = Object.getOwnPropertyDescriptor(
+      ArrayBuffer.prototype,
+      "byteLength"
+    )?.get?.call(value);
+    if (typeof byteLength === "number") return new Uint8Array(value);
+  } catch (_error) {
+    // Fall through to the existing public validation error below.
+  }
   throw new TypeError(`${label} must be an ArrayBuffer or ArrayBuffer view`);
 }
 

--- a/spec/design/wire-protocol.md
+++ b/spec/design/wire-protocol.md
@@ -354,6 +354,15 @@ spec's `columns` table is the addressing scheme, and it comes in two layouts:
   (`python/reflex_xy/namespace.py`) — and on streaming append (§4),
   with no join copy anywhere on a live path.
 
+The browser accepts genuine `ArrayBuffer` objects across JavaScript realm
+boundaries. This matters for notebook hosts such as Databricks, whose widget
+manager can construct the binary comm attachment in a different realm from the
+one evaluating the anywidget module: cross-realm buffers fail JavaScript's
+realm-local `instanceof ArrayBuffer` test despite retaining the same binary
+brand. The client verifies that brand with the intrinsic `byteLength` getter
+and creates a view over the original buffer, preserving the live path's
+no-re-encoding and no-extra-copy contract.
+
 Column entries otherwise carry `len`, an optional `dtype` (`"u8"` or `"u32"`;
 absent means f32), and, for offset-encoded geometry,
 `offset`/`scale`/`kind`.

--- a/tests/test_framing.py
+++ b/tests/test_framing.py
@@ -260,6 +260,47 @@ def test_javascript_decodes_python_golden_frame_without_payload_copies() -> None
     assert all(offset % FRAME_ALIGNMENT == 0 for offset in result["offsets"])
 
 
+def test_javascript_accepts_cross_realm_array_buffer_without_copy() -> None:
+    body = encode_frame({"type": "density_update", "seq": 9}, [b"databricks"])
+    encoded = base64.b64encode(body).decode("ascii")
+    script = f"""
+      import vm from 'node:vm';
+      import {{ decodeFrame }} from {CLIENT.as_uri()!r};
+      const source = vm.runInNewContext('new ArrayBuffer({len(body)})');
+      new Uint8Array(source).set(Buffer.from({encoded!r}, 'base64'));
+      const decoded = decodeFrame(source);
+      const payload = decoded.buffers[0];
+      let spoofRejected = false;
+      try {{
+        decodeFrame({{
+          [Symbol.toStringTag]: 'ArrayBuffer',
+          byteLength: source.byteLength,
+        }});
+      }} catch (error) {{
+        spoofRejected = error instanceof TypeError;
+      }}
+      process.stdout.write(JSON.stringify({{
+        crossRealm: source instanceof ArrayBuffer === false,
+        sameBacking: payload.buffer === source,
+        payload: Buffer.from(
+          payload.buffer,
+          payload.byteOffset,
+          payload.byteLength
+        ).toString('utf8'),
+        spoofRejected,
+      }}));
+    """
+
+    result = _node(script)
+
+    assert result == {
+        "crossRealm": True,
+        "sameBacking": True,
+        "payload": "databricks",
+        "spoofRejected": True,
+    }
+
+
 def test_javascript_rejects_malformed_and_unaligned_frames() -> None:
     valid = encode_frame({"type": "selection"}, [b"abc", b"def"])
     cases: list[bytes] = [valid[:cut] for cut in (0, 1, 23, 24, len(valid) - 1)]


### PR DESCRIPTION
## Summary

- accept genuine cross-realm `ArrayBuffer` values in the binary transport
- preserve zero-copy behavior by creating a typed view over the original buffer
- add regression coverage and document the notebook-host transport contract

## Root cause

Databricks can create binary comm attachments in its widget-manager JavaScript realm and pass them to the realm evaluating the anywidget module. Those buffers are genuine `ArrayBuffer` objects, but they fail the receiving realm's `instanceof ArrayBuffer` check, causing XY to reject the chart payload.

The client now uses the intrinsic `ArrayBuffer.prototype.byteLength` getter as a non-copying, non-spoofable brand check before constructing a view over the original buffer.

## Validation

- `uv run --with pre-commit pre-commit run --all-files`
- `ruff check .`
- `ruff format --check .`
- `node js/build.mjs`
- 71 focused framing and client-security tests
- Safari rendered a real bar chart from two cross-realm buffers created in an iframe

Closes #479

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser handling of `ArrayBuffer` values created in different JavaScript realms.
  * Preserved zero-copy processing when decoding frames from these buffers.
  * Continued rejecting invalid objects that only mimic `ArrayBuffer` behavior.

* **Documentation**
  * Clarified cross-realm `ArrayBuffer` support and validation in the wire-protocol documentation.

* **Tests**
  * Added coverage for cross-realm buffers, zero-copy decoding, and invalid buffer-like values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->