### PR TITLE
Deploy docs by commit instead of by release tag

### DIFF
--- a/.github/workflows/deploy-docs-prod.yml
+++ b/.github/workflows/deploy-docs-prod.yml
@@ -1,0 +1,226 @@
+# Promote an already-staged docs image pair to production.
+#
+# Production is never deployed by a push. It is an explicit promotion of an
+# image tag that is *already running in staging*, held behind the `production`
+# environment's approval. By default this workflow reads the tag out of the
+# internal chart's staging values file, so "promote" means the exact images a
+# human just looked at on the staging site — the guarantee the old
+# tag-triggered stage-then-prod chain got from running both halves in one run.
+#
+# Living in its own workflow buys two things that chain could not have:
+#   * a pending production approval no longer sits inside the staging
+#     concurrency group, so it cannot block staging deploys for up to 12 hours;
+#   * rollback is a first-class action — dispatch an older tag and it ships,
+#     without rebuilding anything or re-cutting a release.
+#
+# Promotion is not gated on a library release (see spec/process/docs-deploy.md).
+# The release context of the promoted commit is resolved *before* the approval
+# gate and written to the run summary, so whoever approves can see whether the
+# docs about to go live describe a version users can already `pip install`.
+
+name: Promote XY Docs to Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to promote (default: whatever staging runs now)"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-xy-docs-prod
+  cancel-in-progress: false
+
+env:
+  HELM_REPO: reflex-dev/helm-charts
+  STG_VALUES: charts/internal/values-stg.yaml
+
+jobs:
+  resolve:
+    name: Resolve Promotion Candidate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      image_tag: ${{ steps.tag.outputs.image_tag }}
+      source_ref: ${{ steps.commit.outputs.source_ref }}
+      source_sha: ${{ steps.commit.outputs.source_sha }}
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.HELM_BOT_APP_ID }}
+          private-key: ${{ secrets.HELM_BOT_PRIVATE_KEY }}
+          owner: reflex-dev
+          repositories: helm-charts
+
+      - name: Install yq
+        env:
+          YQ_VERSION: v4.53.2
+          YQ_SHA256: d56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b
+        run: |
+          tmpfile=$(mktemp)
+          curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -o "$tmpfile"
+          echo "${YQ_SHA256}  ${tmpfile}" | sha256sum -c -
+          sudo install -m 0755 "$tmpfile" /usr/local/bin/yq
+          rm -f "$tmpfile"
+
+      - name: Resolve the image tag to promote
+        id: tag
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HELM_REPO: ${{ env.HELM_REPO }}
+          STG_VALUES: ${{ env.STG_VALUES }}
+          INPUT_TAG: ${{ inputs.image_tag }}
+        run: |
+          if [[ -n "$INPUT_TAG" ]]; then
+            IMAGE_TAG="$INPUT_TAG"
+            echo "::notice::Promoting the explicitly requested tag ${IMAGE_TAG} (rollback path)"
+          else
+            gh api "repos/${HELM_REPO}/contents/${STG_VALUES}" \
+              -H "Accept: application/vnd.github.raw" > /tmp/values-stg.yaml
+            FRONTEND=$(yq -r '.apps.xy.frontend.image.tag // ""' /tmp/values-stg.yaml)
+            BACKEND=$(yq -r '.apps.xy.backend.image.tag // ""' /tmp/values-stg.yaml)
+            if [[ -z "$FRONTEND" || -z "$BACKEND" ]]; then
+              echo "::error::${STG_VALUES} does not set both apps.xy.{frontend,backend}.image.tag"
+              exit 1
+            fi
+            # The two tags are written together by _helm-docs-pr.yml. A split
+            # means staging is mid-deploy or hand-edited, and there is no single
+            # thing to promote — refuse rather than guess which half is live.
+            if [[ "$FRONTEND" != "$BACKEND" ]]; then
+              echo "::error::staging is split (frontend=${FRONTEND}, backend=${BACKEND}); refusing to promote"
+              exit 1
+            fi
+            IMAGE_TAG="$FRONTEND"
+            echo "::notice::Promoting the tag staging currently runs: ${IMAGE_TAG}"
+          fi
+          # Same ceiling the reusable build/helm workflows enforce.
+          if [[ ! "$IMAGE_TAG" =~ ^[A-Za-z0-9._-]+$ ]] || (( ${#IMAGE_TAG} > 128 )); then
+            echo "::error::image_tag must match [A-Za-z0-9._-]+ and be <=128 characters"
+            exit 1
+          fi
+          echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve the source commit
+        id: commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
+        run: |
+          # Image tags are `sha-<short>`; older ones are release tags. Either
+          # form resolves through the commits API. A tag whose commit no longer
+          # exists (force-pushed branch, deleted tag) is still promotable — the
+          # images are what ship — so fall back to reporting the tag itself
+          # rather than blocking a rollback on missing git history.
+          CANDIDATE="${IMAGE_TAG#sha-}"
+          SHA=$(gh api "repos/${REPO}/commits/${CANDIDATE}" --jq '.sha' 2>/dev/null || true)
+          if [[ "$SHA" =~ ^[a-f0-9]{40}$ ]]; then
+            echo "source_sha=$SHA" >> "$GITHUB_OUTPUT"
+            echo "source_ref=$SHA" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::could not resolve a commit for ${IMAGE_TAG}; promoting the images anyway"
+            echo "source_sha=" >> "$GITHUB_OUTPUT"
+            echo "source_ref=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Full history and tags: the nearest release tag is what says whether the
+      # docs about to ship describe a published version, and a shallow clone
+      # has neither.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: steps.commit.outputs.source_sha != ''
+        with:
+          ref: ${{ steps.commit.outputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Advisory, never a gate. Docs deploys are decoupled from releases on
+      # purpose; this only makes the consequence visible at approval time
+      # instead of discovered on the live site.
+      - name: Report release context
+        id: context
+        if: steps.commit.outputs.source_sha != ''
+        env:
+          SOURCE_SHA: ${{ steps.commit.outputs.source_sha }}
+        run: |
+          RELEASE=$(git describe --tags --abbrev=0 --match 'v*' "$SOURCE_SHA" 2>/dev/null || true)
+          if [[ -z "$RELEASE" ]]; then
+            echo "release_note=no \`v*\` release tag is reachable from this commit" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PYPI_VERSION="${RELEASE#v}"
+          CODE=$(curl -sS -o /dev/null -w '%{http_code}' \
+            "https://pypi.org/pypi/xy/${PYPI_VERSION}/json" 2>/dev/null || true)
+          case "$CODE" in
+            # An unreachable PyPI must not read as "unpublished": this line is
+            # advisory, and a wrong claim is worse than an honest unknown.
+            200) STATE="published on PyPI" ;;
+            404) STATE="**not on PyPI**" ;;
+            *)   STATE="of unknown PyPI status (query returned '${CODE:-no response}')" ;;
+          esac
+          if [[ "$(git rev-list -n1 "$RELEASE" 2>/dev/null)" == "$SOURCE_SHA" ]]; then
+            WHERE="this commit is exactly \`${RELEASE}\`"
+          else
+            AHEAD=$(git rev-list --count "${RELEASE}..${SOURCE_SHA}" 2>/dev/null || echo "?")
+            WHERE="${AHEAD} commit(s) after \`${RELEASE}\` — the docs may describe unreleased code"
+          fi
+          echo "release_note=${WHERE}; \`${RELEASE}\` is ${STATE}" >> "$GITHUB_OUTPUT"
+
+      - name: Summary
+        env:
+          IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
+          SOURCE_SHA: ${{ steps.commit.outputs.source_sha }}
+          RELEASE_NOTE: ${{ steps.context.outputs.release_note }}
+          REQUESTED: ${{ inputs.image_tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          {
+            echo "### XY docs production promotion"
+            echo ""
+            echo "**Image tag:** \`${IMAGE_TAG}\`"
+            if [[ -n "$REQUESTED" ]]; then
+              echo "**Source:** explicitly requested (rollback path)"
+            else
+              echo "**Source:** the tag staging currently runs"
+            fi
+            if [[ -n "$SOURCE_SHA" ]]; then
+              echo "**Commit:** https://github.com/${REPO}/commit/${SOURCE_SHA}"
+            fi
+            if [[ -n "$RELEASE_NOTE" ]]; then
+              echo "**Release context:** ${RELEASE_NOTE}"
+            fi
+            echo ""
+            echo "Awaiting approval on the \`production\` environment."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  await-approval:
+    name: Await Production Approval
+    needs: resolve
+    runs-on: ubuntu-latest
+    timeout-minutes: 720
+    environment: production
+    permissions:
+      contents: read
+    steps:
+      - env:
+          IMAGE_TAG: ${{ needs.resolve.outputs.image_tag }}
+        run: echo "Approved for production promotion of ${IMAGE_TAG}"
+
+  helm-pr-prod:
+    name: Update Production Helm Values
+    needs: [resolve, await-approval]
+    permissions:
+      contents: read
+    uses: ./.github/workflows/_helm-docs-pr.yml
+    with:
+      image_tag: ${{ needs.resolve.outputs.image_tag }}
+      environment: prod
+      source_ref: ${{ needs.resolve.outputs.source_ref }}
+      auto_merge: true
+    secrets: inherit

--- a/.github/workflows/deploy-docs-stg.yml
+++ b/.github/workflows/deploy-docs-stg.yml
@@ -1,21 +1,31 @@
-# Build one versioned image pair, deploy it to staging, wait for production
-# approval, then promote the exact same images to production.
+# Deploy the docs site to staging.
+#
+# Docs deploys are deliberately *not* tied to library releases. A docs change
+# reaches staging on the merge that makes it, not on the next `v*` tag, and
+# production is a separate explicit promotion (deploy-docs-prod.yml) rather
+# than the tail of this workflow.
+#
+# Two entry points, one image-tag scheme (`sha-<short>`, identical to
+# deploy-docs-dev.yml):
+#
+#   * a successful dev deploy — staging promotes the images that run already
+#     built for that commit, with no second build (build once, promote many);
+#   * workflow_dispatch — deploy any branch, tag, or commit on demand, which
+#     builds because nothing may have built that commit yet.
 
-name: Deploy XY Docs to Stage and Prod
+name: Deploy XY Docs to Stage
 
 on:
+  workflow_run:
+    workflows: ["Deploy XY Docs to Dev"]
+    types: [completed]
   workflow_dispatch:
     inputs:
-      version:
-        description: "Existing XY release tag (semver, for example v0.1.0)"
-        required: true
+      ref:
+        description: "Branch, tag, or commit SHA to deploy (default: main)"
+        required: false
+        default: main
         type: string
-  push:
-    # The library's semver release tags — the same `v*` tags release.yml
-    # publishes to PyPI from, so the docs site ships the version it documents.
-    # Deploying an arbitrary commit outside a release is workflow_dispatch's
-    # job (or deploy-docs-dev.yml, which tracks main on every push).
-    tags: ["v*"]
 
 permissions:
   contents: read
@@ -27,151 +37,105 @@ concurrency:
 jobs:
   prepare:
     name: Prepare
+    # A dev deploy that failed never pushed images, so there is nothing to
+    # promote. (A dev run that skipped its build because the commit was already
+    # deployed did succeed, and its images are already in the registry.)
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      version: ${{ steps.resolve.outputs.version }}
+      image_tag: ${{ steps.resolve.outputs.image_tag }}
       source_sha: ${{ steps.resolve.outputs.source_sha }}
+      needs_build: ${{ steps.resolve.outputs.needs_build }}
     steps:
-      - name: Resolve version and source commit
+      - name: Resolve source commit and image tag
         id: resolve
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ inputs.version || github.ref_name }}
           EVENT_NAME: ${{ github.event_name }}
-          EVENT_SHA: ${{ github.sha }}
+          REF: ${{ inputs.ref }}
+          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
           REPO: ${{ github.repository }}
         run: |
-          # Loose shape check only: this runs before the repo is on disk, so all
-          # it has to establish is that the value can resolve to a ref and is a
-          # legal image tag. check_release_version.py below is the authority on
-          # what a release tag is. Deliberately PEP 440, not strict SemVer — a
-          # pre-release tags as `v0.2.0rc1`, no dash. Local versions are
-          # excluded because `+` is not a legal Docker tag character and this
-          # value becomes the image tag, and the trailing class cannot end in a
-          # separator. 128 chars is the ceiling the reusable build/helm
-          # workflows enforce.
-          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-]?[A-Za-z0-9]+)*$ ]]; then
-            echo "::error::version must be a release tag like v0.1.0 or v0.2.0rc1"
-            exit 1
-          fi
-          if (( ${#VERSION} > 128 )); then
-            echo "::error::version must be <=128 characters (Docker tag limit)"
-            exit 1
-          fi
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            SHA=$(gh api "repos/${REPO}/commits/${VERSION}" --jq '.sha')
+            # Loose shape check only: this runs before the repo is on disk, so
+            # all it has to establish is that the value can be handed to the
+            # API as a ref. `..` is excluded so a ref cannot walk out of the
+            # repository's namespace, the leading class keeps `-` from reading
+            # as a flag, and 128 chars is the ceiling the reusable build/helm
+            # workflows enforce.
+            if [[ ! "$REF" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$ ]] || [[ "$REF" == *".."* ]]; then
+              echo "::error::ref must be a branch, tag, or commit ([A-Za-z0-9._/-], <=128 characters)"
+              exit 1
+            fi
+            SHA=$(gh api "repos/${REPO}/commits/${REF}" --jq '.sha')
+            # A dispatched ref may name a commit nothing has built yet.
+            NEEDS_BUILD=true
           else
-            SHA="$EVENT_SHA"
+            SHA="$RUN_SHA"
+            # The dev deploy pushed this exact tag. Promoting means pointing
+            # staging at those images, not building a second copy of them.
+            NEEDS_BUILD=false
           fi
           if [[ ! "$SHA" =~ ^[a-f0-9]{40}$ ]]; then
             echo "::error::resolved SHA is not a 40-character hex commit"
             exit 1
           fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "source_sha=$SHA" >> "$GITHUB_OUTPUT"
+          {
+            echo "source_sha=$SHA"
+            echo "image_tag=sha-${SHA:0:7}"
+            echo "needs_build=$NEEDS_BUILD"
+          } >> "$GITHUB_OUTPUT"
 
-      # A semver-shaped tag is not necessarily a releasable one. Run the same
-      # gate release.yml runs, from the tagged tree, so a tag the version
-      # derivation cannot read cannot deploy docs for a library version that can
-      # never be published.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ steps.resolve.outputs.source_sha }}
-          persist-credentials: false
-      - name: Release version gate (tag shape)
+      - name: Summary
         env:
-          VERSION: ${{ steps.resolve.outputs.version }}
-        run: python3 scripts/check_release_version.py --tag "$VERSION"
+          SOURCE_SHA: ${{ steps.resolve.outputs.source_sha }}
+          IMAGE_TAG: ${{ steps.resolve.outputs.image_tag }}
+          NEEDS_BUILD: ${{ steps.resolve.outputs.needs_build }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [[ "$NEEDS_BUILD" == true ]]; then
+            ACTION="building images for this commit"
+          else
+            ACTION="promoting the images the dev deploy already built"
+          fi
+          {
+            echo "### XY docs staging deploy"
+            echo ""
+            echo "**Commit:** https://github.com/${REPO}/commit/${SOURCE_SHA}"
+            echo "**Image tag:** \`${IMAGE_TAG}\`"
+            echo "**Action:** ${ACTION}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   build:
-    name: Build Versioned Images
+    name: Build Staging Images
     needs: prepare
+    if: needs.prepare.outputs.needs_build == 'true'
     permissions:
       contents: read
     uses: ./.github/workflows/_build-docs-images.yml
     with:
-      image_tag: ${{ needs.prepare.outputs.version }}
+      image_tag: ${{ needs.prepare.outputs.image_tag }}
       source_ref: ${{ needs.prepare.outputs.source_sha }}
     secrets: inherit
 
   helm-pr-stg:
     name: Update Staging Helm Values
     needs: [prepare, build]
+    # `build` is skipped on the promotion path; a skipped dependency must not
+    # take the deploy with it, but a failed one must.
+    if: >-
+      !cancelled()
+      && needs.prepare.result == 'success'
+      && needs.build.result != 'failure'
     permissions:
       contents: read
     uses: ./.github/workflows/_helm-docs-pr.yml
     with:
-      image_tag: ${{ needs.prepare.outputs.version }}
+      image_tag: ${{ needs.prepare.outputs.image_tag }}
       environment: stg
-      source_ref: ${{ needs.prepare.outputs.source_sha }}
-      auto_merge: true
-    secrets: inherit
-
-  await-prod-approval:
-    name: Await Production Approval
-    needs: helm-pr-stg
-    runs-on: ubuntu-latest
-    timeout-minutes: 720
-    environment: production
-    permissions:
-      contents: read
-    steps:
-      - run: echo "Approved for production promotion"
-
-  # No GitHub Release job here: on a `v*` tag release.yml owns the release
-  # (it gates the tag shape and attaches the Pyodide wheel with generated
-  # notes). A second creator would race it and could win, stamping a
-  # library release with docs-deployment notes. The flip side of not owning it
-  # is that this workflow must confirm it happened before promoting prod.
-  verify-library-release:
-    name: Verify Library Release Published
-    needs: [prepare, await-prod-approval]
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-    steps:
-      # release.yml runs in parallel on the same tag and its wheel matrix is
-      # slow, so poll rather than sample once. Prod must never document a
-      # version users cannot `pip install`.
-      - name: Await GitHub Release and PyPI availability
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.prepare.outputs.version }}
-          REPO: ${{ github.repository }}
-        run: |
-          PYPI_VERSION="${VERSION#v}"
-          for attempt in $(seq 1 30); do
-            RELEASED=false
-            PUBLISHED=false
-            if gh release view "$VERSION" --repo "$REPO" >/dev/null 2>&1; then
-              RELEASED=true
-            fi
-            CODE=$(curl -fsS -o /dev/null -w '%{http_code}' \
-              "https://pypi.org/pypi/xy/${PYPI_VERSION}/json" 2>/dev/null || true)
-            if [[ "$CODE" == "200" ]]; then
-              PUBLISHED=true
-            fi
-            if [[ "$RELEASED" == true && "$PUBLISHED" == true ]]; then
-              echo "::notice::${VERSION} is on GitHub Releases and PyPI"
-              exit 0
-            fi
-            echo "attempt ${attempt}/30 — release=${RELEASED} pypi=${PUBLISHED}; retrying in 60s"
-            sleep 60
-          done
-          echo "::error::${VERSION} did not publish (GitHub Release and/or PyPI missing) — refusing to promote prod"
-          exit 1
-
-  helm-pr-prod:
-    name: Update Production Helm Values
-    needs: [prepare, await-prod-approval, verify-library-release]
-    permissions:
-      contents: read
-    uses: ./.github/workflows/_helm-docs-pr.yml
-    with:
-      image_tag: ${{ needs.prepare.outputs.version }}
-      environment: prod
       source_ref: ${{ needs.prepare.outputs.source_sha }}
       auto_merge: true
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ in the README).
 
 ## [Unreleased]
 
+### Changed
+- Docs-site deployment is driven by commits instead of release tags. Staging no
+  longer triggers on `push: tags: v*`; it promotes the images a successful dev
+  deploy already built for a `main` commit, or builds any branch/tag/commit on
+  demand via `workflow_dispatch`. A docs fix reaches staging on the merge that
+  makes it rather than on the next version tag.
+- Production promotion moved out of the staging workflow into
+  `deploy-docs-prod.yml`, which ships the tag staging currently runs (read from
+  the internal chart's `values-stg.yaml`) or an explicit tag for rollback. The
+  two workflows hold separate concurrency groups, so a production approval
+  pending for up to 12 hours can no longer queue staging deploys behind it.
+- Promotion no longer blocks on the GitHub Release and PyPI upload for a
+  version. The nearest reachable `v*` tag and its PyPI status are resolved
+  before the approval gate and written to the run summary instead — advisory
+  information for the approver, not a gate. New spec:
+  [`spec/process/docs-deploy.md`](spec/process/docs-deploy.md).
+
 ## [0.0.6] - 2026-08-07
 
 ### Added

--- a/scripts/check_release_version.py
+++ b/scripts/check_release_version.py
@@ -22,7 +22,10 @@ Tags accept an optional PEP 440 pre-release suffix in its canonical spelling
 be normalized by the derivation (`0.0.1a1`) and could never match their own
 artifacts.
 
-Docs-deploy CalVer tags (2026.WW.N) do not match the release shape.
+Only `v`-prefixed release tags pass. Any other tag shape a repository might
+carry — CalVer-style `2026.WW.N`, deployment or infrastructure markers — is
+rejected, and nothing outside the release path depends on this gate: the docs
+site deploys by commit rather than by tag (`spec/process/docs-deploy.md`).
 Dev/post/local shapes stay rejected: dev versions are the between-tags marker
 and must stay unpublishable.
 """

--- a/spec/README.md
+++ b/spec/README.md
@@ -102,6 +102,9 @@ Release bar, contribution rules, and audit trail.
 - [`rendering-verification.md`](process/rendering-verification.md) — the
   LOD-invariant property tests and golden visual-regression corpus that make
   renderer churn safe.
+- [`docs-deploy.md`](process/docs-deploy.md) — the dev/stg/prod docs-site
+  ladder: commit-driven triggers, build-once-promote-many image tags, and why
+  deployment is independent of the release cadence.
 - [`security-audit-2026-07-06.md`](process/security-audit-2026-07-06.md) —
   scope, findings, and status of the 2026-07-06 source audit.
 - [`tailwind-customizability-audit-2026-07-26.md`](process/tailwind-customizability-audit-2026-07-26.md)

--- a/spec/process/docs-deploy.md
+++ b/spec/process/docs-deploy.md
@@ -1,0 +1,90 @@
+# Docs Site Deployment
+
+How the XY documentation site reaches its three environments, and why that
+ladder is deliberately independent of the library's release cadence.
+
+The site is a Reflex app under `docs/app`. Each deploy is a frontend/backend
+image pair pushed to ECR, Harbor, and ACR, and rolled out by the Flux consumers
+of `reflex-dev/helm-charts` once a generated values PR merges. No workflow in
+this repository talks to a cluster.
+
+## The ladder
+
+| Environment | Values file | Trigger | Workflow |
+| --- | --- | --- | --- |
+| dev | `charts/internal/values-tenant-dev.yaml` | every push to `main` | `deploy-docs-dev.yml` |
+| stg | `charts/internal/values-stg.yaml` | a successful dev deploy, or dispatch with any ref | `deploy-docs-stg.yml` |
+| prod | `charts/internal/values-prod.yaml` | dispatch + `production` environment approval | `deploy-docs-prod.yml` |
+
+Two reusable workflows do the shared work: `_build-docs-images.yml` builds and
+pushes the image pair, `_helm-docs-pr.yml` opens (and auto-merges) the chart
+values PR.
+
+## Deploys follow commits, not releases
+
+Docs deployment used to hang off `push: tags: v*` — staging built only when the
+library was released, and production additionally waited for the GitHub Release
+and the PyPI upload to appear. That coupled two cadences that have no reason to
+match. A typo fix, a new gallery example, or a corrected benchmark table had to
+wait for the next version tag, and a release that slipped took the docs with it.
+
+The trigger is now the commit. A docs change that lands on `main` is on dev
+immediately and on staging in the same pipeline; shipping it to production is a
+human decision, not a release event.
+
+**The consequence is explicit, not hidden:** production docs can describe code
+that is not on PyPI yet. `deploy-docs-prod.yml` resolves the nearest reachable
+`v*` tag and that version's PyPI status *before* the approval gate and writes
+both to the run summary, so the approver sees exactly how far ahead of the last
+published release the promotion is. It is a report, never a gate — blocking on
+it would restore the coupling this design removes.
+
+## Build once, promote many
+
+Every image pair is tagged `sha-<short7>`, the same scheme in all three
+environments, so an image built once is the image every environment runs:
+
+- the dev deploy builds the pair for a `main` commit;
+- staging **promotes** that pair — the `workflow_run` path deliberately skips
+  the build job, because rebuilding the same commit produces a second copy of
+  bytes that already exist;
+- production promotes whatever staging currently runs, read straight out of
+  `values-stg.yaml`. It refuses to act if that file's frontend and backend tags
+  disagree, since a split staging state has no single thing to promote.
+
+The one path that does build is a `workflow_dispatch` of `deploy-docs-stg.yml`
+with an explicit `ref`: an arbitrary branch, tag, or commit may never have been
+built. That is also how a preview of an unmerged branch reaches staging.
+
+## Rollback
+
+Dispatch `deploy-docs-prod.yml` with an explicit `image_tag`. Any tag still in
+the registry ships without a rebuild, a revert commit, or a re-cut release. The
+run summary marks it as the rollback path, and the commit lookup is
+non-blocking — a tag whose git history has since been force-pushed away is
+still promotable, because the images are what serve traffic.
+
+## Separation of concerns
+
+- **Staging never waits on production.** The workflows hold separate
+  concurrency groups (`deploy-xy-docs-stg`, `deploy-xy-docs-prod`), so a
+  production approval pending for up to 12 hours cannot queue staging deploys
+  behind it. When both halves lived in one workflow they shared a group and it
+  could.
+- **Releases stay owned by `release.yml`.** No docs workflow creates tags or
+  GitHub Releases, and `scripts/check_release_version.py` gates release tags
+  only. Nothing in the docs ladder calls it.
+
+## Repository configuration
+
+| Kind | Name | Used by |
+| --- | --- | --- |
+| variable | `DOCS_DEPOT_PROJECT` | image builds |
+| variable | `HELM_BOT_APP_ID` | chart PRs, prod tag lookup, dev SHA bookkeeping |
+| variable | `LAST_DOCS_DEPLOY_SHA` | dev idempotency |
+| secret | `HELM_BOT_PRIVATE_KEY` | as above |
+| secret | `DEPOT_TOKEN` | image builds |
+| secret | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | ECR push |
+| secret | `HARBOR_PUSH_USERNAME` / `HARBOR_PUSH_SECRET` | Harbor push |
+| secret | `ACR_USERNAME` / `ACR_PASSWORD` | ACR push |
+| environment | `production` | the prod approval gate |

--- a/tests/test_check_release_version.py
+++ b/tests/test_check_release_version.py
@@ -23,7 +23,7 @@ def test_gate_passes_a_release_tag() -> None:
 
 
 def test_gate_rejects_a_tag_that_is_not_a_release_tag() -> None:
-    # The docs site deploys on CalVer tags (2026.WW.N) that the version
+    # A CalVer-shaped tag (2026.WW.N) is one of the shapes the version
     # derivation deliberately ignores; one must never publish a release.
     errors = check_release_version.check_release("2026.30.1")
 


### PR DESCRIPTION
## What was wrong

`deploy-docs-stg.yml` triggered on `push: tags: v*`, so the docs site could only ship when the library shipped. A typo fix, a new gallery example, or a corrected benchmark table waited for the next version tag, and a slipped release took the docs with it. Three further things fell out of that design:

- **Production promotion lived in the same run**, gated on the GitHub Release *and* the PyPI upload appearing (`verify-library-release`).
- **A pending production approval blocked staging.** `await-prod-approval` has `timeout-minutes: 720` and sits inside the workflow-level `concurrency` group with `cancel-in-progress: false`, so any later staging deploy queued behind it for up to 12 hours. Rare at release cadence; unworkable at commit cadence.
- **`verify-library-release` could never report its own failure.** 30 attempts × 60s of sleeping exceeded the job's `timeout-minutes: 30`, so the job was killed a beat before printing the explicit "refusing to promote" error.

Separately, `scripts/check_release_version.py` and its test claimed the docs site deploys on CalVer `2026.WW.N` tags. Nothing has ever done that — the workflow deployed on `v*`.

## What this does

**Staging follows commits** (`deploy-docs-stg.yml`, rewritten). Two entry points, one `sha-<short7>` tag scheme shared with the dev deploy:

- `workflow_run` after a successful dev deploy — staging *promotes* the images that run already built for the commit, skipping the build job entirely rather than producing a second copy of bytes that already exist;
- `workflow_dispatch` with a `ref` — any branch, tag, or commit on demand, which does build, since nothing may have built that ref yet. This is also how an unmerged branch gets previewed on staging.

**Production promotion moves to its own workflow** (`deploy-docs-prod.yml`, new). It promotes the tag staging currently runs, read out of the internal chart's `values-stg.yaml` — preserving the "prod gets exactly what a human looked at on staging" guarantee the old single-run chain got for free — and refuses to act if that file's frontend and backend tags disagree, since a split staging state has no single thing to promote. An explicit `image_tag` input is the rollback path: any tag still in the registry ships without a rebuild or a re-cut release. The `production` environment approval is unchanged. The separate concurrency group is what un-blocks staging.

**The release coupling becomes information, not a gate.** Decoupling means production docs can describe code that is not on PyPI yet, so the consequence is surfaced where the decision is made: `resolve` computes the nearest reachable `v*` tag, how far ahead of it the promoted commit is, and that version's PyPI status, and writes them to the run summary *before* the approval gate. An unreachable PyPI reports unknown rather than unpublished — a wrong claim there is worse than an honest one. Blocking on any of it would restore the coupling this PR removes.

## Verification

Workflow YAML parses; every `run:` block passes `bash -n`; both resolve scripts were executed against stubbed `gh`/`yq` and a scratch git repo with real tags:

- staging: promotion path, dispatch on a branch/tag, and rejection of `../../etc`, `refs/heads/../x`, `-rf`, `a b`, a 129-char ref, an empty ref, an unresolvable ref, and a malformed upstream SHA;
- production: default-from-staging, explicit rollback tag, legacy release-tag shape, split staging state, missing tags, an injection-shaped tag, and an overlong tag;
- release context: exact-tag, N-commits-past-tag, and untagged-history cases.

`make check-ci`, `ruff check`, `ruff format --check`, and `pytest tests/test_check_release_version.py` all pass. The `docs-app-codespell` pre-commit hook fails in this sandbox (`docs/app` venv cannot be provisioned, `codespell` binary missing) — it fails identically on a clean checkout and only matches `^docs/`, which this PR does not touch.

## Notes for review

- `workflow_run` triggers only fire once the workflow file is on the default branch, so the automatic staging promotion starts working after this merges; `workflow_dispatch` works immediately.
- Staging now tracks `main` rather than release candidates. That is the intended shape of the change, but it is the one behavioral judgment call here worth a second opinion.
- New spec: `spec/process/docs-deploy.md`, linked from `spec/README.md`, documenting the ladder, the trigger model, build-once-promote-many, rollback, and the required repository variables/secrets.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PE6pptkiFGuLdMpDWjHeU8)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added independent development, staging, and production documentation deployment workflows.
  - Supports commit-based staging deployments, tag-based production promotion, and production rollback without rebuilding.
  - Added approval controls and deployment summaries for production releases.

- **Documentation**
  - Documented the documentation deployment process and promotion workflow.
  - Clarified accepted release tag formats and deployment behavior.

- **Tests**
  - Clarified coverage for non-release CalVer tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->