### PR TITLE
Fix state-backed docs module identity

### DIFF
--- a/docs/app/tests/test_docs_site.py
+++ b/docs/app/tests/test_docs_site.py
@@ -66,6 +66,7 @@ from xy_docs.gallery import (
 )
 from xy_docs.markdown import (
     XyDocsMarkdownTransformer,
+    _page_virtual_filepath,
     _split_demo_data,
     page_with_api_reference_toc,
     render_xy_markdown_page,
@@ -1251,10 +1252,45 @@ def test_editing_a_page_drops_the_fence_snapshots_keyed_to_its_old_layout(
     # The edit removes the leading copy, renumbering the survivor to occurrence
     # 0 — and revises the trailing fence, as a real edit does, so it is a cache
     # miss and runs against whatever namespace the restore left behind.
-    render_xy_markdown_page(page_of("between = 2", duplicated, "second = (shared, between)"))
+    edited_page = page_of("between = 2", duplicated, "second = (shared, between)")
+    render_xy_markdown_page(edited_page)
 
-    module = _file_modules[str(source_path.resolve())]
+    module = _file_modules[_page_virtual_filepath(edited_page)]
     assert module.__dict__["second"] == (1, 2)
+
+
+def test_exec_module_identity_is_stable_across_build_roots(tmp_path: Path) -> None:
+    """Keep frontend and backend State module names independent of checkout paths."""
+    relative_path = Path("tests/split-build-state.md")
+    content = """~~~python exec
+class SplitBuildSymbol:
+    pass
+~~~"""
+
+    def page_at(build_root: str) -> DocsPage:
+        return DocsPage(
+            source_path=tmp_path / build_root / "docs" / relative_path,
+            relative_path=relative_path,
+            route="/tests/split-build-state/",
+            title="Split build state",
+            description=None,
+            metadata={},
+            content=content,
+        )
+
+    frontend_page = page_at("home/runner/work/xy/xy")
+    backend_page = page_at("app")
+    assert _page_virtual_filepath(frontend_page) == _page_virtual_filepath(backend_page)
+    render_xy_markdown_page(frontend_page)
+
+    virtual_filepath = _page_virtual_filepath(frontend_page)
+    frontend_symbol = _file_modules[virtual_filepath].SplitBuildSymbol
+    render_xy_markdown_page(backend_page)
+    backend_symbol = _file_modules[virtual_filepath].SplitBuildSymbol
+
+    assert frontend_symbol is backend_symbol
+    assert frontend_symbol.__module__ == "_docgen_exec.xy_docs_tests_split_build_state_md"
+    assert str(tmp_path) not in frontend_symbol.__module__
 
 
 def _assigned_names(target: ast.expr) -> set[str]:
@@ -2877,7 +2913,7 @@ def test_reflex_integration_renders_the_state_backed_data_example() -> None:
     assert "rxy.scatter_chart(" in state_backed.content
     state_rendered = str(
         XyDocsMarkdownTransformer(
-            virtual_filepath=str(page.source_path.resolve()),
+            virtual_filepath=_page_virtual_filepath(page),
             filename=str(page.source_path),
         ).code_block(state_backed)
     )

--- a/docs/app/xy_docs/markdown.py
+++ b/docs/app/xy_docs/markdown.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 from collections import Counter
 from dataclasses import replace
+from pathlib import Path
 
 import reflex as rx
 from reflex_docgen.markdown import CodeBlock, HeadingBlock, parse_document
@@ -36,6 +37,15 @@ from xy_docs.examples import chart_example_demo
 _DEMO_DATA_DIVIDER = "# --- chart ---"
 _DEMO_DATA_TAB_LINE_THRESHOLD = 10
 
+# Executable fences become in-memory Python modules, and Reflex includes that
+# module name in every State subclass's full name. Frontend and backend docs
+# images are built in different checkout roots, so an absolute source path here
+# produces incompatible state names (for example ``/home/runner/...`` in the
+# frontend and ``/app/...`` in the backend). Keep the module identity rooted in
+# the documentation tree instead; ``DocsPage.relative_path`` is stable in every
+# build environment and unique within this site.
+_EXEC_MODULE_ROOT = "xy-docs"
+
 # Namespace of the page module as of the end of each executed fence, keyed by
 # (virtual filepath, fence source, occurrence of that source in the page). The
 # occurrence disambiguates a page that repeats an identical fence: those are
@@ -47,6 +57,11 @@ _FENCE_NAMESPACES: dict[tuple[str, str, int], dict] = {}
 # snapshot's key includes the fence's *position*, so entries are only valid for
 # the exact page content that produced them. See `_invalidate_stale_fences`.
 _FENCE_PAGE_DIGESTS: dict[str, str] = {}
+
+
+def _page_virtual_filepath(page: DocsPage) -> str:
+    """Return one deployment-stable identity for a page's executable fences."""
+    return (Path(_EXEC_MODULE_ROOT) / page.relative_path).as_posix()
 
 
 def _invalidate_stale_fences(virtual_filepath: str, content: str) -> None:
@@ -269,16 +284,17 @@ class XyDocsMarkdownTransformer(ReflexDocTransformer):
 def render_xy_markdown_page(page: DocsPage) -> rx.Component:
     """Render one discovered XY documentation page."""
     source_path = page.source_path.resolve()
+    virtual_filepath = _page_virtual_filepath(page)
     # Cached snapshots are keyed by fence position, so they only survive while
     # the page source that produced them does.
-    _invalidate_stale_fences(str(source_path), page.content)
+    _invalidate_stale_fences(virtual_filepath, page.content)
     # One fence sequence per page render, even though the body and the FAQ are
     # transformed separately around the generated API section.
     fence_occurrences: Counter[str] = Counter()
 
     def _render(markdown_text: str) -> rx.Component:
         transformer = XyDocsMarkdownTransformer(
-            virtual_filepath=str(source_path),
+            virtual_filepath=virtual_filepath,
             filename=str(source_path),
             fence_occurrences=fence_occurrences,
         )


### PR DESCRIPTION
## Summary

- derive executable Markdown module identities from each page's stable docs-relative path instead of its absolute checkout path
- use that identity consistently for fence cache invalidation and execution
- add a regression test that renders the same executable page from different frontend and backend build roots

## Root cause

Reflex includes the dynamically executed module name in each `State` subclass's full name. The docs frontend is compiled under a GitHub Actions checkout such as `/home/runner/work/xy/xy`, while the deployed backend runs under `/app`. Using the absolute Markdown source path therefore produced different State identifiers in the frontend and backend. The client could not dispatch the backend State update, so the state-backed XY data handle never hydrated and the chart remained blank.

## Impact

State-backed charts and other executable docs examples that define Reflex State now keep the same State identity across split frontend/backend builds.

## Validation

- `uv run --project docs/app --no-sync pytest docs/app/tests -q` — 120 passed, 2 skipped
- focused state-backed and split-build regression tests — 2 passed
- Ruff lint and format checks
- sitemap, Markdown asset, and generated HTML route validators
- production-mode docs build checked in a fresh browser tab: the state-backed chart rendered its plot area with no State-dispatch or unknown-token warning


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed executable documentation examples so their identity remains stable across different build and checkout locations.
  - Ensured edited documentation pages correctly invalidate outdated code-example snapshots.
  - Improved consistency when rendering and executing code examples from documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->