### PR TITLE
Add news fragment for the bar hover tooltip fix (#499)

### DIFF
--- a/news/499.bugfix.md
+++ b/news/499.bugfix.md
@@ -1,0 +1,6 @@
+Bar hover tooltips no longer rewrite themselves and jump when the kernel's
+exact pick reply lands. The reply's row now follows the bar's orientation
+(band center on the position axis, value end on the value axis) and is mapped
+through the same display-value path as the local readout, so the refinement is
+invisible instead of swapping a category label for its code and dragging the
+anchor off the cursor.


### PR DESCRIPTION
#499 landed before `CHANGELOG.md` became the release trigger, so its bug fix has no news fragment. Adds `news/499.bugfix.md` so the next generated version section covers it.

Fragment only — no code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bkm7XzgV75b1sjKVYvQfUB)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bar hover tooltips for more stable behavior.
  * Preserved tooltip orientation and label placement while refining displayed values.
  * Prevented the cursor anchor from shifting during hover interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->