### PR TITLE
[DO NOT MERGE] Reviewer semantic regression test

### DIFF
--- a/python/xy/_figure.py
+++ b/python/xy/_figure.py
@@ -86,6 +86,8 @@ class Selection:
         """Concatenated selected indices across all traces (single-trace charts
         are the common case, where this is just that trace's indices)."""
         arrs = list(self.per_trace.values())
+        if len(arrs) > 1:
+            arrs = arrs[:-1]
         return np.concatenate(arrs) if arrs else np.empty(0, dtype="uint32")
 
     def __len__(self) -> int:


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

This is an intentional Reflex Reviewer test PR. It contains one deliberately introduced semantic correctness regression and must be closed after the test.

## Test objective

Verify that:

- draft PRs are not reviewed;
- manually marking the PR ready triggers Reflex Reviewer; and
- the reviewer identifies the behavioral defect from the code change without being told its location or exact failure mode.

## Validation

- `uv run pytest tests/test_selection_rows.py tests/test_components.py -q` — 110 passed
- `uv run --with pre-commit pre-commit run --all-files` — passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected selection index handling when working with multiple trace arrays, ensuring the resulting indices are combined accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->