### PR TITLE
fix(pyplot): stop minorticks_on() pinning automatic major ticks

### DIFF
--- a/python/xy/pyplot/_axes.py
+++ b/python/xy/pyplot/_axes.py
@@ -7245,10 +7245,6 @@ class Axes(PlotTypeMixin):
                 pad = (hi - lo) * 1e-9
                 ticks = ticks[(ticks >= lo - pad) & (ticks <= hi + pad)]
             auto_log = is_log
-        # A minor locator alone must not pin the majors. `ticks` is still needed
-        # below to subdivide between them, but authoring `tick_values` here would
-        # freeze an otherwise automatic axis: the renderer filters authored
-        # positions to the visible window, so zooming past them drops the labels.
         majors_are_auto = (
             locator is None
             and formatter is None
@@ -7256,8 +7252,6 @@ class Axes(PlotTypeMixin):
             and not is_log
             and "tick_values" not in props
         )
-        if not majors_are_auto:
-            props["tick_values"] = list(map(float, _scale_values(ticks, spec)))
         if formatter is not None:
             props["tick_labels"] = _formatter_tick_labels(
                 formatter,
@@ -7275,11 +7269,13 @@ class Axes(PlotTypeMixin):
             props["tick_labels"] = [f"{value:g}" for value in ticks]
         else:
             props.pop("tick_labels", None)
-        if not majors_are_auto:
-            if len(ticks):
-                props["tick_count"] = len(ticks)
-            else:
-                props.pop("tick_count", None)
+        # Authoring positions freezes an automatic axis; labels need them anyway.
+        if not majors_are_auto or "tick_labels" in props:
+            props["tick_values"] = list(map(float, _scale_values(ticks, spec)))
+        if len(ticks):
+            props["tick_count"] = len(ticks)
+        else:
+            props.pop("tick_count", None)
         if promoted_minor:
             props.pop("minor_tick_values", None)
             props["style"] = {

--- a/python/xy/pyplot/_axes.py
+++ b/python/xy/pyplot/_axes.py
@@ -7245,7 +7245,19 @@ class Axes(PlotTypeMixin):
                 pad = (hi - lo) * 1e-9
                 ticks = ticks[(ticks >= lo - pad) & (ticks <= hi + pad)]
             auto_log = is_log
-        props["tick_values"] = list(map(float, _scale_values(ticks, spec)))
+        # A minor locator alone must not pin the majors. `ticks` is still needed
+        # below to subdivide between them, but authoring `tick_values` here would
+        # freeze an otherwise automatic axis: the renderer filters authored
+        # positions to the visible window, so zooming past them drops the labels.
+        majors_are_auto = (
+            locator is None
+            and formatter is None
+            and authored_labels is None
+            and not is_log
+            and "tick_values" not in props
+        )
+        if not majors_are_auto:
+            props["tick_values"] = list(map(float, _scale_values(ticks, spec)))
         if formatter is not None:
             props["tick_labels"] = _formatter_tick_labels(
                 formatter,
@@ -7263,10 +7275,11 @@ class Axes(PlotTypeMixin):
             props["tick_labels"] = [f"{value:g}" for value in ticks]
         else:
             props.pop("tick_labels", None)
-        if len(ticks):
-            props["tick_count"] = len(ticks)
-        else:
-            props.pop("tick_count", None)
+        if not majors_are_auto:
+            if len(ticks):
+                props["tick_count"] = len(ticks)
+            else:
+                props.pop("tick_count", None)
         if promoted_minor:
             props.pop("minor_tick_values", None)
             props["style"] = {

--- a/tests/pyplot/test_axis_tick_gallery_compat.py
+++ b/tests/pyplot/test_axis_tick_gallery_compat.py
@@ -310,3 +310,24 @@ def test_minorticks_on_leaves_automatic_major_ticks_unpinned() -> None:
     spec, _blob = ax._build_chart(600, 400).figure().build_payload()
     assert spec["x_axis"].get("minor_tick_values")
     assert spec["x_axis"].get("tick_values") is None
+
+
+@pytest.mark.parametrize("scale", ["symlog", "asinh", "logit"])
+def test_shared_axis_keeps_nonlinear_labels_paired_with_positions(scale: str) -> None:
+    """A follower axis publishes tick labels, so it must publish positions too.
+
+    Scale defaults live on the axes that set the scale, not on the shared ticker
+    source, so a `sharex` follower reaches the label branch with no locator of
+    its own. Labels without positions are rejected when the chart is built.
+    """
+    xs = np.linspace(-100, 100, 50)
+    _fig, (leader, follower) = plt.subplots(2, sharex=True)
+    leader.plot(xs, xs)
+    follower.plot(xs, xs)
+    follower.set_xscale(scale, **({"linthresh": 2.0} if scale == "symlog" else {}))
+    follower.minorticks_on()
+
+    spec, _blob = follower._build_chart(600, 400).figure().build_payload()
+    x_axis = spec["x_axis"]
+
+    assert len(x_axis["tick_labels"]) == len(x_axis["tick_values"])

--- a/tests/pyplot/test_axis_tick_gallery_compat.py
+++ b/tests/pyplot/test_axis_tick_gallery_compat.py
@@ -294,3 +294,19 @@ def test_named_annotation_accepts_relative_fontsize() -> None:
     annotation = ax.annotate(text="note", xy=(0, 0), fontsize="small")
 
     assert annotation._entry["kwargs"]["style"]["font_size"] == pytest.approx(8.5)
+
+
+def test_minorticks_on_leaves_automatic_major_ticks_unpinned() -> None:
+    """Enabling minor ticks must not freeze the majors into authored positions.
+
+    Authored `tick_values` are filtered to the visible window by the renderer,
+    so pinning them here makes the tick labels disappear once the view is
+    zoomed past them.
+    """
+    _fig, ax = plt.subplots()
+    ax.plot([0, 10], [0, 10])
+    ax.minorticks_on()
+
+    spec, _blob = ax._build_chart(600, 400).figure().build_payload()
+    assert spec["x_axis"].get("minor_tick_values")
+    assert spec["x_axis"].get("tick_values") is None


### PR DESCRIPTION
Closes #493.

## The problem

`minorticks_on()` freezes the major tick positions. Asking for minor ticks turns an automatic axis into a fixed one, and because the renderer filters authored positions to the visible window, the tick labels disappear once you zoom past them. Without `minorticks_on()` the labels rescale normally.

Visible in the compiled payload, no browser needed:

```python
import xy.pyplot as plt

def x_axis(minor):
    fig, ax = plt.subplots(figsize=(6, 4))
    ax.plot([0, 10], [0, 10])
    if minor:
        ax.minorticks_on()
    spec, _blob = ax._build_chart(600, 400).figure().build_payload()
    return spec["x_axis"]

for key in ("tick_values", "tick_count"):
    print(key, x_axis(False).get(key), "->", x_axis(True).get(key))
```

Before this change:

```
tick_values None -> [0.0, 2.0, 4.0, 6.0, 8.0, 10.0]
tick_count  9    -> 6
```

## The cause

`_apply_tickers` returns early when nothing is registered:

```python
if locator is None and formatter is None and minor_locator is None and not is_log:
    return
```

`minorticks_on()` registers a `minor_locator`, so that guard stops short-circuiting and execution reaches `props["tick_values"] = ...`, which publishes the majors as authored positions.

That write is right when the caller sets a major locator or formatter, since those define where the majors go. It is wrong when the only thing registered is a minor locator: the majors were still chosen by `AutoLocator`, and pinning them is not correct.

## The change

Compute `ticks` as before. It is still needed to subdivide between the majors, but only publish `tick_values` and `tick_count` when the majors were actually determined by the caller:

```python
majors_are_auto = (
    locator is None
    and formatter is None
    and authored_labels is None
    and not is_log
    and "tick_values" not in props
)
```

After:

```
tick_values None -> None
tick_count  9    -> 9
```

with `minor_tick_values` still populated.

## Testing

- New regression test asserting `minorticks_on()` leaves `tick_values` unset while minor values are still emitted. It fails on `main` with `assert [0.0, 2.0, 4.0, 6.0, 8.0, 10.0] is None`.
- Confirmed by hand in a notebook: with minor ticks on, the tick labels now survive zooming instead of disappearing past roughly 2x.

## Caveat: this does not make minor ticks regenerate

The majors are automatic again, but the minors are not. `minor_tick_values` is the only minor field on the wire, and the client filters that fixed list to the view rather than generating anything:

```js
const minorTicks = (axis, axisId) => {
  if (!Array.isArray(axis.minor_tick_values)) return [];
  const [lo, hi] = this._axisRange(axisId);
  return axis.minor_tick_values.map(Number).filter((v) => v >= a && v <= b);
};
```

So the minor positions computed for the initial domain are all that ever exist. Zoom in far enough and none of them fall inside the view, leaving regenerating majors with no minors between them.

Fixing that properly means shipping the subdivision rule rather than the positions, something like `minor_subdivisions`,  and having the client subdivide between the majors it generates. That is a wire field plus client work, which would be a fair bit more work, and I'm not confident enough around the codebase  to tackle it. 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic major tick handling on linear axes.
  * Preserved explicit, formatted, logarithmic, and user-authored tick configurations.
  * Maintained correct tick labels and positions across shared nonlinear axes, including symlog, asinh, and logit scales.
  * Ensured minor ticks do not disrupt automatic major tick generation.

* **Tests**
  * Added regression coverage for automatic and nonlinear axis tick behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->