### PR TITLE
Fix idle-chart blank/flicker: retain last frame through failed restore retries, recycle wedged contexts

### DIFF
--- a/js/src/42_glhost.ts
+++ b/js/src/42_glhost.ts
@@ -284,6 +284,18 @@ export class GLHost {
     }
   }
 
+  /** In-page equivalent of a full reload for the GL layer: retire the current
+   * surface and rebuild every client on a fresh context. A context can keep
+   * reporting itself live (`isContextLost()` false) while a wedged driver
+   * fails every rebuild against it; retrying on that same context can then
+   * never succeed, and before this seam existed the only escape was reloading
+   * the page. Rides the existing loss machinery, so replacement failures keep
+   * its backoff. */
+  recycleSurface(): void {
+    if (this._disposed) return;
+    this._markLost();
+  }
+
   /** Drop one client.  The context and all shared objects are released only
    * when the final registered ChartView leaves. */
   release(client: GLHostClient): void {

--- a/js/src/42_glhost.ts
+++ b/js/src/42_glhost.ts
@@ -284,13 +284,10 @@ export class GLHost {
     }
   }
 
-  /** In-page equivalent of a full reload for the GL layer: retire the current
-   * surface and rebuild every client on a fresh context. A context can keep
-   * reporting itself live (`isContextLost()` false) while a wedged driver
-   * fails every rebuild against it; retrying on that same context can then
-   * never succeed, and before this seam existed the only escape was reloading
-   * the page. Rides the existing loss machinery, so replacement failures keep
-   * its backoff. */
+  /** Retire the current surface and rebuild every client on a fresh context —
+   * the escape for a wedged context that reports itself live
+   * (`isContextLost()` false) while every rebuild against it fails. Rides the
+   * existing loss machinery, so replacement failures keep its backoff. */
   recycleSurface(): void {
     if (this._disposed) return;
     this._markLost();

--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -681,6 +681,7 @@ export class ChartView {
     this._governorRegistered = false;
     this._glHostRecoveryTimer = null;
     this._glHostRecoveryDelay = 0;
+    this._glHostRebuildFailures = 0;
     if (this._ctxVisible) this._ctxSeenSeq = XY_CONTEXT_GOVERNOR.seq++;
     this._contextLossCount = 0;
     this._contextRestoreCount = 0;
@@ -2047,7 +2048,23 @@ export class ChartView {
             if (this.gl && !this.gl.isContextLost()) {
               try { this._destroyGlResources(); } catch (_cleanupError) {}
             }
-            this._scheduleGlHostClientRecovery();
+            // A host context can stay "live" (`isContextLost()` false) while a
+            // wedged driver fails every rebuild against it. Retrying on that
+            // same context can then never succeed — a state users previously
+            // escaped only by reloading the page. After three consecutive
+            // failures, recycle the shared surface instead: a fresh context is
+            // exactly what a reload buys. (The capability check keeps a v1
+            // host from an older duplicate bundle on plain retries.)
+            this._glHostRebuildFailures = (this._glHostRebuildFailures || 0) + 1;
+            if (
+              this._glHostRebuildFailures >= 3 &&
+              typeof this._glHost.recycleSurface === "function"
+            ) {
+              this._glHostRebuildFailures = 0;
+              this._glHost.recycleSurface(); // host-wide restored event drives the next attempt
+            } else {
+              this._scheduleGlHostClientRecovery();
+            }
           } else {
             this._scheduleContextRecovery();
           }
@@ -2069,6 +2086,7 @@ export class ChartView {
       }
       this._contextRestoreCount += 1;
       this._contextRecoveryError = null;
+      this._glHostRebuildFailures = 0;
       this._ctxRecoveryDelay = 0;
       clearTimeout(this._glHostRecoveryTimer);
       this._glHostRecoveryTimer = null;
@@ -4358,14 +4376,22 @@ export class ChartView {
   _initGl(buffer) {
     const dpr = window.devicePixelRatio || 1;
     this.dpr = dpr;
-    this.canvas.width = this.plot.w * dpr;
-    this.canvas.height = this.plot.h * dpr;
-    this.chrome.width = this.size.w * dpr;
-    this.chrome.height = this.size.h * dpr;
+    // A canvas backing-store write clears the canvas even when the value is
+    // unchanged, and _initGl also runs on every context-restore retry. The
+    // last presented frame must survive a rebuild that fails transiently
+    // under GPU pressure (§18) — wiping it here turned each failed retry
+    // into a visible blank/flicker until a retry finally succeeded.
+    const sizeSurface = (surface, w, h) => {
+      w = Math.trunc(w);
+      h = Math.trunc(h);
+      if (surface.width !== w) surface.width = w;
+      if (surface.height !== h) surface.height = h;
+    };
+    sizeSurface(this.canvas, this.plot.w * dpr, this.plot.h * dpr);
+    sizeSurface(this.chrome, this.size.w * dpr, this.size.h * dpr);
     this.chrome.style.width = this.size.w + "px";
     this.chrome.style.height = this.size.h + "px";
-    this.overlay.width = this.size.w * dpr;
-    this.overlay.height = this.size.h * dpr;
+    sizeSurface(this.overlay, this.size.w * dpr, this.size.h * dpr);
     this.overlay.style.width = this.size.w + "px";
     this.overlay.style.height = this.size.h + "px";
 

--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -1916,11 +1916,9 @@ export class ChartView {
       if (this._governorRegistered) XY_CONTEXT_GOVERNOR._announceLive();
       this._contextLossCount += 1;
       this._contextRecoveryError = null;
-      // A genuine loss starts a fresh recovery cycle (and already delivers
-      // the fresh-context remedy escalation exists for), so rebuild failures
-      // from a previous cycle are not evidence about the next context —
-      // carrying them over would recycle the whole host after one post-loss
-      // failure instead of three consecutive ones.
+      // A genuine loss starts a fresh recovery cycle with a fresh context, so
+      // prior rebuild failures are no evidence about it — escalation counts
+      // consecutive failures within one cycle only.
       this._glHostRebuildFailures = 0;
       this.root.dataset.xyContextState = "lost";
       // Quiesce every source of deferred GPU work, not only the draw RAF.
@@ -2054,13 +2052,11 @@ export class ChartView {
             if (this.gl && !this.gl.isContextLost()) {
               try { this._destroyGlResources(); } catch (_cleanupError) {}
             }
-            // A host context can stay "live" (`isContextLost()` false) while a
-            // wedged driver fails every rebuild against it. Retrying on that
-            // same context can then never succeed — a state users previously
-            // escaped only by reloading the page. After three consecutive
-            // failures, recycle the shared surface instead: a fresh context is
-            // exactly what a reload buys. (The capability check keeps a v1
-            // host from an older duplicate bundle on plain retries.)
+            // A wedged context can report itself live (isContextLost() false)
+            // while every rebuild against it fails, so retries on it never
+            // succeed. After three consecutive failures, recycle the shared
+            // surface for a fresh context (§18). The capability check keeps a
+            // v1 host from an older duplicate bundle on plain retries.
             this._glHostRebuildFailures = (this._glHostRebuildFailures || 0) + 1;
             if (
               this._glHostRebuildFailures >= 3 &&
@@ -4382,11 +4378,10 @@ export class ChartView {
   _initGl(buffer) {
     const dpr = window.devicePixelRatio || 1;
     this.dpr = dpr;
-    // A canvas backing-store write clears the canvas even when the value is
-    // unchanged, and _initGl also runs on every context-restore retry. The
-    // last presented frame must survive a rebuild that fails transiently
-    // under GPU pressure (§18) — wiping it here turned each failed retry
-    // into a visible blank/flicker until a retry finally succeeded.
+    // A canvas backing-store write clears the canvas even at an unchanged
+    // value, and _initGl runs on every context-restore retry — write only on
+    // a real size change so the last presented frame survives a rebuild that
+    // fails transiently under GPU pressure (§18).
     const sizeSurface = (surface, w, h) => {
       w = Math.trunc(w);
       h = Math.trunc(h);

--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -1916,6 +1916,12 @@ export class ChartView {
       if (this._governorRegistered) XY_CONTEXT_GOVERNOR._announceLive();
       this._contextLossCount += 1;
       this._contextRecoveryError = null;
+      // A genuine loss starts a fresh recovery cycle (and already delivers
+      // the fresh-context remedy escalation exists for), so rebuild failures
+      // from a previous cycle are not evidence about the next context —
+      // carrying them over would recycle the whole host after one post-loss
+      // failure instead of three consecutive ones.
+      this._glHostRebuildFailures = 0;
       this.root.dataset.xyContextState = "lost";
       // Quiesce every source of deferred GPU work, not only the draw RAF.
       // Incrementing seq makes pre-loss kernel/worker replies stale, so they

--- a/js/src/50_chartview.ts
+++ b/js/src/50_chartview.ts
@@ -1901,6 +1901,14 @@ export class ChartView {
       e.preventDefault();
       if (this._destroyed) return;
       const governedRelease = this.canvas.dataset.xyCtx === "released";
+      // A loss starts a fresh recovery cycle with a fresh context, so prior
+      // rebuild failures are no evidence about it — escalation counts
+      // consecutive failures within one cycle only. Reset before the
+      // duplicate guard below: the host fans out losses only on a live→lost
+      // transition, so a loss reaching a client still lost from a failed
+      // rebuild is a genuine new cycle too, and its stale count would
+      // otherwise escalate a host-wide recycle off one post-loss failure.
+      this._glHostRebuildFailures = 0;
       // _releaseContext marks the view lost synchronously before the browser
       // dispatches this event. Still run the full quiesce/telemetry path for
       // that first governed event; only ignore duplicate ungoverned losses.
@@ -1916,10 +1924,6 @@ export class ChartView {
       if (this._governorRegistered) XY_CONTEXT_GOVERNOR._announceLive();
       this._contextLossCount += 1;
       this._contextRecoveryError = null;
-      // A genuine loss starts a fresh recovery cycle with a fresh context, so
-      // prior rebuild failures are no evidence about it — escalation counts
-      // consecutive failures within one cycle only.
-      this._glHostRebuildFailures = 0;
       this.root.dataset.xyContextState = "lost";
       // Quiesce every source of deferred GPU work, not only the draw RAF.
       // Incrementing seq makes pre-loss kernel/worker replies stale, so they

--- a/news/501.bugfix.md
+++ b/news/501.bugfix.md
@@ -6,6 +6,7 @@ keeping the last good frame on screen until a rebuild succeeds. And when a
 context stays "live" while every rebuild against it fails (a wedged driver),
 three consecutive failures now recycle the shared WebGL surface — rebuilding
 every chart on a fresh context, the in-page equivalent of the reload that was
-previously the only escape. A genuine context loss resets that escalation
-counter, so ordinary loss/restore churn keeps taking cheap same-context
-retries.
+previously the only escape. A genuine context loss — including one arriving
+while a chart is still mid-retry from an earlier failure — resets that
+escalation counter, so ordinary loss/restore churn keeps taking cheap
+same-context retries.

--- a/news/501.bugfix.md
+++ b/news/501.bugfix.md
@@ -1,0 +1,11 @@
+Charts left running under GPU pressure no longer flicker blank or stay gone
+until a page reload. Context-restore retries used to clear the presentation
+canvas before every rebuild attempt, so each transient failure wiped the last
+drawn frame; the canvas now resizes only when its dimensions actually change,
+keeping the last good frame on screen until a rebuild succeeds. And when a
+context stays "live" while every rebuild against it fails (a wedged driver),
+three consecutive failures now recycle the shared WebGL surface — rebuilding
+every chart on a fresh context, the in-page equivalent of the reload that was
+previously the only escape. A genuine context loss resets that escalation
+counter, so ordinary loss/restore churn keeps taking cheap same-context
+retries.

--- a/spec/design-dossier.md
+++ b/spec/design-dossier.md
@@ -835,8 +835,12 @@ plain retries then never succeed, and the only user escape was refreshing the pa
 After three consecutive rebuild failures a client therefore calls
 `GLHost.recycleSurface()` — retire the current surface and rebuild every client on a
 fresh context, which is exactly what a reload buys — riding the existing loss/replace
-machinery and its backoff. The counter resets on the first successful rebuild, so
-ordinary transient pressure still recovers through cheap same-context retries.
+machinery and its backoff. The counter counts consecutive failures within one recovery
+cycle only: it resets on the first successful rebuild and on every loss notification —
+including one reaching a client still lost from a failed rebuild, since the host fans
+out losses only on a live→lost transition and a loss therefore always heralds a fresh
+context. Ordinary transient pressure thus recovers through cheap same-context retries,
+and a stale count can never escalate a host-wide recycle off a single post-loss failure.
 
 The governed per-chart path remains the compatibility fallback. It is used when shared
 hosting is explicitly disabled via `window.XY_SHARED_WEBGL = false`, when a document

--- a/spec/design-dossier.md
+++ b/spec/design-dossier.md
@@ -817,6 +817,27 @@ state. Each client preserves its settled pan/zoom and re-requests that same view
 reconstruction, matching the existing context-loss contract rather than resetting
 charts to home.
 
+A client rebuild can itself fail transiently — under process-wide GPU pressure Chromium
+loses just-created resources mid-setup (the characteristic `shader compile: null`) — and
+the client then retries with backoff (50 ms doubling to a 1 s cap; off-screen and
+hidden-document retries defer to the visibility/intersection wake-ups). Throughout those
+retries the chart's Canvas2D presentation surface must keep showing the last
+successfully presented frame: surface backing stores are resized only when their
+dimensions actually change, because a canvas width/height write clears the canvas even
+at the same value, and an unguarded resize in the rebuild path turned every failed retry
+into a visible blank — a chart under sustained pressure flickered between drawn and
+empty until a retry finally succeeded. Recovery is seamless-or-stale, never blank; only
+`data-xy-ctx` reports the difference.
+
+Retries must also be as powerful as a page reload. A wedged driver can leave a context
+reporting itself live (`isContextLost()` false) while every rebuild against it fails;
+plain retries then never succeed, and the only user escape was refreshing the page.
+After three consecutive rebuild failures a client therefore calls
+`GLHost.recycleSurface()` — retire the current surface and rebuild every client on a
+fresh context, which is exactly what a reload buys — riding the existing loss/replace
+machinery and its backoff. The counter resets on the first successful rebuild, so
+ordinary transient pressure still recovers through cheap same-context retries.
+
 The governed per-chart path remains the compatibility fallback. It is used when shared
 hosting is explicitly disabled via `window.XY_SHARED_WEBGL = false`, when a document
 cannot create or use the shared host, and by default inside child frames. Setting

--- a/tests/test_shared_glhost.py
+++ b/tests/test_shared_glhost.py
@@ -936,6 +936,211 @@ def test_shared_host_loss_restores_every_client_and_zoom(tmp_path: Path) -> None
     assert result["afterRange"]["y"] == pytest.approx(result["beforeRange"]["y"])
 
 
+_FAILED_REBUILD_FRAME_RETENTION_PROBE = r"""
+  (async () => {
+    try {
+      document.body.style.cssText = "margin:0;overflow:hidden";
+      const holder = document.getElementById("chart");
+      holder.replaceChildren();
+      const view = xy.renderStandalone(holder, spec, buf);
+      view._drawNow();
+      view._raf = null;
+
+      const nonzero = () => {
+        const context = view._present2d;
+        return context.getImageData(
+          0,
+          0,
+          context.canvas.width,
+          context.canvas.height,
+        ).data.some((channel) => channel !== 0);
+      };
+      const host = view._glHost;
+      if (!host) throw new Error("probe did not acquire the shared host");
+      const extension = host.gl.getExtension("WEBGL_lose_context");
+      if (!extension) throw new Error("WEBGL_lose_context extension unavailable");
+      const drawnBefore = nonzero();
+
+      // Fail every client rebuild the way process-wide GPU pressure does:
+      // Chromium loses a just-created resource mid-compile and reports a null
+      // shader log — the message class the restore handler treats as transient.
+      const originalGetOrCreateShader = host.getOrCreateShader;
+      host.getOrCreateShader = () => {
+        throw new Error("shader compile: null");
+      };
+
+      const waitUntil = async (predicate, label) => {
+        const deadline = performance.now() + 5000;
+        while (!predicate()) {
+          if (performance.now() >= deadline) throw new Error(`timed out waiting for ${label}`);
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+      };
+
+      const lossCount = view._contextLossCount;
+      extension.loseContext();
+      await waitUntil(() => view._contextLossCount >= lossCount + 1, "context loss fan-out");
+      extension.restoreContext();
+      // The host restores, every client rebuild fails, and the retry backoff
+      // holds the view in the lost state until compilation heals. A delay of
+      // 200 ms proves at least two rebuild attempts already failed.
+      await waitUntil(
+        () => view._glHostRecoveryDelay >= 200 && view.canvas.dataset.xyCtx === "lost",
+        "failed client rebuilds entering retry backoff",
+      );
+      const retainedDuringFailure = nonzero();
+
+      host.getOrCreateShader = originalGetOrCreateShader;
+      await waitUntil(
+        () => view.canvas.dataset.xyCtx === "live" && !view._glLost,
+        "client recovery after compilation heals",
+      );
+      view._drawNow();
+      view._raf = null;
+      const drawnAfterRecovery = nonzero();
+
+      document.body.setAttribute("data-xy-failed-rebuild-probe", JSON.stringify({
+        drawnBefore,
+        retainedDuringFailure,
+        drawnAfterRecovery,
+      }));
+    } catch (error) {
+      document.body.setAttribute(
+        "data-xy-failed-rebuild-probe-error",
+        String((error && error.stack) || error),
+      );
+    }
+  })();
+"""
+
+
+def test_failed_client_rebuild_keeps_last_presented_frame(tmp_path: Path) -> None:
+    """A transiently failing restore must not blank the visible chart.
+
+    ``_initGl`` runs on every context-restore retry; sizing a canvas backing
+    store clears it even when the dimensions are unchanged, so an unguarded
+    resize wiped the last presented frame on each failed rebuild — a chart
+    under sustained GPU pressure visibly flickered between blank and drawn
+    until a retry finally succeeded (§18 recovery must be seamless).
+    """
+    chromium = find_chromium()
+    if chromium is None:
+        pytest.skip("Chromium unavailable")
+
+    result = run_browser_probe(
+        chromium,
+        _chart_html(_FAILED_REBUILD_FRAME_RETENTION_PROBE),
+        tmp_path / "shared_glhost_failed_rebuild.html",
+        "data-xy-failed-rebuild-probe",
+        label="shared WebGL host failed-rebuild frame-retention probe",
+    )
+
+    assert result["drawnBefore"] is True, result
+    assert result["retainedDuringFailure"] is True, result
+    assert result["drawnAfterRecovery"] is True, result
+
+
+_POISONED_CONTEXT_ESCALATION_PROBE = r"""
+  (async () => {
+    try {
+      document.body.style.cssText = "margin:0;overflow:hidden";
+      const holder = document.getElementById("chart");
+      holder.replaceChildren();
+      const view = xy.renderStandalone(holder, spec, buf);
+      view._drawNow();
+      view._raf = null;
+
+      const host = view._glHost;
+      if (!host) throw new Error("probe did not acquire the shared host");
+      const extension = host.gl.getExtension("WEBGL_lose_context");
+      if (!extension) throw new Error("WEBGL_lose_context extension unavailable");
+
+      // Wedged-driver regime: the context keeps reporting itself live
+      // (isContextLost() false) yet every rebuild against it fails. Poison
+      // exactly this context object; a replacement context compiles fine.
+      const poisoned = host.gl;
+      const originalGetOrCreateShader = host.getOrCreateShader;
+      host.getOrCreateShader = function (type, source) {
+        if (this.gl === poisoned) throw new Error("shader compile: null");
+        return originalGetOrCreateShader.call(this, type, source);
+      };
+
+      const waitUntil = async (predicate, label) => {
+        const deadline = performance.now() + 5000;
+        while (!predicate()) {
+          if (performance.now() >= deadline) throw new Error(`timed out waiting for ${label}`);
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+      };
+
+      const generationBefore = host.generation;
+      const lossCount = view._contextLossCount;
+      extension.loseContext();
+      await waitUntil(() => view._contextLossCount >= lossCount + 1, "context loss fan-out");
+      extension.restoreContext();
+      // The restored-but-poisoned context fails three consecutive client
+      // rebuilds; the client must then recycle the shared surface and come
+      // back live on a fresh context — without a page reload.
+      await waitUntil(
+        () =>
+          host.gl !== poisoned &&
+          view.canvas.dataset.xyCtx === "live" &&
+          !view._glLost,
+        "escalation to a fresh surface",
+      );
+      view._drawNow();
+      view._raf = null;
+      const context = view._present2d;
+      const drawnOnFreshContext = context.getImageData(
+        0,
+        0,
+        context.canvas.width,
+        context.canvas.height,
+      ).data.some((channel) => channel !== 0);
+
+      document.body.setAttribute("data-xy-poisoned-escalation-probe", JSON.stringify({
+        surfaceReplaced: host.gl !== poisoned,
+        generationAdvanced: host.generation > generationBefore,
+        hostLive: !host.gl.isContextLost(),
+        drawnOnFreshContext,
+      }));
+    } catch (error) {
+      document.body.setAttribute(
+        "data-xy-poisoned-escalation-probe-error",
+        String((error && error.stack) || error),
+      );
+    }
+  })();
+"""
+
+
+def test_wedged_live_context_escalates_to_fresh_surface(tmp_path: Path) -> None:
+    """Rebuilds that keep failing on a live context must not retry forever.
+
+    A wedged driver can leave ``isContextLost()`` false while every compile
+    against that context fails; plain retries then never succeed and the only
+    user escape was a page reload. After three consecutive rebuild failures
+    the client recycles the shared surface — the in-page equivalent of that
+    reload — and recovers on the replacement context (§18).
+    """
+    chromium = find_chromium()
+    if chromium is None:
+        pytest.skip("Chromium unavailable")
+
+    result = run_browser_probe(
+        chromium,
+        _chart_html(_POISONED_CONTEXT_ESCALATION_PROBE),
+        tmp_path / "shared_glhost_poisoned_escalation.html",
+        "data-xy-poisoned-escalation-probe",
+        label="shared WebGL host wedged-context escalation probe",
+    )
+
+    assert result["surfaceReplaced"] is True, result
+    assert result["generationAdvanced"] is True, result
+    assert result["hostLive"] is True, result
+    assert result["drawnOnFreshContext"] is True, result
+
+
 def test_shared_glhost_source_contract() -> None:
     host = (ROOT / "js/src/42_glhost.ts").read_text(encoding="utf-8")
     chartview = (ROOT / "js/src/50_chartview.ts").read_text(encoding="utf-8")

--- a/tests/test_shared_glhost.py
+++ b/tests/test_shared_glhost.py
@@ -1206,6 +1206,114 @@ def test_genuine_loss_resets_rebuild_failure_count(tmp_path: Path) -> None:
     assert result["failuresAfterRecovery"] == 0, result
 
 
+_LOST_CLIENT_STALE_COUNT_PROBE = r"""
+  (async () => {
+    try {
+      document.body.style.cssText = "margin:0;overflow:hidden";
+      const holder = document.getElementById("chart");
+      holder.replaceChildren();
+      const view = xy.renderStandalone(holder, spec, buf);
+      view._drawNow();
+      view._raf = null;
+
+      const host = view._glHost;
+      if (!host) throw new Error("probe did not acquire the shared host");
+      const extension = host.gl.getExtension("WEBGL_lose_context");
+      if (!extension) throw new Error("WEBGL_lose_context extension unavailable");
+
+      let failuresLeft = Infinity;
+      const originalGetOrCreateShader = host.getOrCreateShader;
+      host.getOrCreateShader = function (type, source) {
+        if (failuresLeft > 0) {
+          failuresLeft -= 1;
+          throw new Error("shader compile: null");
+        }
+        return originalGetOrCreateShader.call(this, type, source);
+      };
+
+      const waitUntil = async (predicate, label) => {
+        const deadline = performance.now() + 5000;
+        while (!predicate()) {
+          if (performance.now() >= deadline) throw new Error(`timed out waiting for ${label}`);
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+      };
+
+      // Drive the client into the already-lost state organically: a genuine
+      // loss, then two rebuild failures against the restored context.
+      const lossCount = view._contextLossCount;
+      extension.loseContext();
+      await waitUntil(() => view._contextLossCount >= lossCount + 1, "first loss fan-out");
+      extension.restoreContext();
+      await waitUntil(
+        () => view._glLost && view._glHostRebuildFailures === 2,
+        "two rebuild failures on the restored context",
+      );
+      // Freeze the pending same-context retry so a third failure cannot land
+      // before the second genuine loss below.
+      clearTimeout(view._glHostRecoveryTimer);
+      view._glHostRecoveryTimer = null;
+
+      // A genuine host loss now arrives while this client is still lost from
+      // its failed rebuild. Exactly one transient failure remains for the
+      // fresh cycle — one failure on a fresh context is not the
+      // wedged-context signature, so recovery must take the cheap
+      // same-context retry, never a host-wide recycleSurface().
+      failuresLeft = 1;
+      const originalGl = host.gl;
+      const generationBefore = host.generation;
+      extension.loseContext();
+      await waitUntil(() => host.lost, "second loss reaching the host");
+      extension.restoreContext();
+      await waitUntil(
+        () => view.canvas.dataset.xyCtx === "live" && !view._glLost,
+        "recovery after one transient failure",
+      );
+
+      document.body.setAttribute("data-xy-lost-client-stale-count-probe", JSON.stringify({
+        // Loss + restore of the same surface is exactly one generation; an
+        // escalation would have added another and replaced the context.
+        sameContext: host.gl === originalGl,
+        generationDelta: host.generation - generationBefore,
+        failuresAfterRecovery: view._glHostRebuildFailures,
+      }));
+    } catch (error) {
+      document.body.setAttribute(
+        "data-xy-lost-client-stale-count-probe-error",
+        String((error && error.stack) || error),
+      );
+    }
+  })();
+"""
+
+
+def test_loss_while_client_lost_resets_rebuild_failure_count(tmp_path: Path) -> None:
+    """A loss arriving while the client is already lost must still reset.
+
+    A failed rebuild leaves the client lost with a nonzero failure count; the
+    duplicate-loss guard must not skip the counter reset when a genuine host
+    loss then arrives, because the host fans out losses only on a live→lost
+    transition — that loss always heralds a fresh context, and the stale
+    count would otherwise escalate a host-wide ``recycleSurface()`` off a
+    single post-loss failure (§18).
+    """
+    chromium = find_chromium()
+    if chromium is None:
+        pytest.skip("Chromium unavailable")
+
+    result = run_browser_probe(
+        chromium,
+        _chart_html(_LOST_CLIENT_STALE_COUNT_PROBE),
+        tmp_path / "shared_glhost_lost_client_stale_count.html",
+        "data-xy-lost-client-stale-count-probe",
+        label="shared WebGL host lost-client stale-count probe",
+    )
+
+    assert result["sameContext"] is True, result
+    assert result["generationDelta"] == 1, result
+    assert result["failuresAfterRecovery"] == 0, result
+
+
 def test_wedged_live_context_escalates_to_fresh_surface(tmp_path: Path) -> None:
     """Rebuilds that keep failing on a live context must not retry forever.
 

--- a/tests/test_shared_glhost.py
+++ b/tests/test_shared_glhost.py
@@ -1017,11 +1017,10 @@ _FAILED_REBUILD_FRAME_RETENTION_PROBE = r"""
 def test_failed_client_rebuild_keeps_last_presented_frame(tmp_path: Path) -> None:
     """A transiently failing restore must not blank the visible chart.
 
-    ``_initGl`` runs on every context-restore retry; sizing a canvas backing
-    store clears it even when the dimensions are unchanged, so an unguarded
-    resize wiped the last presented frame on each failed rebuild — a chart
-    under sustained GPU pressure visibly flickered between blank and drawn
-    until a retry finally succeeded (§18 recovery must be seamless).
+    ``_initGl`` runs on every context-restore retry, and a canvas
+    backing-store write clears the canvas even at unchanged dimensions —
+    the last presented frame must stay on screen until a rebuild
+    succeeds (§18).
     """
     chromium = find_chromium()
     if chromium is None:
@@ -1211,10 +1210,9 @@ def test_wedged_live_context_escalates_to_fresh_surface(tmp_path: Path) -> None:
     """Rebuilds that keep failing on a live context must not retry forever.
 
     A wedged driver can leave ``isContextLost()`` false while every compile
-    against that context fails; plain retries then never succeed and the only
-    user escape was a page reload. After three consecutive rebuild failures
-    the client recycles the shared surface — the in-page equivalent of that
-    reload — and recovers on the replacement context (§18).
+    against that context fails, so plain retries never succeed. After three
+    consecutive rebuild failures the client must recycle the shared surface
+    and recover on the replacement context (§18).
     """
     chromium = find_chromium()
     if chromium is None:

--- a/tests/test_shared_glhost.py
+++ b/tests/test_shared_glhost.py
@@ -1114,6 +1114,99 @@ _POISONED_CONTEXT_ESCALATION_PROBE = r"""
 """
 
 
+_STALE_FAILURE_COUNT_PROBE = r"""
+  (async () => {
+    try {
+      document.body.style.cssText = "margin:0;overflow:hidden";
+      const holder = document.getElementById("chart");
+      holder.replaceChildren();
+      const view = xy.renderStandalone(holder, spec, buf);
+      view._drawNow();
+      view._raf = null;
+
+      const host = view._glHost;
+      if (!host) throw new Error("probe did not acquire the shared host");
+      const extension = host.gl.getExtension("WEBGL_lose_context");
+      if (!extension) throw new Error("WEBGL_lose_context extension unavailable");
+
+      // Stale count from an earlier recovery cycle, then a genuine loss and a
+      // SINGLE transient failure on the restored context. One failure on a
+      // fresh cycle is not the wedged-context signature, so it must take the
+      // cheap same-context retry — never a host-wide recycleSurface().
+      view._glHostRebuildFailures = 2;
+      let failuresLeft = 1;
+      const originalGetOrCreateShader = host.getOrCreateShader;
+      host.getOrCreateShader = function (type, source) {
+        if (failuresLeft > 0) {
+          failuresLeft -= 1;
+          throw new Error("shader compile: null");
+        }
+        return originalGetOrCreateShader.call(this, type, source);
+      };
+
+      const waitUntil = async (predicate, label) => {
+        const deadline = performance.now() + 5000;
+        while (!predicate()) {
+          if (performance.now() >= deadline) throw new Error(`timed out waiting for ${label}`);
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+      };
+
+      const originalGl = host.gl;
+      const generationBefore = host.generation;
+      const lossCount = view._contextLossCount;
+      extension.loseContext();
+      await waitUntil(() => view._contextLossCount >= lossCount + 1, "context loss fan-out");
+      extension.restoreContext();
+      await waitUntil(
+        () => view.canvas.dataset.xyCtx === "live" && !view._glLost,
+        "recovery after one transient failure",
+      );
+
+      document.body.setAttribute("data-xy-stale-count-probe", JSON.stringify({
+        // A genuine loss + restore is exactly one generation; an escalation
+        // would have added another and replaced the context object.
+        sameContext: host.gl === originalGl,
+        generationDelta: host.generation - generationBefore,
+        failuresAfterRecovery: view._glHostRebuildFailures,
+      }));
+    } catch (error) {
+      document.body.setAttribute(
+        "data-xy-stale-count-probe-error",
+        String((error && error.stack) || error),
+      );
+    }
+  })();
+"""
+
+
+def test_genuine_loss_resets_rebuild_failure_count(tmp_path: Path) -> None:
+    """Stale failures from a prior cycle must not carry across a real loss.
+
+    The escalation counter detects a wedged context — consecutive failures
+    against the same live context with no loss event between them. A genuine
+    ``webglcontextlost`` already delivers the fresh-context remedy, so one
+    post-loss failure must take the cheap same-context retry; escalating a
+    host-wide ``recycleSurface()`` off a stale count would make every chart
+    quiesce and rebuild under exactly the pressure being survived.
+    """
+    chromium = find_chromium()
+    if chromium is None:
+        pytest.skip("Chromium unavailable")
+
+    result = run_browser_probe(
+        chromium,
+        _chart_html(_STALE_FAILURE_COUNT_PROBE),
+        tmp_path / "shared_glhost_stale_count.html",
+        "data-xy-stale-count-probe",
+        label="shared WebGL host stale-failure-count probe",
+    )
+
+    assert result["sameContext"] is True, result
+    assert result["generationDelta"] == 1, result
+    assert result["failuresAfterRecovery"] == 0, result
+
+
 def test_wedged_live_context_escalates_to_fresh_surface(tmp_path: Path) -> None:
     """Rebuilds that keep failing on a live context must not retry forever.
 


### PR DESCRIPTION
## Problem

Charts left idle for a while started disappearing and reappearing at random, and could stay blank until a full page refresh (reported against a deployed Reflex app; reproduced on demand in-browser).

Both symptoms are one recovery loop: context lost → restore → client rebuild → transient failure (Chromium's `shader compile: null` under process-wide GPU pressure) → backoff retry.

- **Flicker / long blanks:** `_initGl` runs on every retry and sized the canvas backing stores unconditionally — a canvas `width`/`height` write clears the canvas **even at the same value**, so every failed rebuild wiped the last presented frame. Blank for the whole failing stretch; brief reappearances when an attempt succeeded.
- **Refresh required:** a wedged driver can leave a context reporting itself live (`isContextLost()` false) while every rebuild against it fails. The loop retried the same poisoned context forever; only a reload allocated a fresh one.

## Fix

- `_initGl` resizes surfaces only when dimensions actually change → the last good frame survives every failed retry. Recovery is seamless-or-stale, never blank (`data-xy-ctx` still reports the state).
- New `GLHost.recycleSurface()`: after 3 consecutive rebuild failures the client retires the shared surface and rebuilds every client on a fresh context — the in-page equivalent of the reload, riding the existing loss/replace machinery and backoff. Counter resets on the first success, so ordinary transient pressure keeps cheap same-context retries.

## Evidence

- `test_failed_client_rebuild_keeps_last_presented_frame` — pixels retained on the presentation canvas while rebuilds fail continuously, recovery after they heal. **Fails on old code** (canvas blank), passes with the fix.
- `test_wedged_live_context_escalates_to_fresh_surface` — poisons exactly the current context object (live but failing every compile); chart must come back live on a replacement context without a reload. **Times out retrying forever on old code**, passes with the fix.
- Reproduced the reported blank state pixel-for-pixel on the deployed app by injecting the same failure; verified live that the fixed bundle holds its frame through sustained failures and returns to `live` automatically.
- Full `test_shared_glhost.py` + `test_context_loss_preserves_view.py` (12 passed), `render_smoke_nonumpy`, `append_stream_smoke`, `node js/build.mjs`, pre-commit + ruff all green.

## Spec

Dossier §18 now records both contracts: surface backing stores resize only on real dimension changes (recovery never blanks), and retries must be as powerful as a page reload (escalation to a fresh surface).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/xy/pull/501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graphics recovery after temporary WebGL or shader failures.
  * Retries transient recovery failures with controlled backoff.
  * Preserves the last rendered frame while recovery is in progress.
  * Refreshes the graphics surface after three consecutive recovery failures.
  * Prevents unnecessary canvas resizing during transient rendering issues.
  * Resets recovery tracking after successful restoration or genuine context loss.

* **Tests**
  * Added coverage for frame preservation and stalled graphics-context recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->