### PR TITLE
ENG-11596 Fix bar hover tooltip rewriting and jumping when the exact pick reply lands

### DIFF
--- a/js/src/52_tooltip.ts
+++ b/js/src/52_tooltip.ts
@@ -73,10 +73,16 @@ Object.assign(ChartView.prototype, {
       const x1 = this._decodeValue(r.x1, r.x1Meta, hit.index);
       const y0 = this._decodeValue(r.y0, r.y0Meta, hit.index);
       const y1 = this._decodeValue(r.y1, r.y1Meta, hit.index);
+      // Center/value follows the mark's orientation, matching the kernel's
+      // conventional columns (§16): a horizontal bar reads its value from x1
+      // and its category center from y — never the x midpoint (half the value).
+      const horizontal = g.trace.style && g.trace.style.orientation === "horizontal";
       const [x, xKind] = this._sourceDisplayValue(
-        g, "x", x0 + (x1 - x0) / 2, r.x0Meta.kind,
+        g, "x", horizontal ? x1 : x0 + (x1 - x0) / 2, r.x0Meta.kind,
       );
-      const [y, yKind] = this._sourceDisplayValue(g, "y", y1, r.y1Meta.kind);
+      const [y, yKind] = this._sourceDisplayValue(
+        g, "y", horizontal ? y0 + (y1 - y0) / 2 : y1, r.y1Meta.kind,
+      );
       row.x = x;
       row.y = y;
       if (xKind !== undefined) row.x_kind = xKind;

--- a/js/src/54_kernel.ts
+++ b/js/src/54_kernel.ts
@@ -857,6 +857,21 @@ Object.assign(ChartView.prototype, {
       // them (fields the kernel row lacks are exactly the sibling-sourced
       // ones) so _applySharedTooltipFields finds nothing missing and skips
       // its O(n) sibling scans. It stays as the mismatch fallback.
+      // The kernel row carries raw axis coordinates; a category axis's code
+      // must become its label here, exactly as _localRow did for the instant
+      // readout — otherwise the exact reply visibly swaps "B" for "1" (and
+      // the finite code below would drag the anchor away from the cursor).
+      const rowG = this.gpuTraces.find((t) => t.trace.id === msg.row.trace);
+      if (rowG) {
+        for (const channel of ["x", "y"]) {
+          if (typeof msg.row[channel] !== "number") continue;
+          const [value, kind] = this._sourceDisplayValue(
+            rowG, channel, msg.row[channel], msg.row[`${channel}_kind`],
+          );
+          msg.row[channel] = value;
+          if (kind === undefined) delete msg.row[`${channel}_kind`];
+        }
+      }
       const local = this._lastRow;
       if (local && local.trace === msg.row.trace && local.index === msg.row.index) {
         for (const [key, value] of Object.entries(local)) {

--- a/js/src/54_kernel.ts
+++ b/js/src/54_kernel.ts
@@ -861,16 +861,18 @@ Object.assign(ChartView.prototype, {
       // must become its label here, exactly as _localRow did for the instant
       // readout — otherwise the exact reply visibly swaps "B" for "1" (and
       // the finite code below would drag the anchor away from the cursor).
+      // A reply for a trace no longer in gpuTraces (dropped by a data update
+      // while the pick was in flight) has no mapping source and describes a
+      // mark that no longer exists — a miss.
       const rowG = this.gpuTraces.find((t) => t.trace.id === msg.row.trace);
-      if (rowG) {
-        for (const channel of ["x", "y"]) {
-          if (typeof msg.row[channel] !== "number") continue;
-          const [value, kind] = this._sourceDisplayValue(
-            rowG, channel, msg.row[channel], msg.row[`${channel}_kind`],
-          );
-          msg.row[channel] = value;
-          if (kind === undefined) delete msg.row[`${channel}_kind`];
-        }
+      if (!rowG) { this._hideTooltip(); return; }
+      for (const channel of ["x", "y"]) {
+        if (typeof msg.row[channel] !== "number") continue;
+        const [value, kind] = this._sourceDisplayValue(
+          rowG, channel, msg.row[channel], msg.row[`${channel}_kind`],
+        );
+        msg.row[channel] = value;
+        if (kind === undefined) delete msg.row[`${channel}_kind`];
       }
       const local = this._lastRow;
       if (local && local.trace === msg.row.trace && local.index === msg.row.index) {

--- a/python/xy/_figure.py
+++ b/python/xy/_figure.py
@@ -1401,8 +1401,16 @@ class Figure(AnnotationsMixin, PayloadMixin):
             x1c = self.store.ingest(x1)
             y0c = self.store.ingest(y0)
             y1c = self.store.ingest(y1)
-            xc = self.store.ingest(x0c.values + (x1c.values - x0c.values) / 2.0)
-            yc = self.store.ingest(y1c.values)
+            # Conventional center/value columns follow the orientation: the
+            # pick readout (§16) reports the category-band center and the value
+            # end, so a horizontal bar must not read back its x midpoint (half
+            # the value) or its y1 edge (category position + half width).
+            if orientation == "horizontal":
+                xc = self.store.ingest(x1c.values)
+                yc = self.store.ingest(y0c.values + (y1c.values - y0c.values) / 2.0)
+            else:
+                xc = self.store.ingest(x0c.values + (x1c.values - x0c.values) / 2.0)
+                yc = self.store.ingest(y1c.values)
             style: dict[str, Any] = {"color": color, "opacity": opacity, "role": role}
             if orientation is not None:
                 style["orientation"] = orientation

--- a/spec/api/chart-kind-contract.md
+++ b/spec/api/chart-kind-contract.md
@@ -421,6 +421,11 @@ usually wrong). Each has an explicit trigger:
   `MARK_KINDS` at that call site.
 - **Trace shape & autorange**: `Trace(x, y)` remains the conventional center/value
   pair, while rectangle and segment marks carry explicit `x0/x1/y0/y1` columns.
+  For oriented bar-like marks the convention follows the orientation: the
+  position axis holds the band center and the value axis holds the value end
+  (`x1` for horizontal bars, `y1` for vertical), because the exact pick readout
+  (§16) projects these columns and must agree with the client's instant local
+  row — a horizontal bar must never read back its x midpoint (half the value).
   `Figure._range_columns()` already includes those geometry extents, so error
   bars, boxes, violins, contours, and other multi-column marks do not autorange
   to their midpoint only. *Trigger: a future mark whose extent is not expressible

--- a/spec/design/wire-protocol.md
+++ b/spec/design/wire-protocol.md
@@ -230,6 +230,14 @@ and `size_value` when those channels exist. A heatmap row is
 use their own client-side sequence (`_pickSeq`), not the view `seq` — sharing
 one counter let a hover invalidate an in-flight `tier_update`.
 
+`x`/`y` are raw axis coordinates from the conventional center/value columns
+(orientation-aware for bars: band center on the position axis, value end on
+the value axis). The client maps a category axis's code to its label before
+rendering or re-anchoring — the exact reply must land as an invisible
+refinement of the instant local readout, never a visible rewrite (a category
+code replacing its label, or a finite code dragging the tooltip anchor away
+from the cursor).
+
 **`selection`** — `{type, traces, total}` plus one u32 buffer per trace. Each
 entry is `{id, count, buf, drill_seq}`. Masks speak **shipped-vertex
 positions** (`fig.to_shipped_indices`), so `count` is the wire mask length,

--- a/spec/design/wire-protocol.md
+++ b/spec/design/wire-protocol.md
@@ -236,7 +236,10 @@ the value axis). The client maps a category axis's code to its label before
 rendering or re-anchoring — the exact reply must land as an invisible
 refinement of the instant local readout, never a visible rewrite (a category
 code replacing its label, or a finite code dragging the tooltip anchor away
-from the cursor).
+from the cursor). A reply naming a trace the client no longer holds (dropped
+by a data update while the pick was in flight) has no mapping source and
+describes a mark that no longer exists; the client treats it as a miss and
+hides the tooltip.
 
 **`selection`** — `{type, traces, total}` plus one u32 buffer per trace. Each
 entry is `{id, count, buf, drill_seq}`. Masks speak **shipped-vertex

--- a/tests/test_ui_issue_regressions.py
+++ b/tests/test_ui_issue_regressions.py
@@ -1129,3 +1129,119 @@ def test_categorical_tick_bounds_follow_anchor_rotation_and_extra_axis_side(
     assert extra, result
     assert all(row["side"] == "right" for row in extra), result
     assert all(row["pinnedRight"] for row in extra), result
+
+
+def test_bar_pick_reports_band_center_and_value_for_both_orientations() -> None:
+    """The exact pick row must agree with the instant client readout: the
+    category-band center on the position axis and the value end on the value
+    axis. Horizontal bars used to report the rect x midpoint (half the value)
+    and the y1 edge (band position + half width), so the kernel's exact reply
+    visibly rewrote the tooltip a round-trip after hover."""
+    vertical = xy.bar_chart(xy.bar(x=["A", "B", "C"], y=[10.0, 42.0, 7.0]))
+    assert vertical.pick(0, 1) == {
+        "trace": 0,
+        "index": 1,
+        "x": 1.0,
+        "y": 42.0,
+        "x_kind": "float",
+        "y_kind": "float",
+    }
+    horizontal = xy.bar_chart(
+        xy.bar(x=["A", "B", "C"], y=[10.0, 42.0, 7.0], orientation="horizontal")
+    )
+    assert horizontal.pick(0, 1) == {
+        "trace": 0,
+        "index": 1,
+        "x": 42.0,
+        "y": 1.0,
+        "x_kind": "float",
+        "y_kind": "float",
+    }
+    # Stacked horizontal: the value end is the signed cumulative edge and the
+    # band center stays the category code, including on the negative branch.
+    stacked = xy.bar_chart(
+        xy.bar(
+            x=["A", "B"],
+            y=[[1.0, -2.0], [3.0, 4.0]],
+            mode="stacked",
+            orientation="horizontal",
+        )
+    )
+    assert stacked.pick(1, 0) == {
+        "trace": 1,
+        "index": 0,
+        "x": 4.0,
+        "y": 0.0,
+        "x_kind": "float",
+        "y_kind": "float",
+    }
+    assert stacked.pick(0, 1) == {
+        "trace": 0,
+        "index": 1,
+        "x": -2.0,
+        "y": 1.0,
+        "x_kind": "float",
+        "y_kind": "float",
+    }
+
+
+@pytest.mark.parametrize("orientation", ["vertical", "horizontal"])
+def test_bar_tooltip_survives_the_exact_pick_reply_unchanged(
+    tmp_path: Path, orientation: str
+) -> None:
+    """Hovering a bar shows the instant local readout; the kernel's exact
+    pick_result then replaces it. Both must say the same thing: the exact row
+    used to arrive as raw axis coordinates (category code, and for horizontal
+    bars half the value), so the tooltip visibly changed content and jumped to
+    a new anchor a round-trip after every hover."""
+    chart = xy.bar_chart(
+        xy.bar(x=["A", "B", "C"], y=[10.0, 42.0, 7.0], orientation=orientation),
+        width=520,
+        height=320,
+    )
+    pick_row = chart.pick(0, 1)
+    hover_xy = (21.0, 1.0) if orientation == "horizontal" else (1.0, 21.0)
+    script = (
+        _PRELUDE
+        + f"""
+    const pickRow = {json.dumps(pick_row)};
+    const [hx, hy] = {json.dumps(hover_xy)};
+"""
+        + """
+    const rect = view.canvas.getBoundingClientRect();
+    // _projectDataPoint is root-relative; the hover canvas covers the plot.
+    const [lx, ly] = view._projectDataPoint("x", "y", hx, hy);
+    const cssX = lx - view.plot.x;
+    const cssY = ly - view.plot.y;
+    const hit = view._hoverAt(cssX, cssY);
+    if (!hit || hit.index !== 1) throw new Error("expected to hover bar index 1");
+    const clientX = rect.left + cssX;
+    const clientY = rect.top + cssY;
+    view._hoverTarget = hit;
+    view._lastHoverXY = {clientX, clientY};
+    view._showTooltip(hit, clientX, clientY);
+    const snapshot = () => ({
+      text: view.tooltip.textContent,
+      left: view.tooltip.style.left,
+      top: view.tooltip.style.top,
+      display: view.tooltip.style.display,
+    });
+    const before = snapshot();
+    view._onKernelMsg({type: "pick_result", row: pickRow}, []);
+    const after = snapshot();
+    document.body.setAttribute("data-xy-issue-probe", JSON.stringify({
+      before, after, exactRow: view._lastRow,
+    }));
+"""
+        + _POSTLUDE
+    )
+    result = _probe(chart, script, tmp_path, f"bar tooltip exact reply {orientation}")
+
+    expected = "x42yB" if orientation == "horizontal" else "xBy42"
+    assert result["before"]["text"] == expected, result
+    assert result["after"] == result["before"], result
+    # The exact row reads like the local one: category label, full value.
+    label_field = "y" if orientation == "horizontal" else "x"
+    value_field = "x" if orientation == "horizontal" else "y"
+    assert result["exactRow"][label_field] == "B", result
+    assert result["exactRow"][value_field] == 42.0, result

--- a/tests/test_ui_issue_regressions.py
+++ b/tests/test_ui_issue_regressions.py
@@ -1245,3 +1245,45 @@ def test_bar_tooltip_survives_the_exact_pick_reply_unchanged(
     value_field = "x" if orientation == "horizontal" else "y"
     assert result["exactRow"][label_field] == "B", result
     assert result["exactRow"][value_field] == 42.0, result
+
+
+def test_pick_reply_for_a_dropped_trace_is_a_miss(tmp_path: Path) -> None:
+    """A pick_result can land after a data update removed its trace. With no
+    trace to map against, the raw kernel row must not render: the category
+    code would replace the label and drag the anchor — the exact rewrite/jump
+    this fix removes. A reply for a trace that no longer exists is a miss."""
+    chart = xy.bar_chart(
+        xy.bar(x=["A", "B", "C"], y=[10.0, 42.0, 7.0]),
+        width=520,
+        height=320,
+    )
+    pick_row = chart.pick(0, 1)
+    script = (
+        _PRELUDE
+        + f"""
+    const pickRow = {json.dumps(pick_row)};
+"""
+        + """
+    const rect = view.canvas.getBoundingClientRect();
+    const [lx, ly] = view._projectDataPoint("x", "y", 1.0, 21.0);
+    const cssX = lx - view.plot.x;
+    const cssY = ly - view.plot.y;
+    const hit = view._hoverAt(cssX, cssY);
+    if (!hit || hit.index !== 1) throw new Error("expected to hover bar index 1");
+    const clientX = rect.left + cssX;
+    const clientY = rect.top + cssY;
+    view._hoverTarget = hit;
+    view._lastHoverXY = {clientX, clientY};
+    view._showTooltip(hit, clientX, clientY);
+    // Simulate a data update dropping the trace while the pick is in flight.
+    view.gpuTraces = view.gpuTraces.filter((t) => t.trace.id !== pickRow.trace);
+    view._onKernelMsg({type: "pick_result", row: pickRow}, []);
+    document.body.setAttribute("data-xy-issue-probe", JSON.stringify({
+      display: view.tooltip.style.display,
+      text: view.tooltip.textContent,
+    }));
+"""
+        + _POSTLUDE
+    )
+    result = _probe(chart, script, tmp_path, "pick reply dropped trace")
+    assert result["display"] == "none", result


### PR DESCRIPTION
## Problem

Hovering a bar shows a correct tooltip, then a few milliseconds later the tooltip changes its data and position. Reported for both horizontal and vertical bar charts.

Hover is two-phase (§16): an instant local readout decoded from the shipped f32, then the kernel's exact f64 `pick_result` replaces it. The reply is supposed to be an invisible refinement; for bars it was a visible rewrite, on both seams:

- **Kernel**: `_append_rect_trace` built the conventional `Trace(x, y)` columns as x-midpoint / y1-edge regardless of orientation. A horizontal bar of value 42 replied `x: 21` (half the value) and `y: 1.4` (band position + half the bar width).
- **Client**: the `pick_result` handler rendered the kernel row raw — a category code replaced its label ("Beta" became "1"), and the finite code then overwrote the tooltip anchor, snapping the tooltip away from the cursor.

## Fix

- `python/xy/_figure.py`: the conventional center/value columns now follow the bar orientation — band center on the position axis, value end on the value axis. Histogram/box/violin pass no orientation and are unchanged.
- `js/src/54_kernel.ts`: `pick_result` maps `x`/`y` through the same `_sourceDisplayValue` path the local row uses, so category codes become labels and a label (non-finite) never moves the anchor.
- `js/src/52_tooltip.ts`: the `_cpuRect` local readout (variable-width bars fall back to plain rect payloads) is orientation-aware too, matching the corrected kernel convention.

## Tests

Both fail on the old code:

- `Figure.pick` readout pinned for vertical, horizontal, and stacked-with-negatives bars.
- A headless-Chromium probe per orientation: hover bar "Beta" with a real pointer event, snapshot the tooltip, inject the real `pick_result` row, and assert text and position are byte-identical before and after.

Verified live in Chrome against both builds: old bundle rewrites `x: 42 / y: Beta` to `x: 21 / y: 1.4` and jumps ~47px; fixed bundle is unchanged through the reply in both orientations.

## Spec

- `spec/api/chart-kind-contract.md`: orientation-aware center/value convention for bar-like marks.
- `spec/design/wire-protocol.md`: `pick_result` coordinate semantics and the invisible-refinement requirement.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tooltips and exact selections for horizontal and vertical bars.
  - Corrected bar readouts to use the value endpoint and category-band center.
  - Prevented stale selection results from displaying tooltips when traces are removed.
  - Preserved categorical axis value conversion in selection results.

- **Documentation**
  - Clarified coordinate conventions for oriented bar charts and handling of removed traces.

- **Tests**
  - Added coverage for stacked, negative, cumulative, horizontal, and vertical bar selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->