### PR TITLE
Reject unknown browser column dtypes

### DIFF
--- a/js/src/00_header.ts
+++ b/js/src/00_header.ts
@@ -130,6 +130,27 @@ export function bytesToSpan(b) {
   return span.byteOffset % 4 === 0 ? span : new Uint8Array(span);
 }
 
+const WIRE_F32 = Object.freeze({ name: "f32", bytesPerElement: 4, ArrayType: Float32Array });
+const WIRE_U8 = Object.freeze({ name: "u8", bytesPerElement: 1, ArrayType: Uint8Array });
+const WIRE_U32 = Object.freeze({ name: "u32", bytesPerElement: 4, ArrayType: Uint32Array });
+
+/** Resolve one column-like wire descriptor exhaustively.
+ *
+ * First-paint float columns omit `dtype`; incremental LOD/style messages use
+ * explicit `f32`. Both spellings mean the same thing. Every explicit future
+ * or malformed value is a protocol error: treating an unknown four-byte type
+ * as f32 can produce a coherent-looking span and a plausible but corrupt
+ * chart, which is worse than rejecting the payload at the boundary. */
+export function wireColumnDtype(meta, context = "column") {
+  const dtype = meta?.dtype;
+  if (dtype === undefined || dtype === "f32") return WIRE_F32;
+  if (dtype === "u8") return WIRE_U8;
+  if (dtype === "u32") return WIRE_U32;
+  throw new TypeError(
+    `xy: unsupported ${context} dtype ${JSON.stringify(dtype)}; expected f32, u8, or u32`,
+  );
+}
+
 /** True when every column in the spec fits inside the supplied buffers.
  * Trait-transported appends can observe a torn update on hosts that set
  * spec and buffers non-atomically (one change event fires between the two
@@ -140,17 +161,20 @@ export function bytesToSpan(b) {
 export function payloadCoherent(spec, raw) {
   const cols = spec?.columns;
   if (!Array.isArray(cols)) return false;
-  const size = (c) => (c.dtype === "u8" ? 1 : 4);
   if (spec.buffer_layout === "split") {
     if (!Array.isArray(raw)) return false;
-    return cols.every((c) => {
+    return cols.every((c, index) => {
+      const { bytesPerElement } = wireColumnDtype(c, `column ${index}`);
       if (!Number.isInteger(c.buf)) return true; // raster-only borrowed span
       const b = raw[c.buf];
-      return !!b && c.len * size(c) <= b.byteLength;
+      return !!b && c.len * bytesPerElement <= b.byteLength;
     });
   }
   if (Array.isArray(raw) || !raw) return false;
-  return cols.every((c) => c.byte_offset + c.len * size(c) <= raw.byteLength);
+  return cols.every((c, index) => {
+    const { bytesPerElement } = wireColumnDtype(c, `column ${index}`);
+    return c.byte_offset + c.len * bytesPerElement <= raw.byteLength;
+  });
 }
 
 /** Wire buffers in the shape the spec declares (§29): packed is one blob;

--- a/js/src/45_lod.ts
+++ b/js/src/45_lod.ts
@@ -1,4 +1,4 @@
-import { TRACE_GPU_BUFFERS } from "./00_header";
+import { TRACE_GPU_BUFFERS, wireColumnDtype } from "./00_header";
 import { parseColor } from "./20_theme";
 
 // ---------------------------------------------------------------------------
@@ -805,6 +805,19 @@ export function lodPromoteCachedDrill(view, g, x0, x1, y0, y1) {
 // (channels restored). Build/refresh a direct-shaped sibling on the tiered
 // trace; the tier draw uses it until the kernel switches back.
 export function lodApplyDrill(view, g, upd, buffers) {
+  wireColumnDtype(upd.x, "drill x");
+  wireColumnDtype(upd.y, "drill y");
+  for (const [name, meta] of [
+    ["color", upd.color],
+    ["size", upd.size],
+    ["stroke", upd.stroke],
+    ["density_val", upd.density_val],
+  ]) {
+    if (meta && meta.buf !== undefined) wireColumnDtype(meta, `drill ${name}`);
+  }
+  for (const [name, meta] of Object.entries(upd.channels || {})) {
+    if (meta && (meta as any).buf !== undefined) wireColumnDtype(meta, `drill ${name}`);
+  }
   const gl = view.gl;
   g._stepReqWin = null; // real points supersede any outstanding ladder step
   const win = {
@@ -834,8 +847,8 @@ export function lodApplyDrill(view, g, upd, buffers) {
   d.trace = { ...g.trace, style: upd.style || g.trace.style || {} };
   d.xAxis = g.xAxis;
   d.yAxis = g.yAxis;
-  const xs = view._asF32(buffers[upd.x.buf]);
-  const ys = view._asF32(buffers[upd.y.buf]);
+  const xs = view._wireColumnView(buffers[upd.x.buf], upd.x, "drill x");
+  const ys = view._wireColumnView(buffers[upd.y.buf], upd.y, "drill y");
   gl.bindBuffer(gl.ARRAY_BUFFER, d.xBuf);
   gl.bufferData(gl.ARRAY_BUFFER, xs, gl.STATIC_DRAW);
   gl.bindBuffer(gl.ARRAY_BUFFER, d.yBuf);
@@ -873,9 +886,9 @@ export function lodApplyDrill(view, g, upd, buffers) {
   if (upd.color && upd.color.buf !== undefined) {
     d.colorMode = upd.color.mode === "continuous" ? 1 :
       (upd.color.mode === "categorical" ? 2 : 3);
-    const colorValues = upd.color.dtype === "u8"
-      ? view._asU8(buffers[upd.color.buf])
-      : view._asF32(buffers[upd.color.buf]);
+    const colorValues = view._wireColumnView(
+      buffers[upd.color.buf], upd.color, "drill color",
+    );
     if (d.colorMode === 3) d._cpu.rgba = colorValues;
     else d._cpu.color = colorValues;
     const colorBufferName = d.colorMode === 3 ? "rgbaBuf" : "cBuf";
@@ -894,9 +907,9 @@ export function lodApplyDrill(view, g, upd, buffers) {
   d.sizeRange = [2, 18];
   if (upd.size && upd.size.mode === "continuous") {
     d.sizeMode = 1;
-    const sizeValues = upd.size.dtype === "u8"
-      ? view._asU8(buffers[upd.size.buf])
-      : view._asF32(buffers[upd.size.buf]);
+    const sizeValues = view._wireColumnView(
+      buffers[upd.size.buf], upd.size, "drill size",
+    );
     d._cpu.size = sizeValues;
     if (!d.sBuf) d.sBuf = gl.createBuffer();
     view._tagChannelBuf(d.sBuf, sizeValues, true);
@@ -918,9 +931,7 @@ export function lodApplyDrill(view, g, upd, buffers) {
     const copy = (name, component, scale = 1) => {
       const spec = styleChannel(name);
       if (!spec) return;
-      const source = spec.dtype === "u8"
-        ? view._asU8(buffers[spec.buf])
-        : view._asF32(buffers[spec.buf]);
+      const source = view._wireColumnView(buffers[spec.buf], spec, `drill ${name}`);
       const components = spec.components || 1;
       for (let i = 0; i < d.n; i++) values[i * 4 + component] = source[i * components] * scale;
     };
@@ -939,7 +950,7 @@ export function lodApplyDrill(view, g, upd, buffers) {
     gl.bufferData(gl.ARRAY_BUFFER, values, gl.STATIC_DRAW);
   }
   if (upd.stroke && upd.stroke.mode === "direct_rgba") {
-    const values = view._asU8(buffers[upd.stroke.buf]);
+    const values = view._wireColumnView(buffers[upd.stroke.buf], upd.stroke, "drill stroke");
     d._cpuStroke = values;
     if (!d.strokeBuf) d.strokeBuf = gl.createBuffer();
     d.strokeBuf._fcType = gl.UNSIGNED_BYTE;
@@ -956,9 +967,9 @@ export function lodApplyDrill(view, g, upd, buffers) {
   // surfaces keep the ramp (their texture still wears the log tone curve).
   const meanColorSurface = !!(g.density && g.density.rgba);
   if (!meanColorSurface && upd.density_val && upd.density_val.buf !== undefined) {
-    const dvalValues = upd.density_val.dtype === "u8"
-      ? view._asU8(buffers[upd.density_val.buf])
-      : view._asF32(buffers[upd.density_val.buf]);
+    const dvalValues = view._wireColumnView(
+      buffers[upd.density_val.buf], upd.density_val, "drill density_val",
+    );
     if (!d.dBuf) d.dBuf = gl.createBuffer();
     view._tagChannelBuf(d.dBuf, dvalValues, true);
     gl.bindBuffer(gl.ARRAY_BUFFER, d.dBuf);

--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -1,4 +1,4 @@
-import { FUNNEL_SLOTS, PROTOCOL, TRACE_GPU_BUFFERS, xyByteSpan } from "./00_header";
+import { FUNNEL_SLOTS, PROTOCOL, TRACE_GPU_BUFFERS, wireColumnDtype, xyByteSpan } from "./00_header";
 import { buildLutData, colormapKey, colormapStops } from "./10_colormaps";
 import { chartBackdrop, cssColor, ensureChromeStylesheet, hexColor, parseColor, readTheme, safeCssPaint } from "./20_theme";
 import { angularTicks, categoryTicks, fmtAxis, fmtGeneral, fmtLinear, fmtLog, fmtValue, linearTicks, logTicks, timeTicks } from "./30_ticks";
@@ -482,6 +482,9 @@ export class ChartView {
         `xy: protocol mismatch (client speaks ${PROTOCOL}, kernel sent ${spec.protocol}). ` +
         "Update the xy package and restart the kernel.";
       throw new Error("protocol mismatch");
+    }
+    if (Array.isArray(spec.columns)) {
+      spec.columns.forEach((meta, index) => wireColumnDtype(meta, `column ${index}`));
     }
     this.spec = spec;
     // Title y/pad placement is a binary geometry column, so it must be
@@ -4263,6 +4266,20 @@ export class ChartView {
       this._refreshReductionBadges();
       return;
     }
+    wireColumnDtype(sample.x, "density sample x");
+    wireColumnDtype(sample.y, "density sample y");
+    for (const [name, meta] of [
+      ["color", sample.color],
+      ["size", sample.size],
+      ["stroke", sample.stroke],
+    ]) {
+      if (meta && meta.buf !== undefined) wireColumnDtype(meta, `density sample ${name}`);
+    }
+    for (const [name, meta] of Object.entries(sample.channels || {})) {
+      if (meta && (meta as any).buf !== undefined) {
+        wireColumnDtype(meta, `density sample ${name}`);
+      }
+    }
     const gl = this.gl;
     const trace = {
       id: g.trace.id,
@@ -4299,8 +4316,8 @@ export class ChartView {
       size: (sample.size && sample.size.size) || 4.0,
       sizeRange: [2, 18],
     };
-    const xValues = this._asF32(buffers[sample.x.buf]);
-    const yValues = this._asF32(buffers[sample.y.buf]);
+    const xValues = this._wireColumnView(buffers[sample.x.buf], sample.x, "density sample x");
+    const yValues = this._wireColumnView(buffers[sample.y.buf], sample.y, "density sample y");
     s._cpu = { x: xValues, y: yValues, xMeta: s.xMeta, yMeta: s.yMeta };
     gl.bindBuffer(gl.ARRAY_BUFFER, s.xBuf);
     gl.bufferData(gl.ARRAY_BUFFER, xValues, gl.STATIC_DRAW);
@@ -4309,9 +4326,9 @@ export class ChartView {
     if (sample.color && sample.color.buf !== undefined) {
       s.colorMode = sample.color.mode === "continuous" ? 1 :
         (sample.color.mode === "categorical" ? 2 : 3);
-      const colorValues = sample.color.dtype === "u8"
-        ? this._asU8(buffers[sample.color.buf])
-        : this._asF32(buffers[sample.color.buf]);
+      const colorValues = this._wireColumnView(
+        buffers[sample.color.buf], sample.color, "density sample color",
+      );
       if (s.colorMode === 3) s._cpu.rgba = colorValues;
       else s._cpu.color = colorValues;
       const colorBufferName = s.colorMode === 3 ? "rgbaBuf" : "cBuf";
@@ -4327,9 +4344,9 @@ export class ChartView {
     }
     if (sample.size && sample.size.mode === "continuous") {
       s.sizeMode = 1;
-      const sizeValues = sample.size.dtype === "u8"
-        ? this._asU8(buffers[sample.size.buf])
-        : this._asF32(buffers[sample.size.buf]);
+      const sizeValues = this._wireColumnView(
+        buffers[sample.size.buf], sample.size, "density sample size",
+      );
       s._cpu.size = sizeValues;
       s.sBuf = gl.createBuffer();
       this._tagChannelBuf(s.sBuf, sizeValues, true);
@@ -4351,9 +4368,9 @@ export class ChartView {
       const copy = (name, component, scale = 1) => {
         const spec = channel(name);
         if (!spec) return;
-        const source = spec.dtype === "u8"
-          ? this._asU8(buffers[spec.buf])
-          : this._asF32(buffers[spec.buf]);
+        const source = this._wireColumnView(
+          buffers[spec.buf], spec, `density sample ${name}`,
+        );
         const components = spec.components || 1;
         for (let i = 0; i < s.n; i++) values[i * 4 + component] = source[i * components] * scale;
       };
@@ -4368,7 +4385,9 @@ export class ChartView {
       s._styleDpr = this.dpr;
     }
     if (sample.stroke && sample.stroke.mode === "direct_rgba") {
-      s._cpuStroke = this._asU8(buffers[sample.stroke.buf]);
+      s._cpuStroke = this._wireColumnView(
+        buffers[sample.stroke.buf], sample.stroke, "density sample stroke",
+      );
       s.strokeBuf = this._upload(s._cpuStroke);
     }
     this._pointMarkStyle(s, trace);
@@ -5252,7 +5271,7 @@ export class ChartView {
   // lifecycle live in 45_lod.js — chart-agnostic so future tiered kinds
   // (heatmap, histogram) reuse them instead of copy-pasting.
 
-  _columnView(buffer, meta) {
+  _columnView(buffer, meta, context = null) {
     // Packed layout: one blob, columns addressed by global byte_offset.
     // Split layout (§29 first paint): `buffer` is a list of per-column
     // buffers and the column entry carries `buf`, its list index. A
@@ -5273,14 +5292,15 @@ export class ChartView {
         !Number.isSafeInteger(length) || length < 0) {
       throw new RangeError("column offset/length must be non-negative safe integers");
     }
-    const bytesPerElement = meta.dtype === "u8" ? 1 : 4;
+    const dtypeContext = context || (Number.isInteger(meta.buf)
+      ? `column buffer ${meta.buf}`
+      : `column at byte_offset ${meta.byte_offset}`);
+    const { bytesPerElement, ArrayType } = wireColumnDtype(meta, dtypeContext);
     const absoluteOffset = span.byteOffset + relativeOffset;
     const end = relativeOffset + length * bytesPerElement;
     if (end > span.byteLength) throw new RangeError("column extends past chart payload");
     if (absoluteOffset % bytesPerElement !== 0) throw new RangeError("column is misaligned");
-    if (meta.dtype === "u8") return new Uint8Array(span.buffer, absoluteOffset, length);
-    if (meta.dtype === "u32") return new Uint32Array(span.buffer, absoluteOffset, length);
-    return new Float32Array(span.buffer, absoluteOffset, length);
+    return new ArrayType(span.buffer, absoluteOffset, length);
   }
 
   _upload(view) {
@@ -8440,6 +8460,13 @@ export class ChartView {
       return new Uint32Array(b.buffer, b.byteOffset, Math.floor(b.byteLength / 4));
     }
     return new Uint32Array(b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength));
+  }
+
+  _wireColumnView(buffer, meta, context = "column") {
+    const { name } = wireColumnDtype(meta, context);
+    if (name === "u8") return this._asU8(buffer);
+    if (name === "u32") return this._asU32(buffer);
+    return this._asF32(buffer);
   }
 
   _applyTheme() {

--- a/js/src/54_kernel.ts
+++ b/js/src/54_kernel.ts
@@ -1,4 +1,4 @@
-import { payloadBuffers } from "./00_header";
+import { payloadBuffers, wireColumnDtype } from "./00_header";
 import { buildLutData } from "./10_colormaps";
 import { parseColor } from "./20_theme";
 import {
@@ -411,6 +411,9 @@ Object.assign(ChartView.prototype, {
   _applyAppend(msg, buffers) {
     const spec = msg.spec;
     if (!spec || !spec.traces) return;
+    if (Array.isArray(spec.columns)) {
+      spec.columns.forEach((meta, index) => wireColumnDtype(meta, `append column ${index}`));
+    }
     const raw = spec.buffer_layout === "split" ? buffers : buffers && buffers[0];
     if (raw == null) return;
     const payload = payloadBuffers(spec, raw);
@@ -551,7 +554,9 @@ Object.assign(ChartView.prototype, {
       const om = Number.isInteger(a) ? oldCols[a] : null;
       const nm = Number.isInteger(b) ? newCols[b] : null;
       if (!om || !nm) return null;
-      if ((om.dtype || "f32") !== (nm.dtype || "f32")) return null;
+      const oldDtype = wireColumnDtype(om, `previous append column ${a}`);
+      const newDtype = wireColumnDtype(nm, `append column ${b}`);
+      if (oldDtype.name !== newDtype.name) return null;
       if ((om.offset ?? null) !== (nm.offset ?? null)) return null;
       if ((om.scale ?? null) !== (nm.scale ?? null)) return null;
       if (!(nm.len >= om.len)) return null;
@@ -732,9 +737,11 @@ Object.assign(ChartView.prototype, {
         const g = this.gpuTraces.find((t) => t.trace.id === upd.id);
         if (!g) continue;
         const gl = this.gl;
-        const xArr = this._asF32(buffers[upd.x.buf]);
-        const yArr = this._asF32(buffers[upd.y.buf]);
-        const bArr = upd.base && g.baseBuf ? this._asF32(buffers[upd.base.buf]) : null;
+        const xArr = this._wireColumnView(buffers[upd.x.buf], upd.x, "tier update x");
+        const yArr = this._wireColumnView(buffers[upd.y.buf], upd.y, "tier update y");
+        const bArr = upd.base && g.baseBuf
+          ? this._wireColumnView(buffers[upd.base.buf], upd.base, "tier update base")
+          : null;
         let n = Math.min(upd.x.len, upd.y.len);
         if (bArr) n = Math.min(n, upd.base.len);
         // curve:"smooth" traces re-smooth every refined window, so the curve

--- a/js/src/56_animation.ts
+++ b/js/src/56_animation.ts
@@ -1,4 +1,4 @@
-import { FUNNEL_SLOTS, PROTOCOL } from "./00_header";
+import { FUNNEL_SLOTS, PROTOCOL, wireColumnDtype } from "./00_header";
 import { ChartView } from "./50_chartview";
 
 // Declarative data animation: one browser clock, bounded previous/next GPU
@@ -517,6 +517,9 @@ Object.assign(ChartView.prototype, {
 
   updatePayload(spec, buffer) {
     if (this._destroyed || !spec || spec.protocol !== PROTOCOL) return false;
+    if (Array.isArray(spec.columns)) {
+      spec.columns.forEach((meta, index) => wireColumnDtype(meta, `column ${index}`));
+    }
     if (this._dataAnimRaf) cancelAnimationFrame(this._dataAnimRaf);
     this._dataAnimRaf = null;
     if (this._dataAnim) {

--- a/spec/design/wire-protocol.md
+++ b/spec/design/wire-protocol.md
@@ -367,6 +367,14 @@ Column entries otherwise carry `len`, an optional `dtype` (`"u8"` or `"u32"`;
 absent means f32), and, for offset-encoded geometry,
 `offset`/`scale`/`kind`.
 
+The client resolves column-like dtypes through one exhaustive definition used
+by coherence checks, first-paint decoding, streaming append, and incremental
+LOD/sample channel replies. Incremental replies may spell the default as
+explicit `"f32"`; every other explicit value is a fatal protocol error that
+names the offending dtype and column/channel context. In particular, an
+unknown four-byte dtype never inherits the f32 byte width or typed-array view
+merely because its span happens to fit.
+
 Decimated line/area trace entries additionally record `decimation_px`, the px
 width their M4 pass was computed for (§28: every decimation decision is
 recorded, never silent). The client reads it to skip a redundant at-home

--- a/tests/test_framing.py
+++ b/tests/test_framing.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+import re
 import struct
 import subprocess
 from pathlib import Path
@@ -9,6 +10,7 @@ from pathlib import Path
 import pytest
 from scripts.js_exports import missing_esm_exports
 
+import xy
 from xy.channel import (
     FRAME_ALIGNMENT,
     FRAME_HEADER_SIZE,
@@ -332,6 +334,110 @@ def test_javascript_rejects_malformed_and_unaligned_frames() -> None:
     assert all(result["rejected"])
     assert result["unalignedRejected"] is True
     assert result["limitRejected"] is True
+
+
+def test_javascript_column_dtypes_are_exhaustive_for_every_wire_layout() -> None:
+    chart = xy.scatter_chart(
+        xy.scatter(
+            x=[1.0, 2.0],
+            y=[3.0, 4.0],
+            color=["A", "B"],
+            key=["ES", "FR"],
+        ),
+        xy.animation(match="key"),
+    )
+    figure = chart.figure()
+    packed_spec, packed_raw = figure.build_payload()
+    split_spec, split_raw = figure.build_payload_split()
+    packed_encoded = base64.b64encode(packed_raw).decode("ascii")
+    split_encoded = [base64.b64encode(bytes(value)).decode("ascii") for value in split_raw]
+    header_source = (ROOT / "js" / "src" / "00_header.ts").read_bytes()
+    header_url = "data:text/javascript;base64," + base64.b64encode(header_source).decode("ascii")
+    script = f"""
+      import {{ ChartView }} from {CLIENT.as_uri()!r};
+      import {{ payloadCoherent }} from {header_url!r};
+
+      const decode = (value) => Uint8Array.from(Buffer.from(value, 'base64'));
+      const packedSpec = {json.dumps(packed_spec)};
+      const splitSpec = {json.dumps(split_spec)};
+      const packed = decode({packed_encoded!r});
+      const split = {json.dumps(split_encoded)}.map(decode);
+      const columnView = ChartView.prototype._columnView;
+      const names = (spec, payload) => spec.columns.map((meta, index) =>
+        columnView.call(null, payload, meta, `column ${{index}}`).constructor.name);
+      const capture = (fn) => {{
+        try {{ fn(); return {{threw: false, message: ''}}; }}
+        catch (error) {{ return {{threw: true, message: String(error && error.message)}}; }}
+      }};
+      const badPacked = structuredClone(packedSpec);
+      badPacked.columns[0].dtype = 'f64';
+      const badSplit = structuredClone(splitSpec);
+      badSplit.columns[0].dtype = 'future32';
+
+      const receiver = {{
+        _asF32: ChartView.prototype._asF32,
+        _asU8: ChartView.prototype._asU8,
+        _asU32: ChartView.prototype._asU32,
+      }};
+      const updateView = ChartView.prototype._wireColumnView;
+      const explicit = [
+        updateView.call(receiver, packed, {{}}, 'drill x').constructor.name,
+        updateView.call(receiver, packed, {{dtype: 'f32'}}, 'drill opacity').constructor.name,
+        updateView.call(receiver, packed, {{dtype: 'u8'}}, 'drill color').constructor.name,
+        updateView.call(receiver, packed, {{dtype: 'u32'}}, 'drill key').constructor.name,
+      ];
+
+      process.stdout.write(JSON.stringify({{
+        packedNames: names(packedSpec, packed),
+        splitNames: names(splitSpec, split),
+        packedCoherent: payloadCoherent(packedSpec, packed),
+        splitCoherent: payloadCoherent(splitSpec, split),
+        packedColumnError: capture(() =>
+          columnView.call(null, packed, badPacked.columns[0], 'packed column 0')),
+        splitColumnError: capture(() =>
+          columnView.call(null, split, badSplit.columns[0], 'split column 0')),
+        packedCoherenceError: capture(() => payloadCoherent(badPacked, packed)),
+        splitCoherenceError: capture(() => payloadCoherent(badSplit, split)),
+        explicit,
+        updateError: capture(() =>
+          updateView.call(receiver, packed, {{dtype: 'i32'}}, 'drill color')),
+      }}));
+    """
+
+    result = _node(script)
+
+    expected = ["Float32Array", "Float32Array", "Uint32Array", "Uint32Array", "Uint8Array"]
+    assert result["packedNames"] == expected
+    assert result["splitNames"] == expected
+    assert result["packedCoherent"] is True
+    assert result["splitCoherent"] is True
+    assert result["explicit"] == ["Float32Array", "Float32Array", "Uint8Array", "Uint32Array"]
+    for key, dtype, context in (
+        ("packedColumnError", "f64", "packed column 0"),
+        ("splitColumnError", "future32", "split column 0"),
+        ("packedCoherenceError", "f64", "column 0"),
+        ("splitCoherenceError", "future32", "column 0"),
+        ("updateError", "i32", "drill color"),
+    ):
+        error = result[key]
+        assert error["threw"] is True
+        assert dtype in error["message"]
+        assert context in error["message"]
+
+
+def test_javascript_wire_dtype_decisions_stay_centralized() -> None:
+    sources = {
+        path.name: path.read_text(encoding="utf-8")
+        for path in sorted((ROOT / "js" / "src").glob("*.ts"))
+    }
+    dtype_decision = re.compile(r"\.dtype\s*(?:===|==|!==|!=|\|\||\?\?)")
+
+    assert "wireColumnDtype" in sources["00_header.ts"]
+    for name, source in sources.items():
+        if name != "00_header.ts":
+            assert not dtype_decision.search(source), f"dtype interpretation escaped into {name}"
+    for name in ("45_lod.ts", "50_chartview.ts", "54_kernel.ts", "56_animation.ts"):
+        assert "wireColumnDtype" in sources[name]
 
 
 def test_widget_entry_no_longer_slices_binary_views() -> None:

--- a/tests/test_static_client_security.py
+++ b/tests/test_static_client_security.py
@@ -628,7 +628,7 @@ def test_authored_markers_keep_lod_and_style_channels_cpu_readable() -> None:
     assert "s._cpuStyle = values;" in chartview
     assert "d._cpuStyle = values;" in lod
     assert "g._cpuStroke = this._columnView(" in chartview
-    assert "s._cpuStroke = this._asU8(" in chartview
+    assert "s._cpuStroke = this._wireColumnView(" in chartview
     assert "d._cpuStroke = values;" in lod
 
     draw_start = annotations.index("_drawAuthoredScatterMarkers(ctx) {")


### PR DESCRIPTION
## Summary

- centralize browser wire-column dtype decoding for packed and split payloads
- accept the existing default/explicit `f32`, `u8`, and `u32` encodings
- reject unknown dtypes with contextual errors before first-paint or incremental state/GL mutations
- cover initial render, animation updates, append, LOD/drill, and density-sample paths
- document the exhaustive wire contract and add regression/structural coverage

## Why

Unknown four-byte dtype metadata previously fell through to `Float32Array`, allowing future or malformed values such as `i32` or `f64` to be silently misdecoded. The browser now fails loudly at the decode boundary instead.

## Impact

Valid payload behavior is unchanged. Unsupported dtypes produce an actionable error containing the dtype and column/update context.

Fixes #434.

## Validation

- `node js/build.mjs`
- `npm run typecheck`
- Ruff lint and formatting checks
- full `pytest` suite
- `make check-security` — 54 passed
- `make check-errors` — 303 passed
- real Chromium rendering smoke test


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

